### PR TITLE
Support pointers in pulumi.All

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,13 +1,18 @@
 ### Improvements
 
-- [area/cli] - Implement `pulumi stack unselect` [#9179](https://github.com/pulumi/pulumi/pull/9179)
+- [area/cli] - Implement `pulumi stack unselect`.
+  [#9179](https://github.com/pulumi/pulumi/pull/9179)
+
 - [language/dotnet] - Updated Pulumi dotnet packages to use grpc-dotnet instead of grpc.
-   [#9149](https://github.com/pulumi/pulumi/pull/9149)
+  [#9149](https://github.com/pulumi/pulumi/pull/9149)
 
 - [cli/config] Rename the `config` property in `Pulumi.yaml` to `stackConfigDir`. The `config` key will continue to be supported.
   [#9145](https://github.com/pulumi/pulumi/pull/9145)
 
 ### Bug Fixes
 
-  [sdk/nodejs] - Fix uncaught error "ENOENT: no such file or directory" when an error occurs during the stack up
+- [sdk/nodejs] - Fix uncaught error "ENOENT: no such file or directory" when an error occurs during the stack up.
   [#9065](https://github.com/pulumi/pulumi/issues/9065)
+
+- [sdk/go] - Fix a panic in `pulumi.All` when using pointer inputs.
+  [#9197](https://github.com/pulumi/pulumi/issues/9197)

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -718,10 +718,18 @@ func awaitInputs(ctx context.Context, v, resolved reflect.Value) (bool, bool, []
 		} else {
 			// Handle pointer inputs.
 			if v.Kind() == reflect.Ptr {
-				v, valueType = v.Elem(), valueType.Elem()
-
-				resolved.Set(reflect.New(resolved.Type().Elem()))
-				resolved = resolved.Elem()
+				v = v.Elem()
+				valueType = valueType.Elem()
+				if resolved.Type() != anyType {
+					// resolved should be some pointer type U such that value Type is convertable to U.
+					resolved.Set(reflect.New(resolved.Type().Elem()))
+					resolved = resolved.Elem()
+				} else {
+					// Allocate storage for a pointer and assign that to resolved, then continue below with resolved set to the inner value of the pointer just allocated
+					ptr := reflect.New(valueType)
+					resolved.Set(ptr)
+					resolved = ptr.Elem()
+				}
 			}
 		}
 	}


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

In awaitInputs we didn't correctly handle the case of the input value being a pointer and the resolved destination being `interface{}`. We now handle this by allocating a new pointer of the same type of the input, and assiging that to the resolved location if resolved.Type is `any`.

Else we expect resolved.Type() to be some pointer type that the exisiting logic can handle.

Fixes https://github.com/pulumi/pulumi/issues/9192

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
