### PR TITLE
Add a --generate-code flag to import

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,9 @@
 - [cli/backend] - `pulumi cancel` is now supported for the file state backend.
   [#9100](https://github.com/pulumi/pulumi/pull/9100)
 
+- [cli/import] - Code generation in `pulumi import` can now be disabled with the `--generate-code=false` flag.
+  [#9141](https://github.com/pulumi/pulumi/pull/9141)
+
 ### Bug Fixes
 
 - [sdk/python] - Fix build warnings. See

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -380,7 +380,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			if !generateCode && outputFilePath != "" {
-				fmt.Print("Output file will not be used as --generate-code is false.\n")
+				fmt.Fprintln(os.Stderr, "Output file will not be used as --generate-code is false.")
 			}
 
 			var outputResult bytes.Buffer

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -279,6 +279,7 @@ func newImportCmd() *cobra.Command {
 	var providerSpec string
 	var importFilePath string
 	var outputFilePath string
+	var generateCode bool
 
 	var debug bool
 	var message string
@@ -376,6 +377,10 @@ func newImportCmd() *cobra.Command {
 					return result.FromError(err)
 				}
 				importFile = f
+			}
+
+			if !generateCode && outputFilePath != "" {
+				return result.Errorf("an output file may not be specified in conjunction with --generate-code=false")
 			}
 
 			var outputResult bytes.Buffer
@@ -496,37 +501,39 @@ func newImportCmd() *cobra.Command {
 				Scopes:             cancellationScopes,
 			}, imports)
 
-			deployment, err := getCurrentDeploymentForStack(s)
-			if err != nil {
-				return result.FromError(err)
-			}
-
-			validImports, err := generateImportedDefinitions(
-				output, s.Ref().Name(), proj.Name, deployment, programGenerator, nameTable, imports,
-				protectResources)
-			if err != nil {
-				if _, ok := err.(*importer.DiagnosticsError); ok {
-					err = fmt.Errorf("internal error: %w", err)
+			if generateCode {
+				deployment, err := getCurrentDeploymentForStack(s)
+				if err != nil {
+					return result.FromError(err)
 				}
-				return result.FromError(err)
-			}
 
-			if validImports {
-				// we only want to output the helper string if there is a set of valid imports to convert into code
-				// this protects against invalid package types or import errors that will not actually result in
-				// in a codegen call
-				// It's a little bit more memory but is a better experience that writing to stdout and then an error
-				// occurring
-				if outputFilePath == "" {
-					fmt.Print("Please copy the following code into your Pulumi application. Not doing so\n" +
-						"will cause Pulumi to report that an update will happen on the next update command.\n\n")
-					if protectResources {
-						fmt.Print(("Please note that the imported resources are marked as protected. " +
-							"To destroy them\n" +
-							"you will need to remove the `protect` option and run `pulumi update` *before*\n" +
-							"the destroy will take effect.\n\n"))
+				validImports, err := generateImportedDefinitions(
+					output, s.Ref().Name(), proj.Name, deployment, programGenerator, nameTable, imports,
+					protectResources)
+				if err != nil {
+					if _, ok := err.(*importer.DiagnosticsError); ok {
+						err = fmt.Errorf("internal error: %w", err)
 					}
-					fmt.Print(outputResult.String())
+					return result.FromError(err)
+				}
+
+				if validImports {
+					// we only want to output the helper string if there is a set of valid imports to convert into code
+					// this protects against invalid package types or import errors that will not actually result in
+					// in a codegen call
+					// It's a little bit more memory but is a better experience that writing to stdout and then an error
+					// occurring
+					if outputFilePath == "" {
+						fmt.Print("Please copy the following code into your Pulumi application. Not doing so\n" +
+							"will cause Pulumi to report that an update will happen on the next update command.\n\n")
+						if protectResources {
+							fmt.Print(("Please note that the imported resources are marked as protected. " +
+								"To destroy them\n" +
+								"you will need to remove the `protect` option and run `pulumi update` *before*\n" +
+								"the destroy will take effect.\n\n"))
+						}
+						fmt.Print(outputResult.String())
+					}
 				}
 			}
 
@@ -574,6 +581,8 @@ func newImportCmd() *cobra.Command {
 		&importFilePath, "file", "f", "", "The path to a JSON-encoded file containing a list of resources to import")
 	cmd.PersistentFlags().StringVarP(
 		&outputFilePath, "out", "o", "", "The path to the file that will contain the generated resource declarations")
+	cmd.PersistentFlags().BoolVar(
+		&generateCode, "generate-code", true, "Generate resource declaration code for the imported resources")
 
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -380,7 +380,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			if !generateCode && outputFilePath != "" {
-				return result.Errorf("an output file may not be specified in conjunction with --generate-code=false")
+				fmt.Print("Output file will not be used as --generate-code is false.\n")
 			}
 
 			var outputResult bytes.Buffer


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds a flag `--generate-code` to pulumi import. By default this is true, but users can pass `--generate-code=false` to skip the code generation step of import.

Fixes https://github.com/pulumi/pulumi/issues/9134

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
