### PR TITLE
[sdk/nodejs] Fix make install

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -29,6 +29,7 @@ build_package:: ensure
 	cp tests/runtime/jsClosureCases_10_4.js bin/tests/runtime
 	cp -R tests/automation/data/. bin/tests/automation/data/
 	cp README.md ../../LICENSE ./dist/* bin/
+# safely remove mockpackage dependency see [pulumi/pulumi#9026]
 	cp package.json yarn.lock bin/ && cd bin && yarn remove mockpackage && rm yarn.lock
 	node ../../scripts/reversion.js bin/package.json ${VERSION}
 	node ../../scripts/reversion.js bin/version.js ${VERSION}

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -28,11 +28,11 @@ build_package:: ensure
 	cp tests/runtime/jsClosureCases_8.js bin/tests/runtime
 	cp tests/runtime/jsClosureCases_10_4.js bin/tests/runtime
 	cp -R tests/automation/data/. bin/tests/automation/data/
-	cp README.md ../../LICENSE package.json ./dist/* bin/
+	cp README.md ../../LICENSE ./dist/* bin/
+	sed 's/"devDependencies"/"_devDependencies"/g' package.json > bin/package.json
 	node ../../scripts/reversion.js bin/package.json ${VERSION}
 	node ../../scripts/reversion.js bin/version.js ${VERSION}
 	cp -R proto/. bin/proto/
-	cp -R tests/mockpackage bin/tests/
 	mkdir -p bin/tests/runtime/langhost/cases/
 	find tests/runtime/langhost/cases/* -type d -exec cp -R {} bin/tests/runtime/langhost/cases/ \;
 

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -29,7 +29,7 @@ build_package:: ensure
 	cp tests/runtime/jsClosureCases_10_4.js bin/tests/runtime
 	cp -R tests/automation/data/. bin/tests/automation/data/
 	cp README.md ../../LICENSE ./dist/* bin/
-	cat package.json | grep -v '"mockpackage"'> bin/package.json
+	cp package.json yarn.lock bin/ && cd bin && yarn remove mockpackage && rm yarn.lock
 	node ../../scripts/reversion.js bin/package.json ${VERSION}
 	node ../../scripts/reversion.js bin/version.js ${VERSION}
 	cp -R proto/. bin/proto/

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -29,7 +29,7 @@ build_package:: ensure
 	cp tests/runtime/jsClosureCases_10_4.js bin/tests/runtime
 	cp -R tests/automation/data/. bin/tests/automation/data/
 	cp README.md ../../LICENSE ./dist/* bin/
-	sed 's/"devDependencies"/"_devDependencies"/g' package.json > bin/package.json
+	cat package.json | grep -v '"mockpackage"'> bin/package.json
 	node ../../scripts/reversion.js bin/package.json ${VERSION}
 	node ../../scripts/reversion.js bin/version.js ${VERSION}
 	cp -R proto/. bin/proto/

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -32,6 +32,7 @@ build_package:: ensure
 	node ../../scripts/reversion.js bin/package.json ${VERSION}
 	node ../../scripts/reversion.js bin/version.js ${VERSION}
 	cp -R proto/. bin/proto/
+	cp -R tests/mockpackage bin/tests/
 	mkdir -p bin/tests/runtime/langhost/cases/
 	find tests/runtime/langhost/cases/* -type d -exec cp -R {} bin/tests/runtime/langhost/cases/ \;
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Fixed nodejs make install script by dropping `devDependencies` in `.pulumi-dev/node_modules` as it does not use them. Yarn attempts to resolve devDependencies on prod builds. Linked a discussion in #9019. Opening an issue #9027 to add CI tests for dev scripts.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9019

Filing #9027 #9042

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
