### PR TITLE
Allow trivial stack with no engine events

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1587,15 +1587,17 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 	}
 	defer contract.IgnoreClose(eventsFile)
 	decoder, events := json.NewDecoder(eventsFile), []apitype.EngineEvent{}
-	for {
-		var event apitype.EngineEvent
-		if err = decoder.Decode(&event); err != nil {
-			if err == io.EOF {
-				break
+	if len(events) > 0 {
+		for {
+			var event apitype.EngineEvent
+			if err = decoder.Decode(&event); err != nil {
+				if err == io.EOF {
+					break
+				}
+				return fmt.Errorf("decoding engine event: %w", err)
 			}
-			return fmt.Errorf("decoding engine event: %w", err)
+			events = append(events, event)
 		}
-		events = append(events, event)
 	}
 
 	// Populate stack info object with all of this data to pass to the validation function


### PR DESCRIPTION
While testing another feature, I needed to create a stack to exercise _only_ outputs. That stack emitted no engine events and therefore failed in programtest.