### PR TITLE
Support `pulumi cancel` for filestate backend

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- [cli/backend] - `pulumi cancel` is now supported for the file state backend.
+  [#9100](https://github.com/pulumi/pulumi/pull/9100)
+
 ### Bug Fixes
 
 - [sdk/nodejs] - Fix Node `fs.rmdir` DeprecationWarning for Node JS 15.X+

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -201,6 +201,9 @@ type Backend interface {
 	LogoutAll() error
 	// Returns the identity of the current user for the backend.
 	CurrentUser() (string, error)
+
+	// Cancel the current update for the given stack.
+	CancelCurrentUpdate(ctx context.Context, stackRef StackReference) error
 }
 
 // SpecificDeploymentExporter is an interface defining an additional capability of a Backend, specifically the

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -861,3 +861,17 @@ func (b *localBackend) UpdateStackTags(ctx context.Context,
 	// The local backend does not currently persist tags.
 	return errors.New("stack tags not supported in --local mode")
 }
+
+func (b *localBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend.StackReference) error {
+	// Try to delete the lock file
+	err := b.bucket.Delete(ctx, b.lockPath(stackRef.Name()))
+	if err != nil {
+		// Don't error if it just wasn't found
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -107,7 +107,6 @@ type Backend interface {
 
 	CloudURL() string
 
-	CancelCurrentUpdate(ctx context.Context, stackRef backend.StackReference) error
 	StackConsoleURL(stackRef backend.StackReference) (string, error)
 	Client() *client.Client
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -70,6 +70,8 @@ type MockBackend struct {
 		UpdateOperation, []string) result.Result
 	GetLogsF func(context.Context, Stack, StackConfiguration,
 		operations.LogQuery) ([]operations.LogEntry, error)
+
+	CancelCurrentUpdateF func(ctx context.Context, stackRef StackReference) error
 }
 
 var _ Backend = (*MockBackend)(nil)
@@ -322,6 +324,13 @@ func (be *MockBackend) LogoutAll() error {
 func (be *MockBackend) CurrentUser() (string, error) {
 	if be.CurrentUserF != nil {
 		return be.CurrentUserF()
+	}
+	panic("not implemented")
+}
+
+func (be *MockBackend) CancelCurrentUpdate(ctx context.Context, stackRef StackReference) error {
+	if be.CancelCurrentUpdateF != nil {
+		return be.CancelCurrentUpdateF(ctx, stackRef)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
@@ -61,12 +60,6 @@ func newCancelCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			// Ensure that we are targeting the Pulumi cloud.
-			backend, ok := s.Backend().(httpstate.Backend)
-			if !ok {
-				return result.Error("the `cancel` command is not supported for local stacks")
-			}
-
 			// Ensure the user really wants to do this.
 			stackName := string(s.Ref().Name())
 			prompt := fmt.Sprintf("This will irreversibly cancel the currently running update for '%s'!", stackName)
@@ -76,7 +69,7 @@ func newCancelCmd() *cobra.Command {
 			}
 
 			// Cancel the update.
-			if err := backend.CancelCurrentUpdate(commandContext(), s.Ref()); err != nil {
+			if err := s.Backend().CancelCurrentUpdate(commandContext(), s.Ref()); err != nil {
 				return result.FromError(err)
 			}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Does what it says on the tin, supports `pulumi cancel` for the filestate backend.

Part of https://github.com/pulumi/pulumi/issues/4605

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
