### PR TITLE
Migrating the dotnet sdk to net6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,12 @@ on:
         type: string
       dotnet-version:
         description: 'Version of the .NET toolchain for the build'
-        default: '3.1.x'
+        default: '6.0.x'
+        required: false
+        type: string
+      dotnet-package-version:
+        description: 'Version of the Pulumi dotnet SDK package'
+        default: '4.0.0'
         required: false
         type: string
       goreleaser-config:
@@ -243,11 +248,11 @@ jobs:
       - name: Build the .NET SDK package
         run: |
           cd sdk/dotnet
-          dotnet build --configuration Release dotnet.sln /p:Version=$DOTNET_VERSION
+          dotnet build --configuration Release dotnet.sln /p:Version=${{ inputs.dotnet-package-version }}
       - name: Pack the .NET SDK package
         run: |
           cd sdk/dotnet
-          dotnet pack --configuration Release --output nupkgs dotnet.sln /p:Version=$DOTNET_VERSION
+          dotnet pack --configuration Release --output nupkgs dotnet.sln /p:Version=${{ inputs.dotnet-package-version }}
       - name: Upload the NuGet packages
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,6 @@ on:
         default: '6.0.x'
         required: false
         type: string
-      dotnet-package-version:
-        description: 'Version of the Pulumi dotnet SDK package'
-        default: '4.0.0'
-        required: false
-        type: string
       goreleaser-config:
         description: 'Config file for goreleaser'
         default: '.goreleaser.prerelease.yml'
@@ -242,17 +237,14 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
-      - name: Compute current version to inform the NuGet package build
-        run: |
-          echo "DOTNET_VERSION=$(pulumictl get version --language dotnet)" >> $GITHUB_ENV
       - name: Build the .NET SDK package
         run: |
           cd sdk/dotnet
-          dotnet build --configuration Release dotnet.sln /p:Version=${{ inputs.dotnet-package-version }}
+          dotnet build --configuration Release dotnet.sln /p:Version=$(pulumictl get version --language dotnet)
       - name: Pack the .NET SDK package
         run: |
           cd sdk/dotnet
-          dotnet pack --configuration Release --output nupkgs dotnet.sln /p:Version=${{ inputs.dotnet-package-version }}
+          dotnet pack --configuration Release --output nupkgs dotnet.sln /p:Version=$(pulumictl get version --language dotnet)
       - name: Upload the NuGet packages
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         go-version: [1.17.x]
         python-version: [3.9.x]
-        dotnet-version: [3.1.x]
+        dotnet-version: [6.0.x]
         node-version: [14.x]
         language: ["nodejs", "python", "dotnet"]
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         go-version: [1.17.x]
         python-version: [3.9.x]
-        dotnet-version: [3.1.x]
+        dotnet-version: [6.0.x]
         node-version: [14.x]
         language: ["nodejs", "python", "dotnet"]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       matrix:
         go-version: [1.17.x]
         python-version: [3.9.x]
-        dotnet-version: [3.1.x]
+        dotnet-version: [6.0.x]
         node-version: [14.x]
         language: ["nodejs", "python", "dotnet"]
     steps:

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -27,7 +27,7 @@ on:
         type: string
       dotnet-version:
         description: 'Version of the .NET toolchain for the build'
-        default: '3.1.x'
+        default: '6.0.x'
         required: false
         type: string
       enable-coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ on:
         type: string
       dotnet-version:
         description: 'Version of the .NET toolchain for the build'
