### PR TITLE
ci: tolerate and retry fluke test failures

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -96,9 +96,7 @@ SHELL       := /bin/bash
 STEP_MESSAGE = @echo -e "\033[0;32m$(shell echo '$@' | tr a-z A-Z | tr '_' ' '):\033[0m"
 
 # Our install targets place items item into $PULUMI_ROOT.
-ifeq ($(PULUMI_ROOT),)
-	PULUMI_ROOT:=$(realpath "$$HOME/.pulumi-dev")
-endif
+PULUMI_ROOT ?= $$HOME/.pulumi-dev
 
 # Use Python 3 explicitly vs expecting that `python` will resolve to a python 3
 # runtime.

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -3,6 +3,7 @@ Wraps `go test`.
 """
 
 from datetime import datetime
+from typing import List
 from integration_test_subsets import INTEGRATION_TESTS
 import os
 import pathlib
@@ -15,19 +16,27 @@ import threading
 
 dryrun = os.environ.get("PULUMI_TEST_DRYRUN", None) == "true"
 
+def options(options_and_packages: List[str]):
+    return [o for o in options_and_packages if not o.startswith('github.com/pulumi/pulumi')]
+
+
+def packages(options_and_packages: List[str]):
+    return [o for o in options_and_packages if o.startswith('github.com/pulumi/pulumi')]
+
+
 root = pathlib.Path(__file__).absolute().parent.parent
 integration_test_subset = os.environ.get('PULUMI_INTEGRATION_TESTS', None)
-options = sys.argv[1:]
+args = sys.argv[1:]
 cov = os.environ.get('PULUMI_TEST_COVERAGE_PATH', None)
 if cov is not None:
-    options = options + [f'-coverprofile={cov}/go-test-{os.urandom(4).hex()}.cov', '-coverpkg=github.com/pulumi/pulumi/pkg/v3/...,github.com/pulumi/pulumi/sdk/v3/...']
+    args = args + [f'-coverprofile={cov}/go-test-{os.urandom(4).hex()}.cov', '-coverpkg=github.com/pulumi/pulumi/pkg/v3/...,github.com/pulumi/pulumi/sdk/v3/...']
 
 if integration_test_subset:
     print(f"Using test subset: {integration_test_subset}")
-    options += ['-run', INTEGRATION_TESTS[integration_test_subset]]
+    args += ['-run', INTEGRATION_TESTS[integration_test_subset]]
 
 if os.environ.get("CI") != "true":
-    options += ['-v']
+    args += ['-v']
 
 
 class RepeatTimer(threading.Timer):
@@ -52,20 +61,23 @@ timer.start()
 if shutil.which('gotestsum') is not None:
     test_run = str(uuid.uuid4())
 
+    opts = options(args)
+    pkgs = " ".join(packages(args))
+
     test_results_dir = root.joinpath('test-results')
     if not test_results_dir.is_dir():
         os.mkdir(str(test_results_dir))
 
     json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
     junit_file = str(test_results_dir.joinpath(f'{test_run}.xml'))
-    args = ['gotestsum', '--jsonfile', json_file, '--junitfile', junit_file, '--'] + \
-        options
+    args = ['gotestsum', '--jsonfile', json_file, '--junitfile', junit_file, '--rerun-fails=2', '--packages', pkgs, '--'] + \
+        opts
 
     print(' '.join(args))
     if not dryrun:
         sp.check_call(args, shell=False)
 else:
-    args = ['go', 'test'] + options
+    args = ['go', 'test'] + args
     print(' '.join(args))
     if not dryrun:
         sp.check_call(args, shell=False)


### PR DESCRIPTION
Uses `--rerun-fails` with `gotestsum` to improve reliability of flakey tests.

#### Miscellany

I noticed a build error creating `/node_modules` and saw locally that if PULUMI_HOME isn't set, in the makefile the expression `$(realpath $$HOME/.pulumi-dev` doesn't do what I would expect:

makefile:
```
test_foo:
	echo $(realpath $$HOME/.pulumi-dev/)
	echo $(realpath $$HOME/.pulumi-dev)
```

output:

```
$ make test_foo
echo 

echo 

```

Fortunately, $HOME is very rarely not an absolute path, so I don't know what we're guarding against with realpath. If we do need to use realpath, we can change that line in common.mk to `$(realpath $(shell echo "$$HOME/.pulumi-dev"))` or even `$(shell mkdir -p $$HOME/.pulumi-dev && readlink -f $$HOME/.pulumi-dev)`, but that actually introduces another oddity: MacOS doesn't bundle readlink because it uses a decade+ old version of GNU coreutils. But I digress.
