### PR TITLE
Ensure filestate stack.json file are atomically replaced

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -423,7 +423,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 
 	// To remove the old stack, just make a backup of the file and don't write out anything new.
 	file := b.stackPath(stackName)
-	backupTarget(b.bucket, file)
+	backupTarget(b.bucket, file, false)
 
 	// And rename the histoy folder as well.
 	if err = b.renameHistory(stackName, newName); err != nil {

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -107,19 +107,3 @@ func removeAllByPrefix(bucket Bucket, dir string) error {
 
 	return nil
 }
-
-// renameObject renames an object in a bucket. the rename requires a download/upload of the object
-// due to a go-cloud API limitation
-func renameObject(bucket Bucket, source string, dest string) error {
-	err := bucket.Copy(context.TODO(), dest, source, nil)
-	if err != nil {
-		return fmt.Errorf("copying %s to %s: %w", source, dest, err)
-	}
-
-	err = bucket.Delete(context.TODO(), source)
-	if err != nil {
-		logging.V(5).Infof("error deleting source object after rename: %v (%v) skipping", source, err)
-	}
-
-	return nil
-}

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -182,8 +182,11 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 		return "", fmt.Errorf("An IO error occurred while marshalling the checkpoint: %w", err)
 	}
 
-	// Back up the existing file if it already exists.
-	bck := backupTarget(b.bucket, file)
+	// Back up the existing file if it already exists. Don't delete the original, the following WriteAll will
+	// atomically replace it anyway and various other bits of the system depend on being able to find the
+	// .json file to know the stack currently exists (see https://github.com/pulumi/pulumi/issues/9033 for
+	// context).
+	bck := backupTarget(b.bucket, file, true)
 
 	// And now write out the new snapshot file, overwriting that location.
 	if err = b.bucket.WriteAll(context.TODO(), file, byts, nil); err != nil {
@@ -249,15 +252,14 @@ func (b *localBackend) removeStack(name tokens.QName) error {
 
 	// Just make a backup of the file and don't write out anything new.
 	file := b.stackPath(name)
-	backupTarget(b.bucket, file)
+	backupTarget(b.bucket, file, false)
 
 	historyDir := b.historyDirectory(name)
 	return removeAllByPrefix(b.bucket, historyDir)
 }
 
-// backupTarget makes a backup of an existing file, in preparation for writing a new one.  Instead of a copy, it
-// simply renames the file, which is simpler, more efficient, etc.
-func backupTarget(bucket Bucket, file string) string {
+// backupTarget makes a backup of an existing file, in preparation for writing a new one.
+func backupTarget(bucket Bucket, file string, keepOriginal bool) string {
 	contract.Require(file != "", "file")
 	bck := file + ".bak"
 
@@ -266,9 +268,11 @@ func backupTarget(bucket Bucket, file string) string {
 		logging.V(5).Infof("error copying %s to %s: %w", file, bck, err)
 	}
 
-	err = bucket.Delete(context.TODO(), file)
-	if err != nil {
-		logging.V(5).Infof("error deleting source object after rename: %v (%v) skipping", file, err)
+	if !keepOriginal {
+		err = bucket.Delete(context.TODO(), file)
+		if err != nil {
+			logging.V(5).Infof("error deleting source object after rename: %v (%v) skipping", file, err)
+		}
 	}
 
 	// IDEA: consider multiple backups (.bak.bak.bak...etc).


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When saving a new version of the stack checkpoint we don't delete the current file, instead we let WriteAll atomically replace it. This ensures that if any concurrent attempts are made to list or read the stack while the write is happening they can still pick up the existing about to be replaced version.

Also inlined the renaming logic to `backupObject` and so can now log a warning if the backup copy fails.

Fixes https://github.com/pulumi/pulumi/issues/9033

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