-        default: '3.1.x'
+        default: '6.0.x'
         required: false
         type: string
       enable-coverage:

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Improvements
- - [area/cli] - Implemented `state rename` command [#9098](https://github.com/pulumi/pulumi/pull/9098)
+- [area/dotnet-sdk] - Migrate the dotnet sdk to target framework net6.0 [#9142](https://github.com/pulumi/pulumi/pull/9142)
+
+- [area/cli] - Implemented `state rename` command [#9098](https://github.com/pulumi/pulumi/pull/9098)
 
 - [cli/plugins] `pulumi plugin install` can now look up the latest version of plugins on GitHub releases.
   [#9012](https://github.com/pulumi/pulumi/pull/9012)

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1801,7 +1801,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 var resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
 
@@ -1810,7 +1810,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Single(state.Deployment.Resources);
             }
             finally
@@ -1864,7 +1864,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 var resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
 
@@ -1876,7 +1876,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Single(state.Deployment.Resources);
             }
             finally
@@ -1886,6 +1886,16 @@ namespace Pulumi.Automation.Tests
                 Assert.Equal(UpdateState.Succeeded, destroyResult.Summary.Result);
                 await stack.Workspace.RemoveStackAsync(stackName);
             }
+        }
+
+        private StackState DeserializeState(string inputJson, JsonSerializerOptions? jsonOptions)
+        {
+            var state = JsonSerializer.Deserialize<StackState>(inputJson, jsonOptions);
+            if (state == null)
+            {
+                throw new InvalidOperationException("Could not deserialize the input JSON into an instance of StackState");
+            }
+            return state;
         }
 
         [Fact]
@@ -1930,7 +1940,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 var resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
                 Assert.True(resource.Protect);
@@ -1940,7 +1950,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
                 Assert.False(resource.Protect);
@@ -2005,7 +2015,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Equal(3, state.Deployment.Resources.Count);
                 var resources = state.Deployment.Resources.Where(x => x.Urn.Contains(type)).ToList();
                 Assert.Equal(2, resources.Count);
@@ -2016,7 +2026,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = DeserializeState(exportResult.Json.GetRawText(), jsonOptions);
                 Assert.Equal(3, state.Deployment.Resources.Count);
                 resources = state.Deployment.Resources.Where(x => x.Urn.Contains(type)).ToList();
                 Assert.Equal(2, resources.Count);
@@ -2055,7 +2065,7 @@ namespace Pulumi.Automation.Tests
             public bool IsEnabled(LogLevel logLevel)
                 => true;
 
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
                 => _action();
         }
 

--- a/sdk/dotnet/Pulumi.Automation.Tests/Pulumi.Automation.Tests.csproj
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Pulumi.Automation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/sdk/dotnet/Pulumi.Automation.Tests/Serialization/DynamicObjectTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Serialization/DynamicObjectTests.cs
@@ -43,7 +43,7 @@ nested:
 }
 ";
 
-            var dict = _serializer.DeserializeJson<Dictionary<string, object>>(json);
+            var dict = _serializer.DeserializeJson<Dictionary<string, object>>(json)!;
             Assert.NotNull(dict);
             Assert.NotEmpty(dict);
             Assert.Equal(4, dict.Count);

--- a/sdk/dotnet/Pulumi.Automation.Tests/Serialization/GeneralJsonConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Serialization/GeneralJsonConverterTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using Pulumi.Automation.Serialization;
 using Xunit;
 
@@ -28,7 +29,10 @@ namespace Pulumi.Automation.Tests.Serialization
 ";
 
             var config = _serializer.DeserializeJson<Dictionary<string, ConfigValue>>(json);
-            Assert.NotNull(config);
+            if (config == null)
+            {
+                throw new JsonException("Deserializing Dictionary<string, ConfigValue> failed");
+            }
             Assert.True(config.TryGetValue("aws:region", out var regionValue));
             Assert.Equal("us-east-1", regionValue!.Value);
             Assert.False(regionValue.IsSecret);
@@ -53,7 +57,8 @@ namespace Pulumi.Automation.Tests.Serialization
             var installTime = new DateTime(2020, 12, 9, 19, 24, 23, 214);
             var lastUsedTime = new DateTime(2020, 12, 9, 19, 24, 26, 059);
 
-            var info = _serializer.DeserializeJson<PluginInfo>(json);
+            var info = _serializer.DeserializeJson<PluginInfo>(json)!;
+            
             Assert.NotNull(info);
             Assert.Equal("aws", info.Name);
             Assert.Equal(PluginKind.Resource, info.Kind);
@@ -117,10 +122,9 @@ namespace Pulumi.Automation.Tests.Serialization
 ]
 ";
 
-            var history = _serializer.DeserializeJson<List<UpdateSummary>>(json);
+            var history = _serializer.DeserializeJson<List<UpdateSummary>>(json)!;
             Assert.NotNull(history);
             Assert.Equal(2, history.Count);
