### PR TITLE
Return organizations from Backend.CurrentUser

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -199,8 +199,8 @@ type Backend interface {
 	Logout() error
 	// LogoutAll logs you out of all the backend and removes any stored credentials.
 	LogoutAll() error
-	// Returns the identity of the current user for the backend.
-	CurrentUser() (string, error)
+	// Returns the identity of the current user and any organizations they are in for the backend.
+	CurrentUser() (string, []string, error)
 
 	// Cancel the current update for the given stack.
 	CancelCurrentUpdate(ctx context.Context, stackRef StackReference) error

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -805,12 +805,12 @@ func (b *localBackend) LogoutAll() error {
 	return workspace.DeleteAllAccounts()
 }
 
-func (b *localBackend) CurrentUser() (string, error) {
+func (b *localBackend) CurrentUser() (string, []string, error) {
 	user, err := user.Current()
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return user.Username, nil
+	return user.Username, nil, nil
 }
 
 func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -212,13 +212,13 @@ func loginWithBrowser(ctx context.Context, d diag.Sink, cloudURL string, opts di
 
 	accessToken := <-c
 
-	username, err := client.NewClient(cloudURL, accessToken, d).GetPulumiAccountName(ctx)
+	username, organizations, err := client.NewClient(cloudURL, accessToken, d).GetPulumiAccountDetails(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Save the token and return the backend
-	account := workspace.Account{AccessToken: accessToken, Username: username, LastValidatedAt: time.Now()}
+	account := workspace.Account{AccessToken: accessToken, Username: username, Organizations: organizations, LastValidatedAt: time.Now()}
 	if err = workspace.StoreAccount(cloudURL, account, true); err != nil {
 		return nil, err
 	}
@@ -237,9 +237,9 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	existingAccount, err := workspace.GetAccount(cloudURL)
 	if err == nil && existingAccount.AccessToken != "" {
 		// If the account was last verified less than an hour ago, assume the token is valid.
-		valid, username := true, existingAccount.Username
+		valid, username, organizations := true, existingAccount.Username, existingAccount.Organizations
 		if username == "" || existingAccount.LastValidatedAt.Add(1*time.Hour).Before(time.Now()) {
-			valid, username, err = IsValidAccessToken(ctx, cloudURL, existingAccount.AccessToken)
+			valid, username, organizations, err = IsValidAccessToken(ctx, cloudURL, existingAccount.AccessToken)
 			if err != nil {
 				return nil, err
 			}
@@ -249,6 +249,7 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 		if valid {
 			// Save the token. While it hasn't changed this will update the current cloud we are logged into, as well.
 			existingAccount.Username = username
+			existingAccount.Organizations = organizations
 			if err = workspace.StoreAccount(cloudURL, existingAccount, true); err != nil {
 				return nil, err
 			}
@@ -328,7 +329,7 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	}
 
 	// Try and use the credentials to see if they are valid.
-	valid, username, err := IsValidAccessToken(ctx, cloudURL, accessToken)
+	valid, username, organizations, err := IsValidAccessToken(ctx, cloudURL, accessToken)
 	if err != nil {
 		return nil, err
 	} else if !valid {
@@ -336,7 +337,7 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	}
 
 	// Save them.
-	account := workspace.Account{AccessToken: accessToken, Username: username, LastValidatedAt: time.Now()}
+	account := workspace.Account{AccessToken: accessToken, Username: username, Organizations: organizations, LastValidatedAt: time.Now()}
 	if err = workspace.StoreAccount(cloudURL, account, true); err != nil {
 		return nil, err
 	}
@@ -389,28 +390,29 @@ func (b *cloudBackend) Name() string {
 }
 
 func (b *cloudBackend) URL() string {
-	user, err := b.CurrentUser()
+	user, _, err := b.CurrentUser()
 	if err != nil {
 		return cloudConsoleURL(b.url)
 	}
 	return cloudConsoleURL(b.url, user)
 }
 
-func (b *cloudBackend) CurrentUser() (string, error) {
+func (b *cloudBackend) CurrentUser() (string, []string, error) {
 	return b.currentUser(context.Background())
 }
 
-func (b *cloudBackend) currentUser(ctx context.Context) (string, error) {
+func (b *cloudBackend) currentUser(ctx context.Context) (string, []string, error) {
 	account, err := workspace.GetAccount(b.CloudURL())
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if account.Username != "" {
 		logging.V(1).Infof("found username for access token")
-		return account.Username, nil
+		return account.Username, account.Organizations, nil
 	}
 	logging.V(1).Infof("no username for access token")
-	return b.client.GetPulumiAccountName(ctx)
+	name, orgs, err := b.client.GetPulumiAccountDetails(ctx)
+	return name, orgs, err
 }
 
 func (b *cloudBackend) CloudURL() string { return b.url }
@@ -430,7 +432,7 @@ func (b *cloudBackend) parsePolicyPackReference(s string) (backend.PolicyPackRef
 	}
 
 	if orgName == "" {
-		currentUser, userErr := b.CurrentUser()
+		currentUser, _, userErr := b.CurrentUser()
 		if userErr != nil {
 			return nil, userErr
 		}
@@ -532,7 +534,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 		if defaultOrg != "" {
 			qualifiedName.Owner = defaultOrg
 		} else {
-			currentUser, userErr := b.CurrentUser()
+			currentUser, _, userErr := b.CurrentUser()
 			if userErr != nil {
 				return nil, userErr
 			}
@@ -667,7 +669,7 @@ func (b *cloudBackend) LogoutAll() error {
 
 // DoesProjectExist returns true if a project with the given name exists in this backend, or false otherwise.
 func (b *cloudBackend) DoesProjectExist(ctx context.Context, projectName string) (bool, error) {
-	owner, err := b.currentUser(ctx)
+	owner, _, err := b.currentUser(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -1453,19 +1455,19 @@ func (b *cloudBackend) tryNextUpdate(ctx context.Context, update client.UpdateId
 
 // IsValidAccessToken tries to use the provided Pulumi access token and returns if it is accepted
 // or not. Returns error on any unexpected error.
-func IsValidAccessToken(ctx context.Context, cloudURL, accessToken string) (bool, string, error) {
+func IsValidAccessToken(ctx context.Context, cloudURL, accessToken string) (bool, string, []string, error) {
 	// Make a request to get the authenticated user. If it returns a successful response,
 	// we know the access token is legit. We also parse the response as JSON and confirm
 	// it has a githubLogin field that is non-empty (like the Pulumi Service would return).
-	username, err := client.NewClient(cloudURL, accessToken, cmdutil.Diag()).GetPulumiAccountName(ctx)
+	username, organizations, err := client.NewClient(cloudURL, accessToken, cmdutil.Diag()).GetPulumiAccountDetails(ctx)
 	if err != nil {
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == 401 {
-			return false, "", nil
+			return false, "", nil, nil
 		}
-		return false, "", fmt.Errorf("getting user info from %v: %w", cloudURL, err)
+		return false, "", nil, fmt.Errorf("getting user info from %v: %w", cloudURL, err)
 	}
 
-	return true, username, nil
+	return true, username, organizations, nil
 }
 
 // GetStackTags fetches the stack's existing tags.

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -49,7 +49,7 @@ type cloudBackendReference struct {
 }
 
 func (c cloudBackendReference) String() string {
-	curUser, err := c.b.CurrentUser()
+	curUser, _, err := c.b.CurrentUser()
 	if err != nil {
 		curUser = ""
 	}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -55,7 +55,7 @@ type MockBackend struct {
 	ImportDeploymentF       func(context.Context, Stack, *apitype.UntypedDeployment) error
 	LogoutF                 func() error
 	LogoutAllF              func() error
-	CurrentUserF            func() (string, error)
+	CurrentUserF            func() (string, []string, error)
 	PreviewF                func(context.Context, Stack,
 		UpdateOperation) (*deploy.Plan, engine.ResourceChanges, result.Result)
 	UpdateF func(context.Context, Stack,
@@ -321,7 +321,7 @@ func (be *MockBackend) LogoutAll() error {
 	panic("not implemented")
 }
 
-func (be *MockBackend) CurrentUser() (string, error) {
+func (be *MockBackend) CurrentUser() (string, []string, error) {
 	if be.CurrentUserF != nil {
 		return be.CurrentUserF()
 	}

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -280,22 +280,22 @@ func (host hostAbout) String() string {
 }
 
 type backendAbout struct {
-	Name string `json:"name"`
-	URL  string `json:"url"`
-	User string `json:"user"`
+	Name          string   `json:"name"`
+	URL           string   `json:"url"`
+	User          string   `json:"user"`
+	Organizations []string `json:"organizations"`
 }
 
 func getBackendAbout(b backend.Backend) backendAbout {
-	var err error
-	var currentUser string
-	currentUser, err = b.CurrentUser()
+	currentUser, currentOrgs, err := b.CurrentUser()
 	if err != nil {
 		currentUser = "Unknown"
 	}
 	return backendAbout{
-		Name: b.Name(),
-		URL:  b.URL(),
-		User: currentUser,
+		Name:          b.Name(),
+		URL:           b.URL(),
+		User:          currentUser,
+		Organizations: currentOrgs,
 	}
 }
 
@@ -306,6 +306,7 @@ func (b backendAbout) String() string {
 			{"Name", b.Name},
 			{"URL", b.URL},
 			{"User", b.User},
+			{"Organizations", strings.Join(b.Organizations, ", ")},
 		}),
 	}.String()
 }

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -151,7 +151,7 @@ func newLoginCmd() *cobra.Command {
 				return fmt.Errorf("problem logging in: %w", err)
 			}
 
-			if currentUser, err := be.CurrentUser(); err == nil {
+			if currentUser, _, err := be.CurrentUser(); err == nil {
 				fmt.Printf("Logged in to %s as %s (%s)\n", be.Name(), currentUser, be.URL())
 			} else {
 				fmt.Printf("Logged in to %s (%s)\n", be.Name(), be.URL())

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -878,7 +878,7 @@ func loadProject(t *testing.T, dir string) *workspace.Project {
 func currentUser(t *testing.T) string {
 	b, err := currentBackend(display.Options{})
 	assert.NoError(t, err)
-	currentUser, err := b.CurrentUser()
+	currentUser, _, err := b.CurrentUser()
 	assert.NoError(t, err)
 	return currentUser
 }

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -56,7 +56,7 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			if len(cliArgs) > 0 {
 				orgName = cliArgs[0]
 			} else {
-				orgName, err = b.CurrentUser()
+				orgName, _, err = b.CurrentUser()
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -47,7 +47,7 @@ func newPolicyLsCmd() *cobra.Command {
 			if len(cliArgs) > 0 {
 				orgName = cliArgs[0]
 			} else {
-				orgName, err = b.CurrentUser()
+				orgName, _, err = b.CurrentUser()
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -42,13 +43,14 @@ func newWhoAmICmd() *cobra.Command {
 				return err
 			}
 
-			name, err := b.CurrentUser()
+			name, orgs, err := b.CurrentUser()
 			if err != nil {
 				return err
 			}
 
 			if verbose {
 				fmt.Printf("User: %s\n", name)
+				fmt.Printf("Organizations: %s\n", strings.Join(orgs, ", "))
 				fmt.Printf("Backend URL: %s\n", b.URL())
 			} else {
 				fmt.Println(name)

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -113,6 +113,7 @@ func StoreAccount(key string, account Account, current bool) error {
 type Account struct {
 	AccessToken     string    `json:"accessToken,omitempty"`     // The access token for this account.
 	Username        string    `json:"username,omitempty"`        // The username for this account.
+	Organizations   []string  `json:"organizations,omitempty"`   // The organizations for this account.
 	LastValidatedAt time.Time `json:"lastValidatedAt,omitempty"` // The last time this token was validated.
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Organizations are shown by `pulumi about` and `pulumi whoami --verbose`

e.g.
```
$ pulumi whoami --verbose
User: Frassle
Organizations: Frassle
Backend URL: https://app.pulumi.com/Frassle
```

Like usernames these are cached in the credentials file.

Fixes https://github.com/pulumi/pulumi/issues/9181

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
