### PR TITLE
Set init.defaultBranch and user info in git tests

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,9 +10,16 @@
 - [sdk/go] - Correctly parse GoLang version.
   [#8920](https://github.com/pulumi/pulumi/pull/8920)
 
+- [sdk/go] - Fix git initialization in git_test.go
+  [#8924](https://github.com/pulumi/pulumi/pull/8924)
+
+- [cli/go] - Fix git initialization in util_test.go
+  [#8924](https://github.com/pulumi/pulumi/pull/8924)
+
 - [sdk/nodejs] - Fix nodejs function serialization module path to comply with package.json 
   exports if exports is specified.
   [#8893](https://github.com/pulumi/pulumi/pull/8893)
 
 - [cli/python] - Parse a larger subset of PEP440 when guessing Pulumi package versions.
   [#8958](https://github.com/pulumi/pulumi/pull/8958)
+

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -49,7 +49,9 @@ func TestReadingGitRepo(t *testing.T) {
 	e := pul_testing.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 
-	e.RunCommand("git", "init")
+	e.RunCommand("git", "init", "-b", "master")
+	e.RunCommand("git", "config", "user.email", "test@test.org")
+	e.RunCommand("git", "config", "user.name", "test")
 	e.RunCommand("git", "remote", "add", "origin", "git@github.com:owner-name/repo-name")
 	e.RunCommand("git", "checkout", "-b", "master")
 
@@ -207,7 +209,9 @@ func TestReadingGitLabMetadata(t *testing.T) {
 	e := pul_testing.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 
-	e.RunCommand("git", "init")
+	e.RunCommand("git", "init", "-b", "master")
+	e.RunCommand("git", "config", "user.email", "test@test.org")
+	e.RunCommand("git", "config", "user.name", "test")
 	e.RunCommand("git", "remote", "add", "origin", "git@gitlab.com:owner-name/repo-name")
 	e.RunCommand("git", "checkout", "-b", "master")
 

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -186,7 +186,9 @@ func TestGetGitReferenceNameOrHashAndSubDirectory(t *testing.T) {
 }
 
 func createTestRepo(e *ptesting.Environment) {
-	e.RunCommand("git", "init")
+	e.RunCommand("git", "init", "-b", "master")
+	e.RunCommand("git", "config", "user.name", "test")
+	e.RunCommand("git", "config", "user.email", "test@test.org")
 
 	e.WriteTestFile("README.md", "test repo")
 	e.RunCommand("git", "add", "*")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Pulumi tests that create and manipulate git repos make the assumptions that config value `init.defaultBranch` is set to `master`, and `user.name` and `user.email` are globally set. These assumption make the following tests fail in development environments where `init.defaultBranch` is not master and where `user.name` and `user.email` are not globally set.

Fixes #8924 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
