### PR TITLE
[secrets] Fix + refactor bulk decryption.

### DIFF
--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -328,10 +328,6 @@ func (b brokenDecrypter) DecryptValue(_ string) (string, error) {
 	return "", fmt.Errorf(b.ErrorMessage)
 }
 
-func (b brokenDecrypter) BulkDecrypt(_ []string) (map[string]string, error) {
-	return nil, fmt.Errorf(b.ErrorMessage)
-}
-
 // Tests that the engine presents a reasonable error message when a decrypter fails to decrypt a config value.
 func TestBrokenDecrypter(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{

--- a/pkg/resource/stack/checkpoint_test.go
+++ b/pkg/resource/stack/checkpoint_test.go
@@ -40,3 +40,13 @@ func TestLoadV1Checkpoint(t *testing.T) {
 	assert.NotNil(t, chk.Latest)
 	assert.Len(t, chk.Latest.Resources, 30)
 }
+
+func TestLoadV3Checkpoint(t *testing.T) {
+	bytes, err := ioutil.ReadFile("testdata/checkpoint-v3.json")
+	assert.NoError(t, err)
+
+	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(bytes)
+	assert.NoError(t, err)
+	assert.NotNil(t, chk.Latest)
+	assert.Len(t, chk.Latest.Resources, 30)
+}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -232,7 +232,6 @@ func DeserializeDeploymentV3(deployment apitype.DeploymentV3, secretsProv Secret
 		if err != nil {
 			return nil, err
 		}
-		dec = config.NewCachedDecrypter(d)
 
 		// Do a first pass through state and collect all of the secrets that need decrypting.
 		// We will collect all secrets and decrypt them all at once, rather than just-in-time.
@@ -240,15 +239,16 @@ func DeserializeDeploymentV3(deployment apitype.DeploymentV3, secretsProv Secret
 		// wait times in stacks with a large number of secrets.
 		var ciphertexts []string
 		for _, res := range deployment.Resources {
-			ciphertexts = append(ciphertexts, scanResource(res)...)
+			collectCiphertexts(&ciphertexts, res.Inputs)
+			collectCiphertexts(&ciphertexts, res.Outputs)
 		}
 
-		// we call BulkDecrypt to Prime the cache with the decrypted cipertexts
-		// we don't actually use the response here at this point
-		_, err = dec.BulkDecrypt(ciphertexts)
+		// Decrypt the collected secrets and create a decrypter that will use the result as a cache.
+		cache, err := config.BulkDecrypt(d, ciphertexts)
 		if err != nil {
 			return nil, err
 		}
+		dec = newMapDecrypter(d, cache)
 
 		e, err := secretsManager.Encrypter()
 		if err != nil {
@@ -456,34 +456,24 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 	return prop.V, nil
 }
 
-// scanProperties collects encrypted secrets from resource properties.
-func scanProperties(props map[string]interface{}) []string {
-	var cipertexts []string
-	for _, prop := range props {
-		if prop != nil {
-			if obj, ok := prop.(map[string]interface{}); ok {
-				if sig, hasSig := obj[resource.SigKey]; hasSig {
-					if sig == resource.SecretSig {
-						if ciphertext, cipherOk := obj["ciphertext"].(string); cipherOk {
-							cipertexts = append(cipertexts, ciphertext)
-						}
-					}
-				}
+// collectCiphertexts collects encrypted secrets from resource properties.
+func collectCiphertexts(ciphertexts *[]string, prop interface{}) {
+	switch prop := prop.(type) {
+	case []interface{}:
+		for _, v := range prop {
+			collectCiphertexts(ciphertexts, v)
+		}
+	case map[string]interface{}:
+		if prop[resource.SigKey] == resource.SecretSig {
+			if ciphertext, cipherOk := prop["ciphertext"].(string); cipherOk {
+				*ciphertexts = append(*ciphertexts, ciphertext)
+			}
+		} else {
+			for _, v := range prop {
+				collectCiphertexts(ciphertexts, v)
 			}
 		}
 	}
-
-	return cipertexts
-}
-
-// scanResource collects encrypted secrets from a serialized resource.
-func scanResource(res apitype.ResourceV3) []string {
-	var cipertexts []string
-	// Scan resource properties for secrets.
-	cipertexts = append(cipertexts, scanProperties(res.Inputs)...)
-	cipertexts = append(cipertexts, scanProperties(res.Outputs)...)
-
-	return cipertexts
 }
 
 // DeserializeResource turns a serialized resource back into its usual form.

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -155,6 +155,12 @@ func (c *cachingCrypter) insert(secret *resource.Secret, plaintext, ciphertext s
 // where the deserializer is expected to prime the cache by scanning each resource for secrets, then decrypting all
 // of the discovered secrets en masse. Although each call to Decrypt _should_ hit the cache, a mapDecrypter does
 // carry an underlying Decrypter in the event that a secret was missed.
+//
+// Note that this is intentionally separate from cachingCrypter. A cachingCrypter is intended to prevent repeated
+// encryption of secrets when the same snapshot is repeatedly serialized over the lifetime of an update, and
+// therefore keys on the identity of the secret value itself. A mapDecrypter is intended to allow the deserializer
+// to decrypt secrets up-front and prevent repeated calls to decrypt within the context of a single deserialization,
+// and cannot key off of secret identity because secrets do not exist when the cache is initialized.
 type mapDecrypter struct {
 	decrypter config.Decrypter
 	cache     map[string]string

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -4,12 +4,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testSecretsManager struct {
@@ -41,21 +44,6 @@ func (t *testSecretsManager) DecryptValue(ciphertext string) (string, error) {
 		return "", errors.New("invalid ciphertext format")
 	}
 	return ciphertext[i+1:], nil
-}
-
-func (t *testSecretsManager) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	secretMap := map[string]string{}
-	for _, cip := range ciphertexts {
-		if _, ok := secretMap[cip]; ok {
-			continue
-		}
-		v, err := t.DecryptValue(cip)
-		if err != nil {
-			return nil, err
-		}
-		secretMap[cip] = v
-	}
-	return secretMap, nil
 }
 
 func deserializeProperty(v interface{}, dec config.Decrypter) (resource.PropertyValue, error) {
@@ -186,4 +174,74 @@ func TestCachingCrypter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, barSer, barSer2)
+}
+
+type mapTestSecretsProvider struct {
+	m *mapTestSecretsManager
+}
+
+func (p *mapTestSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+	m, err := DefaultSecretsProvider.OfType(ty, state)
+	if err != nil {
+		return nil, err
+	}
+	p.m = &mapTestSecretsManager{sm: m}
+	return p.m, nil
+}
+
+type mapTestSecretsManager struct {
+	sm secrets.Manager
+
+	d *mapTestDecrypter
+}
+
+func (t *mapTestSecretsManager) Type() string { return t.sm.Type() }
+
+func (t *mapTestSecretsManager) State() interface{} { return t.sm.State() }
+
+func (t *mapTestSecretsManager) Encrypter() (config.Encrypter, error) {
+	return t.sm.Encrypter()
+}
+
+func (t *mapTestSecretsManager) Decrypter() (config.Decrypter, error) {
+	d, err := t.sm.Decrypter()
+	if err != nil {
+		return nil, err
+	}
+	t.d = &mapTestDecrypter{d: d}
+	return t.d, nil
+}
+
+type mapTestDecrypter struct {
+	d config.Decrypter
+
+	decryptCalls     int
+	bulkDecryptCalls int
+}
+
+func (t *mapTestDecrypter) DecryptValue(ciphertext string) (string, error) {
+	t.decryptCalls++
+	return t.d.DecryptValue(ciphertext)
+}
+
+func (t *mapTestDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	t.bulkDecryptCalls++
+	return config.BulkDecrypt(t.d, ciphertexts)
+}
+
+func TestMapCrypter(t *testing.T) {
+	bytes, err := ioutil.ReadFile("testdata/checkpoint-secrets.json")
+	require.NoError(t, err)
+
+	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(bytes)
+	require.NoError(t, err)
+
+	var prov mapTestSecretsProvider
+
+	_, err = DeserializeDeploymentV3(*chk.Latest, &prov)
+	require.NoError(t, err)
+
+	d := prov.m.d
+	assert.Equal(t, 1, d.bulkDecryptCalls)
+	assert.Equal(t, 0, d.decryptCalls)
 }

--- a/pkg/resource/stack/testdata/checkpoint-secrets.json
+++ b/pkg/resource/stack/testdata/checkpoint-secrets.json
@@ -1,0 +1,803 @@
+{
+    "version": 3,
+    "checkpoint": {
+        "stack": "",
+        "latest": {
+            "manifest": {
+                "time": "0001-01-01T00:00:00Z",
+                "magic": "",
+                "version": ""
+            },
+            "secrets_providers": {
+                "type": "b64",
+                "state": {}
+            },
+            "resources": [
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown",
+                    "custom": true,
+                    "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                    "type": "aws:sns/topic:Topic",
+                    "outputs": {
+                        "arn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                        "displayName": "",
+                        "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                        "name": "countDown-9d430501c4510322",
+                        "policy": "{\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"153052954103\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Resource\":\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\",\"Sid\":\"__default_statement_ID\"}],\"Version\":\"2008-10-17\"}"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:topic:Topic::countDown"
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:topic:Topic::countDown",
+                    "custom": false,
+                    "type": "cloud:topic:Topic"
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:sns/topic:Topic::unhandled-error-topic",
+                    "custom": true,
+                    "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                    "type": "aws:sns/topic:Topic",
+                    "outputs": {
+                        "arn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                        "displayName": "",
+                        "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                        "name": "unhandled-error-topic-ddd8c2cd9a876715",
+                        "policy": "{\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"153052954103\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Resource\":\"arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715\",\"Sid\":\"__default_statement_ID\"}],\"Version\":\"2008-10-17\"}"
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::countDown_watcher-iamrole",
+                    "custom": true,
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "type": "aws:iam/role:Role",
+                    "inputs": {
+                        "assumeRolePolicy": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "IntcIlZlcnNpb25cIjpcIjIwMTItMTAtMTdcIixcIlN0YXRlbWVudFwiOlt7XCJBY3Rpb25cIjpcInN0czpBc3N1bWVSb2xlXCIsXCJQcmluY2lwYWxcIjp7XCJTZXJ2aWNlXCI6XCJsYW1iZGEuYW1hem9uYXdzLmNvbVwifSxcIkVmZmVjdFwiOlwiQWxsb3dcIixcIlNpZFwiOlwiXCJ9XX0i"
+                        }
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "assumeRolePolicy": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "IntcIlZlcnNpb25cIjpcIjIwMTItMTAtMTdcIixcIlN0YXRlbWVudFwiOlt7XCJTaWRcIjpcIlwiLFwiRWZmZWN0XCI6XCJBbGxvd1wiLFwiUHJpbmNpcGFsXCI6e1wiU2VydmljZVwiOlwibGFtYmRhLmFtYXpvbmF3cy5jb21cIn0sXCJBY3Rpb25cIjpcInN0czpBc3N1bWVSb2xlXCJ9XX0i"
+                        },
+                        "createDate": "2017-11-08T19:51:32Z",
+                        "forceDetachPolicies": false,
+                        "id": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "name": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "path": "/",
+                        "uniqueId": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "IkFST0FKQlFBTlBGRVhGVzJTRVZKTSI="
+                        }
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "assumeRolePolicy": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-0",
+                    "custom": true,
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195133331200000001",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "outputs": {
+                        "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195133331200000001",
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-1",
+                    "custom": true,
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195134625700000002",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "outputs": {
+                        "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195134625700000002",
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::countDown_watcher",
+                    "custom": true,
+                    "id": "countDown_watcher-560cf0c8d799e9cd",
+                    "type": "aws:lambda/function:Function",
+                    "inputs": {
+                        "code": {
+                            "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                            "assets": {
+                                ".": {
+                                    "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                    "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                    "path": "."
+                                },
+                                "__index.js": {
+                                    "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                    "hash": "2379662c18737708ce800361028a4bb5cc1d3ea619d90ec50811e299e465307a",
+                                    "text": "exports.handler = __c9e856d50f915ecde20c43f505596928ee91643e;\n\nfunction __c9e856d50f915ecde20c43f505596928ee91643e() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, handler: __db4cc5ebcb1698516c862c46e2aeec3a258aa47f }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n        Promise.all(ev.Records.map((record) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield handler(record.Sns);\n        })))\n            .then(() =\u003e { cb(null, null); })\n            .catch((err) =\u003e { cb(err, null); });\n    })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __db4cc5ebcb1698516c862c46e2aeec3a258aa47f() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, handler: __820d19c6daf60cebb8ca144dd373a37806be5880 }) {\n    return (function() {\n\nreturn ((snsItem) =\u003e __awaiter(this, void 0, void 0, function* () {\n            const item = JSON.parse(snsItem.Message);\n            yield handler(item);\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __820d19c6daf60cebb8ca144dd373a37806be5880() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, countDown: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((num) =\u003e __awaiter(this, void 0, void 0, function* () {\n    console.log(num);\n    if (num \u003e 0) {\n        yield countDown.publish(num - 1);\n    }\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a() {\n  var _this;\n  with({ _this: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((item) =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            const snsconn = new awssdk.SNS();\n            return snsconn.publish({\n                Message: JSON.stringify(item),\n                TopicArn: this.topic.id,\n            }).promise();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                                }
+                            },
+                            "hash": "b9d3b221cf1e03db6f40d62bddaa4087764f26f0b68c0e3aaf02a1d7921ea9a5"
+                        },
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": {
+                                    "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                                    "ciphertext": "ImFybjphd3M6c25zOnVzLWVhc3QtMjoxNTMwNTI5NTQxMDM6dW5oYW5kbGVkLWVycm9yLXRvcGljLWRkZDhjMmNkOWE4NzY3MTUi"
+                                }
+                            }
+                        ],
+                        "handler": "__index.handler",
+                        "memorySize": 128,
+                        "role": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "runtime": "nodejs6.10",
+                        "timeout": 180
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                        "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive203107759",
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": {
+                                    "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                                    "ciphertext": "ImFybjphd3M6c25zOnVzLWVhc3QtMjoxNTMwNTI5NTQxMDM6dW5oYW5kbGVkLWVycm9yLXRvcGljLWRkZDhjMmNkOWE4NzY3MTUi"
+                                }
+                            }
+                        ],
+                        "description": "",
+                        "environment": [],
+                        "handler": "__index.handler",
+                        "id": "countDown_watcher-560cf0c8d799e9cd",
+                        "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd/invocations",
+                        "kmsKeyArn": "",
+                        "lastModified": "2017-11-08T19:51:46.320+0000",
+                        "memorySize": "128",
+                        "name": "countDown_watcher-560cf0c8d799e9cd",
+                        "publish": false,
+                        "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd:$LATEST",
+                        "role": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "runtime": "nodejs6.10",
+                        "sourceCodeHash": "4t/d32Qvj5j7gHSYFhXKoroGD1NDBKC7wsr1mmPB3AM=",
+                        "tags": {},
+                        "timeout": "180",
+                        "tracingConfig": [
+                            {
+                                "mode": "PassThrough"
+                            }
+                        ],
+                        "version": "$LATEST",
+                        "vpcConfig": []
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "code": null,
+                        "deadLetterConfig": null,
+                        "handler": null,
+                        "memorySize": null,
+                        "role": null,
+                        "runtime": null,
+                        "timeout": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "custom": false,
+                    "type": "aws:serverless:Function",
+                    "inputs": {
+                        "options": {
+                            "deadLetterConfig": {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            },
+                            "memorySize": 128,
+                            "policies": [
+                                "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                                "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                            ]
+                        }
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "options": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::countDown_watcher-func-logs",
+                    "custom": true,
+                    "id": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                    "type": "aws:cloudwatch/logGroup:LogGroup",
+                    "inputs": {
+                        "name": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "retentionInDays": 1
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/countDown_watcher-560cf0c8d799e9cd:*",
+                        "id": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "name": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "retentionInDays": "1",
+                        "tags": {}
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "name": null,
+                        "retentionInDays": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::pulumi-foo-log-collector-iamrole",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "type": "aws:iam/role:Role",
+                    "inputs": {
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                        "createDate": "2017-11-08T19:51:49Z",
+                        "forceDetachPolicies": false,
+                        "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "name": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "path": "/",
+                        "uniqueId": "AROAIQAQPEUAL7EJ3HOZM"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "propertyDependencies": {
+                        "assumeRolePolicy": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-foo-log-collector-iampolicy-0",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07-20171108195150465100000003",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07"
+                    },
+                    "outputs": {
+                        "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07-20171108195150465100000003",
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::pulumi-foo-log-collector",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "type": "aws:lambda/function:Function",
+                    "inputs": {
+                        "code": {
+                            "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                            "assets": {
+                                ".": {
+                                    "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                    "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                    "path": "."
+                                },
+                                "__index.js": {
+                                    "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                    "hash": "371d4d8ead106550e5d7e2d0c02dd2e479dba060c765e09f98840fdfe73ea824",
+                                    "text": "exports.handler = __88442d0b4365f25c858d35485cca4f999253cc40;\n\nfunction __88442d0b4365f25c858d35485cca4f999253cc40() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n            const zlib = require(\"zlib\");\n            const payload = new Buffer(ev.awslogs.data, \"base64\");\n            zlib.gunzip(payload, (err, result) =\u003e {\n                if (err !== undefined \u0026\u0026 err !== null) {\n                    cb(err, null);\n                }\n                else {\n                    console.log(result.toString(\"utf8\"));\n                    cb(null, {});\n                }\n            });\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                                }
+                            },
+                            "hash": "8a00ca481f85fe64b20537ac86fcb551b471dcfbff8c4623927d4654cd8a4ed2"
+                        },
+                        "handler": "__index.handler",
+                        "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "runtime": "nodejs6.10",
+                        "timeout": 180
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive938160569",
+                        "deadLetterConfig": [],
+                        "description": "",
+                        "environment": [],
+                        "handler": "__index.handler",
+                        "id": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8/invocations",
+                        "kmsKeyArn": "",
+                        "lastModified": "2017-11-08T19:52:01.821+0000",
+                        "memorySize": "128",
+                        "name": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "publish": false,
+                        "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8:$LATEST",
+                        "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "runtime": "nodejs6.10",
+                        "sourceCodeHash": "ZFzSi0OvUjtU4arIaBHfsxusBAoknUjiAxUTAB6U9oA=",
+                        "tags": {},
+                        "timeout": "180",
+                        "tracingConfig": [
+                            {
+                                "mode": "PassThrough"
+                            }
+                        ],
+                        "version": "$LATEST",
+                        "vpcConfig": []
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "propertyDependencies": {
+                        "code": null,
+                        "handler": null,
+                        "role": null,
+                        "runtime": null,
+                        "timeout": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "custom": false,
+                    "type": "aws:serverless:Function",
+                    "inputs": {
+                        "options": {
+                            "policies": [
+                                "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+                            ]
+                        }
+                    },
+                    "propertyDependencies": {
+                        "options": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::pulumi-foo-log-collector",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-ba2b0a268e749fe6",
+                    "type": "aws:lambda/permission:Permission",
+                    "inputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "principal": "logs.us-east-2.amazonaws.com"
+                    },
+                    "outputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "id": "pulumi-foo-log-collector-ba2b0a268e749fe6",
+                        "principal": "logs.us-east-2.amazonaws.com",
+                        "qualifier": "",
+                        "statementId": "pulumi-foo-log-collector-ba2b0a268e749fe6"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "action": null,
+                        "function": null,
+                        "principal": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::countDown_watcher",
+                    "custom": true,
+                    "id": "cwlsf-2481582075",
+                    "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                    "inputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "logGroup": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd"
+                    },
+                    "outputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "id": "cwlsf-2481582075",
+                        "logGroup": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "name": "countDown_watcher-57808b716bf46c1d"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "destinationArn": null,
+                        "filterPattern": null,
+                        "logGroup": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "custom": false,
+                    "type": "cloud:function:Function",
+                    "inputs": {
+                        "handler": {}
+                    },
+                    "propertyDependencies": {
+                        "handler": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::countDown_watcher",
+                    "custom": true,
+                    "id": "countDown_watcher-aa73943ce15ac420",
+                    "type": "aws:lambda/permission:Permission",
+                    "inputs": {
+                        "action": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "ImxhbWJkYTppbnZva2VGdW5jdGlvbiI="
+                        },
+                        "function": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "ImNvdW50RG93bl93YXRjaGVyLTU2MGNmMGM4ZDc5OWU5Y2Qi"
+                        },
+                        "principal": "sns.amazonaws.com",
+                        "sourceArn": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "ImFybjphd3M6c25zOnVzLWVhc3QtMjoxNTMwNTI5NTQxMDM6Y291bnREb3duLTlkNDMwNTAxYzQ1MTAzMjIi"
+                        }
+                    },
+                    "outputs": {
+                        "action": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "ImxhbWJkYTppbnZva2VGdW5jdGlvbiI="
+                        },
+                        "function": "countDown_watcher-560cf0c8d799e9cd",
+                        "id": "countDown_watcher-aa73943ce15ac420",
+                        "principal": "sns.amazonaws.com",
+                        "qualifier": "",
+                        "sourceArn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                        "statementId": "countDown_watcher-aa73943ce15ac420"
+                    },
+                    "propertyDependencies": {
+                        "action": null,
+                        "function": null,
+                        "principal": null,
+                        "sourceArn": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:sns/topicSubscription:TopicSubscription::countDown_watcher",
+                    "custom": true,
+                    "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                    "type": "aws:sns/topicSubscription:TopicSubscription",
+                    "inputs": {
+                        "endpoint": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                        "protocol": "lambda",
+                        "topic": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                        "confirmationTimeoutInMinutes": "1",
+                        "endpoint": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                        "endpointAutoConfirms": false,
+                        "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                        "protocol": "lambda",
+                        "rawMessageDelivery": false,
+                        "topic": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                    },
+                    "propertyDependencies": {
+                        "endpoint": null,
+                        "protocol": null,
+                        "topic": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::heartbeat-iamrole",
+                    "custom": true,
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983",
+                    "type": "aws:iam/role:Role",
+                    "inputs": {
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                        "createDate": "2017-11-08T19:52:06Z",
+                        "forceDetachPolicies": false,
+                        "id": "heartbeat-iamrole-ea19407f5d1f9983",
+                        "name": "heartbeat-iamrole-ea19407f5d1f9983",
+                        "path": "/",
+                        "uniqueId": "AROAJTGNWRNQ7OCLFKY7U"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "assumeRolePolicy": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-0",
+                    "custom": true,
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195207299700000004",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "outputs": {
+                        "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195207299700000004",
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-1",
+                    "custom": true,
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195208724900000005",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "outputs": {
+                        "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195208724900000005",
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-5614fce52cdefed1",
+                    "type": "aws:lambda/function:Function",
+                    "inputs": {
+                        "code": {
+                            "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                            "assets": {
+                                ".": {
+                                    "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                    "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                    "path": "."
+                                },
+                                "__index.js": {
+                                    "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                    "hash": "a468f1c8c9ab41698856ed3792332e6b5777feaed065a53649bdb060cf7f3230",
+                                    "text": "exports.handler = __a455c2c731f5040281af02a4818453f11f0b328b;\n\nfunction __a455c2c731f5040281af02a4818453f11f0b328b() {\n  var _this;\n  with({ handler: __cc09ee843518b38f3cd7adfbed024016fa68320d }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n                handler().then(() =\u003e {\n                    cb(null, null);\n                }).catch((err) =\u003e {\n                    cb(err, null);\n                });\n            })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __cc09ee843518b38f3cd7adfbed024016fa68320d() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, countDown: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn (() =\u003e __awaiter(this, void 0, void 0, function* () {\n    yield countDown.publish(25);\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a() {\n  var _this;\n  with({ _this: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((item) =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            const snsconn = new awssdk.SNS();\n            return snsconn.publish({\n                Message: JSON.stringify(item),\n                TopicArn: this.topic.id,\n            }).promise();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                                }
+                            },
+                            "hash": "28d308ff48619077125cb154436fed798c678ede238fc09aad199252747bb9af"
+                        },
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            }
+                        ],
+                        "handler": "__index.handler",
+                        "memorySize": 128,
+                        "role": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                        "runtime": "nodejs6.10",
+                        "timeout": 180
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                        "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive024127571",
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            }
+                        ],
+                        "description": "",
+                        "environment": [],
+                        "handler": "__index.handler",
+                        "id": "heartbeat-5614fce52cdefed1",
+                        "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1/invocations",
+                        "kmsKeyArn": "",
+                        "lastModified": "2017-11-08T19:52:20.380+0000",
+                        "memorySize": "128",
+                        "name": "heartbeat-5614fce52cdefed1",
+                        "publish": false,
+                        "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1:$LATEST",
+                        "role": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                        "runtime": "nodejs6.10",
+                        "sourceCodeHash": "H7sZcBf1/eLXcG/KVqmj6frm09XMQkpiLPaf2WEpLUs=",
+                        "tags": {},
+                        "timeout": "180",
+                        "tracingConfig": [
+                            {
+                                "mode": "PassThrough"
+                            }
+                        ],
+                        "version": "$LATEST",
+                        "vpcConfig": []
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "code": null,
+                        "deadLetterConfig": null,
+                        "handler": null,
+                        "memorySize": null,
+                        "role": null,
+                        "runtime": null,
+                        "timeout": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "custom": false,
+                    "type": "aws:serverless:Function",
+                    "inputs": {
+                        "options": {
+                            "deadLetterConfig": {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            },
+                            "memorySize": 128,
+                            "policies": [
+                                "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                                "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                            ]
+                        }
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "propertyDependencies": {
+                        "options": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::heartbeat-func-logs",
+                    "custom": true,
+                    "id": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                    "type": "aws:cloudwatch/logGroup:LogGroup",
+                    "inputs": {
+                        "name": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "retentionInDays": 1
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/heartbeat-5614fce52cdefed1:*",
+                        "id": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "name": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "retentionInDays": "1",
+                        "tags": {}
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "propertyDependencies": {
+                        "name": null,
+                        "retentionInDays": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::heartbeat",
+                    "custom": true,
+                    "id": "cwlsf-2719389737",
+                    "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                    "inputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "logGroup": "/aws/lambda/heartbeat-5614fce52cdefed1"
+                    },
+                    "outputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "id": "cwlsf-2719389737",
+                        "logGroup": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "name": "heartbeat-26ff913c249c7734"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "propertyDependencies": {
+                        "destinationArn": null,
+                        "filterPattern": null,
+                        "logGroup": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "custom": false,
+                    "type": "cloud:function:Function",
+                    "inputs": {
+                        "handler": {}
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "handler": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/eventRule:EventRule::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-c7779a3d5f53ed1e",
+                    "type": "aws:cloudwatch/eventRule:EventRule",
+                    "inputs": {
+                        "scheduleExpression": "rate(5 minutes)"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e",
+                        "description": "",
+                        "id": "heartbeat-c7779a3d5f53ed1e",
+                        "isEnabled": true,
+                        "name": "heartbeat-c7779a3d5f53ed1e",
+                        "roleArn": "",
+                        "scheduleExpression": "rate(5 minutes)"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "scheduleExpression": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/eventTarget:EventTarget::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-c7779a3d5f53ed1e-heartbeat",
+                    "type": "aws:cloudwatch/eventTarget:EventTarget",
+                    "inputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                        "rule": "heartbeat-c7779a3d5f53ed1e",
+                        "targetId": "heartbeat"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                        "id": "heartbeat-c7779a3d5f53ed1e-heartbeat",
+                        "input": "",
+                        "inputPath": "",
+                        "roleArn": "",
+                        "rule": "heartbeat-c7779a3d5f53ed1e",
+                        "targetId": "heartbeat"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "arn": null,
+                        "rule": null,
+                        "targetId": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-15d43252e0160c80",
+                    "type": "aws:lambda/permission:Permission",
+                    "inputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "heartbeat-5614fce52cdefed1",
+                        "principal": "events.amazonaws.com",
+                        "sourceArn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e"
+                    },
+                    "outputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "heartbeat-5614fce52cdefed1",
+                        "id": "heartbeat-15d43252e0160c80",
+                        "principal": "events.amazonaws.com",
+                        "qualifier": "",
+                        "sourceArn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e",
+                        "statementId": "heartbeat-15d43252e0160c80"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "action": null,
+                        "function": null,
+                        "principal": null,
+                        "sourceArn": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "custom": false,
+                    "type": "cloud:timer:Timer",
+                    "inputs": {
+                        "scheduleExpression": {
+                            "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                            "ciphertext": "InJhdGUoNSBtaW51dGVzKSI="
+                        }
+                    },
+                    "propertyDependencies": {
+                        "scheduleExpression": null
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/pkg/resource/stack/testdata/checkpoint-v3.json
+++ b/pkg/resource/stack/testdata/checkpoint-v3.json
@@ -1,0 +1,773 @@
+{
+    "version": 3,
+    "checkpoint": {
+        "stack": "",
+        "latest": {
+            "manifest": {
+                "time": "0001-01-01T00:00:00Z",
+                "magic": "",
+                "version": ""
+            },
+            "secrets_providers": {
+                "type": "b64",
+                "state": {}
+            },
+            "resources": [
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown",
+                    "custom": true,
+                    "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                    "type": "aws:sns/topic:Topic",
+                    "outputs": {
+                        "arn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                        "displayName": "",
+                        "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                        "name": "countDown-9d430501c4510322",
+                        "policy": "{\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"153052954103\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Resource\":\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\",\"Sid\":\"__default_statement_ID\"}],\"Version\":\"2008-10-17\"}"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:topic:Topic::countDown"
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:topic:Topic::countDown",
+                    "custom": false,
+                    "type": "cloud:topic:Topic"
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:sns/topic:Topic::unhandled-error-topic",
+                    "custom": true,
+                    "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                    "type": "aws:sns/topic:Topic",
+                    "outputs": {
+                        "arn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                        "displayName": "",
+                        "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                        "name": "unhandled-error-topic-ddd8c2cd9a876715",
+                        "policy": "{\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"153052954103\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Resource\":\"arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715\",\"Sid\":\"__default_statement_ID\"}],\"Version\":\"2008-10-17\"}"
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::countDown_watcher-iamrole",
+                    "custom": true,
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "type": "aws:iam/role:Role",
+                    "inputs": {
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                        "createDate": "2017-11-08T19:51:32Z",
+                        "forceDetachPolicies": false,
+                        "id": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "name": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "path": "/",
+                        "uniqueId": "AROAJBQANPFEXFW2SEVJM"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "assumeRolePolicy": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-0",
+                    "custom": true,
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195133331200000001",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "outputs": {
+                        "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195133331200000001",
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-1",
+                    "custom": true,
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195134625700000002",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "outputs": {
+                        "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195134625700000002",
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::countDown_watcher",
+                    "custom": true,
+                    "id": "countDown_watcher-560cf0c8d799e9cd",
+                    "type": "aws:lambda/function:Function",
+                    "inputs": {
+                        "code": {
+                            "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                            "assets": {
+                                ".": {
+                                    "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                    "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                    "path": "."
+                                },
+                                "__index.js": {
+                                    "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                    "hash": "2379662c18737708ce800361028a4bb5cc1d3ea619d90ec50811e299e465307a",
+                                    "text": "exports.handler = __c9e856d50f915ecde20c43f505596928ee91643e;\n\nfunction __c9e856d50f915ecde20c43f505596928ee91643e() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, handler: __db4cc5ebcb1698516c862c46e2aeec3a258aa47f }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n        Promise.all(ev.Records.map((record) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield handler(record.Sns);\n        })))\n            .then(() =\u003e { cb(null, null); })\n            .catch((err) =\u003e { cb(err, null); });\n    })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __db4cc5ebcb1698516c862c46e2aeec3a258aa47f() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, handler: __820d19c6daf60cebb8ca144dd373a37806be5880 }) {\n    return (function() {\n\nreturn ((snsItem) =\u003e __awaiter(this, void 0, void 0, function* () {\n            const item = JSON.parse(snsItem.Message);\n            yield handler(item);\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __820d19c6daf60cebb8ca144dd373a37806be5880() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, countDown: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((num) =\u003e __awaiter(this, void 0, void 0, function* () {\n    console.log(num);\n    if (num \u003e 0) {\n        yield countDown.publish(num - 1);\n    }\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a() {\n  var _this;\n  with({ _this: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((item) =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            const snsconn = new awssdk.SNS();\n            return snsconn.publish({\n                Message: JSON.stringify(item),\n                TopicArn: this.topic.id,\n            }).promise();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                                }
+                            },
+                            "hash": "b9d3b221cf1e03db6f40d62bddaa4087764f26f0b68c0e3aaf02a1d7921ea9a5"
+                        },
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            }
+                        ],
+                        "handler": "__index.handler",
+                        "memorySize": 128,
+                        "role": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "runtime": "nodejs6.10",
+                        "timeout": 180
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                        "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive203107759",
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            }
+                        ],
+                        "description": "",
+                        "environment": [],
+                        "handler": "__index.handler",
+                        "id": "countDown_watcher-560cf0c8d799e9cd",
+                        "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd/invocations",
+                        "kmsKeyArn": "",
+                        "lastModified": "2017-11-08T19:51:46.320+0000",
+                        "memorySize": "128",
+                        "name": "countDown_watcher-560cf0c8d799e9cd",
+                        "publish": false,
+                        "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd:$LATEST",
+                        "role": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                        "runtime": "nodejs6.10",
+                        "sourceCodeHash": "4t/d32Qvj5j7gHSYFhXKoroGD1NDBKC7wsr1mmPB3AM=",
+                        "tags": {},
+                        "timeout": "180",
+                        "tracingConfig": [
+                            {
+                                "mode": "PassThrough"
+                            }
+                        ],
+                        "version": "$LATEST",
+                        "vpcConfig": []
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "code": null,
+                        "deadLetterConfig": null,
+                        "handler": null,
+                        "memorySize": null,
+                        "role": null,
+                        "runtime": null,
+                        "timeout": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                    "custom": false,
+                    "type": "aws:serverless:Function",
+                    "inputs": {
+                        "options": {
+                            "deadLetterConfig": {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            },
+                            "memorySize": 128,
+                            "policies": [
+                                "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                                "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                            ]
+                        }
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "options": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::countDown_watcher-func-logs",
+                    "custom": true,
+                    "id": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                    "type": "aws:cloudwatch/logGroup:LogGroup",
+                    "inputs": {
+                        "name": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "retentionInDays": 1
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/countDown_watcher-560cf0c8d799e9cd:*",
+                        "id": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "name": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "retentionInDays": "1",
+                        "tags": {}
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "name": null,
+                        "retentionInDays": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::pulumi-foo-log-collector-iamrole",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "type": "aws:iam/role:Role",
+                    "inputs": {
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                        "createDate": "2017-11-08T19:51:49Z",
+                        "forceDetachPolicies": false,
+                        "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "name": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "path": "/",
+                        "uniqueId": "AROAIQAQPEUAL7EJ3HOZM"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "propertyDependencies": {
+                        "assumeRolePolicy": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-foo-log-collector-iampolicy-0",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07-20171108195150465100000003",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07"
+                    },
+                    "outputs": {
+                        "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07-20171108195150465100000003",
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::pulumi-foo-log-collector",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "type": "aws:lambda/function:Function",
+                    "inputs": {
+                        "code": {
+                            "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                            "assets": {
+                                ".": {
+                                    "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                    "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                    "path": "."
+                                },
+                                "__index.js": {
+                                    "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                    "hash": "371d4d8ead106550e5d7e2d0c02dd2e479dba060c765e09f98840fdfe73ea824",
+                                    "text": "exports.handler = __88442d0b4365f25c858d35485cca4f999253cc40;\n\nfunction __88442d0b4365f25c858d35485cca4f999253cc40() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n            const zlib = require(\"zlib\");\n            const payload = new Buffer(ev.awslogs.data, \"base64\");\n            zlib.gunzip(payload, (err, result) =\u003e {\n                if (err !== undefined \u0026\u0026 err !== null) {\n                    cb(err, null);\n                }\n                else {\n                    console.log(result.toString(\"utf8\"));\n                    cb(null, {});\n                }\n            });\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                                }
+                            },
+                            "hash": "8a00ca481f85fe64b20537ac86fcb551b471dcfbff8c4623927d4654cd8a4ed2"
+                        },
+                        "handler": "__index.handler",
+                        "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "runtime": "nodejs6.10",
+                        "timeout": 180
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive938160569",
+                        "deadLetterConfig": [],
+                        "description": "",
+                        "environment": [],
+                        "handler": "__index.handler",
+                        "id": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8/invocations",
+                        "kmsKeyArn": "",
+                        "lastModified": "2017-11-08T19:52:01.821+0000",
+                        "memorySize": "128",
+                        "name": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "publish": false,
+                        "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8:$LATEST",
+                        "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                        "runtime": "nodejs6.10",
+                        "sourceCodeHash": "ZFzSi0OvUjtU4arIaBHfsxusBAoknUjiAxUTAB6U9oA=",
+                        "tags": {},
+                        "timeout": "180",
+                        "tracingConfig": [
+                            {
+                                "mode": "PassThrough"
+                            }
+                        ],
+                        "version": "$LATEST",
+                        "vpcConfig": []
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "propertyDependencies": {
+                        "code": null,
+                        "handler": null,
+                        "role": null,
+                        "runtime": null,
+                        "timeout": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                    "custom": false,
+                    "type": "aws:serverless:Function",
+                    "inputs": {
+                        "options": {
+                            "policies": [
+                                "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+                            ]
+                        }
+                    },
+                    "propertyDependencies": {
+                        "options": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::pulumi-foo-log-collector",
+                    "custom": true,
+                    "id": "pulumi-foo-log-collector-ba2b0a268e749fe6",
+                    "type": "aws:lambda/permission:Permission",
+                    "inputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "principal": "logs.us-east-2.amazonaws.com"
+                    },
+                    "outputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "id": "pulumi-foo-log-collector-ba2b0a268e749fe6",
+                        "principal": "logs.us-east-2.amazonaws.com",
+                        "qualifier": "",
+                        "statementId": "pulumi-foo-log-collector-ba2b0a268e749fe6"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "action": null,
+                        "function": null,
+                        "principal": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::countDown_watcher",
+                    "custom": true,
+                    "id": "cwlsf-2481582075",
+                    "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                    "inputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "logGroup": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd"
+                    },
+                    "outputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "id": "cwlsf-2481582075",
+                        "logGroup": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                        "name": "countDown_watcher-57808b716bf46c1d"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "propertyDependencies": {
+                        "destinationArn": null,
+                        "filterPattern": null,
+                        "logGroup": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                    "custom": false,
+                    "type": "cloud:function:Function",
+                    "inputs": {
+                        "handler": {}
+                    },
+                    "propertyDependencies": {
+                        "handler": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::countDown_watcher",
+                    "custom": true,
+                    "id": "countDown_watcher-aa73943ce15ac420",
+                    "type": "aws:lambda/permission:Permission",
+                    "inputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "countDown_watcher-560cf0c8d799e9cd",
+                        "principal": "sns.amazonaws.com",
+                        "sourceArn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                    },
+                    "outputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "countDown_watcher-560cf0c8d799e9cd",
+                        "id": "countDown_watcher-aa73943ce15ac420",
+                        "principal": "sns.amazonaws.com",
+                        "qualifier": "",
+                        "sourceArn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                        "statementId": "countDown_watcher-aa73943ce15ac420"
+                    },
+                    "propertyDependencies": {
+                        "action": null,
+                        "function": null,
+                        "principal": null,
+                        "sourceArn": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:sns/topicSubscription:TopicSubscription::countDown_watcher",
+                    "custom": true,
+                    "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                    "type": "aws:sns/topicSubscription:TopicSubscription",
+                    "inputs": {
+                        "endpoint": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                        "protocol": "lambda",
+                        "topic": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                        "confirmationTimeoutInMinutes": "1",
+                        "endpoint": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                        "endpointAutoConfirms": false,
+                        "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                        "protocol": "lambda",
+                        "rawMessageDelivery": false,
+                        "topic": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                    },
+                    "propertyDependencies": {
+                        "endpoint": null,
+                        "protocol": null,
+                        "topic": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::heartbeat-iamrole",
+                    "custom": true,
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983",
+                    "type": "aws:iam/role:Role",
+                    "inputs": {
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                        "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                        "createDate": "2017-11-08T19:52:06Z",
+                        "forceDetachPolicies": false,
+                        "id": "heartbeat-iamrole-ea19407f5d1f9983",
+                        "name": "heartbeat-iamrole-ea19407f5d1f9983",
+                        "path": "/",
+                        "uniqueId": "AROAJTGNWRNQ7OCLFKY7U"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "assumeRolePolicy": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-0",
+                    "custom": true,
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195207299700000004",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "outputs": {
+                        "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195207299700000004",
+                        "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-1",
+                    "custom": true,
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195208724900000005",
+                    "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                    "inputs": {
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "outputs": {
+                        "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195208724900000005",
+                        "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                        "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "policyArn": null,
+                        "role": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-5614fce52cdefed1",
+                    "type": "aws:lambda/function:Function",
+                    "inputs": {
+                        "code": {
+                            "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                            "assets": {
+                                ".": {
+                                    "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                    "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                    "path": "."
+                                },
+                                "__index.js": {
+                                    "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                    "hash": "a468f1c8c9ab41698856ed3792332e6b5777feaed065a53649bdb060cf7f3230",
+                                    "text": "exports.handler = __a455c2c731f5040281af02a4818453f11f0b328b;\n\nfunction __a455c2c731f5040281af02a4818453f11f0b328b() {\n  var _this;\n  with({ handler: __cc09ee843518b38f3cd7adfbed024016fa68320d }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n                handler().then(() =\u003e {\n                    cb(null, null);\n                }).catch((err) =\u003e {\n                    cb(err, null);\n                });\n            })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __cc09ee843518b38f3cd7adfbed024016fa68320d() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, countDown: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn (() =\u003e __awaiter(this, void 0, void 0, function* () {\n    yield countDown.publish(25);\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a() {\n  var _this;\n  with({ _this: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((item) =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            const snsconn = new awssdk.SNS();\n            return snsconn.publish({\n                Message: JSON.stringify(item),\n                TopicArn: this.topic.id,\n            }).promise();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                                }
+                            },
+                            "hash": "28d308ff48619077125cb154436fed798c678ede238fc09aad199252747bb9af"
+                        },
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            }
+                        ],
+                        "handler": "__index.handler",
+                        "memorySize": 128,
+                        "role": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                        "runtime": "nodejs6.10",
+                        "timeout": 180
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                        "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive024127571",
+                        "deadLetterConfig": [
+                            {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            }
+                        ],
+                        "description": "",
+                        "environment": [],
+                        "handler": "__index.handler",
+                        "id": "heartbeat-5614fce52cdefed1",
+                        "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1/invocations",
+                        "kmsKeyArn": "",
+                        "lastModified": "2017-11-08T19:52:20.380+0000",
+                        "memorySize": "128",
+                        "name": "heartbeat-5614fce52cdefed1",
+                        "publish": false,
+                        "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1:$LATEST",
+                        "role": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                        "runtime": "nodejs6.10",
+                        "sourceCodeHash": "H7sZcBf1/eLXcG/KVqmj6frm09XMQkpiLPaf2WEpLUs=",
+                        "tags": {},
+                        "timeout": "180",
+                        "tracingConfig": [
+                            {
+                                "mode": "PassThrough"
+                            }
+                        ],
+                        "version": "$LATEST",
+                        "vpcConfig": []
+                    },
+                    "parent": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "propertyDependencies": {
+                        "code": null,
+                        "deadLetterConfig": null,
+                        "handler": null,
+                        "memorySize": null,
+                        "role": null,
+                        "runtime": null,
+                        "timeout": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                    "custom": false,
+                    "type": "aws:serverless:Function",
+                    "inputs": {
+                        "options": {
+                            "deadLetterConfig": {
+                                "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                            },
+                            "memorySize": 128,
+                            "policies": [
+                                "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                                "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                            ]
+                        }
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "propertyDependencies": {
+                        "options": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::heartbeat-func-logs",
+                    "custom": true,
+                    "id": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                    "type": "aws:cloudwatch/logGroup:LogGroup",
+                    "inputs": {
+                        "name": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "retentionInDays": 1
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/heartbeat-5614fce52cdefed1:*",
+                        "id": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "name": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "retentionInDays": "1",
+                        "tags": {}
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "propertyDependencies": {
+                        "name": null,
+                        "retentionInDays": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::heartbeat",
+                    "custom": true,
+                    "id": "cwlsf-2719389737",
+                    "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                    "inputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "logGroup": "/aws/lambda/heartbeat-5614fce52cdefed1"
+                    },
+                    "outputs": {
+                        "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                        "filterPattern": "",
+                        "id": "cwlsf-2719389737",
+                        "logGroup": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                        "name": "heartbeat-26ff913c249c7734"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "propertyDependencies": {
+                        "destinationArn": null,
+                        "filterPattern": null,
+                        "logGroup": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                    "custom": false,
+                    "type": "cloud:function:Function",
+                    "inputs": {
+                        "handler": {}
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "handler": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/eventRule:EventRule::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-c7779a3d5f53ed1e",
+                    "type": "aws:cloudwatch/eventRule:EventRule",
+                    "inputs": {
+                        "scheduleExpression": "rate(5 minutes)"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e",
+                        "description": "",
+                        "id": "heartbeat-c7779a3d5f53ed1e",
+                        "isEnabled": true,
+                        "name": "heartbeat-c7779a3d5f53ed1e",
+                        "roleArn": "",
+                        "scheduleExpression": "rate(5 minutes)"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "scheduleExpression": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/eventTarget:EventTarget::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-c7779a3d5f53ed1e-heartbeat",
+                    "type": "aws:cloudwatch/eventTarget:EventTarget",
+                    "inputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                        "rule": "heartbeat-c7779a3d5f53ed1e",
+                        "targetId": "heartbeat"
+                    },
+                    "outputs": {
+                        "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                        "id": "heartbeat-c7779a3d5f53ed1e-heartbeat",
+                        "input": "",
+                        "inputPath": "",
+                        "roleArn": "",
+                        "rule": "heartbeat-c7779a3d5f53ed1e",
+                        "targetId": "heartbeat"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "arn": null,
+                        "rule": null,
+                        "targetId": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::heartbeat",
+                    "custom": true,
+                    "id": "heartbeat-15d43252e0160c80",
+                    "type": "aws:lambda/permission:Permission",
+                    "inputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "heartbeat-5614fce52cdefed1",
+                        "principal": "events.amazonaws.com",
+                        "sourceArn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e"
+                    },
+                    "outputs": {
+                        "action": "lambda:invokeFunction",
+                        "function": "heartbeat-5614fce52cdefed1",
+                        "id": "heartbeat-15d43252e0160c80",
+                        "principal": "events.amazonaws.com",
+                        "qualifier": "",
+                        "sourceArn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e",
+                        "statementId": "heartbeat-15d43252e0160c80"
+                    },
+                    "parent": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "propertyDependencies": {
+                        "action": null,
+                        "function": null,
+                        "principal": null,
+                        "sourceArn": null
+                    }
+                },
+                {
+                    "urn": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                    "custom": false,
+                    "type": "cloud:timer:Timer",
+                    "inputs": {
+                        "scheduleExpression": "rate(5 minutes)"
+                    },
+                    "propertyDependencies": {
+                        "scheduleExpression": null
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/pkg/secrets/b64/manager.go
+++ b/pkg/secrets/b64/manager.go
@@ -48,18 +48,3 @@ func (c *base64Crypter) DecryptValue(s string) (string, error) {
 	}
 	return string(b), nil
 }
-
-func (c *base64Crypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	secretMap := map[string]string{}
-	for _, cip := range ciphertexts {
-		if _, ok := secretMap[cip]; ok {
-			continue
-		}
-		v, err := c.DecryptValue(cip)
-		if err != nil {
-			return nil, err
-		}
-		secretMap[cip] = v
-	}
-	return secretMap, nil
-}

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -323,8 +323,3 @@ func (ec *errorCrypter) DecryptValue(_ string) (string, error) {
 	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
-
-func (ec *errorCrypter) BulkDecrypt(_ []string) (map[string]string, error) {
-	return nil, errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
-		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
-}

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -32,6 +32,8 @@ import (
 
 const Type = "service"
 
+var _ config.BulkDecrypter = (*serviceCrypter)(nil)
+
 // serviceCrypter is an encrypter/decrypter that uses the Pulumi servce to encrypt/decrypt a stack's secrets.
 type serviceCrypter struct {
 	client *client.Client

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -40,6 +40,8 @@ type Decrypter interface {
 
 // BulkDecrypter is a Decrypter that also supports bulk decryption of secrets.
 type BulkDecrypter interface {
+	Decrypter
+
 	BulkDecrypt(ciphertexts []string) (map[string]string, error)
 }
 

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -36,6 +36,10 @@ type Encrypter interface {
 // Decrypter decrypts encrypted ciphertext to its plaintext representation.
 type Decrypter interface {
 	DecryptValue(ciphertext string) (string, error)
+}
+
+// BulkDecrypter is a Decrypter that also supports bulk decryption of secrets.
+type BulkDecrypter interface {
 	BulkDecrypt(ciphertexts []string) (map[string]string, error)
 }
 
@@ -53,14 +57,6 @@ var NopEncrypter Encrypter = nopCrypter{}
 
 func (nopCrypter) DecryptValue(ciphertext string) (string, error) {
 	return ciphertext, nil
-}
-
-func (nopCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	secretMap := map[string]string{}
-	for _, c := range ciphertexts {
-		secretMap[c] = c
-	}
-	return secretMap, nil
 }
 
 func (nopCrypter) EncryptValue(plaintext string) (string, error) {
@@ -93,22 +89,6 @@ func (t *trackingDecrypter) DecryptValue(ciphertext string) (string, error) {
 	return v, nil
 }
 
-func (t *trackingDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	secretMap := map[string]string{}
-	for _, c := range ciphertexts {
-		if _, ok := secretMap[c]; ok {
-			continue
-		}
-		v, err := t.decrypter.DecryptValue(c)
-		if err != nil {
-			return secretMap, err
-		}
-		secretMap[c] = v
-		t.secureValues = append(t.secureValues, v)
-	}
-	return secretMap, nil
-}
-
 func (t *trackingDecrypter) SecureValues() []string {
 	return t.secureValues
 }
@@ -129,78 +109,8 @@ func (b blindingCrypter) DecryptValue(_ string) (string, error) {
 	return "[secret]", nil //nolint:goconst
 }
 
-func (b blindingCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	secretMap := map[string]string{}
-	for _, c := range ciphertexts {
-		if _, ok := secretMap[c]; ok {
-			continue
-		}
-		secretMap[c] = "[secret]"
-	}
-	return secretMap, nil
-}
-
 func (b blindingCrypter) EncryptValue(plaintext string) (string, error) {
 	return "[secret]", nil
-}
-
-type CachedDecrypter interface {
-	Decrypter
-}
-
-// cachedDecrypter is a Decrypter that keeps track if decrypted values, which
-// can be retrieved via SecureValues().
-type cachedDecrypter struct {
-	decrypter Decrypter
-	cache     map[string]string
-}
-
-func NewCachedDecrypter(decrypter Decrypter) CachedDecrypter {
-	return &cachedDecrypter{decrypter: decrypter}
-}
-
-func (c *cachedDecrypter) BulkDecrypt(ciperTexts []string) (map[string]string, error) {
-	secretMap, err := c.decrypter.BulkDecrypt(ciperTexts)
-	if err != nil {
-		return nil, err
-	}
-
-	if c.cache == nil {
-		c.cache = make(map[string]string, len(secretMap))
-	}
-
-	// lets ensure that we loop over the cipertexts to ensure that when we write to the cache
-	// an existing entry in the cache doesn't get updated with a new version of the decrypted value
-	// if this happens, we error as this may be a bug
-	for k, v := range secretMap {
-		if plaintext, ok := c.cache[k]; ok && plaintext != v {
-			return nil, fmt.Errorf("inconsistent decryption value found for cipertext: %q", k)
-		}
-
-		c.cache[k] = v
-	}
-
-	return secretMap, nil
-}
-
-func (c *cachedDecrypter) DecryptValue(ciperText string) (string, error) {
-	if plainText, ok := c.cache[ciperText]; ok {
-		return plainText, nil
-	}
-
-	// The value is not currently in the cache so we need to decrypt it
-	// and add it to the cache
-	plainText, err := c.decrypter.DecryptValue(ciperText)
-	if err != nil {
-		return "", err
-	}
-
-	if c.cache == nil {
-		c.cache = make(map[string]string)
-	}
-	c.cache[ciperText] = plainText
-
-	return plainText, nil
 }
 
 // NewPanicCrypter returns a new config crypter that will panic if used.
@@ -212,10 +122,6 @@ type panicCrypter struct{}
 
 func (p panicCrypter) EncryptValue(_ string) (string, error) {
 	panic("attempt to encrypt value")
-}
-
-func (p panicCrypter) BulkDecrypt(_ []string) (map[string]string, error) {
-	return nil, nil
 }
 
 func (p panicCrypter) DecryptValue(_ string) (string, error) {
@@ -274,21 +180,6 @@ func (s symmetricCrypter) DecryptValue(value string) (string, error) {
 	return decryptAES256GCM(enc, s.key, nonce)
 }
 
-func (s symmetricCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	secretMap := map[string]string{}
-	for _, c := range ciphertexts {
-		if _, ok := secretMap[c]; ok {
-			continue
-		}
-		v, err := s.DecryptValue(c)
-		if err != nil {
-			return nil, err
-		}
-		secretMap[c] = v
-	}
-	return secretMap, nil
-}
-
 // encryptAES256GCGM returns the ciphertext and the generated nonce
 func encryptAES256GCGM(plaintext string, key []byte) ([]byte, []byte) {
 	contract.Requiref(len(key) == SymmetricCrypterKeyBytes, "key", "AES-256-GCM needs a 32 byte key")
@@ -341,17 +232,24 @@ func (c prefixCrypter) EncryptValue(plaintext string) (string, error) {
 	return c.prefix + plaintext, nil
 }
 
-func (c prefixCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+// BulkDecrypt decrypts a list of ciphertexts. If decrypter implements BulkDecrypter, then its BulkDecrypt method will
+// be called. Otherwise, each ciphertext is decrypted individually. The returned map maps from ciphertext to plaintext.
+func BulkDecrypt(decrypter Decrypter, ciphertexts []string) (map[string]string, error) {
+	if len(ciphertexts) == 0 {
+		return nil, nil
+	}
+
+	if bulk, ok := decrypter.(BulkDecrypter); ok {
+		return bulk.BulkDecrypt(ciphertexts)
+	}
+
 	secretMap := map[string]string{}
-	for _, cip := range ciphertexts {
-		if _, ok := secretMap[cip]; ok {
-			continue
-		}
-		v, err := c.DecryptValue(cip)
+	for _, ct := range ciphertexts {
+		pt, err := decrypter.DecryptValue(ct)
 		if err != nil {
 			return nil, err
 		}
-		secretMap[cip] = v
+		secretMap[ct] = pt
 	}
 	return secretMap, nil
 }

--- a/sdk/go/common/resource/config/value_test.go
+++ b/sdk/go/common/resource/config/value_test.go
@@ -199,14 +199,6 @@ func (d passThroughDecrypter) DecryptValue(ciphertext string) (string, error) {
 	return ciphertext, nil
 }
 
-func (d passThroughDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	secretMap := map[string]string{}
-	for _, c := range ciphertexts {
-		secretMap[c] = c
-	}
-	return secretMap, nil
-}
-
 func TestSecureValues(t *testing.T) {
 	tests := []struct {
 		Value    Value


### PR DESCRIPTION
The bulk decryption logic in deployment deserialization did not recur
into slices or maps. This prevented the bulk decryption of nested secret
values. These changes fix that bug, improve test coverage, and refactor
the bulk decryption code for simplicity, clarity, and separation of
concerns.

Related to https://github.com/pulumi/home/issues/1842.