### PR TITLE
Fix (Read,Invoke) denied default provider handling

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,6 @@
 
 - [sdk/nodejs] - Fix Node `fs.rmdir` DeprecationWarning for Node JS 15.X+
   [#9044](https://github.com/pulumi/pulumi/pull/9044)
+
+- [engine] - Fix deny default provider handling for Invokes and Reads.
+  [#9067](https://github.com/pulumi/pulumi/pull/9067)

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -134,7 +134,7 @@ func disableDefaultProviders(runInfo *EvalRunInfo, pkgs ...string) {
 	if _, ok, err := c.Get(key, false); err != nil {
 		panic(err)
 	} else if ok {
-		panic("disbaleDefaultProviders cannot be called twice")
+		panic("disableDefaultProviders cannot be called twice")
 	}
 	b, err := json.Marshal(pkgs)
 	if err != nil {
@@ -527,7 +527,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 // - enabled  vs disabled
 // - explicit vs default
 //
-// B exists as a sanity check, to ensure that we can still do perform arbitrary
+// B exists as a sanity check, to ensure that we can still perform arbitrary
 // operations that belong to other packages.
 func TestDisableDefaultProviders(t *testing.T) {
 	type TT struct {

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -666,8 +666,8 @@ func TestDisableDefaultProviders(t *testing.T) {
 					urn := newURN(event.Goal().Type, string(event.Goal().Name), event.Goal().Parent)
 					event.Done(&RegisterResult{
 						State: resource.NewState(event.Goal().Type, urn, true, false, event.Goal().ID, event.Goal().Properties,
-							resource.PropertyMap{}, event.Goal().Parent, false, false, event.Goal().Dependencies, nil, event.Goal().Provider, nil,
-							false, nil, nil, nil, "", 0, false),
+							resource.PropertyMap{}, event.Goal().Parent, false, false, event.Goal().Dependencies, nil,
+							event.Goal().Provider, nil, false, nil, nil, nil, "", 0, false),
 					})
 					registers++
 				default:

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -329,7 +329,7 @@ func (rm *queryResmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest)
 	if err != nil {
 		return nil, err
 	}
-	prov, err := getProviderFromSource(rm.reg, rm.defaultProviders, providerReq, req.GetProvider())
+	prov, err := getProviderFromSource(rm.reg, rm.defaultProviders, providerReq, req.GetProvider(), tok)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (rm *queryResmon) StreamInvoke(
 	if err != nil {
 		return err
 	}
-	prov, err := getProviderFromSource(rm.reg, rm.defaultProviders, providerReq, req.GetProvider())
+	prov, err := getProviderFromSource(rm.reg, rm.defaultProviders, providerReq, req.GetProvider(), tok)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func (rm *queryResmon) Call(ctx context.Context, req *pulumirpc.CallRequest) (*p
 	if err != nil {
 		return nil, err
 	}
-	prov, err := getProviderFromSource(rm.reg, rm.defaultProviders, providerReq, req.GetProvider())
+	prov, err := getProviderFromSource(rm.reg, rm.defaultProviders, providerReq, req.GetProvider(), tok)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When denying default providers was added, we had no special handling for
Reads and Invokes. This lead to confusing error messages. The fix (#8853)
involved checking on invokes. This check didn't apply to several types
of calls (Read) as well as blocking invokes with providers applied.

This PR fixes the logic to only deny providers when they are default
providers.

It also pushes the change into `getProviderFromSource`, which ensures
that this behavior is handled the same way (and correctly) for both
Invokes and Reads.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9055
Fixes #9060

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
