### PR TITLE
Fix passphrase secrets provider prompting

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,3 +34,6 @@
 
 - [cli/backend] - Revert a change to file state locking that was causing stacks to stay locked.
   [#8995](https://github.com/pulumi/pulumi/pull/8995)
+
+- [cli] - Fix passphrase secrets provider prompting.
+  [#8986](https://github.com/pulumi/pulumi/pull/8986)

--- a/pkg/cmd/pulumi/crypto_local.go
+++ b/pkg/cmd/pulumi/crypto_local.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,53 +15,12 @@
 package main
 
 import (
-	cryptorand "crypto/rand"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
-
-func readPassphraseImpl(prompt string, useEnv bool) (phrase string, interactive bool, err error) {
-	if useEnv {
-		if phrase, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok {
-			return phrase, false, nil
-		}
-		if phraseFile, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE"); ok {
-			phraseFilePath, err := filepath.Abs(phraseFile)
-			if err != nil {
-				return "", false, fmt.Errorf("unable to construct a path the PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
-			}
-			phraseDetails, err := ioutil.ReadFile(phraseFilePath)
-			if err != nil {
-				return "", false, fmt.Errorf("unable to read PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
-			}
-			return strings.TrimSpace(string(phraseDetails)), false, nil
-		}
-		if !cmdutil.Interactive() {
-			return "", false, errors.New("passphrase must be set with PULUMI_CONFIG_PASSPHRASE or " +
-				"PULUMI_CONFIG_PASSPHRASE_FILE environment variables")
-		}
-	}
-	phrase, err = cmdutil.ReadConsoleNoEcho(prompt)
-	return phrase, true, err
-}
-
-func readPassphrase(prompt string) (phrase string, interactive bool, err error) {
-	return readPassphraseImpl(prompt, true)
-}
 
 func newPassphraseSecretsManager(stackName tokens.QName, configFile string,
 	rotatePassphraseSecretsProvider bool) (secrets.Manager, error) {
@@ -93,76 +52,21 @@ func newPassphraseSecretsManager(stackName tokens.QName, configFile string,
 
 	// If we have a salt, we can just use it.
 	if info.EncryptionSalt != "" {
-		for {
-			phrase, interactive, phraseErr := readPassphrase("Enter your passphrase to unlock config/secrets\n" +
-				"    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember)")
-			if phraseErr != nil {
-				return nil, phraseErr
-			}
-
-			sm, smerr := passphrase.NewPassphaseSecretsManager(phrase, info.EncryptionSalt)
-			switch {
-			case interactive && smerr == passphrase.ErrIncorrectPassphrase:
-				cmdutil.Diag().Errorf(diag.Message("", "incorrect passphrase"))
-				continue
-			case smerr != nil:
-				return nil, smerr
-			default:
-				return sm, nil
-			}
-		}
+		return passphrase.NewPromptingPassphraseSecretsManager(info.EncryptionSalt)
 	}
 
-	var phrase string
-
-	// Get a the passphrase from the user, ensuring that they match.
-	for {
-		firstMessage := "Enter your passphrase to protect config/secrets"
-		if rotatePassphraseSecretsProvider {
-			firstMessage = "Enter your new passphrase to protect config/secrets"
-
-			if test, ok := os.LookupEnv("PULUMI_TEST_PASSPHRASE"); (!ok || !cmdutil.IsTruthy(test)) && !cmdutil.Interactive() {
-				return nil, fmt.Errorf("passphrase rotation requires an interactive terminal")
-			}
-		}
-		// Here, the stack does not have an EncryptionSalt, so we will get a passphrase and create one
-		first, _, err := readPassphraseImpl(firstMessage, !rotatePassphraseSecretsProvider)
-		if err != nil {
-			return nil, err
-		}
-		secondMessage := "Re-enter your passphrase to confirm"
-		if rotatePassphraseSecretsProvider {
-			secondMessage = "Re-enter your new passphrase to confirm"
-		}
-		second, _, err := readPassphraseImpl(secondMessage, !rotatePassphraseSecretsProvider)
-		if err != nil {
-			return nil, err
-		}
-
-		if first == second {
-			phrase = first
-			break
-		}
-		// If they didn't match, print an error and try again
-		cmdutil.Diag().Errorf(diag.Message("", "passphrases do not match"))
+	// Otherwise, prompt the user for a new passphrase.
+	salt, sm, err := passphrase.PromptForNewPassphrase(rotatePassphraseSecretsProvider)
+	if err != nil {
+		return nil, err
 	}
 
-	// Produce a new salt.
-	salt := make([]byte, 8)
-	_, err = cryptorand.Read(salt)
-	contract.Assertf(err == nil, "could not read from system random")
-
-	// Encrypt a message and store it with the salt so we can test if the password is correct later.
-	crypter := config.NewSymmetricCrypterFromPassphrase(phrase, salt)
-	msg, err := crypter.EncryptValue("pulumi")
-	contract.AssertNoError(err)
-
-	// Now store the result and save it.
-	info.EncryptionSalt = fmt.Sprintf("v1:%s:%s", base64.StdEncoding.EncodeToString(salt), msg)
+	// Store the salt and save it.
+	info.EncryptionSalt = salt
 	if err = info.Save(configFile); err != nil {
 		return nil, err
 	}
 
-	// Finally, build the full secrets manager from the state we just saved
-	return passphrase.NewPassphaseSecretsManager(phrase, info.EncryptionSalt)
+	// Return the passphrase secrets manager.
+	return sm, nil
 }

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.
 	case b64.Type:
 		sm = b64.NewBase64SecretsManager()
 	case passphrase.Type:
-		sm, err = passphrase.NewPassphaseSecretsManagerFromState(state)
+		sm, err = passphrase.NewPromptingPassphaseSecretsManagerFromState(state)
 	case service.Type:
 		sm, err = service.NewServiceSecretsManagerFromState(state)
 	case cloud.Type:

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package passphrase
 
 import (
+	cryptorand "crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -27,7 +28,9 @@ import (
 	"sync"
 
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -114,12 +117,8 @@ var cache map[string]secrets.Manager
 func NewPassphaseSecretsManager(phrase string, state string) (secrets.Manager, error) {
 	// check the cache first, if we have already seen this state before, return a cached value.
 	lock.Lock()
-	if cache == nil {
-		cache = make(map[string]secrets.Manager)
-	}
 	cachedValue := cache[state]
 	lock.Unlock()
-
 	if cachedValue != nil {
 		return cachedValue, nil
 	}
@@ -138,61 +137,57 @@ func NewPassphaseSecretsManager(phrase string, state string) (secrets.Manager, e
 			Salt: state,
 		},
 	}
+	if cache == nil {
+		cache = make(map[string]secrets.Manager)
+	}
 	cache[state] = sm
 	return sm, nil
 }
 
-// Tries to find the Passphrase first using `PULUMI_CONFIG_PASSPHRASE` then
-// `PULUMI_CONFIG_PASSPHRASE_FILE` if it is not found and defaulting to an empty string
-func getConfigPassphrase() (string, bool, error) {
-	if passphrase, isOk := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); isOk {
-		return passphrase, true, nil
+// NewPromptingPassphraseSecretsManager returns a new passphrase-based secrets manager, from the
+// given state. Will use the passphrase found in PULUMI_CONFIG_PASSPHRASE, the file specified by
+// PULUMI_CONFIG_PASSPHRASE_FILE, or otherwise will prompt for the passphrase if interactive.
+func NewPromptingPassphraseSecretsManager(state string) (secrets.Manager, error) {
+	// Check the cache first, if we have already seen this state before, return a cached value.
+	lock.Lock()
+	cachedValue := cache[state]
+	lock.Unlock()
+	if cachedValue != nil {
+		return cachedValue, nil
 	}
 
-	if phraseFile, isOk := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE"); isOk {
-		phraseFilePath, err := filepath.Abs(phraseFile)
-		if err != nil {
-			return "", false, fmt.Errorf("unable to detect passphrase path: %w", err)
+	// Otherwise, prompt for the password.
+	const prompt = "Enter your passphrase to unlock config/secrets\n" +
+		"    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember)"
+	for {
+		phrase, interactive, phraseErr := readPassphrase(prompt, true /*useEnv*/)
+		if phraseErr != nil {
+			return nil, phraseErr
 		}
 
-		phraseDetails, err := ioutil.ReadFile(phraseFilePath)
-		if err != nil {
-			return "", false, fmt.Errorf("unable to read PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
+		sm, smerr := NewPassphaseSecretsManager(phrase, state)
+		switch {
+		case interactive && smerr == ErrIncorrectPassphrase:
+			cmdutil.Diag().Errorf(diag.Message("", "incorrect passphrase"))
+			continue
+		case smerr != nil:
+			return nil, smerr
+		default:
+			return sm, nil
 		}
-
-		return strings.TrimSpace(string(phraseDetails)), true, nil
 	}
-
-	return "", false, nil
 }
 
 // NewPassphaseSecretsManagerFromState returns a new passphrase-based secrets manager, from the
-// given state. Will use the passphrase found in PULUMI_CONFIG_PASSPHRASE.
-func NewPassphaseSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
+// given state. Will use the passphrase found in PULUMI_CONFIG_PASSPHRASE, the file specified by
+// PULUMI_CONFIG_PASSPHRASE_FILE, or otherwise will prompt for the passphrase if interactive.
+func NewPromptingPassphaseSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
 	var s localSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
 		return nil, fmt.Errorf("unmarshalling state: %w", err)
 	}
 
-	// This is not ideal, but we don't have a great way to prompt the user in this case, since this may be
-	// called during an update when trying to read stack outputs as part servicing a StackReference request
-	// (since we need to decrypt the deployment)
-	phrase, isFound, err := getConfigPassphrase()
-	if err != nil {
-		return nil, err // this is already a wrapped error from getConfigPassphrase()
-	}
-
-	// At this point, we don't know if it's an incorrect passphrase. We only know if there is a passphrase or there is
-	// not. Ideally, we would prompt the user for the passphrase at this point but we can't do that in the CLI is in an
-	// update operation, so we should at least error out with an appropriate message here to ensure that the user
-	// understands why the operation fails unexpectedly.
-	if !isFound {
-		return nil, errors.New("unable to find either `PULUMI_CONFIG_PASSPHRASE` or " +
-			"`PULUMI_CONFIG_PASSPHRASE_FILE` when trying to access the Passphrase Secrets Provider; please ensure one " +
-			"of these environment variables is set to allow the operation to continue")
-	}
-
-	sm, err := NewPassphaseSecretsManager(phrase, s.Salt)
+	sm, err := NewPromptingPassphraseSecretsManager(s.Salt)
 	switch {
 	case err == ErrIncorrectPassphrase:
 		return newLockedPasspharseSecretsManager(s), nil
@@ -201,6 +196,95 @@ func NewPassphaseSecretsManagerFromState(state json.RawMessage) (secrets.Manager
 	default:
 		return sm, nil
 	}
+}
+
+// PromptForNewPassphrase prompts for a new passphrase, and returns the state and the secrets manager.
+func PromptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
+	var phrase string
+
+	// Get a the passphrase from the user, ensuring that they match.
+	for {
+		firstMessage := "Enter your passphrase to protect config/secrets"
+		if rotate {
+			firstMessage = "Enter your new passphrase to protect config/secrets"
+
+			if !isInteractive() {
+				return "", nil, fmt.Errorf("passphrase rotation requires an interactive terminal")
+			}
+		}
+		// Here, the stack does not have an EncryptionSalt, so we will get a passphrase and create one
+		first, _, err := readPassphrase(firstMessage, !rotate)
+		if err != nil {
+			return "", nil, err
+		}
+		secondMessage := "Re-enter your passphrase to confirm"
+		if rotate {
+			secondMessage = "Re-enter your new passphrase to confirm"
+		}
+		second, _, err := readPassphrase(secondMessage, !rotate)
+		if err != nil {
+			return "", nil, err
+		}
+
+		if first == second {
+			phrase = first
+			break
+		}
+		// If they didn't match, print an error and try again
+		cmdutil.Diag().Errorf(diag.Message("", "passphrases do not match"))
+	}
+
+	// Produce a new salt.
+	salt := make([]byte, 8)
+	_, err := cryptorand.Read(salt)
+	contract.AssertNoErrorf(err, "could not read from system random")
+
+	// Encrypt a message and store it with the salt so we can test if the password is correct later.
+	crypter := config.NewSymmetricCrypterFromPassphrase(phrase, salt)
+	msg, err := crypter.EncryptValue("pulumi")
+	contract.AssertNoError(err)
+
+	// Encode the salt as the passphrase secrets manager state.
+	state := fmt.Sprintf("v1:%s:%s", base64.StdEncoding.EncodeToString(salt), msg)
+
+	// Create the secrets manager using the state.
+	sm, err := NewPassphaseSecretsManager(phrase, state)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Return both the state and the secrets manager.
+	return state, sm, nil
+}
+
+func readPassphrase(prompt string, useEnv bool) (phrase string, interactive bool, err error) {
+	if useEnv {
+		if phrase, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok {
+			return phrase, false, nil
+		}
+		if phraseFile, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE"); ok {
+			phraseFilePath, err := filepath.Abs(phraseFile)
+			if err != nil {
+				return "", false, fmt.Errorf("unable to construct a path the PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
+			}
+			phraseDetails, err := ioutil.ReadFile(phraseFilePath)
+			if err != nil {
+				return "", false, fmt.Errorf("unable to read PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
+			}
+			return strings.TrimSpace(string(phraseDetails)), false, nil
+		}
+		if !isInteractive() {
+			return "", false, errors.New("passphrase must be set with PULUMI_CONFIG_PASSPHRASE or " +
+				"PULUMI_CONFIG_PASSPHRASE_FILE environment variables")
+		}
+	}
+	phrase, err = cmdutil.ReadConsoleNoEcho(prompt)
+	return phrase, true, err
+}
+
+func isInteractive() bool {
+	test, ok := os.LookupEnv("PULUMI_TEST_PASSPHRASE")
+	return cmdutil.Interactive() || ok && cmdutil.IsTruthy(test)
 }
 
 // newLockedPasspharseSecretsManager returns a Passphrase secrets manager that has the correct state, but can not

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -114,6 +114,13 @@ func (sm *localSecretsManager) Encrypter() (config.Encrypter, error) {
 var lock sync.Mutex
 var cache map[string]secrets.Manager
 
+// clearCache is used to clear the cache, for tests.
+func clearCache() {
+	lock.Lock()
+	cache = nil
+	lock.Unlock()
+}
+
 func NewPassphaseSecretsManager(phrase string, state string) (secrets.Manager, error) {
 	// check the cache first, if we have already seen this state before, return a cached value.
 	lock.Lock()

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func setIncorrectPassphraseTestEnvVars() func() {
-	clearCache()
+	clearCachedSecretsManagers()
 
 	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
 	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
@@ -44,7 +44,7 @@ func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
 }
 
 func setCorrectPassphraseTestEnvVars() func() {
-	clearCache()
+	clearCachedSecretsManagers()
 
 	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
 	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
@@ -73,7 +73,7 @@ func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
 }
 
 func unsetAllPassphraseEnvVars() func() {
-	clearCache()
+	clearCachedSecretsManagers()
 
 	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
 	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -18,6 +18,8 @@ const (
 )
 
 func setIncorrectPassphraseTestEnvVars() func() {
+	clearCache()
+
 	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
 	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password123")
@@ -42,6 +44,8 @@ func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
 }
 
 func setCorrectPassphraseTestEnvVars() func() {
+	clearCache()
+
 	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
 	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
@@ -69,6 +73,8 @@ func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
 }
 
 func unsetAllPassphraseEnvVars() func() {
+	clearCache()
+
 	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
 	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -32,7 +32,7 @@ func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
 	setupEnv := setIncorrectPassphraseTestEnvVars()
 	defer setupEnv()
 
-	manager, err := NewPassphaseSecretsManagerFromState([]byte(state))
+	manager, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
 	assert.NoError(t, err) // even if we pass the wrong provider, we should get a lockedPassphraseProvider
 
 	assert.Equal(t, manager, &localSecretsManager{
@@ -56,7 +56,7 @@ func TestPassphraseManagerIncorrectStateReturnsError(t *testing.T) {
 	setupEnv := setCorrectPassphraseTestEnvVars()
 	defer setupEnv()
 
-	_, err := NewPassphaseSecretsManagerFromState([]byte(brokenState))
+	_, err := NewPromptingPassphaseSecretsManagerFromState([]byte(brokenState))
 	assert.Error(t, err)
 }
 
@@ -64,7 +64,7 @@ func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
 	setupEnv := setCorrectPassphraseTestEnvVars()
 	defer setupEnv()
 
-	sm, _ := NewPassphaseSecretsManagerFromState([]byte(state))
+	sm, _ := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
 	assert.NotNil(t, sm)
 }
 
@@ -83,7 +83,7 @@ func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
 	setupEnv := unsetAllPassphraseEnvVars()
 	defer setupEnv()
 
-	_, err := NewPassphaseSecretsManagerFromState([]byte(state))
+	_, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
 	assert.NotNil(t, err, strings.Contains(err.Error(), "unable to find either `PULUMI_CONFIG_PASSPHRASE` nor "+
 		"`PULUMI_CONFIG_PASSPHRASE_FILE`"))
 }

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,6 +52,8 @@ type Environment struct {
 	Env []string
 	// Passphrase for config secrets, if any
 	Passphrase string
+	// Set to true to turn off setting PULUMI_CONFIG_PASSPHRASE.
+	NoPassphrase bool
 
 	// Content to pass on stdin, if any
 	Stdin io.Reader
@@ -203,7 +205,9 @@ func (e *Environment) GetCommandResults(command string, args ...string) (string,
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", pulumiCredentialsPathEnvVar, e.RootPath))
 	cmd.Env = append(cmd.Env, "PULUMI_DEBUG_COMMANDS=true")
-	cmd.Env = append(cmd.Env, fmt.Sprintf("PULUMI_CONFIG_PASSPHRASE=%s", passphrase))
+	if !e.NoPassphrase {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PULUMI_CONFIG_PASSPHRASE=%s", passphrase))
+	}
 	if e.Backend != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("PULUMI_BACKEND_URL=%s", e.Backend))
 	}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2022, Pulumi Corporation.  All rights reserved.
 //go:build nodejs || all
 // +build nodejs all
 
@@ -735,7 +735,7 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 			assert.NotNil(t, secretsProvider)
 			assert.Equal(t, secretsProvider.Type, "passphrase")
 
-			_, err := passphrase.NewPassphaseSecretsManagerFromState(secretsProvider.State)
+			_, err := passphrase.NewPromptingPassphaseSecretsManagerFromState(secretsProvider.State)
 			assert.NoError(t, err)
 
 			out, ok := stackInfo.Outputs["out"].(map[string]interface{})
@@ -753,7 +753,7 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 			assert.NotNil(t, secretsProvider)
 			assert.Equal(t, secretsProvider.Type, "passphrase")
 
-			_, err := passphrase.NewPassphaseSecretsManagerFromState(secretsProvider.State)
+			_, err := passphrase.NewPromptingPassphaseSecretsManagerFromState(secretsProvider.State)
 			assert.Error(t, err)
 		},
 	})


### PR DESCRIPTION
In #2736, caching was introduced inside the passphrase secrets provider to avoid prompting the user for a password multiple times in the same `pulumi` command. However, the cache is not used in all cases, which leads to double prompting and/or erroring if the passphrase is not set in the `PULUMI_CONFIG_PASSPHRASE` envvar. In some cases, the user is prompted for their passphrase and then the command fails because the passphrase wasn't set via the envvar.

This change addresses these issues. The net effect is that when using the passphrase secrets provider, you'll be prompted for your passphrase up-front once (if interactive and the envvar isn't set), and subsequent uses will use the cached value and won't prompt or error if the envvar isn't set.

Implementation note: This moves the prompting code inside the `passphrase` package. I was originally trying to avoid this, to avoid the package depending on `cmdutil.ReadConsoleNoEcho` and `cmdutil.Interactive`, but this lead to unnatural contortions elsewhere. It ended up being much cleaner to have the prompting happen inside the passphrase implementation. Functions that may prompt (when interactive and the envvar isn't set) include "Prompt" in their name.

Fixes #8173

---

Examples:

```sh
# No passphrase env vars set
unset PULUMI_CONFIG_PASSPHRASE
unset PULUMI_CONFIG_PASSPHRASE_FILE

# Before: this would prompt for a password twice to set the password, and then prompt again when saving the stack
# After: prompts for password twice to setup the password, and doesn't prompt again
pulumi new go --secrets-provider passphrase

# Before: This will fail for lack of a passphrase without first prompting for a passphrase
# After: Prompts for a passphrase once, command succeeds
pulumi stack import --file stack.json

# Before: Prompts for a passphrase, but then fails for lack of passphrase
# After: Prompts for a passphrase once, command succeeds
pulumi destroy
```