### PR TITLE
improve no project found error message

### DIFF
--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -142,7 +142,7 @@ func DetectProjectAndPath() (*Project, string, error) {
 		return nil, "", err
 	} else if path == "" {
 		return nil, "", errors.Errorf("no Pulumi project found in the current working directory. " +
-			"Move to a directory with a Pulumi project or try creating a project first with `pulumi new`."
+			"Move to a directory with a Pulumi project or try creating a project first with `pulumi new`.")
 	}
 
 	proj, err := LoadProject(path)

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -142,7 +142,7 @@ func DetectProjectAndPath() (*Project, string, error) {
 		return nil, "", err
 	} else if path == "" {
 		return nil, "", errors.Errorf("no Pulumi project found in the current working directory. " +
-			"If you're using the `--stack` flag, make sure to pass the fully qualified name (org/project/stack)")
+			"Move to a directory with a Pulumi project or try creating a project first with `pulumi new`."
 	}
 
 	proj, err := LoadProject(path)


### PR DESCRIPTION
# Description

if someone uses `pulumi stack init` but is not in a pulumi project we display an error and suggest that they may be using `--stack` incorrectly. but we believe that may be less common, and it may be more common that folks are in the wrong directory, or haven't yet created a pulumi project. this updates the error message to include that info. super open to feedback!! also if anyone feels strongly we should not lose the stack flag message, id be happy to keep it in there, just let me know.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
