### PR TITLE
Support plugins from private Pulumi repos

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,11 +3,11 @@
 - [language/dotnet] - Updated Pulumi dotnet packages to use grpc-dotnet instead of grpc.
   [#9149](https://github.com/pulumi/pulumi/pull/9149)
 
-- [cli/plugins] Add support for downloading plugin from private Pulumi GitHub releases.
-  [#9185](https://github.com/pulumi/pulumi/pull/9185)
-
 - [cli/config] Rename the `config` property in `Pulumi.yaml` to `stackConfigDir`. The `config` key will continue to be supported.
   [#9145](https://github.com/pulumi/pulumi/pull/9145)
+
+- [cli/plugins] Add support for downloading plugin from private Pulumi GitHub releases. This also drops the use of the `GITHUB_ACTOR` and `GITHUB_PERSONAL_ACCESS_TOKEN` environment variables for authenticating to github. Only `GITHUB_TOKEN` is now used, but this can be set to a personal access token.
+  [#9185](https://github.com/pulumi/pulumi/pull/9185)
 
 ### Bug Fixes
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,10 @@
 ### Improvements
 
 - [language/dotnet] - Updated Pulumi dotnet packages to use grpc-dotnet instead of grpc.
-   [#9149](https://github.com/pulumi/pulumi/pull/9149)
+  [#9149](https://github.com/pulumi/pulumi/pull/9149)
+
+- [cli/plugins] Add support for downloading plugin from private Pulumi GitHub releases.
+  [#9185](https://github.com/pulumi/pulumi/pull/9185)
 
 ### Bug Fixes
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -201,6 +201,15 @@ type githubSource struct {
 
 // Creates a new github source adding authentication data in the environment, if it exists
 func newGithubSource(organization, name string, kind PluginKind) *githubSource {
+
+	// 14-03-2022 we stopped looking at GITHUB_PERSONAL_ACCESS_TOKEN and sending basic auth for github and
+	// instead just look at GITHUB_TOKEN and send in a header. Given GITHUB_PERSONAL_ACCESS_TOKEN was an
+	// envvar we made up we check to see if it's set here and log a warning. This can be removed after a few
+	// releases.
+	if os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN") != "" {
+		logging.Warningf("GITHUB_PERSONAL_ACCESS_TOKEN is no longer used for Github authentication, set GITHUB_TOKEN instead")
+	}
+
 	return &githubSource{
 		organization: organization,
 		name:         name,

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -448,7 +448,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 			}
 
 			if req.URL.String() == "https://api.github.com/repos/private/pulumi-private/releases/latest" {
-				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authentication"))
+				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{
@@ -474,7 +474,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		source := info.GetSource()
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mock-private/releases/latest" {
-				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authentication"))
+				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -286,6 +286,7 @@ func TestPluginDownload(t *testing.T) {
 	token := "RaNd0m70K3n_"
 
 	t.Run("Test Downloading From Pulumi GitHub Releases", func(t *testing.T) {
+		os.Setenv("GITHUB_TOKEN", "")
 		version := semver.MustParse("4.32.0")
 		info := PluginInfo{
 			PluginDownloadURL: "",
@@ -462,6 +463,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	token := "RaNd0m70K3n_"
 
 	t.Run("Test GetLatestVersion From Pulumi GitHub Releases", func(t *testing.T) {
+		os.Setenv("GITHUB_TOKEN", "")
 		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -281,6 +282,8 @@ func newMockReadCloserString(data string) (io.ReadCloser, int64, error) {
 
 //nolint:paralleltest // mutates environment variables
 func TestPluginDownload(t *testing.T) {
+	expectedBytes := []byte{1, 2, 3}
+
 	t.Run("Test Downloading From Pulumi GitHub Releases", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
 		info := PluginInfo{
@@ -295,10 +298,14 @@ func TestPluginDownload(t *testing.T) {
 				"https://github.com/pulumi/pulumi-mockdl/releases/download/v4.32.0/"+
 					"pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
 				req.URL.String())
-			return newMockReadCloser([]byte{})
+			return newMockReadCloser(expectedBytes)
 		}
-		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
+		readBytes, err := ioutil.ReadAll(r)
+		assert.Nil(t, err)
+		assert.Equal(t, int(l), len(readBytes))
+		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From get.pulumi.com", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
@@ -318,14 +325,16 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t,
 				"https://get.pulumi.com/releases/plugins/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
 				req.URL.String())
-			return newMockReadCloser([]byte{})
+			return newMockReadCloser(expectedBytes)
 		}
-		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
+		readBytes, err := ioutil.ReadAll(r)
+		assert.Nil(t, err)
+		assert.Equal(t, int(l), len(readBytes))
+		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From Custom Server URL", func(t *testing.T) {
-		t.Skip()
-
 		version := semver.MustParse("4.32.0")
 		info := PluginInfo{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
@@ -339,14 +348,16 @@ func TestPluginDownload(t *testing.T) {
 				"https://customurl.jfrog.io/artifactory/pulumi-packages/"+
 					"package-name/pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz",
 				req.URL.String())
-			return newMockReadCloser([]byte{})
+			return newMockReadCloser(expectedBytes)
 		}
-		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
+		readBytes, err := ioutil.ReadAll(r)
+		assert.Nil(t, err)
+		assert.Equal(t, int(l), len(readBytes))
+		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From GitHub Private Releases", func(t *testing.T) {
-		t.Skip()
-
 		token := "RaNd0m70K3n_"
 		os.Setenv("PULUMI_EXPERIMENTAL", "true")
 		os.Setenv("GITHUB_REPOSITORY_OWNER", "private")
@@ -360,14 +371,13 @@ func TestPluginDownload(t *testing.T) {
 		}
 		source := info.GetSource()
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
-			// Test that the asset isn't on github
-			if req.URL.String() == "https://github.com/pulumi/pulumi-private/releases/download/"+
-				"v1.22.0/pulumi-resource-private-v1.22.0-darwin-amd64.tar.gz" {
+			// Test that the asset isn't on pulumi github
+			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-private/releases/tags/v1.22.0" {
 				return nil, -1, errors.New("404 not found")
 			}
 
 			if req.URL.String() == "https://api.github.com/repos/private/pulumi-private/releases/tags/v1.22.0" {
-				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authentication"))
+				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
 				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				// Minimal JSON from the releases API to get the test to pass
 				return newMockReadCloserString(`{
@@ -386,17 +396,72 @@ func TestPluginDownload(t *testing.T) {
 			}
 
 			assert.Equal(t, "https://api.github.com/repos/private/pulumi-private/releases/assets/123456", req.URL.String())
-			assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authentication"))
+			assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
-			return newMockReadCloser([]byte{})
+			return newMockReadCloser(expectedBytes)
 		}
-		_, _, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
+		readBytes, err := ioutil.ReadAll(r)
+		assert.Nil(t, err)
+		assert.Equal(t, int(l), len(readBytes))
+		assert.Equal(t, expectedBytes, readBytes)
+	})
+	t.Run("Test Downloading From Private Pulumi GitHub Releases", func(t *testing.T) {
+		token := "RaNd0m70K3n_"
+		os.Setenv("GITHUB_TOKEN", token)
+		version := semver.MustParse("4.32.0")
+		info := PluginInfo{
+			PluginDownloadURL: "",
+			Name:              "mockdl",
+			Version:           &version,
+			Kind:              PluginKind("resource"),
+		}
+		source := info.GetSource()
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			// Test that the asset isn't on github
+			if req.URL.String() == "https://github.com/pulumi/pulumi-mockdl/releases/download/"+
+				"v1.22.0/pulumi-resource-mockdl-v1.22.0-darwin-amd64.tar.gz" {
+				return nil, -1, errors.New("404 not found")
+			}
+
+			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.32.0" {
+				assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
+				// Minimal JSON from the releases API to get the test to pass
+				return newMockReadCloserString(`{
+					"assets": [
+					  {
+						"url": "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/654321",
+						"name": "pulumi-mockdl_4.32.0_checksums.txt"
+					  },
+					  {
+						"url": "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/123456",
+						"name": "pulumi-resource-mockdl-v4.32.0-darwin-amd64.tar.gz"
+					  }
+					]
+				  }
+				`)
+			}
+
+			assert.Equal(t, "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/123456", req.URL.String())
+			assert.Equal(t, fmt.Sprintf("token %s", token), req.Header.Get("Authorization"))
+			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
+			return newMockReadCloser(expectedBytes)
+		}
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		assert.Nil(t, err)
+		readBytes, err := ioutil.ReadAll(r)
+		assert.Nil(t, err)
+		assert.Equal(t, int(l), len(readBytes))
+		assert.Equal(t, expectedBytes, readBytes)
 	})
 }
 
 //nolint:paralleltest // mutates environment variables
 func TestPluginGetLatestVersion(t *testing.T) {
+	token := "RaNd0m70K3n_"
+
 	t.Run("Test GetLatestVersion From Pulumi GitHub Releases", func(t *testing.T) {
 		info := PluginInfo{
 			PluginDownloadURL: "",
@@ -430,7 +495,6 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, "GetLatestVersion is not supported for plugins using PluginDownloadURL", err.Error())
 	})
 	t.Run("Test GetLatestVersion From GitHub Private Releases", func(t *testing.T) {
-		token := "RaNd0m70K3n_"
 		os.Setenv("PULUMI_EXPERIMENTAL", "true")
 		os.Setenv("GITHUB_REPOSITORY_OWNER", "private")
 		os.Setenv("GITHUB_TOKEN", token)
@@ -463,7 +527,6 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, expectedVersion, *version)
 	})
 	t.Run("Test GetLatestVersion From Private Pulumi GitHub Releases", func(t *testing.T) {
-		token := "RaNd0m70K3n_"
 		os.Setenv("GITHUB_TOKEN", token)
 		info := PluginInfo{
 			PluginDownloadURL: "",

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -283,6 +283,7 @@ func newMockReadCloserString(data string) (io.ReadCloser, int64, error) {
 //nolint:paralleltest // mutates environment variables
 func TestPluginDownload(t *testing.T) {
 	expectedBytes := []byte{1, 2, 3}
+	token := "RaNd0m70K3n_"
 
 	t.Run("Test Downloading From Pulumi GitHub Releases", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
@@ -358,7 +359,6 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From GitHub Private Releases", func(t *testing.T) {
-		token := "RaNd0m70K3n_"
 		os.Setenv("PULUMI_EXPERIMENTAL", "true")
 		os.Setenv("GITHUB_REPOSITORY_OWNER", "private")
 		os.Setenv("GITHUB_TOKEN", token)
@@ -408,7 +408,6 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From Private Pulumi GitHub Releases", func(t *testing.T) {
-		token := "RaNd0m70K3n_"
 		os.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
 		info := PluginInfo{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This makes a few changes to our github authentication flow.
1) We only look at the GITHUB_TOKEN environment variable now. GITHUB_ACTOR and GITHUB_PERSONAL_ACCESS_TOKEN are no longer used. 
2) The token is sent via the Authorization header instead of Authentication, as documented at https://docs.github.com/en/rest/overview/resources-in-the-rest-api#authentication
3) We try to use this env var even when accessing the pulumi repos.

This allows us to develop plugins in private repos but continue to use our standard plugin flow.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
