### PR TITLE
Use SWC to transpile typescript projects

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+[sdk/nodejs] - Use SWC to transpile Typescript code without typechecking
+  [#9049](https://github.com/pulumi/pulumi/pull/9049)
+
 ### Bug Fixes

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -157,7 +157,6 @@ export function run(
 
     if (typeScript) {
         tsnode.register({
-            typeCheck: !transpileOnly,
             transpileOnly,
             swc: transpileOnly,
             project: process.env["PULUMI_NODEJS_TSCONFIG_PATH"], // will be undefined most of the time

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -150,14 +150,16 @@ export function run(
     }
 
     // If this is a typescript project, we'll want to load node-ts.
-    const typeScript: boolean = process.env["PULUMI_NODEJS_TYPESCRIPT"] === "true";
+    const typeScript = process.env["PULUMI_NODEJS_TYPESCRIPT"] === "true";
 
+    // Users can optionally disable typechecking when using typescript projects 
+    const transpileOnly = process.env["PULUMI_NODEJS_TRANSPILE_ONLY"] === "true";
 
     if (typeScript) {
         tsnode.register({
-            typeCheck: false,
-            transpileOnly: true,
-            swc: true,
+            typeCheck: !transpileOnly,
+            transpileOnly,
+            swc: transpileOnly,
             project: process.env["PULUMI_NODEJS_TSCONFIG_PATH"], // will be undefined most of the time
         });
     }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -21,8 +21,9 @@
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
-        "ts-node": "^7.0.1",
-        "typescript": "~3.7.3",
+        "ts-node": "^10.5.0",
+        "@swc/core": "^1.2.145",
+        "typescript": "~3.8.3",
         "upath": "^1.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

I just went down an interesting rabbit hole following the history of the run.ts file that sets up the ts-node running of typescript pulumi programs, and believe that simplifying the existing code will better future-proof pulumi, while providing better performance, with lower maintenance, while supporting more Typescript setups.

Here's the history of this file as I understand it:

-  Once upon a time, Luke Hoban noticed that having a tsconfig.json file in their home directory caused pulumi to hang, as ts-node was by default looking up the chain for any tsconfig.json file it could find, and was then attempting to typecheck all code in the `files` of that config file (https://github.com/pulumi/pulumi/issues/1772)
- As a solution, https://github.com/pulumi/pulumi/pull/1857 came along and said that pulumi would only check for tsconfig.json files in the project directory, solving Luke's problem, but creating an incompatibility with some fairly standard typescript layouts where the tsconfig file is up the chain.
- Issues and comments came in from users with confusing error messages where their tsconfig files up the directory chain were being ignored, and the error messages were non-obvious as to what was wrong.
  - https://github.com/pulumi/pulumi/pull/1857#issuecomment-677694535 has not been answered
  - Issue https://github.com/pulumi/pulumi/issues/8415 was opened
- PR https://github.com/pulumi/pulumi/pull/8452 patched the situation by adding a new config option that would allow users to specify their tsconfig file. Of note, they would likely have to search through the existing issues to even find that their error messages were related to tsconfig files, as Pulumi's handling here is non-standard
- Performance-related issues began popping up around ts-node, making it hard to support upgrading ts-node or typescript versions:
  - At one point, ts-node was updated from version 7 to version 8: https://github.com/pulumi/pulumi/pull/3627/files
  - An issue opened that startup times were slow for ts pulumi: https://github.com/pulumi/pulumi/issues/3671
  - Joe Duffy found that the lines reading in tsconfig files are non-performant: https://github.com/pulumi/pulumi/issues/3671#issuecomment-584718728
  - Luke Hoban found that the ts-node bump caused the perf decrease: https://github.com/pulumi/pulumi/issues/3671#issuecomment-592810579
  - A PR was merged moving the ts-node version back down: https://github.com/pulumi/pulumi/pull/4007
  - An issue was created to revisit the ts-node version: https://github.com/pulumi/pulumi/issues/4876
  - A PR was opened to bump up ts-node to version 10: https://github.com/pulumi/pulumi/pull/7828
  - That PR was also closed due to performance reasons: https://github.com/pulumi/pulumi/pull/7828#issuecomment-904994057
  - A suggestion for using something like esbuild without typechecking was made: https://github.com/pulumi/pulumi/issues/4876#issuecomment-1028616028. Of note, ts-node can be used without typechecking as well
  - PR https://github.com/pulumi/pulumi/pull/8981 added support to turn off typechecking. This still does not fix all of the problems though, as ts-node can still fail to run the code if skipBuilds was turned on, which was fixed to be on anytime tsconfig.json was not in the project dir.

This PR does a few things:
- Removes some of the patching that has happened over time (while still supporting custom tsconfig.json locations that are not in the parent chain of the project dir in the same way as before).
- Bumps up the ts-node version to major version 10
- Turns off typechecking
- Turns on transpiling typescript using SWC, which is sort of like esbuild (https://typestrong.org/ts-node/docs/transpilers/)

I created a test repo that uses these changes, comparing the performance on a plain `pulumi new aws-typescript` repo using the latest pulumi/pulumi and my fork: https://github.com/dmattia/pulumi-fork-perf-test

Ignoring the CI setup time and yarn installation time, the `pulumi preview` step with pulumi v3.25.0 took:
- 21s: https://github.com/dmattia/pulumi-fork-perf-test/runs/5335693814?check_suite_focus=true
- 16s: https://github.com/dmattia/pulumi-fork-perf-test/runs/5335693888?check_suite_focus=true
- 20s: https://github.com/dmattia/pulumi-fork-perf-test/runs/5335693955?check_suite_focus=true

and using the fork took:
- 9s: https://github.com/dmattia/pulumi-fork-perf-test/runs/5335694020?check_suite_focus=true
- 7s: https://github.com/dmattia/pulumi-fork-perf-test/runs/5335694060?check_suite_focus=true
- 8s: https://github.com/dmattia/pulumi-fork-perf-test/runs/5335694110?check_suite_focus=true

This is a significant performance increase, and I would encourage anyone interested to fork that repo and test for themselves on more operating systems, node versions, etc. if desired. Or, feel free to comment here what systems you're interested in and I will gladly update the job matrix to test using those options.

As for the lack of typechecking, this is where it gets a lot more into a matter of opinion, but my thought is this: If pulumi wants to typecheck by default, it should use standard typescript handling without custom handling of tsconfig.json files. Doing both of those things by default makes for a challenging onboarding experience for anyone in a custom-setup typescript repo that is not using `pulumi new` and doesn't just happen to have their tsconfig file in the correct place.

There is also a middle ground here where we do not use the swc transpiler, turn on typechecking by default, and use `scope` and `scopeDir` in ts-node to tell typescript to only typecheck the files in the pulumi working directory (see: https://github.com/TypeStrong/ts-node/blob/main/src/index.ts#L209-L218). These options, only available in ts-node v10.x and higher, would make the case where someone had a rogue tsconfig.json file in their home directory a non-issue (although they should really remove that 😬) as only the entry file (and other files in the same dir) would be typechecked.

Fixes https://github.com/pulumi/pulumi/issues/4876

Suggested reviewers: @iwahbe, @lukehoban, as they have been involved in many of the above discussions

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [x] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
