### PR TITLE
Aaron friel/issue8890

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,10 @@
 ### Improvements
 
+- [sdk/nodejs] - Fix resource plugins advertising a `pluginDownloadURL` not being downloaded. This
+  should allow resource plugins published via boilerplates to find and consume plugins published
+  outside the registry. See: https://github.com/pulumi/pulumi/issues/8890 for the tracking issue to
+  document this feature.
+
 - [cli] Experimental support for update plans. Only enabled when PULUMI_EXPERIMENTAL is
   set. This enables preview to save a plan of what the engine expects to happen in a file
   with --save-plan. That plan can then be read in by up with --plan and is used to ensure

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -248,13 +248,13 @@ export function call<T>(tok: string, props: Inputs, res?: Resource): Output<T> {
             // Construct a provider reference from the given provider, if one is available on the resource.
             let provider: string | undefined = undefined;
             let version: string | undefined = undefined;
-            let pluginDownloadUrl: string | undefined = undefined;
+            let pluginDownloadURL: string | undefined = undefined;
             if (res) {
                 if (res.__prov) {
                     provider = await ProviderResource.register(res.__prov);
                 }
                 version = res.__version;
-                pluginDownloadUrl = res.__pluginDownloadURL;
+                pluginDownloadURL = res.__pluginDownloadURL;
             }
 
             // We keep output values when serializing inputs for call.
@@ -263,7 +263,7 @@ export function call<T>(tok: string, props: Inputs, res?: Resource): Output<T> {
             });
             log.debug(`Call RPC prepared: tok=${tok}` + excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``);
 
-            const req = await createCallRequest(tok, serialized, propertyDepsResources, provider, version);
+            const req = await createCallRequest(tok, serialized, propertyDepsResources, provider, version, pluginDownloadURL);
 
             const monitor: any = getMonitor();
             const resp: any = await debuggablePromise(new Promise((innerResolve, innerReject) =>


### PR DESCRIPTION
# Description

Provider plugins that publish to a third party destination, and then used via NodeJS sdk don't respect the `pluginDownloadURL` destination for finding the package.

A bit of sleuthing and I found that the variable here was set & not used after assignment.