### PR TITLE
[codecov] Disable the coverage comment.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+comment: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
The data displayed in the coverage comment is not particularly useful
due to instability in our coverage results. That instability is inherent
in the way that our tests run. Most notably, tests take a different amount
of time from run-to-run (which causes changes in e.g. spinner coverage),
and some tests process different input data (this is primarily associated
with property-based tests). Because the coverage comment displays all
changes to coverage rather than only those that are associated with the
changed lines, the comment may make it appear that a PR affects the
coverage of certain files that it does not.