### PR TITLE
Make StackReference.Name a tokens.Name

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -73,7 +73,7 @@ type StackReference interface {
 	// Name is the name that will be passed to the Pulumi engine when preforming operations on this stack. This
 	// name may not uniquely identify the stack (e.g. the cloud backend embeds owner information in the StackReference
 	// but that information is not part of the StackName() we pass to the engine.
-	Name() tokens.QName
+	Name() tokens.Name
 }
 
 // PolicyPackReference is an opaque type that refers to a PolicyPack managed by a backend. The CLI

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -36,7 +36,7 @@ import (
 // it comes in. Once all events have been read from the channel and displayed, it closes the `done`
 // channel so the caller can await all the events being written.
 func ShowEvents(
-	op string, action apitype.UpdateKind, stack tokens.QName, proj tokens.PackageName,
+	op string, action apitype.UpdateKind, stack tokens.Name, proj tokens.PackageName,
 	events <-chan engine.Event, done chan<- bool, opts Options, isPreview bool) {
 
 	if opts.EventLogPath != "" {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -93,7 +93,7 @@ type ProgressDisplay struct {
 	// action is the kind of action (preview, update, refresh, etc) being performed.
 	action apitype.UpdateKind
 	// stack is the stack this progress pertains to.
-	stack tokens.QName
+	stack tokens.Name
 	// proj is the project this progress pertains to.
 	proj tokens.PackageName
 
@@ -270,7 +270,7 @@ func (display *ProgressDisplay) writeBlankLine() {
 }
 
 // ShowProgressEvents displays the engine events with docker's progress view.
-func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName, proj tokens.PackageName,
+func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Name, proj tokens.PackageName,
 	events <-chan engine.Event, done chan<- bool, opts Options, isPreview bool) {
 
 	stdout := opts.Stdout

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -290,7 +290,7 @@ func (data *resourceRowData) ColorizedColumns() []string {
 	urn := data.step.URN
 	if urn == "" {
 		// If we don't have a URN yet, mock parent it to the global stack.
-		urn = resource.DefaultRootStackURN(data.display.stack, data.display.proj)
+		urn = resource.DefaultRootStackURN(data.display.stack.Q(), data.display.proj)
 	}
 	name := string(urn.Name())
 	typ := simplifyTypeName(urn.Type())

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -80,14 +80,14 @@ type localBackend struct {
 }
 
 type localBackendReference struct {
-	name tokens.QName
+	name tokens.Name
 }
 
 func (r localBackendReference) String() string {
 	return string(r.name)
 }
 
-func (r localBackendReference) Name() tokens.QName {
+func (r localBackendReference) Name() tokens.Name {
 	return r.name
 }
 
@@ -254,7 +254,7 @@ func (b *localBackend) SupportsOrganizations() bool {
 }
 
 func (b *localBackend) ParseStackReference(stackRefName string) (backend.StackReference, error) {
-	return localBackendReference{name: tokens.QName(stackRefName)}, nil
+	return localBackendReference{name: tokens.Name(stackRefName)}, nil
 }
 
 // ValidateStackName verifies the stack name is valid for the local backend. We use the same rules as the
@@ -400,8 +400,10 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 		return nil, err
 	}
 
+	newStackName := newRef.Name()
+
 	// Ensure the destination stack does not already exist.
-	hasExisting, err := b.bucket.Exists(ctx, b.stackPath(newName))
+	hasExisting, err := b.bucket.Exists(ctx, b.stackPath(newStackName))
 	if err != nil {
 		return nil, err
 	}
@@ -411,13 +413,13 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 
 	// If we have a snapshot, we need to rename the URNs inside it to use the new stack name.
 	if snap != nil {
-		if err = edit.RenameStack(snap, newName, ""); err != nil {
+		if err = edit.RenameStack(snap, newStackName, ""); err != nil {
 			return nil, err
 		}
 	}
 
 	// Now save the snapshot with a new name (we pass nil to re-use the existing secrets manager from the snapshot).
-	if _, err = b.saveStack(newName, snap, nil); err != nil {
+	if _, err = b.saveStack(newStackName, snap, nil); err != nil {
 		return nil, err
 	}
 
@@ -426,7 +428,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 	backupTarget(b.bucket, file)
 
 	// And rename the histoy folder as well.
-	if err = b.renameHistory(stackName, newName); err != nil {
+	if err = b.renameHistory(stackName, newStackName); err != nil {
 		return nil, err
 	}
 	return newRef, err
@@ -813,8 +815,8 @@ func (b *localBackend) CurrentUser() (string, error) {
 	return user.Username, nil
 }
 
-func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
-	var stacks []tokens.QName
+func (b *localBackend) getLocalStacks() ([]tokens.Name, error) {
+	var stacks []tokens.Name
 
 	// Read the stack directory.
 	path := b.stackPath("")
@@ -838,7 +840,7 @@ func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
 		}
 
 		// Read in this stack's information.
-		name := tokens.QName(stackfn[:len(stackfn)-len(ext)])
+		name := tokens.AsName(stackfn[:len(stackfn)-len(ext)])
 
 		stacks = append(stacks, name)
 	}

--- a/pkg/backend/filestate/lock.go
+++ b/pkg/backend/filestate/lock.go
@@ -142,12 +142,12 @@ func lockDir() string {
 	return path.Join(workspace.BookkeepingDir, workspace.LockDir)
 }
 
-func stackLockDir(stack tokens.QName) string {
+func stackLockDir(stack tokens.Name) string {
 	contract.Require(stack != "", "stack")
-	return path.Join(lockDir(), fsutil.QnamePath(stack))
+	return path.Join(lockDir(), fsutil.NamePath(stack))
 }
 
-func (b *localBackend) lockPath(stack tokens.QName) string {
+func (b *localBackend) lockPath(stack tokens.Name) string {
 	contract.Require(stack != "", "stack")
 	return path.Join(stackLockDir(stack), b.lockID+".json")
 }

--- a/pkg/backend/filestate/snapshot.go
+++ b/pkg/backend/filestate/snapshot.go
@@ -23,7 +23,7 @@ import (
 // localSnapshotManager is a simple SnapshotManager implementation that persists snapshots
 // to disk on the local machine.
 type localSnapshotPersister struct {
-	name    tokens.QName
+	name    tokens.Name
 	backend *localBackend
 	sm      secrets.Manager
 }
@@ -38,6 +38,6 @@ func (sp *localSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 
 }
 
-func (b *localBackend) newSnapshotPersister(stackName tokens.QName, sm secrets.Manager) *localSnapshotPersister {
+func (b *localBackend) newSnapshotPersister(stackName tokens.Name, sm secrets.Manager) *localSnapshotPersister {
 	return &localSnapshotPersister{name: stackName, backend: b, sm: sm}
 }

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -93,7 +93,7 @@ func (b *localBackend) newQuery(ctx context.Context,
 	return &localQuery{root: op.Root, proj: op.Proj}, nil
 }
 
-func (b *localBackend) newUpdate(stackName tokens.QName, op backend.UpdateOperation) (*update, error) {
+func (b *localBackend) newUpdate(stackName tokens.Name, op backend.UpdateOperation) (*update, error) {
 	contract.Require(stackName != "", "stackName")
 
 	// Construct the deployment target.
@@ -111,7 +111,7 @@ func (b *localBackend) newUpdate(stackName tokens.QName, op backend.UpdateOperat
 	}, nil
 }
 
-func (b *localBackend) getTarget(stackName tokens.QName, cfg config.Map, dec config.Decrypter) (*deploy.Target, error) {
+func (b *localBackend) getTarget(stackName tokens.Name, cfg config.Map, dec config.Decrypter) (*deploy.Target, error) {
 	snapshot, _, err := b.getStack(stackName)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func (b *localBackend) getTarget(stackName tokens.QName, cfg config.Map, dec con
 	}, nil
 }
 
-func (b *localBackend) getStack(name tokens.QName) (*deploy.Snapshot, string, error) {
+func (b *localBackend) getStack(name tokens.Name) (*deploy.Snapshot, string, error) {
 	if name == "" {
 		return nil, "", errors.New("invalid empty stack name")
 	}
@@ -153,7 +153,7 @@ func (b *localBackend) getStack(name tokens.QName) (*deploy.Snapshot, string, er
 }
 
 // GetCheckpoint loads a checkpoint file for the given stack in this project, from the current project workspace.
-func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.CheckpointV3, error) {
+func (b *localBackend) getCheckpoint(stackName tokens.Name) (*apitype.CheckpointV3, error) {
 	chkpath := b.stackPath(stackName)
 	bytes, err := b.bucket.ReadAll(context.TODO(), chkpath)
 	if err != nil {
@@ -163,7 +163,7 @@ func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.Checkpoin
 	return stack.UnmarshalVersionedCheckpointToLatestCheckpoint(bytes)
 }
 
-func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm secrets.Manager) (string, error) {
+func (b *localBackend) saveStack(name tokens.Name, snap *deploy.Snapshot, sm secrets.Manager) (string, error) {
 	// Make a serializable stack and then use the encoder to encode it.
 	file := b.stackPath(name)
 	m, ext := encoding.Detect(file)
@@ -244,7 +244,7 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 }
 
 // removeStack removes information about a stack from the current workspace.
-func (b *localBackend) removeStack(name tokens.QName) error {
+func (b *localBackend) removeStack(name tokens.Name) error {
 	contract.Require(name != "", "name")
 
 	// Just make a backup of the file and don't write out anything new.
@@ -267,7 +267,7 @@ func backupTarget(bucket Bucket, file string) string {
 }
 
 // backupStack copies the current Checkpoint file to ~/.pulumi/backups.
-func (b *localBackend) backupStack(name tokens.QName) error {
+func (b *localBackend) backupStack(name tokens.Name) error {
 	contract.Require(name != "", "name")
 
 	// Exit early if backups are disabled.
@@ -293,28 +293,28 @@ func (b *localBackend) backupStack(name tokens.QName) error {
 	return b.bucket.WriteAll(context.TODO(), filepath.Join(backupDir, backupFile), byts, nil)
 }
 
-func (b *localBackend) stackPath(stack tokens.QName) string {
+func (b *localBackend) stackPath(stack tokens.Name) string {
 	path := filepath.Join(b.StateDir(), workspace.StackDir)
 	if stack != "" {
-		path = filepath.Join(path, fsutil.QnamePath(stack)+".json")
+		path = filepath.Join(path, fsutil.NamePath(stack)+".json")
 	}
 
 	return path
 }
 
-func (b *localBackend) historyDirectory(stack tokens.QName) string {
+func (b *localBackend) historyDirectory(stack tokens.Name) string {
 	contract.Require(stack != "", "stack")
-	return filepath.Join(b.StateDir(), workspace.HistoryDir, fsutil.QnamePath(stack))
+	return filepath.Join(b.StateDir(), workspace.HistoryDir, fsutil.NamePath(stack))
 }
 
-func (b *localBackend) backupDirectory(stack tokens.QName) string {
+func (b *localBackend) backupDirectory(stack tokens.Name) string {
 	contract.Require(stack != "", "stack")
-	return filepath.Join(b.StateDir(), workspace.BackupDir, fsutil.QnamePath(stack))
+	return filepath.Join(b.StateDir(), workspace.BackupDir, fsutil.NamePath(stack))
 }
 
 // getHistory returns locally stored update history. The first element of the result will be
 // the most recent update record.
-func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]backend.UpdateInfo, error) {
+func (b *localBackend) getHistory(name tokens.Name, pageSize int, page int) ([]backend.UpdateInfo, error) {
 	contract.Require(name != "", "name")
 
 	dir := b.historyDirectory(name)
@@ -381,7 +381,7 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 	return updates, nil
 }
 
-func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName) error {
+func (b *localBackend) renameHistory(oldName tokens.Name, newName tokens.Name) error {
 	contract.Require(oldName != "", "oldName")
 	contract.Require(newName != "", "newName")
 
@@ -418,7 +418,7 @@ func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName)
 }
 
 // addToHistory saves the UpdateInfo and makes a copy of the current Checkpoint file.
-func (b *localBackend) addToHistory(name tokens.QName, update backend.UpdateInfo) error {
+func (b *localBackend) addToHistory(name tokens.Name, update backend.UpdateInfo) error {
 	contract.Require(name != "", "name")
 
 	dir := b.historyDirectory(name)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -557,7 +557,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	return cloudBackendReference{
 		owner:   qualifiedName.Owner,
 		project: qualifiedName.Project,
-		name:    tokens.QName(qualifiedName.Name),
+		name:    tokens.AsName(qualifiedName.Name),
 		b:       b,
 	}, nil
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -554,6 +554,10 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 		qualifiedName.Project = currentProject.Name.String()
 	}
 
+	if !tokens.IsName(qualifiedName.Name) {
+		return nil, errors.New("stack names may only contain alphanumeric, hyphens, underscores, and periods")
+	}
+
 	return cloudBackendReference{
 		owner:   qualifiedName.Owner,
 		project: qualifiedName.Project,

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -42,7 +42,7 @@ type Stack interface {
 }
 
 type cloudBackendReference struct {
-	name    tokens.QName
+	name    tokens.Name
 	project string
 	owner   string
 	b       *cloudBackend
@@ -65,7 +65,7 @@ func (c cloudBackendReference) String() string {
 	return fmt.Sprintf("%s/%s/%s", c.owner, c.project, c.name)
 }
 
-func (c cloudBackendReference) Name() tokens.QName {
+func (c cloudBackendReference) Name() tokens.Name {
 	return c.name
 }
 
@@ -93,7 +93,7 @@ func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
 		ref: cloudBackendReference{
 			owner:   apistack.OrgName,
 			project: apistack.ProjectName,
-			name:    apistack.StackName,
+			name:    tokens.AsName(apistack.StackName.String()),
 			b:       b,
 		},
 		cloudURL:         b.CloudURL(),
@@ -198,7 +198,7 @@ func (css cloudStackSummary) Name() backend.StackReference {
 	return cloudBackendReference{
 		owner:   css.summary.OrgName,
 		project: css.summary.ProjectName,
-		name:    tokens.QName(css.summary.StackName),
+		name:    tokens.AsName(css.summary.StackName),
 		b:       css.b,
 	}
 }

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -672,21 +672,21 @@ var stackConfigFile string
 
 func getProjectStackPath(stack backend.Stack) (string, error) {
 	if stackConfigFile == "" {
-		return workspace.DetectProjectStackPath(stack.Ref().Name())
+		return workspace.DetectProjectStackPath(stack.Ref().Name().Q())
 	}
 	return stackConfigFile, nil
 }
 
 func loadProjectStack(stack backend.Stack) (*workspace.ProjectStack, error) {
 	if stackConfigFile == "" {
-		return workspace.DetectProjectStack(stack.Ref().Name())
+		return workspace.DetectProjectStack(stack.Ref().Name().Q())
 	}
 	return workspace.LoadProjectStack(stackConfigFile)
 }
 
 func saveProjectStack(stack backend.Stack, ps *workspace.ProjectStack) error {
 	if stackConfigFile == "" {
-		return workspace.SaveProjectStack(stack.Ref().Name(), ps)
+		return workspace.SaveProjectStack(stack.Ref().Name().Q(), ps)
 	}
 	return ps.Save(stackConfigFile)
 }

--- a/pkg/cmd/pulumi/crypto_cloud.go
+++ b/pkg/cmd/pulumi/crypto_cloud.go
@@ -24,11 +24,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newCloudSecretsManager(stackName tokens.QName, configFile, secretsProvider string) (secrets.Manager, error) {
+func newCloudSecretsManager(stackName tokens.Name, configFile, secretsProvider string) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
 	if configFile == "" {
-		f, err := workspace.DetectProjectStackPath(stackName)
+		f, err := workspace.DetectProjectStackPath(stackName.Q())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/crypto_http.go
+++ b/pkg/cmd/pulumi/crypto_http.go
@@ -23,11 +23,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newServiceSecretsManager(s httpstate.Stack, stackName tokens.QName, configFile string) (secrets.Manager, error) {
+func newServiceSecretsManager(s httpstate.Stack, stackName tokens.Name, configFile string) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
 	if configFile == "" {
-		f, err := workspace.DetectProjectStackPath(stackName)
+		f, err := workspace.DetectProjectStackPath(stackName.Q())
 		if err != nil {
 			return nil, err
 		}
@@ -51,7 +51,7 @@ func newServiceSecretsManager(s httpstate.Stack, stackName tokens.QName, configF
 	// reload the configuration file to be sorted or an empty {} when creating a stack
 	// this is not the desired behaviour.
 	if changeProjectStackSecretDetails(info) {
-		if err := workspace.SaveProjectStack(stackName, info); err != nil {
+		if err := workspace.SaveProjectStack(stackName.Q(), info); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cmd/pulumi/crypto_local.go
+++ b/pkg/cmd/pulumi/crypto_local.go
@@ -22,12 +22,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newPassphraseSecretsManager(stackName tokens.QName, configFile string,
+func newPassphraseSecretsManager(stackName tokens.Name, configFile string,
 	rotatePassphraseSecretsProvider bool) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
 	if configFile == "" {
-		f, err := workspace.DetectProjectStackPath(stackName)
+		f, err := workspace.DetectProjectStackPath(stackName.Q())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -202,7 +202,7 @@ func getCurrentDeploymentForStack(s backend.Stack) (*deploy.Snapshot, error) {
 
 type programGeneratorFunc func(p *pcl.Program) (map[string][]byte, hcl.Diagnostics, error)
 
-func generateImportedDefinitions(out io.Writer, stackName tokens.QName, projectName tokens.PackageName,
+func generateImportedDefinitions(out io.Writer, stackName tokens.Name, projectName tokens.PackageName,
 	snap *deploy.Snapshot, programGenerator programGeneratorFunc, names importer.NameTable,
 	imports []deploy.Import, protectResources bool) (bool, error) {
 
@@ -233,7 +233,7 @@ func generateImportedDefinitions(out io.Writer, stackName tokens.QName, projectN
 		if i.Parent != "" {
 			parentType = i.Parent.QualifiedType()
 		}
-		urn := resource.NewURN(stackName, projectName, parentType, i.Type, i.Name)
+		urn := resource.NewURN(stackName.Q(), projectName, parentType, i.Type, i.Name)
 		if state, ok := resourceTable[urn]; ok {
 			// Copy the state and override the protect bit.
 			s := *state

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -82,7 +82,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 			var result error
 			for _, res := range snapshot.Resources {
-				if res.URN.Stack() != stackName {
+				if res.URN.Stack() != stackName.Q() {
 					msg := fmt.Sprintf("resource '%s' is from a different stack (%s != %s)",
 						res.URN, res.URN.Stack(), stackName)
 					if force {

--- a/pkg/cmd/pulumi/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack_ls_test.go
@@ -76,8 +76,8 @@ type mockStackReference struct {
 	name string
 }
 
-func (msr *mockStackReference) Name() tokens.QName {
-	return tokens.QName(msr.name)
+func (msr *mockStackReference) Name() tokens.Name {
+	return tokens.Name(msr.name)
 }
 
 func (msr *mockStackReference) String() string {

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -55,7 +55,7 @@ func newStackRenameCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			oldConfigPath, err := workspace.DetectProjectStackPath(s.Ref().Name())
+			oldConfigPath, err := workspace.DetectProjectStackPath(s.Ref().Name().Q())
 			if err != nil {
 				return err
 			}
@@ -66,7 +66,7 @@ func newStackRenameCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			newConfigPath, err := workspace.DetectProjectStackPath(newStackRef.Name())
+			newConfigPath, err := workspace.DetectProjectStackPath(newStackRef.Name().Q())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -82,7 +82,7 @@ func newStackRmCmd() *cobra.Command {
 
 			if !preserveConfig {
 				// Blow away stack specific settings if they exist. If we get an ENOENT error, ignore it.
-				if path, err := workspace.DetectProjectStackPath(s.Ref().Name()); err == nil {
+				if path, err := workspace.DetectProjectStackPath(s.Ref().Name().Q()); err == nil {
 					if err = os.Remove(path); err != nil && !os.IsNotExist(err) {
 						return result.FromError(err)
 					}

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -160,7 +160,7 @@ type TestPlan struct {
 }
 
 //nolint: goconst
-func (p *TestPlan) getNames() (stack tokens.QName, project tokens.PackageName, runtime string) {
+func (p *TestPlan) getNames() (stack tokens.Name, project tokens.PackageName, runtime string) {
 	project = tokens.PackageName(p.Project)
 	if project == "" {
 		project = "test"
@@ -169,7 +169,7 @@ func (p *TestPlan) getNames() (stack tokens.QName, project tokens.PackageName, r
 	if runtime == "" {
 		runtime = "test"
 	}
-	stack = tokens.QName(p.Stack)
+	stack = tokens.Name(p.Stack)
 	if stack == "" {
 		stack = "test"
 	}
@@ -182,7 +182,7 @@ func (p *TestPlan) NewURN(typ tokens.Type, name string, parent resource.URN) res
 	if parent != "" {
 		pt = parent.Type()
 	}
-	return resource.NewURN(stack, project, pt, typ, tokens.QName(name))
+	return resource.NewURN(stack.Q(), project, pt, typ, tokens.QName(name))
 }
 
 func (p *TestPlan) NewProviderURN(pkg tokens.Package, name string, parent resource.URN) resource.URN {

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -416,12 +416,12 @@ func (d *Deployment) generateURN(parent resource.URN, ty tokens.Type, name token
 		parentType = parent.QualifiedType()
 	}
 
-	return resource.NewURN(d.Target().Name, d.source.Project(), parentType, ty, name)
+	return resource.NewURN(d.Target().Name.Q(), d.source.Project(), parentType, ty, name)
 }
 
 // defaultProviderURN generates the URN for the global provider given a package.
 func defaultProviderURN(target *Target, source Source, pkg tokens.Package) resource.URN {
-	return resource.NewURN(target.Name, source.Project(), "", providers.MakeProviderType(pkg), "default")
+	return resource.NewURN(target.Name.Q(), source.Project(), "", providers.MakeProviderType(pkg), "default")
 }
 
 // generateEventURN generates a URN for the resource associated with the given event.

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -166,7 +166,7 @@ func (i *importer) getOrCreateStackResource(ctx context.Context) (resource.URN, 
 
 	projectName, stackName := i.deployment.source.Project(), i.deployment.target.Name
 	typ, name := resource.RootStackType, fmt.Sprintf("%s-%s", projectName, stackName)
-	urn := resource.NewURN(stackName, projectName, "", typ, tokens.QName(name))
+	urn := resource.NewURN(stackName.Q(), projectName, "", typ, tokens.QName(name))
 	state := resource.NewState(typ, urn, false, false, "", resource.PropertyMap{}, nil, "", false, false, nil, nil, "",
 		nil, false, nil, nil, nil, "", 0, false)
 	// TODO(seqnum) should stacks be created with 1? When do they ever get recreated/replaced?

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -85,7 +85,7 @@ func (src *evalSource) Project() tokens.PackageName {
 }
 
 // Stack is the name of the stack being targeted by this evaluation source.
-func (src *evalSource) Stack() tokens.QName {
+func (src *evalSource) Stack() tokens.Name {
 	return src.runinfo.Target.Name
 }
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -157,7 +157,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 		if parent != "" {
 			pt = parent.Type()
 		}
-		return resource.NewURN(runInfo.Target.Name, runInfo.Proj.Name, pt, t, tokens.QName(name))
+		return resource.NewURN(runInfo.Target.Name.Q(), runInfo.Proj.Name, pt, t, tokens.QName(name))
 	}
 
 	newProviderURN := func(pkg tokens.Package, name string, parent resource.URN) resource.URN {
@@ -254,7 +254,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 		if parent != "" {
 			pt = parent.Type()
 		}
-		return resource.NewURN(runInfo.Target.Name, runInfo.Proj.Name, pt, t, tokens.QName(name))
+		return resource.NewURN(runInfo.Target.Name.Q(), runInfo.Proj.Name, pt, t, tokens.QName(name))
 	}
 
 	componentURN := newURN("component", "component", "")
@@ -346,7 +346,7 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 		if parent != "" {
 			pt = parent.Type()
 		}
-		return resource.NewURN(runInfo.Target.Name, runInfo.Proj.Name, pt, t, tokens.QName(name))
+		return resource.NewURN(runInfo.Target.Name.Q(), runInfo.Proj.Name, pt, t, tokens.QName(name))
 	}
 
 	newProviderURN := func(pkg tokens.Package, name string, parent resource.URN) resource.URN {
@@ -436,7 +436,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 		if parent != "" {
 			pt = parent.Type()
 		}
-		return resource.NewURN(runInfo.Target.Name, runInfo.Proj.Name, pt, t, tokens.QName(name))
+		return resource.NewURN(runInfo.Target.Name.Q(), runInfo.Proj.Name, pt, t, tokens.QName(name))
 	}
 
 	invokes := int32(0)
@@ -574,7 +574,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 				if parent != "" {
 					pt = parent.Type()
 				}
-				return resource.NewURN(runInfo.Target.Name, runInfo.Proj.Name, pt, t, tokens.QName(name))
+				return resource.NewURN(runInfo.Target.Name.Q(), runInfo.Proj.Name, pt, t, tokens.QName(name))
 			}
 
 			newProviderURN := func(pkg tokens.Package, name string, parent resource.URN) resource.URN {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1718,7 +1718,7 @@ func (sg *stepGenerator) AnalyzeResources() result.Result {
 				}
 			}
 			if urn == "" {
-				urn = resource.DefaultRootStackURN(sg.deployment.Target().Name, sg.deployment.source.Project())
+				urn = resource.DefaultRootStackURN(sg.deployment.Target().Name.Q(), sg.deployment.source.Project())
 			}
 			sg.opts.Events.OnPolicyViolation(urn, d)
 		}

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -22,7 +22,7 @@ import (
 
 // Target represents information about a deployment target.
 type Target struct {
-	Name      tokens.QName     // the target stack name.
+	Name      tokens.Name      // the target stack name.
 	Config    config.Map       // optional configuration key/value pairs.
 	Decrypter config.Decrypter // decrypter for secret configuration values.
 	Snapshot  *Snapshot        // the last snapshot deployed to the target.

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -98,7 +98,7 @@ func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 
 // RenameStack changes the `stackName` component of every URN in a snapshot. In addition, it rewrites the name of
 // the root Stack resource itself. May optionally change the project/package name as well.
-func RenameStack(snap *deploy.Snapshot, newName tokens.QName, newProject tokens.PackageName) error {
+func RenameStack(snap *deploy.Snapshot, newName tokens.Name, newProject tokens.PackageName) error {
 	contract.Require(snap != nil, "snap")
 
 	rewriteUrn := func(u resource.URN) resource.URN {
@@ -110,10 +110,10 @@ func RenameStack(snap *deploy.Snapshot, newName tokens.QName, newProject tokens.
 		// The pulumi:pulumi:Stack resource's name component is of the form `<project>-<stack>` so we want
 		// to rename the name portion as well.
 		if u.QualifiedType() == "pulumi:pulumi:Stack" {
-			return resource.NewURN(newName, project, "", u.QualifiedType(), tokens.QName(project)+"-"+newName)
+			return resource.NewURN(newName.Q(), project, "", u.QualifiedType(), tokens.QName(project)+"-"+newName.Q())
 		}
 
-		return resource.NewURN(newName, project, "", u.QualifiedType(), u.Name())
+		return resource.NewURN(newName.Q(), project, "", u.QualifiedType(), u.Name())
 	}
 
 	rewriteState := func(res *resource.State) {

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -288,7 +288,7 @@ func TestRenameStack(t *testing.T) {
 
 	// Rename just the stack.
 	t.Run("JustTheStack", func(t *testing.T) {
-		err := RenameStack(snap, tokens.QName("new-stack"), tokens.PackageName(""))
+		err := RenameStack(snap, tokens.Name("new-stack"), tokens.PackageName(""))
 		if err != nil {
 			t.Fatalf("Error renaming stack: %v", err)
 		}
@@ -307,7 +307,7 @@ func TestRenameStack(t *testing.T) {
 
 	// Rename the stack and project.
 	t.Run("StackAndProject", func(t *testing.T) {
-		err := RenameStack(snap, tokens.QName("new-stack2"), tokens.PackageName("new-project"))
+		err := RenameStack(snap, tokens.Name("new-stack2"), tokens.PackageName("new-project"))
 		if err != nil {
 			t.Fatalf("Error renaming stack: %v", err)
 		}

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -77,7 +77,7 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(bytes []byte) (*apitype.Chec
 }
 
 // SerializeCheckpoint turns a snapshot into a data structure suitable for serialization.
-func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
+func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
 	sm secrets.Manager, showSecrets bool) (*apitype.VersionedCheckpoint, error) {
 	// If snap is nil, that's okay, we will just create an empty deployment; otherwise, serialize the whole snapshot.
 	var latest *apitype.DeploymentV3
@@ -90,7 +90,7 @@ func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
 	}
 
 	b, err := json.Marshal(apitype.CheckpointV3{
-		Stack:  stack,
+		Stack:  stack.Q(),
 		Latest: latest,
 	})
 	if err != nil {

--- a/sdk/go/common/util/fsutil/qname.go
+++ b/sdk/go/common/util/fsutil/qname.go
@@ -25,3 +25,10 @@ import (
 func QnamePath(nm tokens.QName) string {
 	return strings.Replace(string(nm), tokens.QNameDelimiter, string(os.PathSeparator), -1)
 }
+
+// NamePath just cleans a name and makes sure it's appropriate to use as a path.
+func NamePath(nm tokens.Name) string {
+	// Currently we assume this is a no-op because the set of chars allowed in a Name [A-Za-z0-9_.-] are also
+	// valid file names
+	return string(nm)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Stack names don't allow "/" delimiters and as such are `tokens.Name`s not `tokens.QNames`. This goes through the "pkg" side of the codebase to change uses of stack names into `tokens.Name`, mostly this is around the `StackReference` and backend types.

As part of 4.0 we ought to follow these changes through to the "sdk" side of the codebase as well.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
