### PR TITLE
Remove type test in `org set-default`

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -230,10 +230,6 @@ func loginWithBrowser(ctx context.Context, d diag.Sink, cloudURL string, opts di
 	return New(d, cloudURL)
 }
 
-func SetDefaultOrg(url string, orgName string) error {
-	return workspace.SetBackendConfigDefaultOrg(url, orgName)
-}
-
 // Login logs into the target cloud URL and returns the cloud backend for it.
 func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Options) (Backend, error) {
 	cloudURL = ValueOrDefaultURL(cloudURL)

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -142,7 +142,7 @@ func newLoginCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					if err := httpstate.SetDefaultOrg(cloudURL, defaultOrg); err != nil {
+					if err := workspace.SetBackendConfigDefaultOrg(cloudURL, defaultOrg); err != nil {
 						return err
 					}
 				}

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -93,14 +92,12 @@ func newOrgSetDefaultCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			if _, ok := currentBe.(httpstate.Backend); ok {
-				cloudURL, err := workspace.GetCurrentCloudURL()
-				if err != nil {
-					return err
-				}
-				if err := httpstate.SetDefaultOrg(cloudURL, orgName); err != nil {
-					return err
-				}
+			cloudURL, err := workspace.GetCurrentCloudURL()
+			if err != nil {
+				return err
+			}
+			if err := workspace.SetBackendConfigDefaultOrg(cloudURL, orgName); err != nil {
+				return err
 			}
 
 			return nil


### PR DESCRIPTION
We've already tested if the current backend supports Organizations.
There's no need to type test for the httpstate.Backend as well.

Also remove `httpstate.SetDefaultOrg` which was just a straight call to `workspace.SetBackendConfigDefaultOrg`.