### PR TITLE
CI: split integration-and-codegen tests, reduce test parallelism

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -143,7 +143,7 @@ jobs:
   test:
     name: Test
     needs: build
-    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    uses: pulumi/pulumi/.github/workflows/test.yml@aaronfriel/ci-split
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       enable-coverage: true

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -57,7 +57,8 @@ jobs:
           - macos-latest
         test-subset:
           - integration
-          - integration-and-codegen
+          - integration-subtests
+          - codegen
           - auto
           - etc
         exclude:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
+      - name: Reduce test parallelism
+        if: ${{ matrix.test-subset == 'integration' && matrix.platform == 'windows-latest' }}
+        run: |
+          echo "Setting test parallelism to 1"
+          echo "TESTPARALLELISM=1" >> $GITHUB_ENV
       - name: Enable code coverage
         if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,14 @@ jobs:
           - macos-latest
         test-subset:
           - integration
-          - integration-and-codegen
+          - integration-subtests
+          - codegen
           - auto
           - etc
       fail-fast: false
+
+    env:
+      PULUMI_TEST_SUBSET: ${{ matrix.test-subset }}
 
     runs-on: ${{ matrix.platform }}
 
@@ -69,9 +73,6 @@ jobs:
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
-      - name: Set PULUMI_TEST_SUBSET env var
-        run: |
-          echo "PULUMI_TEST_SUBSET=${{ matrix.test-subset }}" >> $GITHUB_ENV
       - name: Enable code coverage
         if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test_pkg::
 	cd pkg && $(GO_TEST) ${PROJECT_PKGS}
 
 test_integration::
-	cd tests && $(GO_TEST) -p=1 ${TESTS_PKGS}
+	cd tests && $(GO_TEST) -p 1 ${TESTS_PKGS}
 
 tidy::
 	./scripts/tidy.sh

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PROJECT_PKGS    := $(shell cd ./pkg && go list ./... | grep -v /vendor/)
 TESTS_PKGS      := $(shell cd ./tests && go list -tags all ./... | grep -v tests/templates | grep -v /vendor/)
 VERSION         := $(shell pulumictl get version)
 
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 4
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running
 # `test_all` without the dependencies.

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -65,4 +65,5 @@ if shutil.which('gotestsum') is not None:
     sp.check_call(['gotestsum', '--jsonfile', json_file, '--junitfile', junit_file, '--'] + \
                   options_and_packages, shell=False)
 else:
+
     sp.check_call(['go', 'test'] + options_and_packages, shell=False)

--- a/scripts/test_subsets.py
+++ b/scripts/test_subsets.py
@@ -27,7 +27,7 @@ TEST_SUBSETS = {
         'github.com/pulumi/pulumi/tests/integration',
     ],
 
-    'integration-and-codegen': [
+    'integration-subtests': [
         'github.com/pulumi/pulumi/tests/integration/aliases',
         'github.com/pulumi/pulumi/tests/integration/custom_timeouts',
         'github.com/pulumi/pulumi/tests/integration/delete_before_create',
@@ -47,6 +47,9 @@ TEST_SUBSETS = {
         'github.com/pulumi/pulumi/tests/integration/targets',
         'github.com/pulumi/pulumi/tests/integration/transformations',
         'github.com/pulumi/pulumi/tests/integration/types',
+    ],
+
+    'codegen': [
         'github.com/pulumi/pulumi/pkg/v3/codegen',
         'github.com/pulumi/pulumi/pkg/v3/codegen/docs',
         'github.com/pulumi/pulumi/pkg/v3/codegen/dotnet',

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -6,7 +6,7 @@ PROJECT_ROOT    := $(realpath ../..)
 
 DOTNET_VERSION  := $(shell cd ../../ && pulumictl get version --language dotnet)
 
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 4
 
 include ../../build/common.mk
 

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -3,7 +3,7 @@ LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/go/pulumi-language-go
 VERSION          := $(shell cd ../../ && pulumictl get version)
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
-TESTPARALLELISM  := 10
+TESTPARALLELISM  ?= 4
 PROJECT_ROOT     := $(realpath ../..)
 
 include ../../build/common.mk

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -6,7 +6,7 @@ LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-n
 PROJECT_ROOT     := $(realpath ../..)
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 4
 TEST_FAST_TIMEOUT := 2m
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -8,7 +8,7 @@ PYENV := ./env
 PYENVSRC := $(PYENV)/src
 
 PROJECT_PKGS    := $(shell go list ./cmd/...)
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 4
 
 include ../../build/common.mk
 


### PR DESCRIPTION
Keep trunk green by mitigating CI failure on Windows.