### PR TITLE
Add a `schema extract` command

### DIFF
--- a/pkg/cmd/pulumi/schema.go
+++ b/pkg/cmd/pulumi/schema.go
@@ -31,5 +31,6 @@ package schemas for errors.`,
 	}
 
 	cmd.AddCommand(newSchemaCheckCommand())
+	cmd.AddCommand(newSchemaExtractCommand())
 	return cmd
 }

--- a/pkg/cmd/pulumi/schema_extract.go
+++ b/pkg/cmd/pulumi/schema_extract.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/blang/semver"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+)
+
+func newSchemaExtractCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "extract",
+		Args:  cmdutil.ExactArgs(2),
+		Short: "Extract a Pulumi package schema from a plugin",
+		Long: `Extract a Pulumi package schema from a resource plugin.
+
+Resolves the specified resource plugin and extracts its schema spec
+in JSON format, printing it to stdout. If the plugin is not found,
+attempts to install the plugin first.
+
+To manage plugins, see:
+
+    pulumi help plugin
+
+For more information about package schemas, see:
+
+https://www.pulumi.com/docs/guides/pulumi-packages/schema/
+`,
+		Example: "pulumi schema extract aws 4.37.1",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			packageName := args[0]
+			packageVersion, err := semver.Parse(args[1])
+			if err != nil {
+				return err
+			}
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			sink := cmdutil.Diag()
+
+			ctx, err := plugin.NewContext(
+				sink,
+				sink,
+				nil, /*Host*/
+				nil, /*ConfigSource*/
+				cwd,
+				nil,  /*runtimeOptions*/
+				true, /*disableProviderPreview*/
+				nil,  /*opentracing.Span*/
+			)
+			if err != nil {
+				return err
+			}
+			defer contract.IgnoreClose(ctx)
+
+			pluginLoader := schema.NewPluginLoader(ctx.Host)
+
+			pkg, err := pluginLoader.LoadPackage(packageName, &packageVersion)
+			if err != nil {
+				return err
+			}
+
+			jsonBytes, err := pkg.MarshalJSON()
+			if err != nil {
+				return err
+			}
+
+			var jsonTree interface{}
+			if err := json.Unmarshal(jsonBytes, &jsonTree); err != nil {
+				return err
+			}
+
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "    ")
+			if err := enc.Encode(jsonTree); err != nil {
+				return err
+			}
+
+			return nil
+		}),
+	}
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/schema_extract.go
+++ b/pkg/cmd/pulumi/schema_extract.go
@@ -31,9 +31,10 @@ import (
 
 func newSchemaExtractCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "extract",
-		Args:  cmdutil.ExactArgs(2),
-		Short: "Extract a Pulumi package schema from a plugin",
+		Use:    "extract",
+		Args:   cmdutil.ExactArgs(2),
+		Hidden: !hasDebugCommands(),
+		Short:  "Extract a Pulumi package schema from a plugin",
 		Long: `Extract a Pulumi package schema from a resource plugin.
 
 Resolves the specified resource plugin and extracts its schema spec

--- a/pkg/cmd/pulumi/schema_test.go
+++ b/pkg/cmd/pulumi/schema_test.go
@@ -1,0 +1,52 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/blang/semver"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemaExtract(t *testing.T) {
+	// Reset PULUMI_HOME to avoid contaminating global Pulumi
+	// plugin store with the downloaded random resource plugin.
+	pulumiHomeEnvVar := "PULUMI_HOME"
+	oldHome := os.Getenv(pulumiHomeEnvVar)
+	defer func() {
+		if oldHome == "" {
+			os.Unsetenv(pulumiHomeEnvVar)
+		} else {
+			os.Setenv(pulumiHomeEnvVar, oldHome)
+		}
+	}()
+	err := os.Setenv(pulumiHomeEnvVar, t.TempDir())
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+	ver := semver.MustParse("4.3.1")
+	err = schemaExtract(&buf, "random", &ver)
+	assert.NoError(t, err)
+
+	var spec map[string]interface{}
+	err = json.NewDecoder(&buf).Decode(&spec)
+	assert.NoError(t, err)
+	assert.Equal(t, spec["name"].(string), "random")
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adding a command to extract schema from plugins. All the functionality is already in the codebase.. This seems useful in general, though my use-case is rather specific in trying to cross-build a provider extracting a schema from a Go resource provider and building a provider SDK in another language.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
