### PR TITLE
Roll back to setup-python-v1 to avoid build failure

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -238,7 +238,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip


### PR DESCRIPTION
Fix #9188 (or rather work around it)