-
             var destroy = history[0];
             Assert.Equal(UpdateKind.Destroy, destroy.Kind);
             Assert.Equal(UpdateState.InProgress, destroy.Result);

--- a/sdk/dotnet/Pulumi.Automation.Tests/Serialization/ProjectRuntimeJsonConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Serialization/ProjectRuntimeJsonConverterTests.cs
@@ -32,7 +32,10 @@ namespace Pulumi.Automation.Tests.Serialization
 ";
 
             var settings = _serializer.DeserializeJson<ProjectSettings>(json);
-            Assert.NotNull(settings);
+            if (settings == null)
+            {
+                throw new JsonException("Deserializing StackSettings failed");
+            }
             Assert.IsType<ProjectSettings>(settings);
             Assert.Equal("test-project", settings.Name);
             Assert.Equal(runtimeName, settings.Runtime.Name);
@@ -61,7 +64,10 @@ namespace Pulumi.Automation.Tests.Serialization
 ";
 
             var settings = _serializer.DeserializeJson<ProjectSettings>(json);
-            Assert.NotNull(settings);
+            if (settings == null)
+            {
+                throw new JsonException("Deserializing StackSettings failed");
+            }
             Assert.IsType<ProjectSettings>(settings);
             Assert.Equal("test-project", settings.Name);
             Assert.Equal(runtimeName, settings.Runtime.Name);

--- a/sdk/dotnet/Pulumi.Automation.Tests/Serialization/StackSettingsConfigValueJsonConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Serialization/StackSettingsConfigValueJsonConverterTests.cs
@@ -23,6 +23,10 @@ namespace Pulumi.Automation.Tests.Serialization
 ";
 
             var settings = _serializer.DeserializeJson<StackSettings>(json);
+            if (settings == null)
+            {
+                throw new JsonException("Deserializing StackSettings failed");
+            }
             Assert.NotNull(settings.Config);
             Assert.True(settings!.Config!.ContainsKey("test"));
 
@@ -46,7 +50,12 @@ namespace Pulumi.Automation.Tests.Serialization
 ";
 
             var settings = _serializer.DeserializeJson<StackSettings>(json);
-            Assert.NotNull(settings.Config);
+
+            if (settings == null)
+            {
+                throw new JsonException("Deserializing StackSettings failed");
+            }
+            
             Assert.True(settings!.Config!.ContainsKey("test"));
 
             var value = settings.Config["test"];

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -145,7 +145,10 @@ namespace Pulumi.Automation.Commands
                 var dir = Path.GetDirectoryName(this.FilePath);
                 try
                 {
-                    Directory.Delete(dir, recursive: true);
+                    if (dir != null)
+                    {
+                        Directory.Delete(dir, recursive: true);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/sdk/dotnet/Pulumi.Automation/Events/EventLogWatcher.cs
+++ b/sdk/dotnet/Pulumi.Automation/Events/EventLogWatcher.cs
@@ -101,8 +101,11 @@ namespace Pulumi.Automation.Events
                 if (!string.IsNullOrWhiteSpace(line))
                 {
                     line = line.Trim();
-                    var @event = _localSerializer.DeserializeJson<EngineEvent>(line);
-                    _onEvent.Invoke(@event);
+                    var engineEvent = _localSerializer.DeserializeJson<EngineEvent>(line);
+                    if (engineEvent != null)
+                    {
+                        _onEvent.Invoke(engineEvent);
+                    }
                 }
             }
         }

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>

--- a/sdk/dotnet/Pulumi.Automation/Serialization/Json/StackSettingsConfigValueJsonConverter.cs
+++ b/sdk/dotnet/Pulumi.Automation/Serialization/Json/StackSettingsConfigValueJsonConverter.cs
@@ -16,7 +16,9 @@ namespace Pulumi.Automation.Serialization.Json
             if (element.ValueKind == JsonValueKind.String)
             {
                 var value = element.GetString();
-                return new StackSettingsConfigValue(value, false);
+                // telling the compiler this is non-null because otherwise 
+                // element.ValueKind would have been JsonValueKind.Null
+                return new StackSettingsConfigValue(value!, false);
             }
 
             // confirm object
