### PR TITLE
[cli] use defaultOrg anywhere where ParseStackReference is used

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -31,6 +31,9 @@
   infer the correct property set for.
   [#8846](https://github.com/pulumi/pulumi/pull/8846)
 
+- [cli] Ensure defaultOrg is used as part of any stack name
+  [#8903](https://github.com/pulumi/pulumi/pull/8903)
+
 ## Bug Fixes
 
 - [codegen] - Correctly handle third party resource imports.

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -107,15 +107,11 @@ func newStackInitCmd() *cobra.Command {
 				return errors.New("missing stack name")
 			}
 
-			formattedStackName, err := buildStackName(stackName)
-			if err != nil {
-				return err
-			}
-			if err := b.ValidateStackName(formattedStackName); err != nil {
+			if err := b.ValidateStackName(stackName); err != nil {
 				return err
 			}
 
-			stackRef, err := b.ParseStackReference(formattedStackName)
+			stackRef, err := b.ParseStackReference(stackName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes: #8409

Anywhere we parse a stack name, we now take into account if a defaultOrg
is set for the stack. This means stack selection, stack up, stack delete
etc are all going to be able to take advantage of using defaultOrg

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
