### PR TITLE
Check resource names are valid

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- [engine] Resource names are now validated by the engine before use.
+  [#9157](https://github.com/pulumi/pulumi/pull/9157)
+
 ### Bug Fixes

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -4379,6 +4379,7 @@ func TestInvalidResourceName(t *testing.T) {
 	}
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		//nolint:errcheck
 		monitor.RegisterResource("pkgA:m:typA", "invalid::name", true, deploytest.ResourceOptions{})
 		assert.Fail(t, "RegisterResource should fail and so won't return")
 		return nil
@@ -4400,7 +4401,8 @@ func TestInvalidResourceName(t *testing.T) {
 				payload := event.Payload().(DiagEventPayload)
 				// URN should be empty (the name is invalid so we can't make an URN)
 				assert.Equal(t, resource.URN(""), payload.URN)
-				assert.Equal(t, "<{%reset%}>Invalid resource name 'invalid::name'; resource names may only contain alphanumeric, hyphens, underscores, and periods<{%reset%}>\n", payload.Message)
+				assert.Equal(t, "<{%reset%}>Invalid resource name 'invalid::name'; "+
+					"resource names may only contain alphanumeric, hyphens, underscores, and periods<{%reset%}>\n", payload.Message)
 			}
 		}
 

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -4369,3 +4369,46 @@ func TestRetainOnDelete(t *testing.T) {
 	assert.NotNil(t, snap)
 	assert.Len(t, snap.Resources, 0)
 }
+
+func TestInvalidResourceName(t *testing.T) {
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}, deploytest.WithoutGrpc),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		monitor.RegisterResource("pkgA:m:typA", "invalid::name", true, deploytest.ResourceOptions{})
+		assert.Fail(t, "RegisterResource should fail and so won't return")
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+	}
+
+	project := p.GetProject()
+
+	validate := func(project workspace.Project, target deploy.Target, entries JournalEntries,
+		events []Event, res result.Result) result.Result {
+		assert.NotNil(t, res)
+
+		for _, event := range events {
+			if event.Type == DiagEvent {
+				payload := event.Payload().(DiagEventPayload)
+				// URN should be empty (the name is invalid so we can't make an URN)
+				assert.Equal(t, resource.URN(""), payload.URN)
+				assert.Equal(t, "<{%reset%}>Invalid resource name 'invalid::name'; resource names may only contain alphanumeric, hyphens, underscores, and periods<{%reset%}>\n", payload.Message)
+			}
+		}
+
+		return nil
+	}
+
+	snap, res := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, validate)
+	assert.Nil(t, res)
+	assert.NotNil(t, snap)
+	assert.Len(t, snap.Resources, 1)
+}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -271,6 +271,17 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 	var invalid bool // will be set to true if this object fails validation.
 
 	goal := event.Goal()
+
+	// Validate the resource name is valid, if the name is invalid we can't even generate an URN for this
+	resourceName := goal.Name.String()
+	if !tokens.IsName(resourceName) {
+		sg.deployment.Diag().Errorf(diag.GetInvalidResourceName(), resourceName)
+		return nil, result.Bail()
+	}
+	// TODO We ought to do a similar check as above for the resource type. But the IsValid logic for that is a
+	// bit more complicated and isn't already in place, and it's much less likely for users to be making up
+	// type tokens and thus getting it wrong.
+
 	// Generate a URN for this new resource, confirm we haven't seen it before in this deployment.
 	urn := sg.deployment.generateURN(goal.Parent, goal.Type, goal.Name)
 	if sg.urns[urn] {

--- a/sdk/go/common/diag/errors.go
+++ b/sdk/go/common/diag/errors.go
@@ -84,3 +84,7 @@ Either include resource in --target list or pass --target-dependents to proceed.
 func GetDefaultProviderDenied(urn resource.URN) *Diag {
 	return newError(urn, 2015, `Default provider for '%v' disabled. '%v' must use an explicit provider.`)
 }
+
+func GetInvalidResourceName() *Diag {
+	return newError("", 2016, "Invalid resource name '%v'; resource names may only contain alphanumeric, hyphens, underscores, and periods")
+}

--- a/sdk/go/common/diag/errors.go
+++ b/sdk/go/common/diag/errors.go
@@ -86,5 +86,6 @@ func GetDefaultProviderDenied(urn resource.URN) *Diag {
 }
 
 func GetInvalidResourceName() *Diag {
-	return newError("", 2016, "Invalid resource name '%v'; resource names may only contain alphanumeric, hyphens, underscores, and periods")
+	return newError("", 2016, "Invalid resource name '%v'; "+
+		"resource names may only contain alphanumeric, hyphens, underscores, and periods")
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Validate that resource names are valid names in the step generator before trying to make URNs or anything else with them.

Fixes https://github.com/pulumi/pulumi/issues/8949

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