@@ -31,7 +33,9 @@ namespace Pulumi.Automation.Serialization.Json
                     throw new JsonException($"Unable to deserialize [{typeToConvert.FullName}] as a secure string. Expecting a string secret.");
 
                 var secret = secureProperty.GetString();
-                return new StackSettingsConfigValue(secret, true);
+                // telling the compiler this is non-null because otherwise 
+                // secureProperty.ValueKind would have been JsonValueKind.Null
+                return new StackSettingsConfigValue(secret!, true);
             }
 
             throw new NotSupportedException("Automation API does not currently support deserializing complex objects from stack settings.");

--- a/sdk/dotnet/Pulumi.Automation/Serialization/Json/StringToEnumJsonConverter.cs
+++ b/sdk/dotnet/Pulumi.Automation/Serialization/Json/StringToEnumJsonConverter.cs
@@ -14,7 +14,11 @@ namespace Pulumi.Automation.Serialization.Json
 
         public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return _converter.Convert(reader.GetString());
+            var enumValue = reader.GetString();
+            if (String.IsNullOrEmpty(enumValue))
+                throw new JsonException($"Unable to deserialize [{typeToConvert.FullName}] as an enum from empty string.");
+            
+            return _converter.Convert(enumValue);
         }
 
         public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/sdk/dotnet/Pulumi.Automation/Serialization/Json/SystemObjectJsonConverter.cs
+++ b/sdk/dotnet/Pulumi.Automation/Serialization/Json/SystemObjectJsonConverter.cs
@@ -38,17 +38,19 @@ namespace Pulumi.Automation.Serialization.Json
                     return datetime;
                 }
 
-                return reader.GetString();
+                var value = reader.GetString();
+                return value!;
             }
 
             if (reader.TokenType == JsonTokenType.StartArray)
             {
-                return JsonSerializer.Deserialize<object[]>(ref reader, options);
+                var deserializedObjects = JsonSerializer.Deserialize<object[]>(ref reader, options);
+                return deserializedObjects ?? new object[] { };
             }
 
             if (reader.TokenType == JsonTokenType.StartObject)
             {
-                var dictionary = new Dictionary<string, object>();
+                var dictionary = new Dictionary<string, object?>();
 
                 reader.Read();
                 while (reader.TokenType != JsonTokenType.EndObject)

--- a/sdk/dotnet/Pulumi.Automation/Serialization/LocalSerializer.cs
+++ b/sdk/dotnet/Pulumi.Automation/Serialization/LocalSerializer.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Automation.Serialization
             this._yamlSerializer = BuildYamlSerializer();
         }
 
-        public T DeserializeJson<T>(string content)
+        public T? DeserializeJson<T>(string content)
             => JsonSerializer.Deserialize<T>(content, this._jsonOptions);
 
         public T DeserializeYaml<T>(string content)
@@ -45,7 +45,7 @@ namespace Pulumi.Automation.Serialization
             var options = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
-                IgnoreNullValues = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -630,7 +630,7 @@ namespace Pulumi.Automation
 
             var jsonOptions = LocalSerializer.BuildJsonSerializerOptions();
             var list = JsonSerializer.Deserialize<List<UpdateSummary>>(result.StandardOutput, jsonOptions);
-            return list.ToImmutableList();
+            return (list ?? new List<UpdateSummary>()).ToImmutableList();
         }
 
         /// <summary>
