### PR TITLE
Update tokens.Name to match what's actually in the service

### DIFF
--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -35,8 +35,8 @@ var nameRestCharRegexp = regexp.MustCompile("^" + nameRestCharRegexpPattern + "$
 
 var NameRegexpPattern = nameFirstCharRegexpPattern + nameRestCharRegexpPattern
 
-const nameFirstCharRegexpPattern = "[A-Za-z_.]"
-const nameRestCharRegexpPattern = `[A-Za-z0-9_.-]*`
+const nameFirstCharRegexpPattern = "[A-Za-z0-9_.-]"
+const nameRestCharRegexpPattern = "[A-Za-z0-9_.-]*"
 
 // IsName checks whether a string is a legal Name.
 func IsName(s string) bool {

--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -61,7 +61,7 @@ const QNameDelimiter = "/"
 var QNameRegexp = regexp.MustCompile(QNameRegexpPattern)
 var QNameRegexpPattern = "(" + NameRegexpPattern + "\\" + QNameDelimiter + ")*" + NameRegexpPattern
 
-// IsQName checks whether a string is a legal Name.
+// IsQName checks whether a string is a legal QName.
 func IsQName(s string) bool {
 	return s != "" && QNameRegexp.FindString(s) == s
 }

--- a/sdk/go/common/tokens/names_test.go
+++ b/sdk/go/common/tokens/names_test.go
@@ -24,14 +24,18 @@ func TestIsAsName(t *testing.T) {
 	t.Parallel()
 
 	var goodNames = []string{
-		"simple",  // all alpha.
-		"SiMplE",  // mixed-case alpha.
-		"simple0", // alphanumeric.
-		"SiMpLe0", // mixed-case alphanumeric.
-		"_",       // permit underscore.
-		"s1MPl3_", // mixed-case alphanumeric/underscore.
-		"_s1MPl3", // ditto.
-		"hy-phy",  // permit hyphens.
+		"simple",       // all alpha.
+		"SiMplE",       // mixed-case alpha.
+		"simple0",      // alphanumeric.
+		"SiMpLe0",      // mixed-case alphanumeric.
+		"_",            // permit underscore.
+		"s1MPl3_",      // mixed-case alphanumeric/underscore.
+		"_s1MPl3",      // ditto.
+		"hy-phy",       // permit hyphens.
+		".dotstart",    // start with .
+		"-hyphenstart", // start with -
+		"0num",         // start with numbers
+		"9num",         // start with numbers
 	}
 	for _, nm := range goodNames {
 		assert.True(t, IsName(nm), "IsName expected to be true: %v", nm)
@@ -50,12 +54,9 @@ func TestIsAsName(t *testing.T) {
 	}
 
 	var badNames = []string{
-		"0_s1MPl3",                         // cannot start with a number.
-		"namespace/0complex",               // ditto.
-		"namespace/morenamespace/0complex", // ditto.
-		"s!mple",                           // bad characters.
-		"namesp@ce/complex",                // ditto.
-		"namespace/morenamespace/compl#x",  // ditto.
+		"s!mple",                          // bad characters.
+		"namesp@ce/complex",               // ditto.
+		"namespace/morenamespace/compl#x", // ditto.
 	}
 	for _, nm := range badNames {
 		assert.False(t, IsName(nm), "IsName expected to be false: %v", nm)


### PR DESCRIPTION
I download all the stack names currently in metabase and checked this new regex against them with:

```
func TestStackNames(t *testing.T) {

	f, err := os.Open("/home/fraser/query_result_2022-03-09T14_21_20.792902-08_00.csv")
	if err != nil {
		log.Fatal("Unable to read input file", err)
	}
	defer f.Close()

	r := csv.NewReader(f)

	for {
		rec, err := r.Read()
		if err == io.EOF {
			break
		}
		assert.NoError(t, err)

		name := rec[0]
		assert.True(t, IsName(name), "'%s' isn't a name", name)
	}
}
```

Before the changes in this PR that flagged up a number of problematic stack names like `--diff`, `0`, `.dev`