### PR TITLE
ci: default builder to linux, not macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: macos-latest
+          - platform: ${{ inputs.default-build-platform }}
             os: darwin
           - platform: ${{ inputs.default-build-platform }}
             os: linux

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -78,7 +78,7 @@ jobs:
           make -C sdk/${{ matrix.language}} publish
   publish-binaries:
     name: Publish Binaries
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [lint, build, test]
     strategy:
       matrix:
@@ -235,9 +235,7 @@ jobs:
     name: Build
     uses: pulumi/pulumi/.github/workflows/build.yml@master
     with:
-      # Cross-compiling from ubuntu-latest is faster but the artifact
-      # checksums will not match what publish-binaries expects.
-      default-build-platform: macos-latest
+      default-build-platform: ubuntu-latest
       enable-coverage: true
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -77,7 +77,7 @@ jobs:
           make -C sdk/${{ matrix.language}} publish
   publish-binaries:
     name: Publish Binaries
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [lint, build, test]
     strategy:
       matrix:
@@ -265,9 +265,7 @@ jobs:
     name: Build
     uses: pulumi/pulumi/.github/workflows/build.yml@master
     with:
-      # Cross-compiling from ubuntu-latest is faster but the artifact
-      # checksums will not match what publish-binaries expects.
-      default-build-platform: macos-latest
+      default-build-platform: ubuntu-latest
       enable-coverage: false
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
           make -C sdk/${{ matrix.language}} publish
   publish-binaries:
     name: Publish Binaries
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [lint, build, test]
     strategy:
       matrix:
@@ -358,9 +358,7 @@ jobs:
     name: Build
     uses: pulumi/pulumi/.github/workflows/build.yml@master
     with:
-      # Cross-compiling from ubuntu-latest is faster but the artifact
-      # checksums will not match what publish-binaries expects.
-      default-build-platform: macos-latest
+      default-build-platform: ubuntu-latest
       enable-coverage: false
       goreleaser-config: '.goreleaser.yml'
       goreleaser-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md --skip-publish --skip-announce --skip-validate'


### PR DESCRIPTION
Per comment in CI workflow, ubuntu-latest is the quicker build agent. Aligns the checksums by also publishing via ubuntu-latest.

