### PR TITLE
Support looking up plugin version from GitHub

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,7 +11,10 @@
 
 - [cli/plugins] Add support for downloading plugin from private GitHub releases.
   [#8944](https://github.com/pulumi/pulumi/pull/8944)
-  
+
+- [cli/plugins] `pulumi plugin install` can now look up the latest version of plugins on GitHub releases.
+  [#9012](https://github.com/pulumi/pulumi/pull/9012)
+
 ### Bug Fixes
 
 - [sdk/go] - Normalize merge behavior for `ResourceOptions`, inline

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -142,6 +142,312 @@ func (err *MissingError) Error() string {
 		err.Info.Kind, err.Info.String())
 }
 
+// PluginSource deals with downloading a specific version of a plugin, or looking up the latest version of it.
+type PluginSource interface {
+	// Download fetches an io.ReadCloser for this plugin and also returns the size of the response (if known).
+	Download(version semver.Version, opSy string, arch string, getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (io.ReadCloser, int64, error)
+	// GetLatestVersion tries to find the latest version for this plugin. This is currently only supported for
+	// plugins we can get from github releases.
+	GetLatestVersion(getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error)
+}
+
+// getPulumiSource can download a plugin from get.pulumi.com
+type getPulumiSource struct {
+	name string
+	kind PluginKind
+}
+
+func newGetPulumiSource(name string, kind PluginKind) *getPulumiSource {
+	return &getPulumiSource{name: name, kind: kind}
+}
+
+func (source *getPulumiSource) GetLatestVersion(getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error) {
+	return nil, errors.New("GetLatestVersion is not supported for plugins from get.pulumi.com")
+}
+
+func (source *getPulumiSource) Download(version semver.Version, opSy string, arch string, getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (io.ReadCloser, int64, error) {
+	serverURL := "https://get.pulumi.com/releases/plugins"
+
+	logging.V(1).Infof("%s downloading from %s", source.name, serverURL)
+
+	serverURL = interpolateURL(serverURL, version, opSy, arch)
+	serverURL = strings.TrimSuffix(serverURL, "/")
+
+	logging.V(1).Infof("%s downloading from %s", source.name, serverURL)
+	endpoint := fmt.Sprintf("%s/%s",
+		serverURL,
+		url.QueryEscape(fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz", source.kind, source.name, version.String(), opSy, arch)))
+
+	req, err := buildHTTPRequest(endpoint, "", "", "", "")
+	if err != nil {
+		return nil, -1, err
+	}
+	return getHTTPResponse(req)
+}
+
+// githubSource can download a plugin from github releases
+type githubSource struct {
+	organization string
+	name         string
+	kind         PluginKind
+
+	tokenType string
+	token     string
+	username  string
+	secret    string
+}
+
+func newGithubSource(organization, name string, kind PluginKind) *githubSource {
+	return &githubSource{
+		organization: organization,
+		name:         name,
+		kind:         kind,
+	}
+}
+
+// Creates a new github source from authentication data in the environment, if it exists
+func newAuthenticatedGithubSource(organization, name string, kind PluginKind) (*githubSource, error) {
+	ghToken := os.Getenv("GITHUB_TOKEN")
+	paToken := ""
+	actor := ""
+	tokenType := "token"
+	if ghToken == "" {
+		tokenType = ""
+		paToken = os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+		actor = os.Getenv("GITHUB_ACTOR")
+	}
+	if ghToken == "" && (paToken == "" || actor == "") {
+		return nil, errors.New("no GitHub authentication information provided")
+	}
+
+	source := &githubSource{
+		organization: organization,
+		name:         name,
+		kind:         kind,
+
+		tokenType: tokenType,
+		token:     ghToken,
+		username:  actor,
+		secret:    paToken,
+	}
+
+	return source, nil
+}
+
+func (source *githubSource) GetLatestVersion(getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error) {
+	releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/pulumi-%s/releases/latest", source.organization, source.name)
+	logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
+	req, err := buildHTTPRequest(releaseURL, source.tokenType, source.token, source.username, source.secret)
+	if err != nil {
+		return nil, err
+	}
+	resp, length, err := getHTTPResponse(req)
+	if err != nil {
+		return nil, err
+	}
+	jsonBody, err := ioutil.ReadAll(resp)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal github response len(%d): %s", length, err.Error())
+	}
+	release := struct {
+		TagName string `json:"tag_name"`
+	}{}
+	err = json.Unmarshal(jsonBody, &release)
+	if err != nil {
+		return nil, err
+	}
+	parsedVersion, err := semver.ParseTolerant(release.TagName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid plugin semver: %w", err)
+	}
+	return &parsedVersion, nil
+}
+
+func (source *githubSource) Download(version semver.Version, opSy string, arch string, getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (io.ReadCloser, int64, error) {
+	if source.tokenType == "" && source.token == "" && source.username == "" && source.secret == "" {
+		// If we're not using authentication we can just download from the release/download URL
+
+		logging.V(1).Infof("%s downloading from github.com/%s/pulumi-%s/releases", source.name, source.organization, source.name)
+
+		pluginURL := fmt.Sprintf("https://github.com/%s/pulumi-%s/releases/download/v%s/%s",
+			source.organization, source.name, version.String(), url.QueryEscape(fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz",
+				source.kind, source.name, version.String(), opSy, arch)))
+
+		req, err := buildHTTPRequest(pluginURL, "", "", "", "")
+		if err != nil {
+			return nil, -1, err
+		}
+		return getHTTPResponse(req)
+	} else {
+		// If we are using authentication we need to lookup the asset via the github releases API
+		assetName := fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz", source.kind, source.name, version.String(), opSy, arch)
+
+		releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/pulumi-%s/releases/tags/v%s", source.organization, source.name, version.String())
+		logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
+
+		req, err := buildHTTPRequest(releaseURL, source.tokenType, source.token, source.username, source.secret)
+		if err != nil {
+			return nil, -1, err
+		}
+		req.Header.Set("Accept", "application/json")
+		resp, length, err := getHTTPResponse(req)
+		if err != nil {
+			return nil, -1, err
+		}
+		jsonBody, err := ioutil.ReadAll(resp)
+		if err != nil {
+			logging.V(9).Infof("cannot unmarshal github response len(%d): %s", length, err.Error())
+			return nil, -1, err
+		}
+		release := struct {
+			Assets []struct {
+				Name string `json:"name"`
+				URL  string `json:"url"`
+			} `json:"assets"`
+		}{}
+		err = json.Unmarshal(jsonBody, &release)
+		if err != nil {
+			logging.V(9).Infof("github json response: %s", jsonBody)
+			logging.V(9).Infof("cannot unmarshal github response: %s", err.Error())
+			return nil, -1, err
+		}
+		assetURL := ""
+		for _, asset := range release.Assets {
+			if asset.Name == assetName {
+				assetURL = asset.URL
+			}
+		}
+		if assetURL == "" {
+			logging.V(9).Infof("github json response: %s", jsonBody)
+			logging.V(9).Infof("plugin asset '%s' not found", assetName)
+			return nil, -1, errors.Errorf("plugin asset '%s' not found", assetName)
+		}
+
+		logging.V(1).Infof("%s downloading from %s", source.name, assetURL)
+
+		req, err = buildHTTPRequest(assetURL, source.tokenType, source.token, source.username, source.secret)
+		if err != nil {
+			return nil, -1, err
+		}
+		req.Header.Set("Accept", "application/octet-stream")
+		return getHTTPResponse(req)
+	}
+}
+
+// pluginUrlSource can download a plugin from a given PluginDownloadURL, it doesn't support GetLatestVersion
+type pluginUrlSource struct {
+	name              string
+	kind              PluginKind
+	pluginDownloadURL string
+}
+
+func newPluginUrlSource(name string, kind PluginKind, pluginDownloadURL string) *pluginUrlSource {
+	return &pluginUrlSource{
+		name:              name,
+		kind:              kind,
+		pluginDownloadURL: pluginDownloadURL,
+	}
+}
+
+func (source *pluginUrlSource) GetLatestVersion(getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error) {
+	return nil, errors.New("GetLatestVersion is not supported for plugins using PluginDownloadURL")
+}
+
+func (source *pluginUrlSource) Download(version semver.Version, opSy string, arch string, getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (io.ReadCloser, int64, error) {
+	serverURL := source.pluginDownloadURL
+	logging.V(1).Infof("%s downloading from %s", source.name, serverURL)
+
+	serverURL = interpolateURL(serverURL, version, opSy, arch)
+	serverURL = strings.TrimSuffix(serverURL, "/")
+
+	logging.V(1).Infof("%s downloading from %s", source.name, serverURL)
+	endpoint := fmt.Sprintf("%s/%s",
+		serverURL,
+		url.QueryEscape(fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz", source.kind, source.name, version.String(), opSy, arch)))
+
+	req, err := buildHTTPRequest(endpoint, "", "", "", "")
+	if err != nil {
+		return nil, -1, err
+	}
+	return getHTTPResponse(req)
+}
+
+// fallbackSource handles our current complicated default logic of trying the pulumi public github, then maybe the users private github, then get.pulumi.com
+type fallbackSource struct {
+	name string
+	kind PluginKind
+}
+
+func newFallbackSource(name string, kind PluginKind) *fallbackSource {
+	return &fallbackSource{
+		name: name,
+		kind: kind,
+	}
+}
+
+func (source *fallbackSource) GetLatestVersion(getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error) {
+	// Try and get this package from public pulumi github
+	public := newGithubSource("pulumi", source.name, source.kind)
+	version, err := public.GetLatestVersion(getHTTPResponse)
+	if err == nil {
+		return version, nil
+	}
+
+	// Are we in experimental mode? Try a private github release
+	if _, ok := os.LookupEnv("PULUMI_EXPERIMENTAL"); ok {
+		// Check if we have a repo owner set
+		repoOwner := os.Getenv("GITHUB_REPOSITORY_OWNER")
+		var privateErr error
+		if repoOwner == "" {
+			privateErr = errors.New("ENV[GITHUB_REPOSITORY_OWNER] not set")
+		} else {
+			private, privateErr := newAuthenticatedGithubSource(repoOwner, source.name, source.kind)
+			if privateErr == nil {
+				version, privateErr := private.GetLatestVersion(getHTTPResponse)
+				if privateErr == nil {
+					return version, nil
+				}
+			}
+		}
+
+		logging.V(1).Infof("cannot find plugin %s on private GitHub releases: %s", source.name, privateErr.Error())
+	}
+
+	return nil, err
+}
+
+func (source *fallbackSource) Download(version semver.Version, opSy string, arch string, getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (io.ReadCloser, int64, error) {
+	// Try and get this package from public pulumi github
+	public := newGithubSource("pulumi", source.name, source.kind)
+	resp, length, err := public.Download(version, opSy, arch, getHTTPResponse)
+	if err == nil {
+		return resp, length, nil
+	}
+
+	// Are we in experimental mode? Try a private github release
+	if _, ok := os.LookupEnv("PULUMI_EXPERIMENTAL"); ok {
+		// Check if we have a repo owner set
+		repoOwner := os.Getenv("GITHUB_REPOSITORY_OWNER")
+		if repoOwner == "" {
+			err = errors.New("ENV[GITHUB_REPOSITORY_OWNER] not set")
+		} else {
+			private, err := newAuthenticatedGithubSource(repoOwner, source.name, source.kind)
+			if err == nil {
+				resp, length, err := private.Download(version, opSy, arch, getHTTPResponse)
+				if err == nil {
+					return resp, length, nil
+				}
+			}
+		}
+
+		logging.V(1).Infof("cannot find plugin %s on private GitHub releases: %s", source.name, err.Error())
+	}
+
+	// Fallback to get.pulumi.com
+	pulumi := newGetPulumiSource(source.name, source.kind)
+	return pulumi.Download(version, opSy, arch, getHTTPResponse)
+}
+
 // PluginInfo provides basic information about a plugin.  Each plugin gets installed into a system-wide
 // location, by default `~/.pulumi/plugins/<kind>-<name>-<version>/`.  A plugin may contain multiple files,
 // however the primary loadable executable must be named `pulumi-<kind>-<name>`.
@@ -278,78 +584,26 @@ func interpolateURL(serverURL string, version semver.Version, os, arch string) s
 	return replacer.Replace(serverURL)
 }
 
+func (info PluginInfo) GetSource() PluginSource {
+	// The plugin has a set URL use that.
+	if info.PluginDownloadURL != "" {
+		return newPluginUrlSource(info.Name, info.Kind, info.PluginDownloadURL)
+	}
+
+	// If the plugin name matches an override, download the plugin from the override URL.
+	if url, ok := pluginDownloadURLOverridesParsed.get(info.Name); ok {
+		return newPluginUrlSource(info.Name, info.Kind, url)
+	}
+
+	// Use our default fallback behaviour of github then get.pulumi.com
+	return newFallbackSource(info.Name, info.Kind)
+}
+
 // GetLatestVersion tries to find the latest version for this plugin. This is currently only supported for
 // plugins we can get from github releases.
 func (info PluginInfo) GetLatestVersion() (*semver.Version, error) {
-
-	if info.PluginDownloadURL != "" {
-		return nil, errors.New("GetLatestVersion is not supported for plugins using PluginDownloadURL")
-	}
-
-	getLatestVersion := func(repoOrganisation, tokenType, token, username, secret string) (*semver.Version, error) {
-		releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/pulumi-%s/releases/latest", repoOrganisation, info.Name)
-		logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
-		req, err := buildHTTPRequest(releaseURL, tokenType, token, username, secret)
-		if err != nil {
-			return nil, err
-		}
-		resp, length, err := getHTTPResponse(req)
-		if err != nil {
-			return nil, err
-		}
-		jsonBody, err := ioutil.ReadAll(resp)
-		if err != nil {
-			return nil, fmt.Errorf("cannot unmarshal github response len(%d): %s", length, err.Error())
-		}
-		release := struct {
-			TagName string `json:"tag_name"`
-		}{}
-		err = json.Unmarshal(jsonBody, &release)
-		if err != nil {
-			return nil, err
-		}
-		parsedVersion, err := semver.ParseTolerant(release.TagName)
-		if err != nil {
-			return nil, fmt.Errorf("invalid plugin semver: %w", err)
-		}
-		return &parsedVersion, nil
-	}
-
-	version, err := getLatestVersion("pulumi", "", "", "", "")
-	if err == nil {
-		return version, nil
-	}
-
-	if _, ok := os.LookupEnv("PULUMI_EXPERIMENTAL"); ok {
-		version, err := (func() (*semver.Version, error) {
-			repoOwner := os.Getenv("GITHUB_REPOSITORY_OWNER")
-			if repoOwner == "" {
-				return nil, errors.New("ENV[GITHUB_REPOSITORY_OWNER] not set")
-			}
-			ghToken := os.Getenv("GITHUB_TOKEN")
-			paToken := ""
-			actor := ""
-			if ghToken == "" {
-				paToken = os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
-				actor = os.Getenv("GITHUB_ACTOR")
-			}
-			if ghToken == "" && (paToken == "" || actor == "") {
-				return nil, errors.New("no GitHub authentication information provided")
-			}
-
-			return getLatestVersion(repoOwner, "token", ghToken, actor, paToken)
-		})()
-
-		if err != nil {
-			return version, nil
-		}
-
-		return nil, fmt.Errorf(
-			"cannot find plugin %s on github.com/pulumi/pulumi-%s/releases or private GitHub release: %w",
-			info.Name, info.Name, err)
-	}
-
-	return nil, fmt.Errorf("cannot find plugin on github.com/pulumi/pulumi-%s/releases: %w", info.Name, err)
+	source := info.GetSource()
+	return source.GetLatestVersion(getHTTPResponse)
 }
 
 // Download fetches an io.ReadCloser for this plugin and also returns the size of the response (if known).
@@ -375,168 +629,8 @@ func (info PluginInfo) Download() (io.ReadCloser, int64, error) {
 		return nil, -1, errors.Errorf("unknown version for plugin %s", info.Name)
 	}
 
-	if info.PluginDownloadURL != "" {
-		return getPluginResponse(
-			buildUserSpecifiedPluginURL(info.PluginDownloadURL, info.Kind, info.Name, info.Version, opSy, arch))
-	}
-
-	// If the plugin name matches an override, download the plugin from the override URL.
-	if url, ok := pluginDownloadURLOverridesParsed.get(info.Name); ok {
-		return getPluginResponse(buildUserSpecifiedPluginURL(url, info.Kind, info.Name, info.Version, opSy, arch))
-	}
-
-	pluginURL := buildGitHubReleasesPluginURL(info.Kind, info.Name, info.Version, opSy, arch)
-
-	resp, length, err := getPluginResponse(pluginURL)
-	if err == nil {
-		return resp, length, nil
-	}
-	logging.V(1).Infof("cannot find plugin on github.com/pulumi/pulumi-%s/releases", info.Name)
-
-	if _, ok := os.LookupEnv("PULUMI_EXPERIMENTAL"); ok {
-		resp, length, err = getPluginFromPrivateGitHubResponse(info, opSy, arch)
-		if err == nil {
-			return resp, length, nil
-		}
-		logging.V(1).Infof("cannot find plugin %s on private GitHub releases: %s", info.Name, err.Error())
-	}
-
-	// we threw an error talking to GitHub so lets fallback to get.pulumi.com for the provider
-	return getPluginResponse(buildPulumiHostedPluginURL(info.Kind, info.Name, info.Version, opSy, arch))
-}
-
-func getPluginFromPrivateGitHubResponse(info PluginInfo, opSy, arch string) (io.ReadCloser, int64, error) {
-	assetName := fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz",
-		info.Kind, info.Name, info.Version.String(), opSy, arch)
-	resp, length, err := getPluginPrivateGitHubReleaseAPIResponse(info)
-	if err != nil {
-		return nil, -1, err
-	}
-	jsonBody, err := ioutil.ReadAll(resp)
-	if err != nil {
-		logging.V(9).Infof("cannot unmarshal github response len(%d): %s", length, err.Error())
-		return nil, -1, err
-	}
-	release := struct {
-		Assets []struct {
-			Name string `json:"name"`
-			URL  string `json:"url"`
-		} `json:"assets"`
-	}{}
-	err = json.Unmarshal(jsonBody, &release)
-	if err != nil {
-		logging.V(9).Infof("github json response: %s", jsonBody)
-		logging.V(9).Infof("cannot unmarshal github response: %s", err.Error())
-		return nil, -1, err
-	}
-	assetURL := ""
-	for _, asset := range release.Assets {
-		if asset.Name == assetName {
-			assetURL = asset.URL
-		}
-	}
-	if assetURL == "" {
-		logging.V(9).Infof("github json response: %s", jsonBody)
-		logging.V(9).Infof("plugin asset '%s' not found", assetName)
-		return nil, -1, errors.Errorf("plugin asset '%s' not found", assetName)
-	}
-	req, err := buildPluginFromPrivateGitHubRequest(assetURL)
-	if err != nil {
-		return nil, -1, err
-	}
-	return getHTTPResponse(req)
-}
-
-func buildPluginFromPrivateGitHubRequest(assetURL string) (req *http.Request, err error) {
-	if ghToken, ok := os.LookupEnv("GITHUB_TOKEN"); ok {
-		req, err = buildHTTPRequest(assetURL, "token", ghToken, "", "")
-	} else if paToken, ok := os.LookupEnv("GITHUB_PERSONAL_ACCESS_TOKEN"); ok {
-		if actor, ok := os.LookupEnv("GITHUB_ACTOR"); ok {
-			req, err = buildHTTPRequest(assetURL, "", "", actor, paToken)
-		}
-	}
-	if err != nil {
-		return nil, err
-	}
-	if req == nil {
-		return nil, errors.New("no authentication information provided")
-	}
-	req.Header.Set("Accept", "application/octet-stream")
-	return req, nil
-}
-
-func buildPluginPrivateGitHubReleaseAPIRequest(info PluginInfo) (*http.Request, error) {
-	repoOwner := os.Getenv("GITHUB_REPOSITORY_OWNER")
-	if repoOwner == "" {
-		return nil, errors.New("ENV[GITHUB_REPOSITORY_OWNER] not set")
-	}
-	ghToken := os.Getenv("GITHUB_TOKEN")
-	paToken := ""
-	actor := ""
-	if ghToken == "" {
-		paToken = os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
-		actor = os.Getenv("GITHUB_ACTOR")
-	}
-	if ghToken == "" && (paToken == "" || actor == "") {
-		return nil, errors.New("no GitHub authentication information provided")
-	}
-	releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/pulumi-%s/releases/tags/v%s",
-		repoOwner, info.Name, info.Version.String())
-	logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
-
-	req, err := buildHTTPRequest(releaseURL, "token", ghToken, actor, paToken)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	return req, nil
-}
-
-func getPluginPrivateGitHubReleaseAPIResponse(info PluginInfo) (io.ReadCloser, int64, error) {
-	req, err := buildPluginPrivateGitHubReleaseAPIRequest(info)
-	if err != nil {
-		return nil, -1, err
-	}
-	return getHTTPResponse(req)
-}
-
-func buildGitHubReleasesPluginURL(kind PluginKind, name string, version *semver.Version, opSy, arch string) string {
-	logging.V(1).Infof("%s downloading from github.com/pulumi/pulumi-%s/releases", name, name)
-
-	return fmt.Sprintf("https://github.com/pulumi/pulumi-%s/releases/download/v%s/%s",
-		name, version.String(), url.QueryEscape(fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz",
-			kind, name, version.String(), opSy, arch)))
-}
-
-func buildPulumiHostedPluginURL(kind PluginKind, name string, version *semver.Version, opSy, arch string) string {
-	serverURL := "https://get.pulumi.com/releases/plugins"
-
-	logging.V(1).Infof("%s downloading from %s", name, serverURL)
-
-	serverURL = interpolateURL(serverURL, *version, opSy, arch)
-	serverURL = strings.TrimSuffix(serverURL, "/")
-
-	logging.V(1).Infof("%s downloading from %s", name, serverURL)
-	endpoint := fmt.Sprintf("%s/%s",
-		serverURL,
-		url.QueryEscape(fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz", kind, name, version.String(), opSy, arch)))
-
-	return endpoint
-}
-
-func buildUserSpecifiedPluginURL(serverURL string, kind PluginKind, name string, version *semver.Version,
-	opSy, arch string) string {
-	logging.V(1).Infof("%s downloading from %s", name, serverURL)
-
-	serverURL = interpolateURL(serverURL, *version, opSy, arch)
-	serverURL = strings.TrimSuffix(serverURL, "/")
-
-	logging.V(1).Infof("%s downloading from %s", name, serverURL)
-	endpoint := fmt.Sprintf("%s/%s",
-		serverURL,
-		url.QueryEscape(fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz", kind, name, version.String(), opSy, arch)))
-
-	return endpoint
+	source := info.GetSource()
+	return source.Download(*info.Version, opSy, arch, getHTTPResponse)
 }
 
 func buildHTTPRequest(pluginEndpoint, tokenType, token, username, secret string) (*http.Request, error) {
@@ -558,14 +652,6 @@ func buildHTTPRequest(pluginEndpoint, tokenType, token, username, secret string)
 	}
 
 	return req, nil
-}
-
-func getPluginResponse(pluginEndpoint string) (io.ReadCloser, int64, error) {
-	req, err := buildHTTPRequest(pluginEndpoint, "", "", "", "")
-	if err != nil {
-		return nil, -1, err
-	}
-	return getHTTPResponse(req)
 }
 
 func getHTTPResponse(req *http.Request) (io.ReadCloser, int64, error) {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -433,7 +433,9 @@ func (source *fallbackSource) GetLatestVersion(
 
 		logging.V(1).Infof("cannot find plugin %s on private GitHub releases: %s", source.name, privateErr.Error())
 
-		return nil, fmt.Errorf("error getting version from Pulumi github: %w\nand from private github: %s", err, privateErr.Error())
+		return nil, fmt.Errorf(
+			"error getting version from Pulumi github: %w\nand from private github: %s",
+			err, privateErr.Error())
 	}
 
 	return nil, err

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -421,9 +421,10 @@ func (source *fallbackSource) GetLatestVersion(
 		if repoOwner == "" {
 			privateErr = errors.New("ENV[GITHUB_REPOSITORY_OWNER] not set")
 		} else {
-			private, privateErr := newAuthenticatedGithubSource(repoOwner, source.name, source.kind)
+			var private PluginSource
+			private, privateErr = newAuthenticatedGithubSource(repoOwner, source.name, source.kind)
 			if privateErr == nil {
-				version, privateErr := private.GetLatestVersion(getHTTPResponse)
+				version, privateErr = private.GetLatestVersion(getHTTPResponse)
 				if privateErr == nil {
 					return version, nil
 				}
@@ -431,6 +432,8 @@ func (source *fallbackSource) GetLatestVersion(
 		}
 
 		logging.V(1).Infof("cannot find plugin %s on private GitHub releases: %s", source.name, privateErr.Error())
+
+		return nil, fmt.Errorf("error getting version from Pulumi github: %w\nand from private github: %s", err, privateErr.Error())
 	}
 
 	return nil, err

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -249,6 +249,7 @@ func (source *githubSource) GetLatestVersion(
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 	resp, length, err := getHTTPResponse(req)
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -299,7 +299,8 @@ func TestPluginDownloadUrl(t *testing.T) {
 		source := info.GetSource()
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
-			if req.URL.String() == "https://github.com/pulumi/pulumi-aws/releases/download/v4.32.0/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz" {
+			if req.URL.String() == "https://github.com/pulumi/pulumi-aws/releases/"+
+				"download/v4.32.0/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz" {
 				return nil, -1, errors.New("404 not found")
 			}
 			assert.Equal(t,
@@ -321,7 +322,8 @@ func TestPluginDownloadUrl(t *testing.T) {
 		source := info.GetSource()
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
-				"https://customurl.jfrog.io/artifactory/pulumi-packages/package-name/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
+				"https://customurl.jfrog.io/artifactory/pulumi-packages/"+
+					"package-name/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
 				req.URL.String())
 			return newMockReadCloser([]byte{})
 		}
@@ -344,7 +346,8 @@ func TestPluginDownloadUrl(t *testing.T) {
 		source := info.GetSource()
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
-			if req.URL.String() == "https://github.com/pulumi/pulumi-private/releases/download/v1.22.0/pulumi-resource-private-v1.22.0-darwin-amd64.tar.gz" {
+			if req.URL.String() == "https://github.com/pulumi/pulumi-private/releases/download/"+
+				"v1.22.0/pulumi-resource-private-v1.22.0-darwin-amd64.tar.gz" {
 				return nil, -1, errors.New("404 not found")
 			}
 

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -15,7 +15,10 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"regexp"
 	"testing"
@@ -238,8 +241,36 @@ func TestPluginSelection_EmptyVersionWithAlternatives(t *testing.T) {
 	assert.Equal(t, "0.2.0", result.Version.String())
 }
 
+type mockReadCloser struct {
+	bytes    []byte
+	position int64
+}
+
+func (mock *mockReadCloser) Read(p []byte) (int, error) {
+	if mock.position == int64(len(mock.bytes)) {
+		return 0, io.EOF
+	}
+	slice := mock.bytes[mock.position:]
+	copied := copy(p, slice)
+	mock.position = mock.position + int64(copied)
+	return copied, nil
+}
+
+func (mock *mockReadCloser) Close() error {
+	return nil
+}
+
+func newMockReadCloser(data []byte) (io.ReadCloser, int64, error) {
+	return &mockReadCloser{bytes: data}, int64(len(data)), nil
+}
+
+func newMockReadCloserString(data string) (io.ReadCloser, int64, error) {
+	bytes := []byte(data)
+	return &mockReadCloser{bytes: bytes}, int64(len(bytes)), nil
+}
+
 func TestPluginDownloadUrl(t *testing.T) {
-	t.Run("Test Downloading From GitHub Releases", func(t *testing.T) {
+	t.Run("Test Downloading From Pulumi GitHub Releases", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
 		info := PluginInfo{
 			PluginDownloadURL: "",
@@ -247,10 +278,15 @@ func TestPluginDownloadUrl(t *testing.T) {
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		serverURL := buildGitHubReleasesPluginURL(info.Kind, info.Name, info.Version, "darwin", "amd64")
-		assert.Equal(t,
-			"https://github.com/pulumi/pulumi-aws/releases/download/v4.32.0/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
-			serverURL)
+		source := info.GetSource()
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			assert.Equal(t,
+				"https://github.com/pulumi/pulumi-aws/releases/download/v4.32.0/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
+				req.URL.String())
+			return newMockReadCloser([]byte{})
+		}
+		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		assert.Nil(t, err)
 	})
 	t.Run("Test Downloading From get.pulumi.com", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
@@ -260,9 +296,19 @@ func TestPluginDownloadUrl(t *testing.T) {
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		serverURL := buildPulumiHostedPluginURL(info.Kind, info.Name, info.Version, "darwin", "amd64")
-		assert.Equal(t,
-			"https://get.pulumi.com/releases/plugins/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz", serverURL)
+		source := info.GetSource()
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			// Test that the asset isn't on github
+			if req.URL.String() == "https://github.com/pulumi/pulumi-aws/releases/download/v4.32.0/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz" {
+				return nil, -1, errors.New("404 not found")
+			}
+			assert.Equal(t,
+				"https://get.pulumi.com/releases/plugins/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
+				req.URL.String())
+			return newMockReadCloser([]byte{})
+		}
+		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		assert.Nil(t, err)
 	})
 	t.Run("Test Downloading From Custom Server URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
@@ -272,42 +318,62 @@ func TestPluginDownloadUrl(t *testing.T) {
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		serverURL := buildUserSpecifiedPluginURL(info.PluginDownloadURL, info.Kind, info.Name, info.Version,
-			"darwin", "amd64")
-		assert.Equal(t,
-			"https://customurl.jfrog.io/artifactory/pulumi-packages/package-name"+
-				"/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
-			serverURL)
+		source := info.GetSource()
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			assert.Equal(t,
+				"https://customurl.jfrog.io/artifactory/pulumi-packages/package-name/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
+				req.URL.String())
+			return newMockReadCloser([]byte{})
+		}
+		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		assert.Nil(t, err)
 	})
-	t.Run("Test Searching GitHub Private Releases", func(t *testing.T) {
+	t.Run("Test Downloading From GitHub Private Releases", func(t *testing.T) {
 		owner := "private"
 		token := "RaNd0m70K3n_"
+		os.Setenv("PULUMI_EXPERIMENTAL", "true")
 		os.Setenv("GITHUB_REPOSITORY_OWNER", owner)
 		os.Setenv("GITHUB_TOKEN", token)
-		version := semver.MustParse("4.32.0")
+		version := semver.MustParse("1.22.0")
 		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "private",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		httpReq, err := buildPluginPrivateGitHubReleaseAPIRequest(info)
-		assert.NoError(t, err)
-		assert.Equal(t,
-			"https://api.github.com/repos/private/pulumi-private/releases/tags/v4.32.0",
-			httpReq.URL.String())
-		assert.Equal(t, fmt.Sprintf("token %s", token), httpReq.Header.Get("Authentication"))
-		assert.Equal(t, "application/json", httpReq.Header.Get("Accept"))
-	})
-	t.Run("Test Downloading From GitHub Private Releases", func(t *testing.T) {
-		token := "RaNd0m70K3n_"
-		os.Setenv("GITHUB_TOKEN", token)
-		url := "https://api.github.com/repos/private/pulumi-private/releases/assets/123456"
-		httpReq, err := buildPluginFromPrivateGitHubRequest(url)
-		assert.NoError(t, err)
-		assert.Equal(t, url, httpReq.URL.String())
-		assert.Equal(t, fmt.Sprintf("token %s", token), httpReq.Header.Get("Authentication"))
-		assert.Equal(t, "application/octet-stream", httpReq.Header.Get("Accept"))
+		source := info.GetSource()
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			// Test that the asset isn't on github
+			if req.URL.String() == "https://github.com/pulumi/pulumi-private/releases/download/v1.22.0/pulumi-resource-private-v1.22.0-darwin-amd64.tar.gz" {
+				return nil, -1, errors.New("404 not found")
+			}
+
+			if req.URL.String() == "https://api.github.com/repos/private/pulumi-private/releases/tags/v1.22.0" {
+				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authentication"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
+				// Minimal JSON from the releases API to get the test to pass
+				return newMockReadCloserString(`{
+					"assets": [
+					  {
+						"url": "https://api.github.com/repos/private/pulumi-private/releases/assets/654321",
+						"name": "pulumi-private_1.22.0_checksums.txt"
+					  },
+					  {
+						"url": "https://api.github.com/repos/private/pulumi-private/releases/assets/123456",
+						"name": "pulumi-resource-private-v1.22.0-darwin-amd64.tar.gz"
+					  }
+					]
+				  }
+				`)
+			}
+
+			assert.Equal(t, "https://api.github.com/repos/private/pulumi-private/releases/assets/123456", req.URL.String())
+			assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authentication"))
+			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
+			return newMockReadCloser([]byte{})
+		}
+		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		assert.Nil(t, err)
 	})
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/9001

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