@@ -765,7 +765,7 @@ namespace Pulumi.Automation
                     try
                     {
                         var serverFeatures = this._host.Services.GetRequiredService<IServer>().Features;
-                        var addresses = serverFeatures.Get<IServerAddressesFeature>().Addresses.ToList();
+                        var addresses = serverFeatures.Get<IServerAddressesFeature>()?.Addresses?.ToList() ?? new List<string>();
                         Debug.Assert(addresses.Count == 1, "Server should only be listening on one address");
                         var uri = new Uri(addresses[0]);
                         this._portTcs.TrySetResult(uri.Port);

--- a/sdk/dotnet/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/dotnet/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/dotnet/Pulumi.Tests/Pulumi.Tests.csproj
+++ b/sdk/dotnet/Pulumi.Tests/Pulumi.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/sdk/dotnet/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -127,7 +127,7 @@ namespace Pulumi.Tests.Serialization
         private static object[] UnknownDefaultValue<T>()
             where T : notnull
         {
-            T inner = default;
+            T inner = default(T)!;
             var outputdata = OutputData.Create(ImmutableHashSet<Resource>.Empty, inner!, isKnown: false, isSecret: false);
             var output = new Output<T>(Task.FromResult(outputdata));
             return new object[]

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Config.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Config.cs
@@ -86,7 +86,11 @@ namespace Pulumi
                 var envObject = JsonDocument.Parse(envConfigSecretKeys);
                 foreach (var element in envObject.RootElement.EnumerateArray())
                 {
-                    parsedConfigSecretKeys.Add(element.GetString());
+                    var secretKey = element.GetString();
+                    if (!String.IsNullOrWhiteSpace(secretKey))
+                    {
+                        parsedConfigSecretKeys.Add(secretKey);
+                    }
                 }
             }
 

--- a/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
@@ -1,8 +1,10 @@
 // Copyright 2016-2020, Pulumi Corporation
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Grpc.Net.Client;
 using Pulumirpc;
 
 namespace Pulumi
@@ -15,8 +17,12 @@ namespace Pulumi
         {
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             var maxRpcMessageSize = 400 * 1024 * 1024;
-            var grpcChannelOptions = new List<ChannelOption> { new ChannelOption(ChannelOptions.MaxReceiveMessageLength, maxRpcMessageSize)};
-            this._engine = new Engine.EngineClient(new Channel(engine, ChannelCredentials.Insecure, grpcChannelOptions));
+            var channel = GrpcChannel.ForAddress($"http://{engine}", new GrpcChannelOptions
+            {
+                MaxReceiveMessageSize = maxRpcMessageSize
+            });
+
+            this._engine = new Engine.EngineClient(channel);
         }
         
         public async Task LogAsync(LogRequest request)

--- a/sdk/dotnet/Pulumi/Deployment/GrpcMonitor.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcMonitor.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Grpc.Net.Client;
 using Pulumirpc;
 
 namespace Pulumi
@@ -15,8 +16,11 @@ namespace Pulumi
         {
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             var maxRpcMessageSize = 400 * 1024 * 1024;
-            var grpcChannelOptions = new List<ChannelOption> { new ChannelOption(ChannelOptions.MaxReceiveMessageLength, maxRpcMessageSize)};
-            this._client = new ResourceMonitor.ResourceMonitorClient(new Channel(monitor, ChannelCredentials.Insecure, grpcChannelOptions));
+            var channel = GrpcChannel.ForAddress($"http://{monitor}", new GrpcChannelOptions
+            {
+                MaxReceiveMessageSize = maxRpcMessageSize
+            });
+            this._client = new ResourceMonitor.ResourceMonitorClient(channel);
         }
         
         public async Task<SupportsFeatureResponse> SupportsFeatureAsync(SupportsFeatureRequest request)

--- a/sdk/dotnet/Pulumi/Pulumi.csproj
+++ b/sdk/dotnet/Pulumi/Pulumi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
@@ -31,8 +31,9 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Grpc" Version="2.37.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.37.0">
+    <PackageReference Include="Grpc.Net.Client" Version="2.43.0" />
+
+    <PackageReference Include="Grpc.Tools" Version="2.44.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR addresses the following issues:
 - #8476
 - #8447

First of all, replaces `Grpc` package which is now in maintenance mode (until 2022 May) with `grpc-dotnet`, specifically using the `Grpc.Net.Client` package instead. 

We are still using the `Grpc.Tools` package as the main way to generate C# types and clients from our proto files. Though updated this one from 2.37.0 to 2.44.0 (latest)

Resolved remaining compile-time issues when respect to nullable references as a result of using APIs from `net6.0` target framework. 

Using a local copy of updated `Pulumi` nuget package and a local, updated version of `Pulumi.Aws` package, I've managed to successfully deploy resources to AWS using `pulumi up` and a console application also running on `net6.0` target framework.

Finally, for the CI I've introduced a new input called `dotnet-package-version` which is the version of the Pulumi packages to be published to nuget, rather than using `DOTNET_VERSION` which is the dotnet toolchain version

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
