### PR TITLE
Remove sequence numbers from dynamic providers

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ## Bug Fixes
+
+- [sdk/{nodejs,python}] - Remove sequence numbers from the dynamic provider interfaces.
+  [#8849](https://github.com/pulumi/pulumi/pull/8849)

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -118,7 +118,7 @@ async function checkRPC(call: any, callback: any): Promise<void> {
         let inputs: any = news;
         let failures: any[] = [];
         if (provider.check) {
-            const result = await provider.check(olds, news, req.getSequencenumber());
+            const result = await provider.check(olds, news);
             if (result.inputs) {
                 inputs = result.inputs;
             }

--- a/sdk/nodejs/dynamic/index.ts
+++ b/sdk/nodejs/dynamic/index.ts
@@ -118,7 +118,7 @@ export interface ResourceProvider {
      * @param olds The old input properties to use for validation.
      * @param news The new input properties to use for validation.
      */
-    check?: (olds: any, news: any, sequenceNumber: number) => Promise<CheckResult>;
+    check?: (olds: any, news: any) => Promise<CheckResult>;
 
     /**
      * Diff checks what impacts a hypothetical update will have on the resource's properties.

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -158,7 +158,7 @@ export interface Provider {
      * @param olds The old input properties to use for validation.
      * @param news The new input properties to use for validation.
      */
-    check?: (urn: resource.URN, olds: any, news: any, sequenceNumber: number) => Promise<CheckResult>;
+    check?: (urn: resource.URN, olds: any, news: any) => Promise<CheckResult>;
 
     /**
      * Diff checks what impacts a hypothetical update will have on the resource's properties.

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -111,7 +111,7 @@ class Server implements grpc.UntypedServiceImplementation {
             let inputs: any = news;
             let failures: any[] = [];
             if (this.provider.check) {
-                const result = await this.provider.check(req.getUrn(), olds, news, req.getSequencenumber());
+                const result = await this.provider.check(req.getUrn(), olds, news);
                 if (result.inputs) {
                     inputs = result.inputs;
                 }

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -126,7 +126,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         else:
             provider = get_provider(news)
 
-        result = provider.check(olds, news, request.sequenceNumber)  # pylint: disable=no-member
+        result = provider.check(olds, news)  # pylint: disable=no-member
         inputs = result.inputs
         failures = result.failures
 

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -159,7 +159,7 @@ class ResourceProvider:
     whose CRUD operations are implemented inside your Python program.
     """
 
-    def check(self, _olds: Any, news: Any, _sequence_number: int) -> CheckResult:
+    def check(self, _olds: Any, news: Any) -> CheckResult:
         """
         Check validates that the given property bag is valid for a resource of the given type.
         """


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Remove sequence numbers from the dynamic provider interfaces. 
It was a source breaking change adding these to the interface declarations. We don't need sequence numbers yet so this can go in as a 4.0 change.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/8848

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
