### PR TITLE
allow to override makefile variables

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -90,7 +90,7 @@
 #
 # Importing common.mk should be the first thing your Makefile does, after
 # optionally setting SUB_PROJECTS, PROJECT_NAME and NODE_MODULE_NAME.
-SHELL       := /bin/bash
+SHELL       ?= /bin/bash
 .SHELLFLAGS := -ec
 
 STEP_MESSAGE = @echo -e "\033[0;32m$(shell echo '$@' | tr a-z A-Z | tr '_' ' '):\033[0m"

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -4,7 +4,7 @@ LANGHOST_PKG    := github.com/pulumi/pulumi/sdk/v3/dotnet/cmd/pulumi-language-do
 PROJECT_PKGS    := $(shell go list ./cmd...)
 PROJECT_ROOT    := $(realpath ../..)
 
-DOTNET_VERSION  := $(shell cd ../../ && pulumictl get version --language dotnet)
+DOTNET_VERSION  := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version --language dotnet))
 
 TESTPARALLELISM := 10
 

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME     := Pulumi Go SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/go/pulumi-language-go
-VERSION 		 := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version))
+VERSION                 := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version))
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
 TESTPARALLELISM  := 10

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME     := Pulumi Go SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/go/pulumi-language-go
-VERSION          := $(shell cd ../../ && pulumictl get version)
+VERSION 		 := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version))
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
 TESTPARALLELISM  := 10

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME     := Pulumi Node.JS SDK
 NODE_MODULE_NAME := @pulumi/pulumi
-VERSION 		 := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version --language javascript))
+VERSION                        := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version --language javascript))
 
 LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-nodejs
 PROJECT_ROOT     := $(realpath ../..)

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME     := Pulumi Node.JS SDK
 NODE_MODULE_NAME := @pulumi/pulumi
-VERSION 		 := $(shell cd ../../ && pulumictl get version --language javascript)
+VERSION 		 := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version --language javascript))
 
 LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-nodejs
 PROJECT_ROOT     := $(realpath ../..)

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -1,7 +1,7 @@
 PROJECT_NAME     := Pulumi Python SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/python/cmd/pulumi-language-python
-VERSION          := $(shell cd ../../ && pulumictl get version)
-PYPI_VERSION 	 := $(shell cd ../../ && pulumictl get version --language python)
+VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version))
+PYPI_VERSION 	 := $(if ${PULUMI_VERSION},${PULUMI_VERSION}, $(shell cd ../../ && pulumictl get version --language python))
 PROJECT_ROOT     := $(realpath ../..)
 
 PYENV := ./env


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
I want to package the pulumi python sdk for my linux distribution www.nixos.org. 
One difficulty is that the shell is not in /bin/bash on that system (there is only /bin/sh, bash is at /nix/store/3pa0xk3mgmx7hqskg63gxviyw7f217i6-bash-interactive-5.1-p12/bin/bash for instance)
When running the tests I would like to be able to override the SHELL value without having to patch all the Makefiles, hence the change.

I also added a way to bypass the `pulumictl get version`. I dont know how it works but it seems like it needed a git repo ? I already know the version from the nix package so I wanted to skip that altogether.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
