### PR TITLE
Fixes #9065: uncaught error "ENOENT: no such file or directory" 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+  [sdk/nodejs] - Fix uncaught error "ENOENT: no such file or directory" when an error occurs during the stack up
+  [#9065](https://github.com/pulumi/pulumi/issues/9065)

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -238,6 +238,11 @@ Event: ${line}\n${e.toString()}`);
             [upResult, logResult] = await Promise.all([upPromise, logPromise]);
         } catch (e) {
             didError = true;
+            if(!logResult) {
+                // Get log result even if error occurs
+                logResult = await logPromise;
+            }
+
             throw e;
         } finally {
             onExit(didError);

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -233,20 +233,14 @@ Event: ${line}\n${e.toString()}`);
 
         const upPromise = this.runPulumiCmd(args, opts?.onOutput);
         let upResult: CommandResult;
-        let logResult: ReadlineResult | undefined;
         try {
-            [upResult, logResult] = await Promise.all([upPromise, logPromise]);
+            upResult = await upPromise;
         } catch (e) {
             didError = true;
-            if(!logResult) {
-                // Get log result even if error occurs
-                logResult = await logPromise;
-            }
-
             throw e;
         } finally {
             onExit(didError);
-            await cleanUp(logFile, logResult);
+            await cleanUp(logFile, await logPromise);
         }
 
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050


### PR DESCRIPTION
# Description

Fixes #9065: uncaught error "ENOENT: no such file or directory" when an error occurs during the stack up

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
  _Suggestion of where to write it ?_
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
