### PR TITLE
Simpler x-plat testing in release.yml; lighten etc subset

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -274,7 +274,7 @@ jobs:
   test:
     name: Test
     needs: build
-    uses: pulumi/pulumi/.github/workflows/test.yml@master
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
     with:
       enable-coverage: false
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,7 @@ jobs:
   test:
     name: Test
     needs: build
-    uses: pulumi/pulumi/.github/workflows/test.yml@master
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
     with:
       enable-coverage: false
     secrets:

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -75,10 +75,6 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
-    # resolved: https://github.com/pulumi/pulumi/issues/8820
-    continue-on-error: ${{ matrix.platform == 'windows-latest' }}
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,6 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
-    # resolved: https://github.com/pulumi/pulumi/issues/8820
-    continue-on-error: ${{ matrix.platform == 'windows-latest' }}
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/scripts/test_subsets.py
+++ b/scripts/test_subsets.py
@@ -72,5 +72,11 @@ TEST_SUBSETS = {
 
         # Auto API tests driven by pytest
         'auto-python',
+
+        # The integration tests and examples do not properly belong
+        # here, but including to lighten up the `etc` test subset and
+        # because `auto` subset is a bit light on work.
+        'github.com/pulumi/pulumi/tests',
+        'github.com/pulumi/pulumi/tests/examples',
     ]
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This compromise is aimed at making release flow more stable, currently affected by Windows OOM and requires lots of restarts. First we move some integration work out of `etc` subset - I suspect this should mitigate the Windows OOM of the `etc` worker. Then we use test-fast.yml in releases (assuming master.yml did the full test.yml already by that time). This means that only the `etc` worker will run on Mac + Windows platforms on releases (similar to what's happening on PRs). 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
