### PR TITLE
Fix error message in `pulumi new`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [cli/new] Fix an error message when the project name picked by default was already used.
+  [#9156](https://github.com/pulumi/pulumi/pull/9156)

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -83,7 +83,7 @@ func runNew(args newArgs) error {
 
 	// Validate name (if specified) before further prompts/operations.
 	if args.name != "" && workspace.ValidateProjectName(args.name) != nil {
-		return fmt.Errorf("'%s' is not a valid project name. %s", args.name, workspace.ValidateProjectName(args.name))
+		return fmt.Errorf("'%s' is not a valid project name. %w", args.name, workspace.ValidateProjectName(args.name))
 	}
 
 	// Validate secrets provider type
@@ -208,6 +208,13 @@ func runNew(args newArgs) error {
 	if args.name == "" {
 		defaultValue := workspace.ValueOrSanitizedDefaultProjectName(args.name, template.ProjectName, filepath.Base(cwd))
 		if err := validateProjectName(defaultValue, args.generateOnly, opts); err != nil {
+			// If --yes is given error out now that the default value is invalid. If we allow prompt to catch
+			// this case it can lead to a confusing error message because we set the defaultValue to "" below.
+			// See https://github.com/pulumi/pulumi/issues/8747.
+			if args.yes {
+				return fmt.Errorf("'%s' is not a valid project name. %w", defaultValue, err)
+			}
+
 			// Do not suggest an invalid or existing name as the default project name.
 			defaultValue = ""
 		}
@@ -1045,11 +1052,11 @@ func promptForValue(
 			if validationError := isValidFn(value); validationError != nil {
 				// If validation failed, let the user know. If interactive, we will print the error and
 				// prompt the user again; otherwise, in the case of --yes, we fail and report an error.
-				msg := fmt.Sprintf("Sorry, '%s' is not a valid %s. %s.", value, valueType, validationError)
+				err := fmt.Errorf("Sorry, '%s' is not a valid %s. %w.", value, valueType, validationError)
 				if yes {
-					return "", errors.New(msg)
+					return "", err
 				}
-				fmt.Printf("%s\n", msg)
+				fmt.Printf("%s\n", err)
 				continue
 			}
 		}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -1052,7 +1052,7 @@ func promptForValue(
 			if validationError := isValidFn(value); validationError != nil {
 				// If validation failed, let the user know. If interactive, we will print the error and
 				// prompt the user again; otherwise, in the case of --yes, we fail and report an error.
-				err := fmt.Errorf("Sorry, '%s' is not a valid %s. %w.", value, valueType, validationError)
+				err := fmt.Errorf("Sorry, '%s' is not a valid %s. %w", value, valueType, validationError)
 				if yes {
 					return "", err
 				}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When running with --yes and letting pulumi select the default project name if it was invalid you got an error message like:
`Sorry, '' is not a valid project name.`

This fixes that case to instead return the actual project name that caused the issue.

Fixes https://github.com/pulumi/pulumi/issues/8747

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
