### PR TITLE
Adding completion alias

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,9 @@
 
 - [sdk] - Add `RetainOnDelete` as a resource option.
   [#8746](https://github.com/pulumi/pulumi/pull/8746)
+  
+- [cli] - Adding `completion` as an alias to `gen-completion`
+  [#9006](https://github.com/pulumi/pulumi/pull/9006)
 
 ### Bug Fixes
 

--- a/pkg/cmd/pulumi/gen_completion.go
+++ b/pkg/cmd/pulumi/gen_completion.go
@@ -29,11 +29,11 @@ import (
 // It is hidden by default since it's not commonly used outside of our own build processes.
 func newGenCompletionCmd(root *cobra.Command) *cobra.Command {
 	return &cobra.Command{
-		Use:    "gen-completion <SHELL>",
+		Use:     "gen-completion <SHELL>",
 		Aliases: []string{"completion"},
-		Args:   cmdutil.ExactArgs(1),
-		Short:  "Generate completion scripts for the Pulumi CLI",
-		Hidden: true,
+		Args:    cmdutil.ExactArgs(1),
+		Short:   "Generate completion scripts for the Pulumi CLI",
+		Hidden:  true,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			switch {
 			case args[0] == "bash":

--- a/pkg/cmd/pulumi/gen_completion.go
+++ b/pkg/cmd/pulumi/gen_completion.go
@@ -30,6 +30,7 @@ import (
 func newGenCompletionCmd(root *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:    "gen-completion <SHELL>",
+		Aliases: []string{"completion"},
 		Args:   cmdutil.ExactArgs(1),
 		Short:  "Generate completion scripts for the Pulumi CLI",
 		Hidden: true,


### PR DESCRIPTION
# Description

Adding alias of `completion` to follow the defacto cli options in other cobra cli tools. This is just a "nice to have" as I didn't think `pulumi` had shell completion 

Fixes #9005 

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works

- [x ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version <~ N/A
