### PR TITLE
Expand pcl intrinsic functions

### DIFF
--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -240,6 +240,7 @@ func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, en
 var functionNamespaces = map[string][]string{
 	"readDir":          {"System.IO", "System.Linq"},
 	"readFile":         {"System.IO"},
+	"cwd":              {"System.IO"},
 	"filebase64":       {"System", "System.IO"},
 	"filebase64sha256": {"System", "System.IO", "System.Security.Cryptography", "System.Text"},
 	"toJSON":           {"System.Text.Json", "System.Collections.Generic"},
@@ -365,6 +366,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "sha1":
 		// Assuming the existence of the following helper method located earlier in the preamble
 		g.Fgenf(w, "ComputeSHA1(%v)", expr.Args[0])
+	case "stack":
+		g.Fgen(w, "Deployment.Instance.StackName")
+	case "project":
+		g.Fgen(w, "Deployment.Instance.ProjectName")
+	case "cwd":
+		g.Fgenf(w, "Directory.GetCurrentDirectory()")
 	default:
 		g.genNYI(w, "call %v", expr.Name)
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -259,6 +259,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "pulumi.IntRef(%.v)", expr.Args[0])
 	case "goOptionalString":
 		g.Fgenf(w, "pulumi.StringRef(%.v)", expr.Args[0])
+	case "stack":
+		g.Fgen(w, "ctx.Stack()")
+	case "project":
+		g.Fgen(w, "ctx.Project()")
+	case "cwd":
+		g.Fgen(w, "func(cwd string, err error) string { if err != nil { panic(err) }; return cwd }(os.Getwd())")
 	default:
 		g.genNYI(w, "call %v", expr.Name)
 	}
@@ -1021,6 +1027,7 @@ var functionPackages = map[string][]string{
 	"toJSON":           {"encoding/json"},
 	"sha1":             {"fmt", "crypto/sha1"},
 	"filebase64sha256": {"fmt", "io/ioutil", "crypto/sha256"},
+	"cwd":              {"os"},
 }
 
 func (g *generator) genFunctionPackages(x *model.FunctionCallExpression) []string {

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -370,6 +370,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "JSON.stringify(%v)", expr.Args[0])
 	case "sha1":
 		g.Fgenf(w, "crypto.createHash('sha1').update(%v).digest('hex')", expr.Args[0])
+	case "stack":
+		g.Fgenf(w, "pulumi.getStack()")
+	case "project":
+		g.Fgenf(w, "pulumi.getProject()")
+	case "cwd":
+		g.Fgen(w, "process.cwd()")
 
 	default:
 		var rng hcl.Range

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -272,4 +272,16 @@ var pulumiBuiltins = map[string]*model.Function{
 		}},
 		ReturnType: model.StringType,
 	}),
+	// Returns the name of the current stack
+	"stack": model.NewFunction(model.StaticFunctionSignature{
+		ReturnType: model.StringType,
+	}),
+	// Returns the name of the current project
+	"project": model.NewFunction(model.StaticFunctionSignature{
+		ReturnType: model.StringType,
+	}),
+	// Returns the directory from which pulumi was run
+	"cwd": model.NewFunction(model.StaticFunctionSignature{
+		ReturnType: model.StringType,
+	}),
 }

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -190,6 +190,9 @@ var functionImports = map[string][]string{
 	"toBase64":         {"base64"},
 	"toJSON":           {"json"},
 	"sha1":             {"hashlib"},
+	"stack":            {"pulumi"},
+	"project":          {"pulumi"},
+	"cwd":              {"os"},
 }
 
 func (g *generator) getFunctionImports(x *model.FunctionCallExpression) []string {
@@ -313,6 +316,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "json.dumps(%.v)", expr.Args[0])
 	case "sha1":
 		g.Fgenf(w, "hashlib.sha1(%v.encode()).hexdigest()", expr.Args[0])
+	case "project":
+		g.Fgen(w, "pulumi.get_project()")
+	case "stack":
+		g.Fgen(w, "pulumi.get_stack()")
+	case "cwd":
+		g.Fgen(w, "os.getcwd()")
 	default:
 		var rng hcl.Range
 		if expr.Syntax != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Adds the `stack`, `project` and `cwd` functions to the list of PCL built in functions. These get the stack name, project name, and current working directory respectively.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
