### PR TITLE
CI: resolve build/test failures on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}
+          check-latest: true
       - id: go-cache-paths
         run: |
           echo "::set-output name=go-build::$(go env GOCACHE)"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -95,6 +96,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Fetch Tags
@@ -183,6 +185,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -87,6 +88,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Fetch Tags
@@ -213,6 +215,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -179,6 +180,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Fetch Tags
@@ -306,6 +308,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
+          check-latest: true
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/run-docs-generation.yml
+++ b/.github/workflows/run-docs-generation.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -98,6 +98,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}
+          check-latest: true
       - id: go-cache-paths
         run: |
           echo "::set-output name=go-build::$(go env GOCACHE)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}
+          check-latest: true
       - id: go-cache-paths
         run: |
           echo "::set-output name=go-build::$(go env GOCACHE)"

--- a/tests/about_test.go
+++ b/tests/about_test.go
@@ -16,6 +16,7 @@ package tests
 
 import (
 	"encoding/json"
+	"regexp"
 	"runtime"
 	"testing"
 
@@ -39,7 +40,7 @@ func TestAboutCommands(t *testing.T) {
 		stdout, _ := e.RunCommand("pulumi", "about", "--json")
 		var res interface{}
 		assert.NoError(t, json.Unmarshal([]byte(stdout), &res), "Should be valid json")
-		assert.Contains(t, stdout, runtime.Version())
+		assert.Contains(t, stdout, runtimeMajorMinor())
 		assert.Contains(t, stdout, runtime.Compiler)
 		assert.Contains(t, stdout, "Failed to get information about the current stack:")
 	})
@@ -55,7 +56,14 @@ func TestAboutCommands(t *testing.T) {
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
 		stdout, _ := e.RunCommand("pulumi", "about")
-		assert.Contains(t, stdout, runtime.Version())
+		assert.Contains(t, stdout, runtimeMajorMinor())
 		assert.Contains(t, stdout, runtime.Compiler)
 	})
+}
+
+// Given a runtime version like "go1.17.123", returns "go1.17.", trimming patch and prerelease
+// values.
+func runtimeMajorMinor() string {
+	re := regexp.MustCompile(`go\d+.\d+.`)
+	return re.FindString(runtime.Version())
 }


### PR DESCRIPTION
See: #9014 

* Ensures our builders & runners check that the version of go in the runner cache is the latest that matches the version requested (currently 1.17.x).

* Makes the failing test more resilient and more likely to pass on developer machines by making the test only check the major and minor version, which matches our CI system which expects go 1.17.x

Detailed build logs:

Builder (macos or ubuntu) builds Pulumi with go 1.17.7: https://github.com/pulumi/pulumi/runs/5271142183?check_suite_focus=true#step:7:14

Test harness (Windows) installs go 1.17.6 from cache: https://github.com/pulumi/pulumi/runs/5271213861?check_suite_focus=true#step:7:17

Test harness then fails on checking if the built binary's "pulumi about" result contains "go1.17.6", which it does not because it was built with 1.17.7: https://github.com/pulumi/pulumi/runs/5271213861?check_suite_focus=true#step:49:37