### PR TITLE
Do not rebuild Go binaries in release.yml, use testsed builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -96,6 +96,40 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
           repo: pulumi/pulumictl
+      - name: Download pulumi-linux-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-x64
+          path: goreleaser-downloads
+      - name: Download pulumi-linux-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-arm64
+          path: goreleaser-downloads
+      - name: Download pulumi-darwin-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-x64
+          path: goreleaser-downloads
+      - name: Download pulumi-darwin-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-arm64
+          path: goreleaser-downloads
+      - name: Download pulumi-windows-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-windows-x64
+          path: goreleaser-downloads
+      - name: Inspect goreleaser-downloads
+        run: |
+          find goreleaser-downloads
+      - name: Unpack goreleaser-downloads
+        run: |
+          ./scripts/unpack.sh
+      - name: Inspect goreleaser-prebuilt
+        run: |
+          find goreleaser-prebuilt
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -58,10 +58,6 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
           repo: pulumi/pulumictl
-      - name: Install goreleaser-filter
-        uses: jaxxstorm/action-install-gh-release@v1.2.0
-        with:
-          repo: t0yv0/goreleaser-filter
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -100,6 +96,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
           repo: pulumi/pulumictl
+      - name: Install goreleaser-filter
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: t0yv0/goreleaser-filter
       - name: Download pulumi-linux-x64
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -58,6 +58,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
           repo: pulumi/pulumictl
+      - name: Install goreleaser-filter
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: t0yv0/goreleaser-filter
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -142,11 +146,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
       - name: Set PreRelease Version
         run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f .goreleaser.prerelease.yml --rm-dist
       - name: Download pulumi-windows-checksums
         uses: actions/download-artifact@v2
         with:
@@ -162,9 +161,31 @@ jobs:
         with:
           name: pulumi-darwin-checksums
           path: artifacts/checksums/darwin
+      - name: Filter goreleaser config for pre-release check
+        run: |
+          cat .goreleaser.prerelease.yml | goreleaser-filter -no-blobs > /tmp/.goreleaser.current.yml
+      - name: Run GoReleaser to verify tarball checksums
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -p 3 -f /tmp/.goreleaser.current.yml --skip-publish --skip-announce --skip-validate --rm-dist --release-notes=CHANGELOG_PENDING.md
       - name: Verify checksums
         run: |
           C=artifacts/checksums/pulumi-tested-checksums.txt
+          echo "Tested tarballs with the following checksums:"
+          cat artifacts/checksums/*/* | sort | tee $C
+          echo "Released tarballs with the following checksums:"
+          sort goreleaser/*-checksums.txt
+          echo "Checking that tested and released checksums are identical:"
+          diff <(sort goreleaser/*-checksums.txt) $C
+      - name: Run GoReleaser to actually release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -p 3 -f .goreleaser.prerelease.yml --rm-dist
+      - name: Verify checksums again
+        run: |
+          C=artifacts/checksums/pulumi-tested-checksums-2.txt
           echo "Tested tarballs with the following checksums:"
           cat artifacts/checksums/*/* | sort | tee $C
           echo "Released tarballs with the following checksums:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
           repo: pulumi/pulumictl
+      - name: Install goreleaser-filter
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: t0yv0/goreleaser-filter
       - name: Download pulumi-linux-x64
         uses: actions/download-artifact@v2
         with:
@@ -235,11 +239,6 @@ jobs:
       - name: Set Release Version
         run: |
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f .goreleaser.yml --rm-dist --release-notes=CHANGELOG_PENDING.md
       - name: Download pulumi-windows-checksums
         uses: actions/download-artifact@v2
         with:
@@ -255,9 +254,31 @@ jobs:
         with:
           name: pulumi-darwin-checksums
           path: artifacts/checksums/darwin
+      - name: Filter goreleaser config for pre-release check
+        run: |
+          cat .goreleaser.yml | goreleaser-filter -no-blobs > /tmp/.goreleaser.current.yml
+      - name: Run GoReleaser to verify tarball checksums
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -p 3 -f /tmp/.goreleaser.current.yml --skip-publish --skip-announce --skip-validate --rm-dist --release-notes=CHANGELOG_PENDING.md
       - name: Verify checksums
         run: |
           C=artifacts/checksums/pulumi-tested-checksums.txt
+          echo "Tested tarballs with the following checksums:"
+          cat artifacts/checksums/*/* | sort | tee $C
+          echo "Planning to release tarballs with the following checksums:"
+          sort goreleaser/*-checksums.txt
+          echo "Checking that tested and release checksums are identical:"
+          diff <(sort goreleaser/*-checksums.txt) $C
+      - name: Run GoReleaser to actually release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -p 3 -f .goreleaser.yml --rm-dist --release-notes=CHANGELOG_PENDING.md
+      - name: Verify checksums again
+        run: |
+          C=artifacts/checksums/pulumi-tested-checksums-2.txt
           echo "Tested tarballs with the following checksums:"
           cat artifacts/checksums/*/* | sort | tee $C
           echo "Released tarballs with the following checksums:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,40 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.3.1
         with:
           repo: pulumi/pulumictl
