### PR TITLE
re-enable and color dot spinner for non-interactive mode

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,3 +23,5 @@
 - [cli/python] - Parse a larger subset of PEP440 when guessing Pulumi package versions.
   [#8958](https://github.com/pulumi/pulumi/pull/8958)
 
+- [cli] -  Re-enabled dot spinner for non-interactive mode
+  [#8996](https://github.com/pulumi/pulumi/pull/8996)

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -53,7 +53,7 @@ func ShowDiffEvents(op string, action apitype.UpdateKind,
 	var spinner cmdutil.Spinner
 	var ticker *time.Ticker
 	if stdout == os.Stdout && stderr == os.Stderr {
-		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, 8 /*timesPerSecond*/)
+		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/)
 	} else {
 		spinner = &nopSpinner{}
 		ticker = time.NewTicker(math.MaxInt64)

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -52,7 +52,7 @@ func ShowDiffEvents(op string, action apitype.UpdateKind,
 
 	var spinner cmdutil.Spinner
 	var ticker *time.Ticker
-	if stdout == os.Stdout && stderr == os.Stderr && opts.IsInteractive {
+	if stdout == os.Stdout && stderr == os.Stderr {
 		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, 8 /*timesPerSecond*/)
 	} else {
 		spinner = &nopSpinner{}

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -287,7 +287,7 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 	// let the user know what is still being worked on.
 	var spinner cmdutil.Spinner
 	var ticker *time.Ticker
-	if stdout == os.Stdout && stderr == os.Stderr && opts.IsInteractive {
+	if stdout == os.Stdout && stderr == os.Stderr {
 		spinner, ticker = cmdutil.NewSpinnerAndTicker(
 			fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op),
 			nil, 1 /*timesPerSecond*/)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -290,7 +290,7 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 	if stdout == os.Stdout && stderr == os.Stderr {
 		spinner, ticker = cmdutil.NewSpinnerAndTicker(
 			fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op),
-			nil, 1 /*timesPerSecond*/)
+			nil, opts.Color, 1 /*timesPerSecond*/)
 	} else {
 		spinner = &nopSpinner{}
 		ticker = time.NewTicker(math.MaxInt64)

--- a/pkg/backend/display/query.go
+++ b/pkg/backend/display/query.go
@@ -36,7 +36,7 @@ func ShowQueryEvents(op string, events <-chan engine.Event,
 	var ticker *time.Ticker
 
 	if opts.IsInteractive {
-		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, 8 /*timesPerSecond*/)
+		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/)
 	} else {
 		spinner = &nopSpinner{}
 		ticker = time.NewTicker(math.MaxInt64)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1367,7 +1367,7 @@ func (b *cloudBackend) waitForUpdate(ctx context.Context, actionLabel string, up
 
 func displayEvents(action string, events <-chan displayEvent, done chan<- bool, opts display.Options) {
 	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), action)
-	spinner, ticker := cmdutil.NewSpinnerAndTicker(prefix, nil, 8 /*timesPerSecond*/)
+	spinner, ticker := cmdutil.NewSpinnerAndTicker(prefix, nil, opts.Color, 8 /*timesPerSecond*/)
 
 	defer func() {
 		spinner.Reset()

--- a/sdk/go/common/util/cmdutil/spinner.go
+++ b/sdk/go/common/util/cmdutil/spinner.go
@@ -27,7 +27,9 @@ import (
 // connected to a tty or not and returns either a nice animated spinner that updates quickly, using
 // the specified ttyFrames, or a simple spinner that just prints a dot on each tick and updates
 // slowly.
-func NewSpinnerAndTicker(prefix string, ttyFrames []string, color colors.Colorization, timesPerSecond time.Duration) (Spinner, *time.Ticker) {
+func NewSpinnerAndTicker(prefix string, ttyFrames []string,
+	color colors.Colorization, timesPerSecond time.Duration) (Spinner, *time.Ticker) {
+
 	if ttyFrames == nil {
 		// If explicit tick frames weren't specified, default to unicode for Mac and ASCII for Windows/Linux.
 		if Emoji {

--- a/sdk/go/common/util/cmdutil/spinner.go
+++ b/sdk/go/common/util/cmdutil/spinner.go
@@ -124,7 +124,7 @@ func (spin *dotSpinner) Tick() {
 
 func (spin *dotSpinner) Reset() {
 	if spin.hasWritten {
-		fmt.Println(spin.color.Colorize(colors.Reset))
+		fmt.Println()
 	}
 	spin.hasWritten = false
 }

--- a/sdk/go/common/util/cmdutil/spinner.go
+++ b/sdk/go/common/util/cmdutil/spinner.go
@@ -116,9 +116,9 @@ type dotSpinner struct {
 
 func (spin *dotSpinner) Tick() {
 	if !spin.hasWritten {
-		fmt.Print(spin.color.Colorize(colors.Yellow + spin.prefix))
+		fmt.Print(spin.color.Colorize(colors.Yellow + spin.prefix + colors.Reset))
 	}
-	fmt.Printf(".")
+	fmt.Print(spin.color.Colorize(colors.Yellow + "." + colors.Reset))
 	spin.hasWritten = true
 }
 

--- a/sdk/go/common/util/cmdutil/spinner.go
+++ b/sdk/go/common/util/cmdutil/spinner.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"time"
 	"unicode/utf8"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
 // NewSpinnerAndTicker returns a new Spinner and a ticker that will fire an event when the next call
@@ -25,7 +27,7 @@ import (
 // connected to a tty or not and returns either a nice animated spinner that updates quickly, using
 // the specified ttyFrames, or a simple spinner that just prints a dot on each tick and updates
 // slowly.
-func NewSpinnerAndTicker(prefix string, ttyFrames []string, timesPerSecond time.Duration) (Spinner, *time.Ticker) {
+func NewSpinnerAndTicker(prefix string, ttyFrames []string, color colors.Colorization, timesPerSecond time.Duration) (Spinner, *time.Ticker) {
 	if ttyFrames == nil {
 		// If explicit tick frames weren't specified, default to unicode for Mac and ASCII for Windows/Linux.
 		if Emoji {
@@ -43,6 +45,7 @@ func NewSpinnerAndTicker(prefix string, ttyFrames []string, timesPerSecond time.
 	}
 
 	return &dotSpinner{
+		color:  color,
 		prefix: prefix,
 	}, time.NewTicker(time.Second * 20)
 }
@@ -104,13 +107,14 @@ func (spin *ttySpinner) Reset() {
 // dotSpinner is the spinner that can be used when standard out is not a tty. In this case, we just write a single
 // dot on each tick.
 type dotSpinner struct {
+	color      colors.Colorization
 	prefix     string
 	hasWritten bool
 }
 
 func (spin *dotSpinner) Tick() {
 	if !spin.hasWritten {
-		fmt.Print(spin.prefix)
+		fmt.Print(spin.color.Colorize(colors.Yellow + spin.prefix))
 	}
 	fmt.Printf(".")
 	spin.hasWritten = true
@@ -118,7 +122,7 @@ func (spin *dotSpinner) Tick() {
 
 func (spin *dotSpinner) Reset() {
 	if spin.hasWritten {
-		fmt.Println()
+		fmt.Println(spin.color.Colorize(colors.Reset))
 	}
 	spin.hasWritten = false
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
The non-interactive dot spinner functionality was not being triggered due to Interactive == true checks in calling functions.

also added color to match the output style
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #6574 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
