### PR TITLE
Allow encrypting the `id` property for a resource

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,3 +6,7 @@
   with other SDKs. See https://github.com/pulumi/pulumi/issues/8796 for more
   details.
   [#8882](https://github.com/pulumi/pulumi/pull/8882)
+
+- [cli] - Encrypt resource `"id"`s if they are secret when serializing to
+  state.
+  [#8948](https://github.com/pulumi/pulumi/pull/8948)

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -280,6 +280,9 @@ func DeserializeDeploymentV3(deployment apitype.DeploymentV3, secretsProv Secret
 }
 
 // SerializeResource turns a resource into a structure suitable for serialization.
+//
+// NOTE: apitype.ResourceV3 cannot be deserialized by DeserializeResource until
+// it roundtrips through a serializer.
 func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bool) (apitype.ResourceV3, error) {
 	contract.Assert(res != nil)
 	contract.Assertf(string(res.URN) != "", "Unexpected empty resource resource.URN")

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -291,6 +291,8 @@ type ResourceV3 struct {
 	// Delete is true when the resource should be deleted during the next update.
 	Delete bool `json:"delete,omitempty" yaml:"delete,omitempty"`
 	// ID is the provider-assigned resource, if any, for custom resources.
+	// If ID = resource.SecretSig, then the ID property can be found in
+	// Outputs as a SecretV1 under the key "id".
 	ID resource.ID `json:"id,omitempty" yaml:"id,omitempty"`
 	// Type is the resource's full type token.
 	Type tokens.Type `json:"type" yaml:"type"`


### PR DESCRIPTION
We already handled id correctly when it was an output. We just didn't
handle it correctly for the special ID field in a serialized resource.

When we serialize a resource, we now check if `"id"` is a secret output.
If so, we set `coreapi.ResourceV3.ID` to `resource.SecretSig`. We
reverse this process when deserializing.

This solution is sound as long as
- `stack.SerializeResource` is the only place where resources are
serialized.
- `stack.DeserializeResource` is the only place where resources are
deserialized.
- We can assume that `resource.SecretSig` is not used as an ID.
- An up to date version of the CLI is used: that makes this a breaking change. 
  The recommended solution is to bump the statefile version.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8946 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
