### PR TITLE
Fix DeprecationWarning  fs.rmdir (take 2)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -51,4 +51,4 @@
   [#9004](https://github.com/pulumi/pulumi/pull/9004)
 
 - [sdk/nodejs] - Fix Node `fs.rmdir` DeprecationWarning for Node JS 15.X+
-  [#TODO](https://github.com/pulumi/pulumi/pull/TODO)
+  [#9044](https://github.com/pulumi/pulumi/pull/9044)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,13 +8,13 @@
 
 - [sdk] - Add `RetainOnDelete` as a resource option.
   [#8746](https://github.com/pulumi/pulumi/pull/8746)
-  
+
 - [cli] - Adding `completion` as an alias to `gen-completion`
   [#9006](https://github.com/pulumi/pulumi/pull/9006)
 
 - [cli/plugins] Add support for downloading plugin from private GitHub releases.
   [#8944](https://github.com/pulumi/pulumi/pull/8944)
-  
+
 ### Bug Fixes
 
 - [sdk/go] - Normalize merge behavior for `ResourceOptions`, inline
@@ -49,3 +49,6 @@
 
 - [cli] - Fix an assert when replacing protected resources.
   [#9004](https://github.com/pulumi/pulumi/pull/9004)
+
+- [sdk/nodejs] - Fix Node `fs.rmdir` DeprecationWarning for Node JS 15.X+
+  [#TODO](https://github.com/pulumi/pulumi/pull/TODO)

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -825,9 +825,12 @@ const cleanUp = async (logFile?: string, rl?: ReadlineResult) => {
     }
     if (logFile) {
         // remove the logfile
-        // remove with Node JS 15.X+
-        if(fs.rm) fs.rm(path.dirname(logFile), { recursive: true }, () => { return; });
-        // remove with Node JS 14.X
-        else fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
+        if(fs.rm) {
+            // remove with Node JS 15.X+
+            fs.rm(path.dirname(logFile), { recursive: true }, () => { return; });
+        } else {
+            // remove with Node JS 14.X
+            fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
+        }
     }
 };

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -825,6 +825,9 @@ const cleanUp = async (logFile?: string, rl?: ReadlineResult) => {
     }
     if (logFile) {
         // remove the logfile
-        fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
+        // remove with Node JS 15.X+
+        if(fs.rm) fs.rm(path.dirname(logFile), { recursive: true }, () => { return; });
+        // remove with Node JS 14.X
+        else fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
     }
 };


### PR DESCRIPTION
# Description

Take 2 of https://github.com/pulumi/pulumi/pull/7872

Fix following deprecation warning

```txt
(node:49420) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```