### PR TITLE
Fix PastTense for ops ending in 'd'

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1171,7 +1171,7 @@ func (op StepOp) RawPrefix() string {
 
 func (op StepOp) PastTense() string {
 	switch op {
-	case OpSame, OpCreate, OpDelete, OpReplace, OpCreateReplacement, OpDeleteReplaced, OpUpdate, OpReadReplacement:
+	case OpSame, OpCreate, OpReplace, OpCreateReplacement, OpUpdate, OpReadReplacement:
 		return string(op) + "d"
 	case OpRefresh:
 		return "refreshed"
@@ -1179,6 +1179,8 @@ func (op StepOp) PastTense() string {
 		return "read"
 	case OpReadDiscard, OpDiscardReplaced:
 		return "discarded"
+	case OpDelete, OpDeleteReplaced:
+		return "deleted"
 	case OpImport, OpImportReplacement:
 		return "imported"
 	default:


### PR DESCRIPTION
OpDeleteReplaced was rendering as "delete-replacedd". Now just renders as "deleted" (same as how OpDiscardReplaced just renders as "discarded")