### PR TITLE
Revert "Remove last few uses of get-version script"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ dist:: build
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
 
 # NOTE: the brew target intentionally avoids the dependency on `build`, as it does not require the language SDKs.
-brew:: BREW_VERSION := $(shell pulumictl get version)
+brew:: BREW_VERSION := $(shell scripts/get-version HEAD)
 brew::
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${BREW_VERSION}" ${PROJECT}
 

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+if [ $# -eq 0 ]; then
+    echo "No arguments provided. Pass appropriate git commit-ish value get version of (i.e. 'HEAD')"
+    exit 1
+fi
+
+## PLEASE NOTE: This script is used primarily for use with homebrew and the "make brew" build target
+## the logic to determine the version of pulumi at build time is now controlled via
+## https://github.com/pulumi/pulumictl and the `pulumictl get version` command
+
+# Allow version to be set manually when building outside of git repo
+if [ -n "${PULUMI_VERSION+x}" ]; then
+    echo "${PULUMI_VERSION}"
+    exit 0
+fi
+
+COMMITISH=$1
+DIRTY_TAG=""
+EXACT=0
+
+# Figure out if the worktree is dirty, we run update-index first
+# as we've seen cases in Travis where not doing so causes git to
+# treat the worktree as dirty when it is not.
+git update-index -q --refresh
+if ! git diff-files --quiet -- . ':!**/go.mod' ':!**/go.sum'; then
+    DIRTY_TAG="dirty"
+fi
+
+# If we have an exact tag, just use it.
+if git describe --tags --exact-match "${COMMITISH}" >/dev/null 2>&1; then
+    EXACT=1
+    TAG=$(git describe --tags --exact-match "${COMMITISH}")
+# Otherwise, increment the minor version version (if the package is 1.X or later) or the
+# patch version (if the package is pre 1.0), add the -alpha tag and some
+# commit metadata. If there's no existing tag, pretend a v0.0.0 was
+# there so we'll produce v0.0.1-dev builds.
+elif git describe --tags --abbrev=0 "${COMMITISH}" > /dev/null 2>&1; then
+    TAG=$(git describe --tags --abbrev=0 "${COMMITISH}")
+else
+    TAG="v0.0.0"
+fi
+
+# Check to see if the latest tag is for a submodule and transform to semver tolerant
+# e.g: submodule/submodule/.../v.X.X.X
+# sdk/v1.1.1 -> v1.1.1
+IFS='/'
+read -a tagsplit <<< "${TAG}"
+
+if echo "${#tagsplit[@]}" > /dev/null 2>&1 -gt 1;
+then
+    TAG=${tagsplit[${#tagsplit[@]}-1]}
+fi
+
+# if we found an exact match, return it at this point
+# after we have removed any submodule prefixes.
+if [ $EXACT -eq 1 ]
+then
+    echo -n "${TAG}"
+    if [ ! -z "${DIRTY_TAG}" ]; then
+        echo -n "+${DIRTY_TAG}"
+    fi
+
+    echo ""
+    exit 0
+fi
+
+# Strip off any pre-release tag we might have (e.g. from doing a -rc build)
+TAG=${TAG%%-*}
+
+MAJOR=$(cut -d. -f1 <<< "${TAG}")
+MINOR=$(cut -d. -f2 <<< "${TAG}")
+PATCH=$(cut -d. -f3 <<< "${TAG}")
+
+if [ "${MAJOR}" = "v0" ]; then
+    PATCH=$((${PATCH}+1))
+else
+    MINOR=$((${MINOR}+1))
+    PATCH=0
+fi
+
+# if we're in a features/xxx branch and caller passed --embed-feature-branch then append `-xxx` to
+# the version as well.
+FEATURE_TAG=""
+for arg in "$@"
+do
+    if [[ "$arg" == "--embed-feature-branch" ]]; then
+        if [[ "${TRAVIS_BRANCH:-}" == features/* ]]; then
+            FEATURE_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|-|g')
+        fi
+        if [[ "${TRAVIS_BRANCH:-}" == feature-* ]]; then
+            FEATURE_TAG=$(echo "${TRAVIS_BRANCH}")
+        fi
+    fi
+done
+
+# We want to include some additional information. To the base tag we
+# add a timestamp and commit hash. We use the timestamp of the commit
+# itself, not the date it was authored (so it will change when someone
+# rebases a PR into master, for example).
+echo -n "${MAJOR}.${MINOR}.${PATCH}-alpha${FEATURE_TAG}.$(git show -s --format='%ct+g%h' ${COMMITISH})"
+if [ ! -z "${DIRTY_TAG}" ]; then
+    echo -n ".${DIRTY_TAG}"
+fi
+
+echo ""

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -68,7 +68,7 @@ test_all:: dotnet_test auto_test go_test
 dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${DOTNET_VERSION}" ${LANGHOST_PKG}
 
-brew:: BREW_VERSION := $(shell pulumictl get version)
+brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
 

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -34,7 +34,7 @@ test_auto:: $(TEST_ALL_DEPS)
 dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
-brew:: BREW_VERSION := $(shell pulumictl get version)
+brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
 

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -89,7 +89,7 @@ dist:: build
 	cp dist/pulumi-resource-pulumi-nodejs "$$(go env GOPATH)"/bin/
 	cp dist/pulumi-analyzer-policy "$$(go env GOPATH)"/bin/
 
-brew:: BREW_VERSION := $(shell pulumictl get version)
+brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGUAGE_HOST}
 	cp dist/pulumi-resource-pulumi-nodejs "$$(go env GOPATH)"/bin/

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -75,7 +75,7 @@ dist::
 	cp ./dist/pulumi-resource-pulumi-python "$$(go env GOPATH)"/bin/
 	cp ./dist/pulumi-analyzer-policy-python "$$(go env GOPATH)"/bin/
 
-brew:: BREW_VERSION := $(shell pulumictl get version)
+brew:: BREW_VERSION := $(shell ../../scripts/get-version HEAD)
 brew::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${BREW_VERSION}" ${LANGHOST_PKG}
 	cp ./cmd/pulumi-language-python-exec "$$(go env GOPATH)"/bin/


### PR DESCRIPTION
Reverts pulumi/pulumi#9132

~When installing for homebrew, we don't have `pulumictl` available.~