### PR TITLE
Pass project path to tsnode

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,6 @@
 
 - [sdk/nodejs] - Fix Node `fs.rmdir` DeprecationWarning for Node JS 15.X+
   [#9044](https://github.com/pulumi/pulumi/pull/9044)
+
+- [sdk/nodejs] - `PULUMI_NODEJS_TSCONFIG_PATH` is now explicitly passed to tsnode for the tsconfig file.
+  [#9062](https://github.com/pulumi/pulumi/pull/9062)

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -175,6 +175,10 @@ export function run(
     if (typeScript) {
         tsnode.register({
             transpileOnly,
+            // PULUMI_NODEJS_TSCONFIG_PATH might be set to a config file such as "tsconfig.pulumi.yaml" which
+            // would not get picked up by tsnode by default, so we explicitly tell tsnode which config file to
+            // use (Which might just be ./tsconfig.yaml)
+            project: tsConfigPath,
             skipProject: skipProject,
             compilerOptions: {
                 target: "es6",


### PR DESCRIPTION
# Description

Fix https://github.com/pulumi/pulumi/discussions/9053

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
