### PR TITLE
ci, workaround: temporarily disable win tests to bypass OOM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
           - integration-and-codegen
           - auto
           - etc
+        # Workaround, test flaking on Windows. See ongoing issue https://github.com/pulumi/pulumi/issues/8820
+        exclude:
+          - platform: windows-latest
+        include:
+          - platform: windows-latest
+            test-subset: etc
       fail-fast: false
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
n/t