### PR TITLE
ci: add platform as input to test jobs, run full test suite only for linux on critical path

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -302,12 +302,31 @@ jobs:
       enable-coverage: true
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
-  test:
-    name: Test
+  test-linux:
+    name: Test Linux
     needs: build
     uses: pulumi/pulumi/.github/workflows/test.yml@master
     with:
       enable-coverage: true
+      platform: ubuntu-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-macos:
+    name: Test MacOS
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: true
+      platform: macos-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-windows:
+    name: Test Windows
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: true
+      platform: windows-latest
     secrets:
       pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   dispatch-docker-containers-ci-build:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -332,12 +332,31 @@ jobs:
       enable-coverage: false
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
-  test:
-    name: Test
+  test-linux:
+    name: Test Linux
     needs: build
     uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
     with:
       enable-coverage: false
+      platform: ubuntu-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-macos:
+    name: Test MacOS
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: false
+      platform: macos-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-windows:
+    name: Test Windows
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: false
+      platform: windows-latest
     secrets:
       pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   dispatch-docker-containers-ci-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,12 +441,31 @@ jobs:
       enable-coverage: false
       goreleaser-config: '.goreleaser.yml'
       goreleaser-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md --skip-publish --skip-announce --skip-validate'
-  test:
-    name: Test
+  test-linux:
+    name: Test Linux
     needs: build
     uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
     with:
       enable-coverage: false
+      platform: ubuntu-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-macos:
+    name: Test MacOS
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: false
+      platform: macos-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-windows:
+    name: Test Windows
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: false
+      platform: windows-latest
     secrets:
       pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   dispatch-docker-containers-release-build:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -170,12 +170,33 @@ jobs:
     with:
       enable-coverage: true
 
-  test:
-    name: Test
-    needs: build
-    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
-    with:
-      enable-coverage: true
-    secrets:
-      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  # test-linux:
+  #   name: Test Linux
+  #   needs: build
+  #   uses: ./.github/workflows/test-fast.yml
+  #   if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+  #   with:
+  #     enable-coverage: true
+  #     platform: ubuntu-latest
+  #   secrets:
+  #     pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  # test-macos:
+  #   name: Test MacOS
+  #   needs: build
+  #   uses: ./.github/workflows/test-fast.yml
+  #   if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+  #   with:
+  #     enable-coverage: true
+  #     platform: macos-latest
+  #   secrets:
+  #     pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  # test-windows:
+  #   name: Test Windows
+  #   needs: build
+  #   uses: ./.github/workflows/test-fast.yml
+  #   if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+  #   with:
+  #     enable-coverage: true
+  #     platform: windows-latest
+  #   secrets:
+  #     pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -10,6 +10,10 @@ defaults:
 on:
   workflow_call:
     inputs:
+      platform:
+        description: 'OS to run tests on, e.g.: ubuntu-latest'
+        required: true
+        type: string
       go-version:
         description: 'Version of the Go toolchain for the build'
         default: '1.17.x'
@@ -54,10 +58,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
         test-suite:
           - run: |
               cd sdk/python
@@ -105,7 +105,7 @@ jobs:
       PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
       TEST_ALL_DEPS: ""
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ inputs.platform }}
 
     steps:
       - name: Checkout Repo
@@ -125,7 +125,7 @@ jobs:
           echo "TESTPARALLELISM=${{ matrix.test-suite.test-parallelism-windows }}" >> $GITHUB_ENV
           mkdir -p "${{ runner.temp }}/tmp"
       - name: Enable code coverage
-        if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
+        if: ${{ inputs.enable-coverage && (inputs.platform != 'windows-latest') }}
         run: |
           echo "PULUMI_TEST_COVERAGE_PATH=$(pwd)/coverage" >> $GITHUB_ENV
       # See: https://github.com/actions/virtual-environments/issues/2642#issuecomment-774988591
@@ -173,7 +173,7 @@ jobs:
           cache: yarn
           cache-dependency-path: sdk/nodejs/package.json
       - name: Uninstall pre-installed Pulumi (windows)
-        if: ${{ matrix.platform == 'windows-latest' }}
+        if: ${{ inputs.platform == 'windows-latest' }}
         run: |
           if which pulumi.exe; then
             echo "Deleting pulumi"
