### PR TITLE
testing: allow mock contexts to get resource options

### DIFF
--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -51,6 +51,10 @@ type MockResourceArgs struct {
 	ID string
 	// Custom specifies whether or not the resource is Custom (i.e. managed by a resource provider).
 	Custom bool
+	// Full register RPC call, if available.
+	RegisterRPC *pulumirpc.RegisterResourceRequest
+	// Full read RPC call, if available
+	ReadRPC *pulumirpc.ReadResourceRequest
 }
 
 type mockMonitor struct {
@@ -165,6 +169,7 @@ func (m *mockMonitor) ReadResource(ctx context.Context, in *pulumirpc.ReadResour
 		Provider:  in.GetProvider(),
 		ID:        in.GetId(),
 		Custom:    false,
+		ReadRPC:   in,
 	})
 	if err != nil {
 		return nil, err
@@ -210,12 +215,13 @@ func (m *mockMonitor) RegisterResource(ctx context.Context, in *pulumirpc.Regist
 	}
 
 	id, state, err := m.mocks.NewResource(MockResourceArgs{
-		TypeToken: in.GetType(),
-		Name:      in.GetName(),
-		Inputs:    inputs,
-		Provider:  in.GetProvider(),
-		ID:        in.GetImportId(),
-		Custom:    in.GetCustom(),
+		TypeToken:   in.GetType(),
+		Name:        in.GetName(),
+		Inputs:      inputs,
+		Provider:    in.GetProvider(),
+		ID:          in.GetImportId(),
+		Custom:      in.GetCustom(),
+		RegisterRPC: in,
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -27,7 +27,6 @@ func (m *testMonitor) Call(args MockCallArgs) (resource.PropertyMap, error) {
 }
 
 func (m *testMonitor) NewResource(args MockResourceArgs) (string, resource.PropertyMap, error) {
-
 	if m.NewResourceF == nil {
 		return args.Name, resource.PropertyMap{}, nil
 	}


### PR DESCRIPTION
For use in other provider / plugin projects, allows unit testing that resource options such as parent, provider, etc. are passed through correctly.