### PR TITLE
Add --insecure option to `pulumi login`

### DIFF
--- a/changelog/pending/20230204--cli--add-insecure-flag-to-pulumi-login-which-disables-https-certificate-checks.yaml
+++ b/changelog/pending/20230204--cli--add-insecure-flag-to-pulumi-login-which-disables-https-certificate-checks.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--insecure` flag to `pulumi login` which disables https certificate checks

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -52,14 +52,17 @@ func newMockServerRequestProcessor(statusCode int, processor func(req *http.Requ
 }
 
 func newMockClient(server *httptest.Server) *Client {
+	httpClient := http.DefaultClient
+
 	return &Client{
-		apiURL:   server.URL,
-		apiToken: "",
-		apiUser:  "",
-		diag:     nil,
-		client: &defaultRESTClient{
+		apiURL:     server.URL,
+		apiToken:   "",
+		apiUser:    "",
+		diag:       nil,
+		httpClient: httpClient,
+		restClient: &defaultRESTClient{
 			client: &defaultHTTPClient{
-				client: http.DefaultClient,
+				client: httpClient,
 			},
 		},
 	}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -163,7 +163,7 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 
 	initPersister := func() *cloudSnapshotPersister {
 		server := newMockServer()
-		backendGeneric, err := New(nil, server.URL)
+		backendGeneric, err := New(nil, server.URL, false)
 		assert.NoError(t, err)
 		backend := backendGeneric.(*cloudBackend)
 		persister := backend.newSnapshotPersister(ctx, client.UpdateIdentifier{

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -35,6 +35,7 @@ func newLoginCmd() *cobra.Command {
 	var cloudURL string
 	var defaultOrg string
 	var localMode bool
+	var insecure bool
 
 	cmd := &cobra.Command{
 		Use:   "login [<url>]",
@@ -141,7 +142,7 @@ func newLoginCmd() *cobra.Command {
 					return fmt.Errorf("unable to set default org for this type of backend")
 				}
 			} else {
-				be, err = httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, displayOptions)
+				be, err = httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, insecure, displayOptions)
 				// if the user has specified a default org to associate with the backend
 				if defaultOrg != "" {
 					cloudURL, err := workspace.GetCurrentCloudURL()
@@ -171,6 +172,7 @@ func newLoginCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&defaultOrg, "default-org", "", "A default org to associate with the login. "+
 		"Please note, currently, only the managed and self-hosted backends support organizations")
 	cmd.PersistentFlags().BoolVarP(&localMode, "local", "l", false, "Use Pulumi in local-only mode")
+	cmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "Allow insecure server connections when using SSL")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -78,7 +78,7 @@ func newLogoutCmd() *cobra.Command {
 				return workspace.DeleteAccount(cloudURL)
 			}
 
-			be, err = httpstate.New(cmdutil.Diag(), cloudURL)
+			be, err = httpstate.New(cmdutil.Diag(), cloudURL, workspace.GetCloudInsecure(cloudURL))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -113,14 +113,14 @@ func requirePolicyPack(ctx context.Context, policyPack string) (backend.PolicyPa
 	cloudURL, err := workspace.GetCurrentCloudURL()
 	if err != nil {
 		return nil, fmt.Errorf("`pulumi policy` command requires the user to be logged into the Pulumi service: %w", err)
-
 	}
 
 	displayOptions := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
 
-	b, err := httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, displayOptions)
+	b, err := httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL,
+		workspace.GetCloudInsecure(cloudURL), displayOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -416,7 +416,7 @@ func getCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, err
 		return latest, oldest, err
 	}
 
-	client := client.NewClient(httpstate.DefaultURL(), "", cmdutil.Diag())
+	client := client.NewClient(httpstate.DefaultURL(), "", false, cmdutil.Diag())
 	latest, oldest, err = client.GetCLIVersionInfo(ctx)
 	if err != nil {
 		return semver.Version{}, semver.Version{}, err

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -124,7 +124,7 @@ func nonInteractiveCurrentBackend(ctx context.Context) (backend.Backend, error) 
 	if filestate.IsFileStateBackendURL(url) {
 		return filestate.New(cmdutil.Diag(), url)
 	}
-	return httpstate.NewLoginManager().Current(ctx, cmdutil.Diag(), url)
+	return httpstate.NewLoginManager().Current(ctx, cmdutil.Diag(), url, workspace.GetCloudInsecure(url))
 }
 
 func currentBackend(ctx context.Context, opts display.Options) (backend.Backend, error) {
@@ -140,7 +140,7 @@ func currentBackend(ctx context.Context, opts display.Options) (backend.Backend,
 	if filestate.IsFileStateBackendURL(url) {
 		return filestate.New(cmdutil.Diag(), url)
 	}
-	return httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), url, opts)
+	return httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), url, workspace.GetCloudInsecure(url), opts)
 }
 
 // This is used to control the contents of the tracing header.

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -89,10 +89,11 @@ func (c *serviceCrypter) BulkDecrypt(ctx context.Context, secrets []string) (map
 }
 
 type serviceSecretsManagerState struct {
-	URL     string `json:"url,omitempty"`
-	Owner   string `json:"owner"`
-	Project string `json:"project"`
-	Stack   string `json:"stack"`
+	URL      string `json:"url,omitempty"`
+	Owner    string `json:"owner"`
+	Project  string `json:"project"`
+	Stack    string `json:"stack"`
+	Insecure bool   `json:"insecure,omitempty"`
 }
 
 var _ secrets.Manager = &serviceSecretsManager{}
@@ -151,10 +152,11 @@ func NewServiceSecretsManager(
 
 	return &serviceSecretsManager{
 		state: serviceSecretsManagerState{
-			URL:     client.URL(),
-			Owner:   id.Owner,
-			Project: id.Project,
-			Stack:   id.Stack,
+			URL:      client.URL(),
+			Owner:    id.Owner,
+			Project:  id.Project,
+			Stack:    id.Stack,
+			Insecure: client.Insecure(),
 		},
 		crypter: newServiceCrypter(client, id),
 	}, nil
@@ -183,7 +185,7 @@ func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, 
 		Project: s.Project,
 		Stack:   s.Stack,
 	}
-	c := client.NewClient(s.URL, token, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
+	c := client.NewClient(s.URL, token, s.Insecure, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 		Color: colors.Never}))
 
 	return &serviceSecretsManager{

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -115,6 +115,7 @@ type Account struct {
 	Username        string    `json:"username,omitempty"`        // The username for this account.
 	Organizations   []string  `json:"organizations,omitempty"`   // The organizations for this account.
 	LastValidatedAt time.Time `json:"lastValidatedAt,omitempty"` // The last time this token was validated.
+	Insecure        bool      `json:"insecure,omitempty"`        // Allow insecure server connections when using SSL.
 }
 
 // Credentials hold the information necessary for authenticating Pulumi Cloud API requests.  It contains
@@ -178,6 +179,19 @@ func GetCurrentCloudURL() (string, error) {
 	}
 
 	return url, nil
+}
+
+// GetCloudInsecure returns if this cloud url is saved as one that should use insecure transport.
+func GetCloudInsecure(cloudURL string) bool {
+	insecure := false
+	creds, err := GetStoredCredentials()
+	// If this errors just assume insecure == false
+	if err == nil {
+		if account, has := creds.Accounts[cloudURL]; has {
+			insecure = account.Insecure
+		}
+	}
+	return insecure
 }
 
 // GetStoredCredentials returns any credentials stored on the local machine.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Add --insecure option to `pulumi login` which disables https certificate checks.

Fixes https://github.com/pulumi/pulumi/issues/9120

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