@@ -207,25 +207,25 @@ jobs:
           repo: t0yv0/goteststats
           tag: v0.0.7
       - name: Download Pulumi Go Binaries (linux-x64)
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        if: ${{ inputs.platform == 'ubuntu-latest' }}
         uses: actions/download-artifact@v2
         with:
           name: pulumi-linux-x64
           path: artifacts/go
       - name: Download Pulumi Go Binaries (darwin-x64)
-        if: ${{ matrix.platform == 'macos-latest' }}
+        if: ${{ inputs.platform == 'macos-latest' }}
         uses: actions/download-artifact@v2
         with:
           name: pulumi-darwin-x64
           path: artifacts/go
       - name: Download Pulumi Go Binaries (windows-x64)
-        if: ${{ matrix.platform == 'windows-latest' }}
+        if: ${{ inputs.platform == 'windows-latest' }}
         uses: actions/download-artifact@v2
         with:
           name: pulumi-windows-x64
           path: artifacts/go
       - name: Install Pulumi Go Binaries (non-windows)
-        if: ${{ matrix.platform != 'windows-latest' }}
+        if: ${{ inputs.platform != 'windows-latest' }}
         run: |
           mkdir -p pulumi-bin
           tar -xf artifacts/go/*.tar.gz -C pulumi-bin
@@ -233,7 +233,7 @@ jobs:
           mv pulumi-bin/pulumi/* bin/
           rm -rf pulumi-bin
       - name: Install Pulumi Go Binaries (windows)
-        if: ${{ matrix.platform == 'windows-latest' }}
+        if: ${{ inputs.platform == 'windows-latest' }}
         run: |
           mkdir -p $PWD/bin
           unzip -d $PWD/bin artifacts/go/*.zip
@@ -303,17 +303,17 @@ jobs:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Convert Node coverage data
-        if: ${{ matrix.platform != 'windows-latest' }}
+        if: ${{ inputs.platform != 'windows-latest' }}
         run: |
           cd sdk/nodejs
           if [ -e .nyc_output ]; then yarn run nyc report -r cobertura --report-dir $PULUMI_TEST_COVERAGE_PATH; fi
       - name: Merge Go coverage data
-        if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
+        if: ${{ inputs.enable-coverage && (inputs.platform != 'windows-latest') }}
         run: |
           pulumictl cover merge --in ./coverage --out ./coverage/go-all.txt
           rm ./coverage/*.cov || true
       - name: Upload code coverage
-        if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
+        if: ${{ inputs.enable-coverage && (inputs.platform != 'windows-latest') }}
         uses: codecov/codecov-action@v2
         with:
           directory: coverage

--- a/.github/workflows/test-macos-cron.yml
+++ b/.github/workflows/test-macos-cron.yml
@@ -1,0 +1,27 @@
+name: Test MacOS Daily
+"on":
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 8 * * *
+
+jobs:
+  build:
+    name: Build
+    uses: pulumi/pulumi/.github/workflows/build.yml@master
+    with:
+      # Cross-compiling from ubuntu-latest is faster but the artifact
+      # checksums will not match what publish-binaries expects.
+      default-build-platform: macos-latest
+      enable-coverage: true
+      goreleaser-config: '.goreleaser.prerelease.yml'
+      goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
+  test-macos:
+    name: Test MacOS
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test.yml@master
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    with:
+      enable-coverage: true
+      platform: macos-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.github/workflows/test-windows-cron.yml
+++ b/.github/workflows/test-windows-cron.yml
@@ -1,0 +1,27 @@
+name: Test Windows (Daily)
+"on":
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 8 * * *
+
+jobs:
+  build:
+    name: Build
+    uses: pulumi/pulumi/.github/workflows/build.yml@master
+    with:
+      # Cross-compiling from ubuntu-latest is faster but the artifact
+      # checksums will not match what publish-binaries expects.
+      default-build-platform: macos-latest
+      enable-coverage: true
+      goreleaser-config: '.goreleaser.prerelease.yml'
+      goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
+  test-windows:
+    name: Test Windows
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test.yml@master
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    with:
+      enable-coverage: true
+      platform: windows-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ defaults:
 on:
   workflow_call:
     inputs:
+      platform:
+        description: 'OS to run tests on, e.g.: ubuntu-latest'
+        required: true
+        type: string
       go-version:
         description: 'Version of the Go toolchain for the build'
         default: '1.17.x'
@@ -51,10 +55,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
         test-suite:
           - run: |
               cd sdk/python
@@ -123,7 +123,7 @@ jobs:
       PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
       TEST_ALL_DEPS: ""
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ inputs.platform }}
 
     steps:
       - name: Checkout Repo
@@ -143,7 +143,7 @@ jobs:
           echo "TESTPARALLELISM=${{ matrix.test-suite.test-parallelism-windows }}" >> $GITHUB_ENV
           mkdir -p "${{ runner.temp }}/tmp"
       - name: Enable code coverage
-        if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
+        if: ${{ inputs.enable-coverage && (inputs.platform != 'windows-latest') }}
         run: |
           echo "PULUMI_TEST_COVERAGE_PATH=$(pwd)/coverage" >> $GITHUB_ENV
       # See: https://github.com/actions/virtual-environments/issues/2642#issuecomment-774988591
@@ -191,7 +191,7 @@ jobs:
           cache: yarn
           cache-dependency-path: sdk/nodejs/package.json
       - name: Uninstall pre-installed Pulumi (windows)
-        if: ${{ matrix.platform == 'windows-latest' }}
+        if: ${{ inputs.platform == 'windows-latest' }}
         run: |
           if which pulumi.exe; then
             echo "Deleting pulumi"
@@ -225,25 +225,25 @@ jobs:
           repo: t0yv0/goteststats
           tag: v0.0.7
       - name: Download Pulumi Go Binaries (linux-x64)
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        if: ${{ inputs.platform == 'ubuntu-latest' }}
         uses: actions/download-artifact@v2
         with:
           name: pulumi-linux-x64
           path: artifacts/go
       - name: Download Pulumi Go Binaries (darwin-x64)
-        if: ${{ matrix.platform == 'macos-latest' }}
+        if: ${{ inputs.platform == 'macos-latest' }}
         uses: actions/download-artifact@v2
         with:
           name: pulumi-darwin-x64
           path: artifacts/go
       - name: Download Pulumi Go Binaries (windows-x64)
-        if: ${{ matrix.platform == 'windows-latest' }}
+        if: ${{ inputs.platform == 'windows-latest' }}
         uses: actions/download-artifact@v2
         with:
           name: pulumi-windows-x64
           path: artifacts/go
       - name: Install Pulumi Go Binaries (non-windows)
-        if: ${{ matrix.platform != 'windows-latest' }}
+        if: ${{ inputs.platform != 'windows-latest' }}
         run: |
           mkdir -p pulumi-bin
           tar -xf artifacts/go/*.tar.gz -C pulumi-bin
@@ -251,7 +251,7 @@ jobs:
           mv pulumi-bin/pulumi/* bin/
           rm -rf pulumi-bin
       - name: Install Pulumi Go Binaries (windows)
-        if: ${{ matrix.platform == 'windows-latest' }}
+        if: ${{ inputs.platform == 'windows-latest' }}
         run: |
           mkdir -p $PWD/bin
           unzip -d $PWD/bin artifacts/go/*.zip
@@ -321,17 +321,17 @@ jobs:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Convert Node coverage data
-        if: ${{ matrix.platform != 'windows-latest' }}
+        if: ${{ inputs.platform != 'windows-latest' }}
         run: |
           cd sdk/nodejs
           if [ -e .nyc_output ]; then yarn run nyc report -r cobertura --report-dir $PULUMI_TEST_COVERAGE_PATH; fi
       - name: Merge Go coverage data
-        if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
+        if: ${{ inputs.enable-coverage && (inputs.platform != 'windows-latest') }}
         run: |
           pulumictl cover merge --in ./coverage --out ./coverage/go-all.txt
           rm ./coverage/*.cov || true
       - name: Upload code coverage
-        if: ${{ inputs.enable-coverage && (matrix.platform != 'windows-latest') }}
+        if: ${{ inputs.enable-coverage && (inputs.platform != 'windows-latest') }}
         uses: codecov/codecov-action@v2
         with:
           directory: coverage


### PR DESCRIPTION
This moves MacOS and Windows tests off the critical path for releases, while putting them on a daily cronjob to monitor.

Both test.yml and test-fast.yml have a new input parameter, platform, which determines the runner OS to target. On our master branch workflow, we then run "test.yml" for Linux, and test-fast for MacOS and Windows. Those tests then run on a daily cronjob.
