### PR TITLE
[codegen/go] Fix secret codegen for input properties

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,5 +4,6 @@
 
 - [sdk/nodejs] - Fix Node `fs.rmdir` DeprecationWarning for Node JS 15.X+
   [#9044](https://github.com/pulumi/pulumi/pull/9044)
+
 - [codegen/go] - Fix secret codegen for input properties
   [#9052](https://github.com/pulumi/pulumi/pull/9052)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,5 @@
 
 - [sdk/nodejs] - Fix Node `fs.rmdir` DeprecationWarning for Node JS 15.X+
   [#9044](https://github.com/pulumi/pulumi/pull/9044)
+- [codegen/go] - Fix secret codegen for input properties
+  [#9052](https://github.com/pulumi/pulumi/pull/9052)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1647,12 +1647,10 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	}
 
 	// Setup secrets
-	if len(secretInputProps) > 0 {
-		for _, p := range secretInputProps {
-			fmt.Fprintf(w, "\tif args.%s != nil {\n", Title(p.Name))
-			fmt.Fprintf(w, "\t\targs.%[1]s = pulumi.ToSecret(args.%[1]s).(%[2]s)\n", Title(p.Name), pkg.outputType(p.Type))
-			fmt.Fprintf(w, "\t}\n")
-		}
+	for _, p := range secretInputProps {
+		fmt.Fprintf(w, "\tif args.%s != nil {\n", Title(p.Name))
+		fmt.Fprintf(w, "\t\targs.%[1]s = pulumi.ToSecret(args.%[1]s).(%[2]s)\n", Title(p.Name), pkg.outputType(p.Type))
+		fmt.Fprintf(w, "\t}\n")
 	}
 	if len(secretProps) > 0 {
 		fmt.Fprintf(w, "\tsecrets := pulumi.AdditionalSecretOutputs([]string{\n")

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1532,6 +1532,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	}
 
 	var secretProps []*schema.Property
+	var secretInputProps []*schema.Property
 
 	for _, p := range r.Properties {
 		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
@@ -1573,6 +1574,10 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			fmt.Fprintf(w, "\tif args.%s == nil {\n", Title(p.Name))
 			fmt.Fprintf(w, "\t\treturn nil, errors.New(\"invalid value for required argument '%s'\")\n", Title(p.Name))
 			fmt.Fprintf(w, "\t}\n")
+		}
+
+		if p.Secret {
+			secretInputProps = append(secretInputProps, p)
 		}
 	}
 
@@ -1642,12 +1647,14 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	}
 
 	// Setup secrets
-	if len(secretProps) > 0 {
-		for _, p := range secretProps {
+	if len(secretInputProps) > 0 {
+		for _, p := range secretInputProps {
 			fmt.Fprintf(w, "\tif args.%s != nil {\n", Title(p.Name))
 			fmt.Fprintf(w, "\t\targs.%[1]s = pulumi.ToSecret(args.%[1]s).(%[2]s)\n", Title(p.Name), pkg.outputType(p.Type))
 			fmt.Fprintf(w, "\t}\n")
 		}
+	}
+	if len(secretProps) > 0 {
 		fmt.Fprintf(w, "\tsecrets := pulumi.AdditionalSecretOutputs([]string{\n")
 		for _, sp := range secretProps {
 			fmt.Fprintf(w, "\t\t\t%q,\n", sp.Name)

--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -153,8 +153,8 @@ var PulumiPulumiSDKTests = []SDKTest{
 		SkipCompileCheck: codegen.NewStringSet(dotnet),
 	},
 	{
-		Directory:        "replace-on-change",
-		Description:      "Simple use of replaceOnChange in schema",
+		Directory:   "replace-on-change",
+		Description: "Simple use of replaceOnChange in schema",
 	},
 	{
 		Directory:        "resource-property-overlap",

--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -155,7 +155,6 @@ var PulumiPulumiSDKTests = []SDKTest{
 	{
 		Directory:        "replace-on-change",
 		Description:      "Simple use of replaceOnChange in schema",
-		SkipCompileCheck: codegen.NewStringSet(golang),
 	},
 	{
 		Directory:        "resource-property-overlap",

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/cat.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/cat.go
@@ -27,9 +27,6 @@ func NewCat(ctx *pulumi.Context,
 		args = &CatArgs{}
 	}
 
-	if args.Name != nil {
-		args.Name = pulumi.ToSecret(args.Name).(pulumi.StringPtrOutput)
-	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"name",
 	})

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/foo.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-random/sdk/v2/go/random"
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test/testdata/simple-methods-schema/go/example/nested"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/schema.json
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/schema.json
@@ -53,13 +53,13 @@
             "plain": true
           },
           "name": {
-            "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
           },
           "nameRequired": {
-            "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
           },
           "namePlain": {
-            "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet",
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet",
             "plain": true
           },
           "baz": {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
@@ -218,7 +218,15 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd></dl>
+    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="baz_csharp">
+<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">string</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language go %}}
@@ -230,7 +238,15 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd></dl>
+    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="baz_go">
+<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">string</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language nodejs %}}
@@ -242,7 +258,15 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
     </dt>
-    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd></dl>
+    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="baz_nodejs">
+<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">string</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language python %}}
@@ -254,7 +278,15 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
     </dt>
-    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd></dl>
+    <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="baz_python">
+<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">str</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
@@ -15,6 +15,9 @@ namespace Pulumi.Example
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
 
+        [Output("baz")]
+        public Output<string?> Baz { get; private set; } = null!;
+
 
         /// <summary>
         /// Create a Resource resource with the given unique name, arguments, and options.
@@ -42,6 +45,7 @@ namespace Pulumi.Example
                 AdditionalSecretOutputs =
                 {
                     "bar",
+                    "baz",
                 },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
@@ -14,6 +14,7 @@ type Resource struct {
 	pulumi.CustomResourceState
 
 	Bar pulumi.StringPtrOutput `pulumi:"bar"`
+	Baz pulumi.StringPtrOutput `pulumi:"baz"`
 }
 
 // NewResource registers a new resource with the given unique name, arguments, and options.
@@ -28,6 +29,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"bar",
+		"baz",
 	})
 	opts = append(opts, secrets)
 	opts = pkgResourceDefaultOpts(opts)

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/resource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/resource.ts
@@ -32,6 +32,7 @@ export class Resource extends pulumi.CustomResource {
     }
 
     public readonly bar!: pulumi.Output<string | undefined>;
+    public /*out*/ readonly baz!: pulumi.Output<string | undefined>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -45,11 +46,13 @@ export class Resource extends pulumi.CustomResource {
         opts = opts || {};
         if (!opts.id) {
             resourceInputs["bar"] = args?.bar ? pulumi.secret(args.bar) : undefined;
+            resourceInputs["baz"] = undefined /*out*/;
         } else {
             resourceInputs["bar"] = undefined /*out*/;
+            resourceInputs["baz"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const secretOpts = { additionalSecretOutputs: ["bar"] };
+        const secretOpts = { additionalSecretOutputs: ["bar", "baz"] };
         opts = pulumi.mergeOptions(opts, secretOpts);
         super(Resource.__pulumiType, name, resourceInputs, opts);
     }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -81,7 +81,8 @@ class Resource(pulumi.CustomResource):
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
             __props__.__dict__["bar"] = None if bar is None else pulumi.Output.secret(bar)
-        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["bar"])
+            __props__.__dict__["baz"] = None
+        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["bar", "baz"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(Resource, __self__).__init__(
             'example::Resource',
@@ -106,10 +107,16 @@ class Resource(pulumi.CustomResource):
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
         __props__.__dict__["bar"] = None
+        __props__.__dict__["baz"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @property
     @pulumi.getter
     def bar(self) -> pulumi.Output[Optional[str]]:
         return pulumi.get(self, "bar")
+
+    @property
+    @pulumi.getter
+    def baz(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "baz")
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/schema.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/schema.json
@@ -112,6 +112,10 @@
         "bar": {
           "type": "string",
           "secret": true
+        },
+        "baz": {
+          "type": "string",
+          "secret": true
         }
       },
       "inputProperties": {


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
#7128 added code to mark properties as secret based on a schema flag, but did not correctly handle the case where output properties do not have a corresponding input property. In this case, code was generated for nonexistent input properties, and would lead to a panic.

Fixes #8967

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
