### PR TITLE
Fix nodejs type mismatch

### DIFF
--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -1,6 +1,7 @@
 package nodejs
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,41 +30,51 @@ func nodejsCheck(t *testing.T, path string, dependencies codegen.StringSet) {
 	ex, err := executable.FindExecutable("yarn")
 	require.NoError(t, err, "Could not find yarn executable")
 	dir := filepath.Dir(path)
-	pkgs := nodejsPackages(dependencies)
+	pkgs := nodejsPackages(t, dependencies)
 	// We delete and regenerate package files for each run.
-	packageJSON := filepath.Join(dir, "package.json")
-	if err := os.Remove(packageJSON); !os.IsNotExist(err) {
-		require.NoError(t, err, "Failed to delete %s", packageJSON)
+	packageJSONPath := filepath.Join(dir, "package.json")
+	if err := os.Remove(packageJSONPath); !os.IsNotExist(err) {
+		require.NoError(t, err, "Failed to delete %s", packageJSONPath)
 	}
 	yarnLock := filepath.Join(dir, "yarn.lock")
 	if err := os.Remove(yarnLock); !os.IsNotExist(err) {
 		require.NoError(t, err, "Failed to delete %s", yarnLock)
 	}
 
-	err = integration.RunCommand(t, "link @pulumi/pulumi",
-		[]string{ex, "link", "@pulumi/pulumi"},
-		dir, &integration.ProgramTestOptions{})
-	require.NoError(t, err, "Failed to link @pulumi/pulumi")
-	for _, pkg := range pkgs {
-		err = integration.RunCommand(t, "yarn add and install",
-			[]string{ex, "add", pkg}, dir, &integration.ProgramTestOptions{})
-		require.NoError(t, err, "Could not install package: %q", pkg)
+	pkgInfo := npmPackage{
+		Dependencies: map[string]string{
+			"@pulumi/pulumi": "latest",
+		},
+		DevDependencies: map[string]string{
+			"@types/node": "latest",
+			"typescript":  "latest",
+		},
 	}
+	for pkg, v := range pkgs {
+		pkgInfo.Dependencies[pkg] = v
+	}
+	pkgJSON, err := json.MarshalIndent(pkgInfo, "", "    ")
+	require.NoError(t, err)
+	err = os.WriteFile(packageJSONPath, pkgJSON, 0600)
+	require.NoError(t, err)
+
+	err = integration.RunCommand(t, "Install dependencies",
+		[]string{ex, "install"},
+		dir, &integration.ProgramTestOptions{})
+	require.NoError(t, err, "Failed install")
+
 	err = integration.RunCommand(t, "tsc check",
 		[]string{ex, "run", "tsc", "--noEmit", filepath.Base(path)}, dir, &integration.ProgramTestOptions{})
 	require.NoError(t, err, "Failed to build %q", path)
 }
 
 // Returns the nodejs equivalent to the hcl2 package names provided.
-func nodejsPackages(deps codegen.StringSet) []string {
-	if len(deps) == 0 {
-		return []string{"@pulumi/pulumi@3.7.0"}
-	}
-	result := make([]string, len(deps))
-	for i, d := range deps.SortedValues() {
+func nodejsPackages(t *testing.T, deps codegen.StringSet) map[string]string {
+	result := make(map[string]string, len(deps))
+	for _, d := range deps.SortedValues() {
 		r := fmt.Sprintf("@pulumi/%s", d)
 		v := func(s string) {
-			r = fmt.Sprintf("%s@%s", r, s)
+			result[r] = "^" + s
 		}
 		switch d {
 		case "aws":
@@ -76,8 +87,10 @@ func nodejsPackages(deps codegen.StringSet) []string {
 			v(test.KubernetesSchema)
 		case "random":
 			v(test.RandomSchema)
+		default:
+			t.Logf("Unknown package requested: %s", d)
 		}
-		result[i] = r
+
 	}
 	return result
 }

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -46,8 +46,8 @@ func nodejsCheck(t *testing.T, path string, dependencies codegen.StringSet) {
 			"@pulumi/pulumi": "latest",
 		},
 		DevDependencies: map[string]string{
-			"@types/node": "latest",
-			"typescript":  "latest",
+			"@types/node": "^17.0.14",
+			"typescript":  "^4.5.5",
 		},
 	}
 	for pkg, v := range pkgs {

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -58,6 +58,11 @@ func nodejsCheck(t *testing.T, path string, dependencies codegen.StringSet) {
 	err = os.WriteFile(packageJSONPath, pkgJSON, 0600)
 	require.NoError(t, err)
 
+	err = integration.RunCommand(t, "Link local pulumi",
+		[]string{ex, "link", "@pulumi/pulumi"},
+		dir, &integration.ProgramTestOptions{})
+	require.NoError(t, err, "Failed local link")
+
 	err = integration.RunCommand(t, "Install dependencies",
 		[]string{ex, "install"},
 		dir, &integration.ProgramTestOptions{})
@@ -72,21 +77,21 @@ func nodejsCheck(t *testing.T, path string, dependencies codegen.StringSet) {
 func nodejsPackages(t *testing.T, deps codegen.StringSet) map[string]string {
 	result := make(map[string]string, len(deps))
 	for _, d := range deps.SortedValues() {
-		r := fmt.Sprintf("@pulumi/%s", d)
-		v := func(s string) {
-			result[r] = "^" + s
+		pkgName := fmt.Sprintf("@pulumi/%s", d)
+		set := func(pkgVersion string) {
+			result[pkgName] = "^" + pkgVersion
 		}
 		switch d {
 		case "aws":
-			v(test.AwsSchema)
+			set(test.AwsSchema)
 		case "azure-native":
-			v(test.AzureNativeSchema)
+			set(test.AzureNativeSchema)
 		case "azure":
-			v(test.AzureSchema)
+			set(test.AzureSchema)
 		case "kubernetes":
-			v(test.KubernetesSchema)
+			set(test.KubernetesSchema)
 		case "random":
-			v(test.RandomSchema)
+			set(test.RandomSchema)
 		default:
 			t.Logf("Unknown package requested: %s", d)
 		}


### PR DESCRIPTION
There was a mismatch between `@types/node` and `typescript` on their
default versions. This was fixed by listing both of them explicitly as a
`devDependency`.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
