### PR TITLE
non-interactive progress heartbeat 6574

### DIFF
--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -143,6 +143,16 @@ func (s *nopSpinner) Tick() {
 func (s *nopSpinner) Reset() {
 }
 
+type nonInteractiveSpinner struct {
+}
+
+func (s *nonInteractiveSpinner) Tick() {
+	fmt.Println("tick...")
+}
+
+func (s *nonInteractiveSpinner) Reset() {
+}
+
 // isRootStack returns true if the step pertains to the rootmost stack component.
 func isRootStack(step engine.StepEventMetadata) bool {
 	return isRootURN(step.URN)

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -143,16 +143,6 @@ func (s *nopSpinner) Tick() {
 func (s *nopSpinner) Reset() {
 }
 
-type nonInteractiveSpinner struct {
-}
-
-func (s *nonInteractiveSpinner) Tick() {
-	fmt.Println("tick...")
-}
-
-func (s *nonInteractiveSpinner) Reset() {
-}
-
 // isRootStack returns true if the step pertains to the rootmost stack component.
 func isRootStack(step engine.StepEventMetadata) bool {
 	return isRootURN(step.URN)

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -49,6 +49,7 @@ type Options struct {
 	JSONDisplay          bool                // true if we should emit the entire diff as JSON.
 	EventLogPath         string              // the path to the file to use for logging events, if any.
 	Debug                bool                // true to enable debug output.
+	HeartbeatRate        int                 // the rate in seconds for non-interactive mode to send output.
 	Stdout               io.Writer           // the writer to use for stdout. Defaults to os.Stdout if unset.
 	Stderr               io.Writer           // the writer to use for stderr. Defaults to os.Stderr if unset.
 }

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -271,7 +271,6 @@ func (display *ProgressDisplay) colorizeAndWriteProgress(progress Progress) {
 			if display.debounceTimer != nil {
 				display.debounceTimer.Stop()
 			}
-			//display.debounceTimer = time.AfterFunc(time.Duration(display.opts.HeartbeatRate)*time.Second, func() {
 			var sendWorkingMessage func()
 			sendWorkingMessage = func() {
 				fmt.Println("working...")
@@ -368,6 +367,9 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 		// no more progress events from this point on.  By closing the pipe, this will then cause
 		// DisplayJSONMessagesToStream to finish once it processes the last message is receives from
 		// pipeReader, causing DisplayEvents to finally complete.
+		if display.debounceTimer != nil {
+			display.debounceTimer.Stop()
+		}
 		close(progressOutput)
 	}()
 

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -291,6 +291,9 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 		spinner, ticker = cmdutil.NewSpinnerAndTicker(
 			fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op),
 			nil, 1 /*timesPerSecond*/)
+	} else if true {
+		spinner = &nonInteractiveSpinner{}
+		ticker = time.NewTicker(8 * time.Second)
 	} else {
 		spinner = &nopSpinner{}
 		ticker = time.NewTicker(math.MaxInt64)

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -41,6 +41,7 @@ func newDestroyCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var heartbeatMessageInterval int
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
@@ -96,6 +97,7 @@ func newDestroyCmd() *cobra.Command {
 				EventLogPath:         eventLogPath,
 				Debug:                debug,
 				JSONDisplay:          jsonDisplay,
+				HeartbeatRate:        heartbeatMessageInterval,
 			}
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
@@ -248,6 +250,9 @@ func newDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
 		"Display operation as a rich diff showing the overall change")
+	cmd.PersistentFlags().IntVar(
+		&heartbeatMessageInterval, "heartbeat-message-interval", 30,
+		"Number of seconds to wait before printing a waiting message in non-interactive mode")
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
 		"Serialize the destroy diffs, operations, and overall output as JSON")

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -46,6 +46,7 @@ func newPreviewCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var heartbeatMessageInterval int
 	var policyPackPaths []string
 	var policyPackConfigPaths []string
 	var diffDisplay bool
@@ -96,6 +97,7 @@ func newPreviewCmd() *cobra.Command {
 				IsInteractive:        cmdutil.Interactive(),
 				Type:                 displayType,
 				JSONDisplay:          jsonDisplay,
+				HeartbeatRate:        heartbeatMessageInterval,
 				EventLogPath:         eventLogPath,
 				Debug:                debug,
 			}
@@ -289,6 +291,9 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
 		"Display operation as a rich diff showing the overall change")
+	cmd.PersistentFlags().IntVar(
+		&heartbeatMessageInterval, "heartbeat-message-interval", 30,
+		"Number of seconds to wait before printing a waiting message in non-interactive mode")
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
 		"Serialize the preview diffs, operations, and overall output as JSON")

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -57,6 +57,7 @@ func newUpCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var heartbeatMessageInterval int
 	var policyPackPaths []string
 	var policyPackConfigPaths []string
 	var diffDisplay bool
@@ -416,6 +417,7 @@ func newUpCmd() *cobra.Command {
 				EventLogPath:         eventLogPath,
 				Debug:                debug,
 				JSONDisplay:          jsonDisplay,
+				HeartbeatRate:        heartbeatMessageInterval,
 			}
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
@@ -503,6 +505,9 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
 		"Display operation as a rich diff showing the overall change")
+	cmd.PersistentFlags().IntVar(
+		&heartbeatMessageInterval, "heartbeat-message-interval", 30,
+		"Number of seconds to wait before printing a waiting message in non-interactive mode")
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
 		"Serialize the update diffs, operations, and overall output as JSON")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Added a parameter to set a delay for a heartbeat message in non-interactive mode to help keep CI from killing jobs.
If output isn't sent for (default: 30) seconds, a message saying `working...\n` is output to the screen.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #6574 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