+      - name: Download pulumi-linux-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-x64
+          path: goreleaser-downloads
+      - name: Download pulumi-linux-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-arm64
+          path: goreleaser-downloads
+      - name: Download pulumi-darwin-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-x64
+          path: goreleaser-downloads
+      - name: Download pulumi-darwin-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-arm64
+          path: goreleaser-downloads
+      - name: Download pulumi-windows-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-windows-x64
+          path: goreleaser-downloads
+      - name: Inspect goreleaser-downloads
+        run: |
+          find goreleaser-downloads
+      - name: Unpack goreleaser-downloads
+        run: |
+          ./scripts/unpack.sh
+      - name: Inspect goreleaser-prebuilt
+        run: |
+          find goreleaser-prebuilt
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -229,7 +263,7 @@ jobs:
           echo "Released tarballs with the following checksums:"
           sort goreleaser/*-checksums.txt
           echo "Checking that tested and released checksums are identical:"
-          diff <(sort goreleaser/*-checksums.txt) $C || echo "WARN ignoring checksum mismatch"
+          diff <(sort goreleaser/*-checksums.txt) $C
   lint:
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -21,11 +21,7 @@ builds:
 # Windows builds
 - id: pulumi-windows
   binary: pulumi
-  # TODO: coverage-enabled builds of pulumi CLI on Windows fail to
-  # parse CLI arguments correctly as in `pulumi version`, disabling
-  # coverage-enabled builds for now:
-  #
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: pkg
   goarch:
     - amd64
@@ -37,10 +33,7 @@ builds:
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
-  # TODO[pulumi/pulumi#8615] - uncomment gobinary line below to enable
-  # coverage-aware builds of the language providers.
-  #
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -52,7 +45,7 @@ builds:
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-windows
   binary: pulumi-language-python
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -64,7 +57,7 @@ builds:
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-windows
   binary: pulumi-language-dotnet
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -76,7 +69,7 @@ builds:
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-windows
   binary: pulumi-language-go
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -103,7 +96,7 @@ builds:
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-unix
   binary: pulumi-language-nodejs
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -117,7 +110,7 @@ builds:
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-unix
   binary: pulumi-language-python
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -131,7 +124,7 @@ builds:
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-unix
   binary: pulumi-language-dotnet
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -145,7 +138,7 @@ builds:
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-unix
   binary: pulumi-language-go
-  # gobinary: ../scripts/go-wrapper.sh
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
 # Windows builds
 - id: pulumi-windows
   binary: pulumi
+  gobinary: ../scripts/go-wrapper.sh
   dir: pkg
   goarch:
     - amd64
@@ -28,6 +29,7 @@ builds:
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -39,6 +41,7 @@ builds:
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-windows
   binary: pulumi-language-python
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -50,6 +53,7 @@ builds:
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-windows
   binary: pulumi-language-dotnet
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -61,6 +65,7 @@ builds:
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-windows
   binary: pulumi-language-go
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -73,6 +78,7 @@ builds:
 # UNIX builds
 - id: pulumi-unix
   binary: pulumi
+  gobinary: ../scripts/go-wrapper.sh
   dir: pkg
   goarch:
     - amd64
@@ -86,6 +92,7 @@ builds:
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-unix
   binary: pulumi-language-nodejs
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -99,6 +106,7 @@ builds:
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-unix
   binary: pulumi-language-python
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -112,6 +120,7 @@ builds:
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-unix
   binary: pulumi-language-dotnet
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -125,6 +134,7 @@ builds:
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-unix
   binary: pulumi-language-go
+  gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 #
-# To be used as a replacement for the `go` toolchain. The wrapper
-# unifies building binaries normally and building them with coverage
-# support using `go test -c`.
+# To be used with Goreleaser as `gobinary` implementation as a
+# replacement for the `go` toolchain.
+#
+# First function: prebuilt binaries
+#
+# The wrapper detects and returns prebuilt binaries to skip actual go
+# builds. If a binary `-o goreleaser/../some-binary` is requested but
+# `goreleaer-prebuilt/../some-binary` already exists, the prebuilt
+# binary is copied instead of building.
+#
+# Second function: coverage-enabled builds for Pulumi CLI
+#
+# This builds binaries via `go test -c` workaround. Disabled for
+# Windows builds. Only enabled on the Pulumi CLI binaries.
 
 PULUMI_TEST_COVERAGE_PATH=$PULUMI_TEST_COVERAGE_PATH
 
@@ -10,22 +21,57 @@ set -euo pipefail
 
 PKG=github.com/pulumi/pulumi/pkg/v3/...
 SDK=github.com/pulumi/pulumi/sdk/v3/...
-COVERPKG=$PKG,$SDK
+COVERPKG="$PKG,$SDK"
 
-if [ -z "$PULUMI_TEST_COVERAGE_PATH" ]; then
-    go "$@"
-else
-    case $1 in
-        build)
-            shift
-            go test -c -cover -coverpkg $COVERPKG "$@"
-            ;;
-        install)
-            echo "install command is not supported, please use build"
-            exit 1
-            ;;
-        *)
-            go "$@"
-            ;;
-    esac
-fi
+case "$1" in
+    build)
+        ARGS=( "$@" )
+        BUILDDIR=${ARGS[${#ARGS[@]}-1]}
+        OUTPUT=${ARGS[${#ARGS[@]}-2]}
+        PREBUILT="${OUTPUT/goreleaser/goreleaser-prebuilt}"
+
+        MODE=coverage
+
+        if [ -z "$PULUMI_TEST_COVERAGE_PATH" ]; then
+            MODE=normal
+        fi
+
+        # TODO: coverage-enabled builds of pulumi CLI on Windows fail
+        # to parse CLI arguments correctly as in `pulumi version`,
+        # disabling coverage-enabled builds on Windows.
+        if [[ "$OUTPUT" == *"windows"* ]]; then
+            MODE=normal
+        fi
+
+        # TODO[pulumi/pulumi#8615] - coverage-aware builds of the
+        # language providers break and are disabled.
+        if [[ "$BUILDDIR" != "./cmd/pulumi" ]]; then
+            MODE=normal
+        fi
+
+        if [ -f "$PREBUILT" ]; then
+            MODE=prebuilt
+        fi
+
+        case "$MODE" in
+            normal)
+                go "$@"
+                ;;
+            prebuilt)
+                mkdir -p $(dirname "$OUTPUT")
+                cp "$PREBUILT" "$OUTPUT"
+                ;;
+            coverage)
+                shift
+                go test -c -cover -coverpkg "$COVERPKG" "$@"
+                ;;
+        esac
+        ;;
+    install)
+        echo "install command is not supported, please use build"
+        exit 1
+        ;;
+    *)
+        go "$@"
+        ;;
+esac

--- a/scripts/unpack.sh
+++ b/scripts/unpack.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Unpacks release archives from `goreleaser-downloads` into
+# `goreleaser-prebuilt`, restoring the filenames and structure that
+# Goreleaser produces. Used in conjunction wtih `go-wrapper.sh` to
+# avoid rebuilding tested binaries in the CI pipeline.
+
+set -euo pipefail
+
+unpack_archive()
+{
+    suffix="$1"
+    archive="$2"
+
+    if [ ! -f "$archive" ]; then
+        return
+    fi
+
+    if [[ "$archive" == *.zip ]]; then
+        unzip -d goreleaser-prebuilt "$archive"
+        bin="goreleaser-prebuilt/pulumi/bin"
+    else
+        tar --directory goreleaser-prebuilt -xf "$archive"
+        bin="goreleaser-prebuilt/pulumi"
+    fi
+
+    for exe in $(ls "$bin"/*)
+    do
+        name=$(basename "$exe")
+        name=${name%.exe}
+        dest="goreleaser-prebuilt/${name}-${suffix}"
+        mkdir "$dest"
+        cp "$exe" "$dest"
+    done
+    rm -rf goreleaser-prebuilt/pulumi
+}
+
+rm -rf goreleaser-prebuilt
+mkdir goreleaser-prebuilt
+unpack_archive unix_darwin_arm64     goreleaser-downloads/pulumi-*-darwin-arm64.tar.gz
+unpack_archive unix_darwin_amd64     goreleaser-downloads/pulumi-*-darwin-x64.tar.gz
+unpack_archive unix_linux_arm64      goreleaser-downloads/pulumi-*-linux-arm64.tar.gz
+unpack_archive unix_linux_amd64      goreleaser-downloads/pulumi-*-linux-x64.tar.gz
+unpack_archive windows_windows_amd64 goreleaser-downloads/pulumi-*-windows-x64.zip


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

With these changes:

- release.yml no longer rebuilds Go binaries, but releases pre-built tested binaries; it only rebuilds the tar/zip archives

- checksum mismatch on the archives now blocks any side-effecting release actions, making sure we cannot enter "partially released" state again

- checksum mismatch is a hard failure again (used to be a warning) 

- the reproduced checksum mismatch seems to be fixed

Motivation: several master.yml builds and release.yml builds during last patch releases were lost to checksum mismatch, after which we made checkum mismatch check advisory.

A bit of background on what the check is about:

- originally we built Go binaries and put them in archives in build.yml and test them with test.yml

- due to peculiarities of Goreleaser, we rebuild the archives again in release.yml and push them out 

- the checksum check looks for these archives to be byte-for-byte identical

Implementation notes

This may be expressed more cleanly with Goreleaser pro feature "prebuilt", for now it wraps the Go toolchain to pretend to build binaries by locating the prebuilt ones.

Root cause

Still do not have full certainty as to the root cause of the mismatch, but it seems that build.yml uses Go cache and release.yml does not. It seems that go.sum go mirrored to a different set of actual binaries in the cache so the Go builds give different results depending on whether the cache is used or not. 

Testing

It is currently tricky to test changes to release.yml directly; this has been tested on a modified workflow in https://github.com/pulumi/pulumi/pull/8869

After we merge, `master.yml` builds will give additional feedback before the next release.


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8877

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
