### PR TITLE
ci: disable dotnet telemetry, emit version

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,6 +17,7 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   TRAVIS_PUBLISH_PACKAGES: true
   PYTHON: python
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 
 jobs:
   publish-sdks:
@@ -248,7 +249,11 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
+      - name: Add NuGet packages as a local NuGet source
+        run: |
+          echo $(which dotnet)
+          echo $(dotnet --version)
+          dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,6 +17,7 @@ env:
   TRAVIS_PUBLISH_PACKAGES: true
   IS_PRERELEASE: true
   PYTHON: python
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 
 jobs:
   publish-sdks:
@@ -278,7 +279,11 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
+      - name: Add NuGet packages as a local NuGet source
+        run: |
+          echo $(which dotnet)
+          echo $(dotnet --version)
+          dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   TRAVIS_PUBLISH_PACKAGES: true
   PYTHON: python
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 
 jobs:
   templates_smoke_test:
@@ -387,7 +388,11 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
+      - name: Add NuGet packages as a local NuGet source
+        run: |
+          echo $(which dotnet)
+          echo $(dotnet --version)
+          dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -16,6 +16,7 @@ env:
   PULUMI_TEST_OWNER: "moolumi"
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
   PYTHON: python
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 
 # Cancel checks on prior commits when new commits are added to a PR.
 # This is motivated by temporary throughput issues on our GitHub
@@ -119,7 +120,11 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
+      - name: Add NuGet packages as a local NuGet source
+        run: |
+          echo $(which dotnet)
+          echo $(dotnet --version)
+          dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ inputs.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -45,6 +45,7 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.pulumi-access-token }}
   PYTHON: python
   TESTPARALLELISM: 4
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 
 jobs:
   test:
@@ -257,6 +258,8 @@ jobs:
           path: ${{ github.workspace }}/nuget
       - name: Add NuGet packages as a local NuGet source
         run: |
+          echo $(which dotnet)
+          echo $(dotnet --version)
           echo "PULUMI_LOCAL_NUGET=$PULUMI_LOCAL_NUGET"
           SOURCE=$(./scripts/normpath $PULUMI_LOCAL_NUGET)
           echo "SOURCE=$SOURCE"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.pulumi-access-token }}
   PYTHON: python
   TESTPARALLELISM: 4
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 
 jobs:
   test:
@@ -275,6 +276,8 @@ jobs:
           path: ${{ github.workspace }}/nuget
       - name: Add NuGet packages as a local NuGet source
         run: |
+          echo $(which dotnet)
+          echo $(dotnet --version)
           echo "PULUMI_LOCAL_NUGET=$PULUMI_LOCAL_NUGET"
           SOURCE=$(./scripts/normpath $PULUMI_LOCAL_NUGET)
           echo "SOURCE=$SOURCE"


### PR DESCRIPTION
n/t

CI errors on the PR may be disregarded as tests use workflow defined on @master by default, and this won't change those until it's merged. (A catch-22 we need to resolve, but separately.)