### PR TITLE
Revert "Lock inside filestate.apply instead of Update/Delete/Import (#8806)"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,12 +16,15 @@
 - [cli/go] - Fix git initialization in util_test.go
   [#8924](https://github.com/pulumi/pulumi/pull/8924)
 
-- [sdk/nodejs] - Fix nodejs function serialization module path to comply with package.json 
+- [sdk/nodejs] - Fix nodejs function serialization module path to comply with package.json
   exports if exports is specified.
   [#8893](https://github.com/pulumi/pulumi/pull/8893)
 
 - [cli/python] - Parse a larger subset of PEP440 when guessing Pulumi package versions.
   [#8958](https://github.com/pulumi/pulumi/pull/8958)
 
-- [sdk/nodejs] - Allow disabling TypeScript typechecking 
+- [sdk/nodejs] - Allow disabling TypeScript typechecking
   [#8981](https://github.com/pulumi/pulumi/pull/8981)
+
+- [cli/backend] - Revert a change to file state locking that was causing stacks to stay locked.
+  [#8995](https://github.com/pulumi/pulumi/pull/8995)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -467,22 +467,50 @@ func (b *localBackend) Preview(ctx context.Context, stack backend.Stack,
 
 func (b *localBackend) Update(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
+
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
+	}
+	defer b.Unlock(ctx, stack.Ref())
+
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply)
 }
 
 func (b *localBackend) Import(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation, imports []deploy.Import) (engine.ResourceChanges, result.Result) {
+
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
+	}
+	defer b.Unlock(ctx, stack.Ref())
+
 	op.Imports = imports
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply)
 }
 
 func (b *localBackend) Refresh(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
+
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
+	}
+	defer b.Unlock(ctx, stack.Ref())
+
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
 
 func (b *localBackend) Destroy(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
+
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
+	}
+	defer b.Unlock(ctx, stack.Ref())
+
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
@@ -510,15 +538,6 @@ func (b *localBackend) apply(
 		// Print a banner so it's clear this is a local deployment.
 		fmt.Printf(op.Opts.Display.Color.Colorize(
 			colors.SpecHeadline+"%s (%s):"+colors.Reset+"\n"), actionLabel, stackRef)
-	}
-
-	// Take a lock unless this is just a preview
-	if kind != apitype.PreviewUpdate {
-		err := b.Lock(ctx, stack.Ref())
-		if err != nil {
-			return nil, nil, result.FromError(err)
-		}
-		defer b.Unlock(ctx, stack.Ref())
 	}
 
 	// Start the update.


### PR DESCRIPTION
This reverts commit 8b4da4eba73cb98fe4c06b44179183562f707247 (reverts #8806).