### PR TITLE
Allow turning ts typechecking off

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,3 +23,5 @@
 - [cli/python] - Parse a larger subset of PEP440 when guessing Pulumi package versions.
   [#8958](https://github.com/pulumi/pulumi/pull/8958)
 
+- [sdk/nodejs] - Allow disabling TypeScript typechecking 
+  [#8981](https://github.com/pulumi/pulumi/pull/8981)

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -161,7 +161,7 @@ export function run(
     const tsConfigPath: string = process.env["PULUMI_NODEJS_TSCONFIG_PATH"] ?? defaultTsConfigPath;
     const skipProject = !fs.existsSync(tsConfigPath);
     
-    const typeCheck = (process.env["PULUMI_NODEJS_TYPECHECK"] ?? "true") === "true";
+    const transpileOnly = (process.env["PULUMI_NODEJS_TRANSPILE_ONLY"] ?? "false") === "true";
 
     let compilerOptions: object;
     try {

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -160,6 +160,8 @@ export function run(
     const defaultTsConfigPath = "tsconfig.json";
     const tsConfigPath: string = process.env["PULUMI_NODEJS_TSCONFIG_PATH"] ?? defaultTsConfigPath;
     const skipProject = !fs.existsSync(tsConfigPath);
+    
+    const typeCheck = (process.env["PULUMI_NODEJS_TYPECHECK"] ?? "true") === "true";
 
     let compilerOptions: object;
     try {
@@ -172,7 +174,7 @@ export function run(
 
     if (typeScript) {
         tsnode.register({
-            typeCheck: true,
+            typeCheck,
             skipProject: skipProject,
             compilerOptions: {
                 target: "es6",

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -174,7 +174,7 @@ export function run(
 
     if (typeScript) {
         tsnode.register({
-            typeCheck,
+            transpileOnly,
             skipProject: skipProject,
             compilerOptions: {
                 target: "es6",

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -160,7 +160,7 @@ export function run(
     const defaultTsConfigPath = "tsconfig.json";
     const tsConfigPath: string = process.env["PULUMI_NODEJS_TSCONFIG_PATH"] ?? defaultTsConfigPath;
     const skipProject = !fs.existsSync(tsConfigPath);
-    
+
     const transpileOnly = (process.env["PULUMI_NODEJS_TRANSPILE_ONLY"] ?? "false") === "true";
 
     let compilerOptions: object;


### PR DESCRIPTION
# Description

Adds an env var `PULUMI_NODEJS_TRANSPILE_ONLY`, defaulting to `false`, that controls if Pulumi will typecheck should perform any typechecking on its own. As this default is what the only allowed value was before this change, this should not break any existing workflows.

In our case, we prefer to run Pulumi separately from `tsc` to compile our code.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
