### PR TITLE
Enable delaying programtest cleanup to test Cleanup

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1055,7 +1055,11 @@ func (pt *ProgramTester) TestLifeCycleInitAndDestroy() error {
 	}
 
 	pt.TestFinished = false
-	defer pt.TestCleanUp()
+	if pt.opts.DestroyOnCleanup {
+		pt.t.Cleanup(pt.TestCleanUp)
+	} else {
+		defer pt.TestCleanUp()
+	}
 
 	err = pt.TestLifeCycleInitialize()
 	if err != nil {

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -193,6 +193,12 @@ type ProgramTestOptions struct {
 	// SkipStackRemoval indicates that the stack should not be removed. (And so the test's results could be inspected
 	// in the Pulumi Service after the test has completed.)
 	SkipStackRemoval bool
+	// Destroy on cleanup defers stack destruction until the test cleanup step, rather than after
+	// program test execution. This is useful for more realistic stack reference testing, allowing one
+	// project and stack to be stood up and a second to be run before the first is destroyed.
+	//
+	// Implies NoParallel because we expect that another caller to ProgramTest will set that
+	DestroyOnCleanup bool
 	// Quick implies SkipPreview, SkipExportImport and SkipEmptyPreviewUpdate
 	Quick bool
 	// PreviewCommandlineFlags specifies flags to add to the `pulumi preview` command line (e.g. "--color=raw")
@@ -433,6 +439,9 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 	if overrides.SkipStackRemoval {
 		opts.SkipStackRemoval = overrides.SkipStackRemoval
 	}
+	if overrides.DestroyOnCleanup {
+		opts.DestroyOnCleanup = overrides.DestroyOnCleanup
+	}
 	if overrides.Quick {
 		opts.Quick = overrides.Quick
 	}
@@ -595,7 +604,7 @@ func prepareProgram(t *testing.T, opts *ProgramTestOptions) {
 	}
 
 	// We want tests to default into being ran in parallel, hence the odd double negative.
-	if !opts.NoParallel {
+	if !opts.NoParallel && !opts.DestroyOnCleanup {
 		t.Parallel()
 	}
 
@@ -1053,11 +1062,17 @@ func (pt *ProgramTester) TestLifeCycleInitAndDestroy() error {
 		return fmt.Errorf("initializing test project: %w", err)
 	}
 
-	// Ensure that before we exit, we attempt to destroy and remove the stack.
-	defer func() {
+	destroyStack := func() {
 		destroyErr := pt.TestLifeCycleDestroy()
 		assert.NoError(pt.t, destroyErr)
-	}()
+	}
+	if pt.opts.DestroyOnCleanup {
+		// Allow other tests to refer to this stack until the test is complete.
+		pt.t.Cleanup(destroyStack)
+	} else {
+		// Ensure that before we exit, we attempt to destroy and remove the stack.
+		defer destroyStack()
+	}
 
 	if err = pt.TestPreviewUpdateAndEdits(); err != nil {
 		return fmt.Errorf("running test preview, update, and edits: %w", err)


### PR DESCRIPTION
# Description

Motivating example is something like (pseudocode):

```go
programTest(t, firstStackOptions)

programTest(t, secondStackOptions)
```

Where "secondStackOptions" will refer to a very basic stack that uses a stack reference to the first. This is a much cleaner example to put at the top level of a repo or in an "examples" folder:

```
repo/
└── examples/
    ├── stackreference-consumer/
    │   ├── Pulumi.yaml
    │   └── ...
    └── stackreference-producer/
        ├── Pulumi.yaml
        └── ...
```

The goal being to ensure all stacks in the examples dir are concise representative of features users would use in projects, without clutter or subdirectories that only the test harness cares about, while still being fully tested.