### PR TITLE
Move `StackIdentifier` to httpstate.Backend

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -110,6 +110,7 @@ type Backend interface {
 	CancelCurrentUpdate(ctx context.Context, stackRef backend.StackReference) error
 	StackConsoleURL(stackRef backend.StackReference) (string, error)
 	Client() *client.Client
+	StackIdentifier(stackRef backend.StackReference) client.StackIdentifier
 }
 
 type cloudBackend struct {
@@ -1488,6 +1489,12 @@ func (b *cloudBackend) UpdateStackTags(ctx context.Context,
 	}
 
 	return b.client.UpdateStackTags(ctx, stackID, tags)
+}
+
+func (b *cloudBackend) StackIdentifier(stackRef backend.StackReference) client.StackIdentifier {
+	si, err := b.getCloudStackIdentifier(stackRef)
+	contract.AssertNoError(err) // the above only fails when ref is of the wrong type.
+	return si
 }
 
 type httpstateBackendClient struct {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -38,7 +37,6 @@ type Stack interface {
 	ConsoleURL() (string, error)                // the URL to view the stack's information on Pulumi.com.
 	CurrentOperation() *apitype.OperationStatus // in progress operation, if applicable.
 	Tags() map[apitype.StackTagName]string      // the stack's tags.
-	StackIdentifier() client.StackIdentifier
 }
 
 type cloudBackendReference struct {
@@ -110,13 +108,6 @@ func (s *cloudStack) CloudURL() string                           { return s.clou
 func (s *cloudStack) OrgName() string                            { return s.orgName }
 func (s *cloudStack) CurrentOperation() *apitype.OperationStatus { return s.currentOperation }
 func (s *cloudStack) Tags() map[apitype.StackTagName]string      { return s.tags }
-
-func (s *cloudStack) StackIdentifier() client.StackIdentifier {
-
-	si, err := s.b.getCloudStackIdentifier(s.ref)
-	contract.AssertNoError(err) // the above only fails when ref is of the wrong type.
-	return si
-}
 
 func (s *cloudStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) {
 	if s.snapshot != nil {

--- a/pkg/cmd/pulumi/crypto_http.go
+++ b/pkg/cmd/pulumi/crypto_http.go
@@ -39,8 +39,10 @@ func newServiceSecretsManager(s httpstate.Stack, stackName tokens.QName, configF
 		return nil, err
 	}
 
-	client := s.Backend().(httpstate.Backend).Client()
-	id := s.StackIdentifier()
+	cloudBackend := s.Backend().(httpstate.Backend)
+
+	client := cloudBackend.Client()
+	id := cloudBackend.StackIdentifier(s.Ref())
 
 	// We should only save the ProjectStack at this point IF we have changed the
 	// secrets provider. To change the secrets provider to a serviceSecretsManager

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -922,27 +922,23 @@ func buildStackName(stackName string) (string, error) {
 // of messages we will log here will range from single secret decryption events
 // to requesting a list of secrets in an individual event e.g. stack export
 // the logging event will only happen during the `--show-secrets` path within the cli
-func log3rdPartySecretsProviderDecryptionEvent(ctx context.Context, backend backend.Stack,
+func log3rdPartySecretsProviderDecryptionEvent(ctx context.Context, stack backend.Stack,
 	secretName, commandName string) {
-	if stack, ok := backend.(httpstate.Stack); ok {
-		// we only want to do something if this is a service backend
-		if be, ok := stack.Backend().(httpstate.Backend); ok {
-			client := be.Client()
-			if client != nil {
-				id := backend.(httpstate.Stack).StackIdentifier()
-				// we don't really care if these logging calls fail as they should not stop the execution
-				if secretName != "" {
-					contract.Assert(commandName == "")
-					err := client.Log3rdPartySecretsProviderDecryptionEvent(ctx, id, secretName)
-					contract.IgnoreError(err)
-				}
+	// we only want to do something if this is a service backend
+	if be, ok := stack.Backend().(httpstate.Backend); ok {
+		client := be.Client()
+		id := be.StackIdentifier(stack.Ref())
+		// we don't really care if these logging calls fail as they should not stop the execution
+		if secretName != "" {
+			contract.Assert(commandName == "")
+			err := client.Log3rdPartySecretsProviderDecryptionEvent(ctx, id, secretName)
+			contract.IgnoreError(err)
+		}
 
-				if commandName != "" {
-					contract.Assert(secretName == "")
-					err := client.LogBulk3rdPartySecretsProviderDecryptionEvent(ctx, id, commandName)
-					contract.IgnoreError(err)
-				}
-			}
+		if commandName != "" {
+			contract.Assert(secretName == "")
+			err := client.LogBulk3rdPartySecretsProviderDecryptionEvent(ctx, id, commandName)
+			contract.IgnoreError(err)
 		}
 	}
 }


### PR DESCRIPTION
The stack method just called into the backend method anyway and this
lets us remove a few more type tests where we can just check for
httpstate.Backend not for that and httpstate.Stack.