### PR TITLE
[dotnet/sdk] Refactor usage of concurrent dictionary

### DIFF
--- a/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
@@ -16,27 +16,27 @@ namespace Pulumi
         private readonly Engine.EngineClient _engine;
         // Using a static dictionary to keep track of and re-use gRPC channels
         // According to the docs (https://docs.microsoft.com/en-us/aspnet/core/grpc/performance?view=aspnetcore-6.0#reuse-grpc-channels), creating GrpcChannels is expensive so we keep track of a bunch of them here
-        private static ConcurrentDictionary<string, GrpcChannel> _engineChannels = new ConcurrentDictionary<string, GrpcChannel>();
+        private static readonly ConcurrentDictionary<string, GrpcChannel> _engineChannels = new ConcurrentDictionary<string, GrpcChannel>();
 
         public GrpcEngine(string engineAddress)
         {
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             var maxRpcMessageSize = 400 * 1024 * 1024;
-            if (!_engineChannels.ContainsKey(engineAddress))
+            var engineChannel = _engineChannels.GetOrAdd(engineAddress, address => 
             {
                 // Allow for insecure HTTP/2 transport (only needed for netcoreapp3.x)
                 // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client
                 AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
                 // Inititialize the engine channel once for this address
-                _engineChannels[engineAddress] = GrpcChannel.ForAddress(new Uri($"http://{engineAddress}"), new GrpcChannelOptions
+                return GrpcChannel.ForAddress(new Uri($"http://{address}"), new GrpcChannelOptions
                 {
                     MaxReceiveMessageSize = maxRpcMessageSize,
                     MaxSendMessageSize = maxRpcMessageSize,
                     Credentials = Grpc.Core.ChannelCredentials.Insecure,
                 });
-            }
+            });
 
-            this._engine = new Engine.EngineClient(_engineChannels[engineAddress]);
+            this._engine = new Engine.EngineClient(engineChannel);
         }
         
         public async Task LogAsync(LogRequest request)

--- a/sdk/dotnet/Pulumi/Deployment/GrpcMonitor.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcMonitor.cs
@@ -15,26 +15,26 @@ namespace Pulumi
         private readonly ResourceMonitor.ResourceMonitorClient _client;
         // Using a static dictionary to keep track of and re-use gRPC channels
         // According to the docs (https://docs.microsoft.com/en-us/aspnet/core/grpc/performance?view=aspnetcore-6.0#reuse-grpc-channels), creating GrpcChannels is expensive so we keep track of a bunch of them here
-        private static ConcurrentDictionary<string, GrpcChannel> _monitorChannels = new ConcurrentDictionary<string, GrpcChannel>();
+        private static readonly ConcurrentDictionary<string, GrpcChannel> _monitorChannels = new ConcurrentDictionary<string, GrpcChannel>();
         public GrpcMonitor(string monitorAddress)
         {
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             var maxRpcMessageSize = 400 * 1024 * 1024;
-            if (!_monitorChannels.ContainsKey(monitorAddress))
+            var monitorChannel = _monitorChannels.GetOrAdd(monitorAddress, address =>
             {
                 // Allow for insecure HTTP/2 transport (only needed for netcoreapp3.x)
                 // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client
                 AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
                 // Inititialize the monitor channel once for this monitor address
-                _monitorChannels[monitorAddress] = GrpcChannel.ForAddress(new Uri($"http://{monitorAddress}"), new GrpcChannelOptions
+                return GrpcChannel.ForAddress(new Uri($"http://{address}"), new GrpcChannelOptions
                 {
                     MaxReceiveMessageSize = maxRpcMessageSize,
                     MaxSendMessageSize = maxRpcMessageSize,
                     Credentials = ChannelCredentials.Insecure
                 });
-            }
+            });
 
-            this._client = new ResourceMonitor.ResourceMonitorClient(_monitorChannels[monitorAddress]);
+            this._client = new ResourceMonitor.ResourceMonitorClient(monitorChannel);
         }
         
         public async Task<SupportsFeatureResponse> SupportsFeatureAsync(SupportsFeatureRequest request)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The PR applies a refactoring to the way `ConcurrentDictionary` is used from the dotnet SDK that keeps track of the gRPC channels as suggested by @justinvp 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
