### PR TITLE
Fix RetainOnDelete for Go SDK

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,3 +23,6 @@
 
 - [cli/backend] - Fixed an issue with non-atomicity when saving file state stacks.
   [#9122](https://github.com/pulumi/pulumi/pull/9122)
+
+- [sdk/go] - Fixed an issue where the RetainOnDelete resource option is not applied. 
+  [#9147](https://github.com/pulumi/pulumi/pull/9147)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1308,7 +1308,7 @@ func (ctx *Context) prepareResourceInputs(res Resource, props Input, t string, o
 		version:                 state.version,
 		pluginDownloadURL:       state.pluginDownloadURL,
 		replaceOnChanges:        resOpts.replaceOnChanges,
-		retainOnDelete:          opts.RetainOnDelete,		
+		retainOnDelete:          opts.RetainOnDelete,
 	}, nil
 }
 

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -843,6 +843,7 @@ func (ctx *Context) registerResource(
 				PluginDownloadURL:       inputs.pluginDownloadURL,
 				Remote:                  remote,
 				ReplaceOnChanges:        inputs.replaceOnChanges,
+				RetainOnDelete:          inputs.retainOnDelete,
 			})
 			if err != nil {
 				logging.V(9).Infof("RegisterResource(%s, %s): error: %v", t, name, err)
@@ -1220,6 +1221,7 @@ type resourceInputs struct {
 	version                 string
 	pluginDownloadURL       string
 	replaceOnChanges        []string
+	retainOnDelete          bool
 }
 
 // prepareResourceInputs prepares the inputs for a resource operation, shared between read and register.
@@ -1306,6 +1308,7 @@ func (ctx *Context) prepareResourceInputs(res Resource, props Input, t string, o
 		version:                 state.version,
 		pluginDownloadURL:       state.pluginDownloadURL,
 		replaceOnChanges:        resOpts.replaceOnChanges,
+		retainOnDelete:          opts.RetainOnDelete,		
 	}, nil
 }
 


### PR DESCRIPTION
# Description
This MR fixes a bug in the Go SDK where the RetainOnDelete configuration is not stored in the state file and therefore, not applied. 

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [CHANGELOG-PENDING]
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
