### PR TITLE
[plugins] Fix plugin reinstallation.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -47,3 +47,9 @@
 - [cli] The engine will allow a resource to be replaced if either it's old or new state
   (or both) is not protected.
   [#8873](https://github.com/pulumi/pulumi/pull/8873)
+
+- [cli] - Fixed CLI duplicating prompt question.
+  [#8858](https://github.com/pulumi/pulumi/pull/8858)
+
+- [cli] - `pulumi plugin install --reinstall` now always reinstalls plugins.
+  [#8892](https://github.com/pulumi/pulumi/pull/8892)

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -136,7 +136,7 @@ func newPluginInstallCmd() *cobra.Command {
 					}
 				}
 				logging.V(1).Infof("%s installing tarball ...", label)
-				if err = install.Install(tarball); err != nil {
+				if err = install.Install(tarball, reinstall); err != nil {
 					return fmt.Errorf("installing %s from %s: %w", label, source, err)
 				}
 			}

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -118,7 +118,7 @@ func (l *pluginLoader) ensurePlugin(pkg string, version *semver.Version) error {
 		if err != nil {
 			return fmt.Errorf("failed to open downloaded plugin: %s: %w", pkgPlugin, err)
 		}
-		if err := pkgPlugin.Install(reader); err != nil {
+		if err := pkgPlugin.Install(reader, false); err != nil {
 			return fmt.Errorf("failed to install plugin %s: %w", pkgPlugin, err)
 		}
 	}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -185,7 +185,7 @@ func installPlugin(plugin workspace.PluginInfo) error {
 
 	logging.V(preparePluginVerboseLog).Infof(
 		"installPlugin(%s, %s): extracting tarball to installation directory", plugin.Name, plugin.Version)
-	if err := plugin.Install(stream); err != nil {
+	if err := plugin.Install(stream, false); err != nil {
 		return fmt.Errorf("installing plugin; run `pulumi plugin install %s %s v%s` to retry manually: %w",
 			plugin.Kind, plugin.Name, plugin.Version, err)
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -467,9 +467,9 @@ func (info PluginInfo) Install(tgz io.ReadCloser, reinstall bool) error {
 			}
 		}
 
-		// The partial file exists, meaning a previous attempt at installing the plugin failed.
-		// Delete finalDir so we can try installing again. There's no need to delete the partial
-		// file since we'd just be recreating it again below anyway.
+		// Either the partial file exists--meaning a previous attempt at installing the plugin failed--or we're
+		// deliberately reinstalling the plugin. Delete finalDir so we can try installing again. There's no need to
+		// delete the partial file since we'd just be recreating it again below anyway.
 		if err := os.RemoveAll(finalDir); err != nil {
 			return err
 		}

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build nodejs || python || all
 // +build nodejs python all
 
 package workspace
@@ -143,7 +144,7 @@ func testPluginInstall(t *testing.T, expectedDir string, files map[string][]byte
 	dir, tarball, plugin := prepareTestDir(t, files)
 	defer os.RemoveAll(dir)
 
-	err := plugin.Install(tarball)
+	err := plugin.Install(tarball, false)
 	assert.NoError(t, err)
 
 	assertPluginInstalled(t, dir, plugin)
@@ -166,7 +167,7 @@ func TestInstallNoDeps(t *testing.T) {
 	dir, tarball, plugin := prepareTestDir(t, map[string][]byte{name: content})
 	defer os.RemoveAll(dir)
 
-	err := plugin.Install(tarball)
+	err := plugin.Install(tarball, false)
 	assert.NoError(t, err)
 
 	assertPluginInstalled(t, dir, plugin)
@@ -205,7 +206,7 @@ func TestConcurrentInstalls(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			err := plugin.Install(tarball)
+			err := plugin.Install(tarball, false)
 			assert.NoError(t, err)
 
 			assertSuccess()
@@ -235,7 +236,7 @@ func TestInstallCleansOldFiles(t *testing.T) {
 	err = ioutil.WriteFile(partialPath, nil, 0600)
 	assert.NoError(t, err)
 
-	err = plugin.Install(tarball)
+	err = plugin.Install(tarball, false)
 	assert.NoError(t, err)
 
 	assertPluginInstalled(t, dir, plugin)
@@ -254,7 +255,7 @@ func TestGetPluginsSkipsPartial(t *testing.T) {
 	dir, tarball, plugin := prepareTestDir(t, nil)
 	defer os.RemoveAll(dir)
 
-	err := plugin.Install(tarball)
+	err := plugin.Install(tarball, false)
 	assert.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(dir, plugin.Dir()+".partial"), nil, 0600)

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -204,7 +204,7 @@ func TestReinstall(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, content, b)
 
-	content := []byte("world\n")
+	content = []byte("world\n")
 	tarball = prepareTestPluginTGZ(t, map[string][]byte{name: content})
 
 	err = plugin.Install(tarball, true)


### PR DESCRIPTION
Plugin installation has an early return path in the case that the plugin
was already installed. For normal plugin installation, this is okay and
saves some work. For reinstallation, however, this defeats the purpose
by causing installation to return before doing any actual work.

With these changes, we can better accommodate developer scenarios
without requiring that plugins are available on the PATH. For example,
the following script can be used to install a plugin under development:

    tar -c [plugin files] | gzip > plugin.tgz
    pulumi plugin install [kind] [name] [version] -f ./plugin.tgz --reinstall