### PR TITLE
Add data attribute tag for swifttype to resource property element

### DIFF
--- a/pkg/codegen/docs/templates/utils.tmpl
+++ b/pkg/codegen/docs/templates/utils.tmpl
@@ -15,5 +15,5 @@ to avoid double-encoding html characters, which is typical of properties type na
 passing it through the htmlSafe function
 to avoid double-encoding html characters, which is typical of properties type names. -->
 {{ define "linkify_wo_style" }}
-<a href="{{ .Link }}" style="color: inherit; text-decoration: inherit;">{{ if ne .DisplayName "" }}{{ htmlSafe .DisplayName }}{{ else }}{{ htmlSafe .Name }}{{ end }}</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="{{ .Link }}" style="color: inherit; text-decoration: inherit;">{{ if ne .DisplayName "" }}{{ htmlSafe .DisplayName }}{{ else }}{{ htmlSafe .Name }}{{ end }}</a>
 {{ end }}

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -486,7 +486,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -494,7 +494,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="resource_csharp">
-<a href="#resource_csharp" style="color: inherit; text-decoration: inherit;">Resource</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_csharp" style="color: inherit; text-decoration: inherit;">Resource</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#sqlcontainergetpropertiesresponseresource">Pulumi.<wbr>Azure<wbr>Native.<wbr>Document<wbr>DB.<wbr>Outputs.<wbr>Sql<wbr>Container<wbr>Get<wbr>Properties<wbr>Response<wbr>Resource</a></span>
@@ -506,7 +506,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -514,7 +514,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="resource_go">
-<a href="#resource_go" style="color: inherit; text-decoration: inherit;">Resource</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_go" style="color: inherit; text-decoration: inherit;">Resource</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#sqlcontainergetpropertiesresponseresource">Sql<wbr>Container<wbr>Get<wbr>Properties<wbr>Response<wbr>Resource</a></span>
@@ -526,7 +526,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -534,7 +534,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="resource_nodejs">
-<a href="#resource_nodejs" style="color: inherit; text-decoration: inherit;">resource</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_nodejs" style="color: inherit; text-decoration: inherit;">resource</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#sqlcontainergetpropertiesresponseresource">Sql<wbr>Container<wbr>Get<wbr>Properties<wbr>Response<wbr>Resource</a></span>
@@ -546,7 +546,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -554,7 +554,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="resource_python">
-<a href="#resource_python" style="color: inherit; text-decoration: inherit;">resource</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_python" style="color: inherit; text-decoration: inherit;">resource</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#sqlcontainergetpropertiesresponseresource">Sql<wbr>Container<wbr>Get<wbr>Properties<wbr>Response<wbr>Resource</a></span>
@@ -578,7 +578,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="order_csharp">
-<a href="#order_csharp" style="color: inherit; text-decoration: inherit;">Order</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#order_csharp" style="color: inherit; text-decoration: inherit;">Order</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -586,7 +586,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Sort order for composite paths.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="path_csharp">
-<a href="#path_csharp" style="color: inherit; text-decoration: inherit;">Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#path_csharp" style="color: inherit; text-decoration: inherit;">Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -598,7 +598,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="order_go">
-<a href="#order_go" style="color: inherit; text-decoration: inherit;">Order</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#order_go" style="color: inherit; text-decoration: inherit;">Order</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -606,7 +606,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Sort order for composite paths.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="path_go">
-<a href="#path_go" style="color: inherit; text-decoration: inherit;">Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#path_go" style="color: inherit; text-decoration: inherit;">Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -618,7 +618,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="order_nodejs">
-<a href="#order_nodejs" style="color: inherit; text-decoration: inherit;">order</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#order_nodejs" style="color: inherit; text-decoration: inherit;">order</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -626,7 +626,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Sort order for composite paths.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="path_nodejs">
-<a href="#path_nodejs" style="color: inherit; text-decoration: inherit;">path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#path_nodejs" style="color: inherit; text-decoration: inherit;">path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -638,7 +638,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="order_python">
-<a href="#order_python" style="color: inherit; text-decoration: inherit;">order</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#order_python" style="color: inherit; text-decoration: inherit;">order</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -646,7 +646,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Sort order for composite paths.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="path_python">
-<a href="#path_python" style="color: inherit; text-decoration: inherit;">path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#path_python" style="color: inherit; text-decoration: inherit;">path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -660,7 +660,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="compositeindexes_csharp">
-<a href="#compositeindexes_csharp" style="color: inherit; text-decoration: inherit;">Composite<wbr>Indexes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#compositeindexes_csharp" style="color: inherit; text-decoration: inherit;">Composite<wbr>Indexes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#compositepathresponse">List&lt;Immutable<wbr>Array&lt;Pulumi.<wbr>Azure<wbr>Native.<wbr>Document<wbr>DB.<wbr>Inputs.<wbr>Composite<wbr>Path<wbr>Response&gt;&gt;</a></span>
@@ -672,7 +672,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="compositeindexes_go">
-<a href="#compositeindexes_go" style="color: inherit; text-decoration: inherit;">Composite<wbr>Indexes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#compositeindexes_go" style="color: inherit; text-decoration: inherit;">Composite<wbr>Indexes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#compositepathresponse">[][]Composite<wbr>Path<wbr>Response</a></span>
@@ -684,7 +684,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="compositeindexes_nodejs">
-<a href="#compositeindexes_nodejs" style="color: inherit; text-decoration: inherit;">composite<wbr>Indexes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#compositeindexes_nodejs" style="color: inherit; text-decoration: inherit;">composite<wbr>Indexes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#compositepathresponse">Composite<wbr>Path<wbr>Response[][]</a></span>
@@ -696,7 +696,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="composite_indexes_python">
-<a href="#composite_indexes_python" style="color: inherit; text-decoration: inherit;">composite_<wbr>indexes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#composite_indexes_python" style="color: inherit; text-decoration: inherit;">composite_<wbr>indexes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#compositepathresponse">Sequence[Sequence[Composite<wbr>Path<wbr>Response]]</a></span>
@@ -710,7 +710,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="indexingpolicy_csharp">
-<a href="#indexingpolicy_csharp" style="color: inherit; text-decoration: inherit;">Indexing<wbr>Policy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#indexingpolicy_csharp" style="color: inherit; text-decoration: inherit;">Indexing<wbr>Policy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#indexingpolicyresponse">Pulumi.<wbr>Azure<wbr>Native.<wbr>Document<wbr>DB.<wbr>Inputs.<wbr>Indexing<wbr>Policy<wbr>Response</a></span>
@@ -722,7 +722,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="indexingpolicy_go">
-<a href="#indexingpolicy_go" style="color: inherit; text-decoration: inherit;">Indexing<wbr>Policy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#indexingpolicy_go" style="color: inherit; text-decoration: inherit;">Indexing<wbr>Policy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#indexingpolicyresponse">Indexing<wbr>Policy<wbr>Response</a></span>
@@ -734,7 +734,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="indexingpolicy_nodejs">
-<a href="#indexingpolicy_nodejs" style="color: inherit; text-decoration: inherit;">indexing<wbr>Policy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#indexingpolicy_nodejs" style="color: inherit; text-decoration: inherit;">indexing<wbr>Policy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#indexingpolicyresponse">Indexing<wbr>Policy<wbr>Response</a></span>
@@ -746,7 +746,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="indexing_policy_python">
-<a href="#indexing_policy_python" style="color: inherit; text-decoration: inherit;">indexing_<wbr>policy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#indexing_policy_python" style="color: inherit; text-decoration: inherit;">indexing_<wbr>policy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#indexingpolicyresponse">Indexing<wbr>Policy<wbr>Response</a></span>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -158,7 +158,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="thing_csharp">
-<a href="#thing_csharp" style="color: inherit; text-decoration: inherit;">Thing</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_csharp" style="color: inherit; text-decoration: inherit;">Thing</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toplevel">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Inputs.<wbr>Top<wbr>Level<wbr>Args</a></span>
@@ -170,7 +170,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="thing_go">
-<a href="#thing_go" style="color: inherit; text-decoration: inherit;">Thing</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_go" style="color: inherit; text-decoration: inherit;">Thing</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toplevel">Top<wbr>Level<wbr>Args</a></span>
@@ -182,7 +182,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="thing_nodejs">
-<a href="#thing_nodejs" style="color: inherit; text-decoration: inherit;">thing</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_nodejs" style="color: inherit; text-decoration: inherit;">thing</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toplevel">Top<wbr>Level<wbr>Args</a></span>
@@ -194,7 +194,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="thing_python">
-<a href="#thing_python" style="color: inherit; text-decoration: inherit;">thing</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_python" style="color: inherit; text-decoration: inherit;">thing</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toplevel">Top<wbr>Level<wbr>Args</a></span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -273,7 +273,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="buzz_csharp">
-<a href="#buzz_csharp" style="color: inherit; text-decoration: inherit;">Buzz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#buzz_csharp" style="color: inherit; text-decoration: inherit;">Buzz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -285,7 +285,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="buzz_go">
-<a href="#buzz_go" style="color: inherit; text-decoration: inherit;">Buzz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#buzz_go" style="color: inherit; text-decoration: inherit;">Buzz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -297,7 +297,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="buzz_nodejs">
-<a href="#buzz_nodejs" style="color: inherit; text-decoration: inherit;">buzz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#buzz_nodejs" style="color: inherit; text-decoration: inherit;">buzz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -309,7 +309,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="buzz_python">
-<a href="#buzz_python" style="color: inherit; text-decoration: inherit;">buzz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#buzz_python" style="color: inherit; text-decoration: inherit;">buzz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -159,7 +159,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_csharp">
-<a href="#varieties_csharp" style="color: inherit; text-decoration: inherit;">Varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_csharp" style="color: inherit; text-decoration: inherit;">Varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">List&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Rubber<wbr>Tree<wbr>Variety&gt;</a></span>
@@ -167,7 +167,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_csharp">
-<a href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;</span>
@@ -179,7 +179,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_go">
-<a href="#varieties_go" style="color: inherit; text-decoration: inherit;">Varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_go" style="color: inherit; text-decoration: inherit;">Varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">[]Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -187,7 +187,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_go">
-<a href="#sizes_go" style="color: inherit; text-decoration: inherit;">Sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_go" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string]Tree<wbr>Size</span>
@@ -199,7 +199,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_nodejs">
-<a href="#varieties_nodejs" style="color: inherit; text-decoration: inherit;">varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_nodejs" style="color: inherit; text-decoration: inherit;">varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety[]</a></span>
@@ -207,7 +207,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_nodejs">
-<a href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Tree<wbr>Size}</span>
@@ -219,7 +219,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_python">
-<a href="#varieties_python" style="color: inherit; text-decoration: inherit;">varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_python" style="color: inherit; text-decoration: inherit;">varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Sequence[Rubber<wbr>Tree<wbr>Variety]</a></span>
@@ -227,7 +227,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_python">
-<a href="#sizes_python" style="color: inherit; text-decoration: inherit;">sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_python" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Tree<wbr>Size]</span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -162,7 +162,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_csharp">
-<a href="#diameter_csharp" style="color: inherit; text-decoration: inherit;">Diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_csharp" style="color: inherit; text-decoration: inherit;">Diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Diameter</a></span>
@@ -170,7 +170,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_csharp">
-<a href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -178,7 +178,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_csharp">
-<a href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args</a></span>
@@ -186,7 +186,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_csharp">
-<a href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
@@ -194,7 +194,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_csharp">
-<a href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size</a></span>
@@ -206,7 +206,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_go">
-<a href="#diameter_go" style="color: inherit; text-decoration: inherit;">Diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_go" style="color: inherit; text-decoration: inherit;">Diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -214,7 +214,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_go">
-<a href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -222,7 +222,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_go">
-<a href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -230,7 +230,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_go">
-<a href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -238,7 +238,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_go">
-<a href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -250,7 +250,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_nodejs">
-<a href="#diameter_nodejs" style="color: inherit; text-decoration: inherit;">diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_nodejs" style="color: inherit; text-decoration: inherit;">diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -258,7 +258,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_nodejs">
-<a href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -266,7 +266,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_nodejs">
-<a href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -274,7 +274,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_nodejs">
-<a href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -282,7 +282,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_nodejs">
-<a href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -294,7 +294,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_python">
-<a href="#diameter_python" style="color: inherit; text-decoration: inherit;">diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_python" style="color: inherit; text-decoration: inherit;">diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -302,7 +302,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_python">
-<a href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -310,7 +310,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_python">
-<a href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -318,7 +318,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_python">
-<a href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | str</span>
@@ -326,7 +326,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_python">
-<a href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -345,7 +345,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -357,7 +357,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -369,7 +369,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -381,7 +381,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -519,7 +519,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_csharp">
-<a href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
@@ -531,7 +531,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_go">
-<a href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -543,7 +543,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_nodejs">
-<a href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -555,7 +555,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_python">
-<a href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | str</span>
@@ -578,7 +578,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_csharp">
-<a href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Pulumi.<wbr>Plant.<wbr>Container<wbr>Size</a></span>
@@ -586,7 +586,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_csharp">
-<a href="#brightness_csharp" style="color: inherit; text-decoration: inherit;">Brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_csharp" style="color: inherit; text-decoration: inherit;">Brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Pulumi.<wbr>Plant.<wbr>Container<wbr>Brightness</a></span>
@@ -594,7 +594,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_csharp">
-<a href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Pulumi.<wbr>Plant.<wbr>Container<wbr>Color</a> | string</span>
@@ -602,7 +602,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_csharp">
-<a href="#material_csharp" style="color: inherit; text-decoration: inherit;">Material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_csharp" style="color: inherit; text-decoration: inherit;">Material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -614,7 +614,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_go">
-<a href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -622,7 +622,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_go">
-<a href="#brightness_go" style="color: inherit; text-decoration: inherit;">Brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_go" style="color: inherit; text-decoration: inherit;">Brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -630,7 +630,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_go">
-<a href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | string</span>
@@ -638,7 +638,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_go">
-<a href="#material_go" style="color: inherit; text-decoration: inherit;">Material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_go" style="color: inherit; text-decoration: inherit;">Material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -650,7 +650,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_nodejs">
-<a href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -658,7 +658,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_nodejs">
-<a href="#brightness_nodejs" style="color: inherit; text-decoration: inherit;">brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_nodejs" style="color: inherit; text-decoration: inherit;">brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -666,7 +666,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_nodejs">
-<a href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | string</span>
@@ -674,7 +674,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_nodejs">
-<a href="#material_nodejs" style="color: inherit; text-decoration: inherit;">material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_nodejs" style="color: inherit; text-decoration: inherit;">material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -686,7 +686,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_python">
-<a href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -694,7 +694,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_python">
-<a href="#brightness_python" style="color: inherit; text-decoration: inherit;">brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_python" style="color: inherit; text-decoration: inherit;">brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -702,7 +702,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_python">
-<a href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | str</span>
@@ -710,7 +710,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_python">
-<a href="#material_python" style="color: inherit; text-decoration: inherit;">material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_python" style="color: inherit; text-decoration: inherit;">material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
@@ -159,7 +159,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_csharp">
-<a href="#varieties_csharp" style="color: inherit; text-decoration: inherit;">Varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_csharp" style="color: inherit; text-decoration: inherit;">Varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">List&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Rubber<wbr>Tree<wbr>Variety&gt;</a></span>
@@ -167,7 +167,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_csharp">
-<a href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;</span>
@@ -179,7 +179,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_go">
-<a href="#varieties_go" style="color: inherit; text-decoration: inherit;">Varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_go" style="color: inherit; text-decoration: inherit;">Varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">[]Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -187,7 +187,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_go">
-<a href="#sizes_go" style="color: inherit; text-decoration: inherit;">Sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_go" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string]Tree<wbr>Size</span>
@@ -199,7 +199,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_nodejs">
-<a href="#varieties_nodejs" style="color: inherit; text-decoration: inherit;">varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_nodejs" style="color: inherit; text-decoration: inherit;">varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety[]</a></span>
@@ -207,7 +207,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_nodejs">
-<a href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Tree<wbr>Size}</span>
@@ -219,7 +219,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_python">
-<a href="#varieties_python" style="color: inherit; text-decoration: inherit;">varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_python" style="color: inherit; text-decoration: inherit;">varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Sequence[Rubber<wbr>Tree<wbr>Variety]</a></span>
@@ -227,7 +227,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_python">
-<a href="#sizes_python" style="color: inherit; text-decoration: inherit;">sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_python" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Tree<wbr>Size]</span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -162,7 +162,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_csharp">
-<a href="#diameter_csharp" style="color: inherit; text-decoration: inherit;">Diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_csharp" style="color: inherit; text-decoration: inherit;">Diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Pulumi.<wbr>Other.<wbr>Tree.<wbr>V1.<wbr>Diameter</a></span>
@@ -170,7 +170,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_csharp">
-<a href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -178,7 +178,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_csharp">
-<a href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args</a></span>
@@ -186,7 +186,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_csharp">
-<a href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
@@ -194,7 +194,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_csharp">
-<a href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size</a></span>
@@ -206,7 +206,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_go">
-<a href="#diameter_go" style="color: inherit; text-decoration: inherit;">Diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_go" style="color: inherit; text-decoration: inherit;">Diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -214,7 +214,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_go">
-<a href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -222,7 +222,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_go">
-<a href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -230,7 +230,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_go">
-<a href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -238,7 +238,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_go">
-<a href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -250,7 +250,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_nodejs">
-<a href="#diameter_nodejs" style="color: inherit; text-decoration: inherit;">diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_nodejs" style="color: inherit; text-decoration: inherit;">diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -258,7 +258,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_nodejs">
-<a href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -266,7 +266,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_nodejs">
-<a href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -274,7 +274,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_nodejs">
-<a href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -282,7 +282,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_nodejs">
-<a href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -294,7 +294,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_python">
-<a href="#diameter_python" style="color: inherit; text-decoration: inherit;">diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_python" style="color: inherit; text-decoration: inherit;">diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -302,7 +302,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_python">
-<a href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -310,7 +310,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_python">
-<a href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -318,7 +318,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_python">
-<a href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | str</span>
@@ -326,7 +326,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_python">
-<a href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -345,7 +345,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -357,7 +357,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -369,7 +369,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -381,7 +381,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -519,7 +519,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_csharp">
-<a href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
@@ -531,7 +531,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_go">
-<a href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -543,7 +543,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_nodejs">
-<a href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -555,7 +555,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_python">
-<a href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | str</span>
@@ -578,7 +578,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_csharp">
-<a href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Pulumi.<wbr>Plant.<wbr>Container<wbr>Size</a></span>
@@ -586,7 +586,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_csharp">
-<a href="#brightness_csharp" style="color: inherit; text-decoration: inherit;">Brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_csharp" style="color: inherit; text-decoration: inherit;">Brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Pulumi.<wbr>Plant.<wbr>Container<wbr>Brightness</a></span>
@@ -594,7 +594,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_csharp">
-<a href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Pulumi.<wbr>Plant.<wbr>Container<wbr>Color</a> | string</span>
@@ -602,7 +602,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_csharp">
-<a href="#material_csharp" style="color: inherit; text-decoration: inherit;">Material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_csharp" style="color: inherit; text-decoration: inherit;">Material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -614,7 +614,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_go">
-<a href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -622,7 +622,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_go">
-<a href="#brightness_go" style="color: inherit; text-decoration: inherit;">Brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_go" style="color: inherit; text-decoration: inherit;">Brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -630,7 +630,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_go">
-<a href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | string</span>
@@ -638,7 +638,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_go">
-<a href="#material_go" style="color: inherit; text-decoration: inherit;">Material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_go" style="color: inherit; text-decoration: inherit;">Material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -650,7 +650,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_nodejs">
-<a href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -658,7 +658,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_nodejs">
-<a href="#brightness_nodejs" style="color: inherit; text-decoration: inherit;">brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_nodejs" style="color: inherit; text-decoration: inherit;">brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -666,7 +666,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_nodejs">
-<a href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | string</span>
@@ -674,7 +674,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_nodejs">
-<a href="#material_nodejs" style="color: inherit; text-decoration: inherit;">material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_nodejs" style="color: inherit; text-decoration: inherit;">material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -686,7 +686,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_python">
-<a href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -694,7 +694,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_python">
-<a href="#brightness_python" style="color: inherit; text-decoration: inherit;">brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_python" style="color: inherit; text-decoration: inherit;">brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -702,7 +702,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_python">
-<a href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | str</span>
@@ -710,7 +710,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_python">
-<a href="#material_python" style="color: inherit; text-decoration: inherit;">material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_python" style="color: inherit; text-decoration: inherit;">material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
@@ -111,7 +111,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -132,7 +132,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="age_csharp">
-<a href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -144,7 +144,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="age_go">
-<a href="#age_go" style="color: inherit; text-decoration: inherit;">Age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_go" style="color: inherit; text-decoration: inherit;">Age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -156,7 +156,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="age_nodejs">
-<a href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="age_python">
-<a href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
@@ -159,7 +159,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="age_csharp">
-<a href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -167,7 +167,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pet_csharp">
-<a href="#pet_csharp" style="color: inherit; text-decoration: inherit;">Pet</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_csharp" style="color: inherit; text-decoration: inherit;">Pet</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
@@ -179,7 +179,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="age_go">
-<a href="#age_go" style="color: inherit; text-decoration: inherit;">Age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_go" style="color: inherit; text-decoration: inherit;">Age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -187,7 +187,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pet_go">
-<a href="#pet_go" style="color: inherit; text-decoration: inherit;">Pet</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_go" style="color: inherit; text-decoration: inherit;">Pet</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="age_nodejs">
-<a href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -207,7 +207,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pet_nodejs">
-<a href="#pet_nodejs" style="color: inherit; text-decoration: inherit;">pet</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_nodejs" style="color: inherit; text-decoration: inherit;">pet</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
@@ -219,7 +219,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="age_python">
-<a href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -227,7 +227,7 @@ The Cat resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pet_python">
-<a href="#pet_python" style="color: inherit; text-decoration: inherit;">pet</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_python" style="color: inherit; text-decoration: inherit;">pet</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -254,7 +254,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -266,7 +266,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -274,7 +274,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -286,7 +286,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -294,7 +294,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -306,7 +306,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -314,7 +314,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -338,7 +338,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredname_csharp">
-<a href="#requiredname_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredname_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
@@ -346,7 +346,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_csharp">
-<a href="#requirednamearray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requirednamemap_csharp">
-<a href="#requirednamemap_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamemap_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
@@ -362,7 +362,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_csharp">
-<a href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -370,7 +370,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
@@ -378,7 +378,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_csharp">
-<a href="#namearray_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
@@ -386,7 +386,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="namemap_csharp">
-<a href="#namemap_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namemap_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
@@ -398,7 +398,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredname_go">
-<a href="#requiredname_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredname_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -406,7 +406,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_go">
-<a href="#requirednamearray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -414,7 +414,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requirednamemap_go">
-<a href="#requirednamemap_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamemap_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -422,7 +422,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_go">
-<a href="#age_go" style="color: inherit; text-decoration: inherit;">Age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_go" style="color: inherit; text-decoration: inherit;">Age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -430,7 +430,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -438,7 +438,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_go">
-<a href="#namearray_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -446,7 +446,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="namemap_go">
-<a href="#namemap_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namemap_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -458,7 +458,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredname_nodejs">
-<a href="#requiredname_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredname_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
@@ -466,7 +466,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requirednamearray_nodejs">
-<a href="#requirednamearray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamearray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet[]</span>
@@ -474,7 +474,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requirednamemap_nodejs">
-<a href="#requirednamemap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requirednamemap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: pulumi<wbr>Random<wbr>Random<wbr>Pet}</span>
@@ -482,7 +482,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_nodejs">
-<a href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -490,7 +490,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
@@ -498,7 +498,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="namearray_nodejs">
-<a href="#namearray_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namearray_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet[]</span>
@@ -506,7 +506,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="namemap_nodejs">
-<a href="#namemap_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#namemap_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: pulumi<wbr>Random<wbr>Random<wbr>Pet}</span>
@@ -518,7 +518,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_name_python">
-<a href="#required_name_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_name_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -526,7 +526,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_name_array_python">
-<a href="#required_name_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name_<wbr>array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_name_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name_<wbr>array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet]</span>
@@ -534,7 +534,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_name_map_python">
-<a href="#required_name_map_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name_<wbr>map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_name_map_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name_<wbr>map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet]</span>
@@ -542,7 +542,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_python">
-<a href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -550,7 +550,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -558,7 +558,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_array_python">
-<a href="#name_array_python" style="color: inherit; text-decoration: inherit;">name_<wbr>array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_array_python" style="color: inherit; text-decoration: inherit;">name_<wbr>array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet]</span>
@@ -566,7 +566,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_map_python">
-<a href="#name_map_python" style="color: inherit; text-decoration: inherit;">name_<wbr>map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_map_python" style="color: inherit; text-decoration: inherit;">name_<wbr>map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet]</span>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
@@ -163,7 +163,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredmetadata_csharp">
-<a href="#requiredmetadata_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadata_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args</a></span>
@@ -171,7 +171,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_csharp">
-<a href="#requiredmetadataarray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">List&lt;Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</a></span>
@@ -179,7 +179,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadatamap_csharp">
-<a href="#requiredmetadatamap_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadatamap_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</span>
@@ -187,7 +187,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_csharp">
-<a href="#metadata_csharp" style="color: inherit; text-decoration: inherit;">Metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_csharp" style="color: inherit; text-decoration: inherit;">Metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args</a></span>
@@ -195,7 +195,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_csharp">
-<a href="#metadataarray_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">List&lt;Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</a></span>
@@ -203,7 +203,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadatamap_csharp">
-<a href="#metadatamap_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatamap_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</span>
@@ -215,7 +215,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredmetadata_go">
-<a href="#requiredmetadata_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadata_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
@@ -223,7 +223,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_go">
-<a href="#requiredmetadataarray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
@@ -231,7 +231,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadatamap_go">
-<a href="#requiredmetadatamap_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadatamap_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Object<wbr>Meta<wbr>Args</span>
@@ -239,7 +239,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_go">
-<a href="#metadata_go" style="color: inherit; text-decoration: inherit;">Metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_go" style="color: inherit; text-decoration: inherit;">Metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
@@ -247,7 +247,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_go">
-<a href="#metadataarray_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
@@ -255,7 +255,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadatamap_go">
-<a href="#metadatamap_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatamap_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Object<wbr>Meta<wbr>Args</span>
@@ -267,7 +267,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredmetadata_nodejs">
-<a href="#requiredmetadata_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadata_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta</a></span>
@@ -275,7 +275,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadataarray_nodejs">
-<a href="#requiredmetadataarray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadataarray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta[]</a></span>
@@ -283,7 +283,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="requiredmetadatamap_nodejs">
-<a href="#requiredmetadatamap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredmetadatamap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta}</span>
@@ -291,7 +291,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_nodejs">
-<a href="#metadata_nodejs" style="color: inherit; text-decoration: inherit;">metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_nodejs" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta</a></span>
@@ -299,7 +299,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadataarray_nodejs">
-<a href="#metadataarray_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta[]</a></span>
@@ -307,7 +307,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadatamap_nodejs">
-<a href="#metadatamap_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatamap_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta}</span>
@@ -319,7 +319,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_metadata_python">
-<a href="#required_metadata_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_metadata_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
@@ -327,7 +327,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_metadata_array_python">
-<a href="#required_metadata_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata_<wbr>array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_metadata_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata_<wbr>array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args]</a></span>
@@ -335,7 +335,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_metadata_map_python">
-<a href="#required_metadata_map_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata_<wbr>map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_metadata_map_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata_<wbr>map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Object<wbr>Meta<wbr>Args]</span>
@@ -343,7 +343,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_python">
-<a href="#metadata_python" style="color: inherit; text-decoration: inherit;">metadata</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_python" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
@@ -351,7 +351,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_array_python">
-<a href="#metadata_array_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>array</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_array_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>array</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args]</a></span>
@@ -359,7 +359,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_map_python">
-<a href="#metadata_map_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_map_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Object<wbr>Meta<wbr>Args]</span>
@@ -378,7 +378,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -386,7 +386,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="securitygroup_csharp">
-<a href="#securitygroup_csharp" style="color: inherit; text-decoration: inherit;">Security<wbr>Group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#securitygroup_csharp" style="color: inherit; text-decoration: inherit;">Security<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Aws.<wbr>Ec2.<wbr>Security<wbr>Group</span>
@@ -394,7 +394,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="provider_csharp">
-<a href="#provider_csharp" style="color: inherit; text-decoration: inherit;">Provider</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_csharp" style="color: inherit; text-decoration: inherit;">Provider</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Kubernetes.<wbr>Provider</span>
@@ -402,7 +402,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="storageclasses_csharp">
-<a href="#storageclasses_csharp" style="color: inherit; text-decoration: inherit;">Storage<wbr>Classes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_csharp" style="color: inherit; text-decoration: inherit;">Storage<wbr>Classes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Kubernetes.<wbr>Storage.<wbr>V1.<wbr>Storage<wbr>Class&gt;</span>
@@ -414,7 +414,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -422,7 +422,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="securitygroup_go">
-<a href="#securitygroup_go" style="color: inherit; text-decoration: inherit;">Security<wbr>Group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#securitygroup_go" style="color: inherit; text-decoration: inherit;">Security<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Security<wbr>Group</span>
@@ -430,7 +430,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="provider_go">
-<a href="#provider_go" style="color: inherit; text-decoration: inherit;">Provider</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_go" style="color: inherit; text-decoration: inherit;">Provider</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
@@ -438,7 +438,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="storageclasses_go">
-<a href="#storageclasses_go" style="color: inherit; text-decoration: inherit;">Storage<wbr>Classes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_go" style="color: inherit; text-decoration: inherit;">Storage<wbr>Classes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Storage<wbr>Class</span>
@@ -450,7 +450,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -458,7 +458,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="securitygroup_nodejs">
-<a href="#securitygroup_nodejs" style="color: inherit; text-decoration: inherit;">security<wbr>Group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#securitygroup_nodejs" style="color: inherit; text-decoration: inherit;">security<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Awsec2Security<wbr>Group</span>
@@ -466,7 +466,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="provider_nodejs">
-<a href="#provider_nodejs" style="color: inherit; text-decoration: inherit;">provider</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_nodejs" style="color: inherit; text-decoration: inherit;">provider</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Kubernetes<wbr>Provider</span>
@@ -474,7 +474,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="storageclasses_nodejs">
-<a href="#storageclasses_nodejs" style="color: inherit; text-decoration: inherit;">storage<wbr>Classes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storageclasses_nodejs" style="color: inherit; text-decoration: inherit;">storage<wbr>Classes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: pulumi<wbr>Kubernetesstoragev1Storage<wbr>Class}</span>
@@ -486,7 +486,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -494,7 +494,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="security_group_python">
-<a href="#security_group_python" style="color: inherit; text-decoration: inherit;">security_<wbr>group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#security_group_python" style="color: inherit; text-decoration: inherit;">security_<wbr>group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Security<wbr>Group</span>
@@ -502,7 +502,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="provider_python">
-<a href="#provider_python" style="color: inherit; text-decoration: inherit;">provider</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#provider_python" style="color: inherit; text-decoration: inherit;">provider</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Provider</span>
@@ -510,7 +510,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="storage_classes_python">
-<a href="#storage_classes_python" style="color: inherit; text-decoration: inherit;">storage_<wbr>classes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#storage_classes_python" style="color: inherit; text-decoration: inherit;">storage_<wbr>classes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Storage<wbr>Class]</span>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="pod_csharp">
-<a href="#pod_csharp" style="color: inherit; text-decoration: inherit;">Pod</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pod_csharp" style="color: inherit; text-decoration: inherit;">Pod</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Outputs.<wbr>Core.<wbr>V1.<wbr>Pod</a></span>
@@ -200,7 +200,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -208,7 +208,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="pod_go">
-<a href="#pod_go" style="color: inherit; text-decoration: inherit;">Pod</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pod_go" style="color: inherit; text-decoration: inherit;">Pod</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod</a></span>
@@ -220,7 +220,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -228,7 +228,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="pod_nodejs">
-<a href="#pod_nodejs" style="color: inherit; text-decoration: inherit;">pod</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pod_nodejs" style="color: inherit; text-decoration: inherit;">pod</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">pulumi<wbr>Kubernetestypesoutputcorev1Pod</a></span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="pod_python">
-<a href="#pod_python" style="color: inherit; text-decoration: inherit;">pod</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pod_python" style="color: inherit; text-decoration: inherit;">pod</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pod">Pod</a></span>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
@@ -158,7 +158,7 @@ The RegistryGeoReplication resource accepts the following [input]({{< relref "/d
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="resourcegroup_csharp">
-<a href="#resourcegroup_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroup_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Azure<wbr>Native.<wbr>Resources.<wbr>Resource<wbr>Group</span>
@@ -170,7 +170,7 @@ The RegistryGeoReplication resource accepts the following [input]({{< relref "/d
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="resourcegroup_go">
-<a href="#resourcegroup_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroup_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource<wbr>Group</span>
@@ -182,7 +182,7 @@ The RegistryGeoReplication resource accepts the following [input]({{< relref "/d
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="resourcegroup_nodejs">
-<a href="#resourcegroup_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroup_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Azure<wbr>Nativeresources<wbr>Resource<wbr>Group</span>
@@ -194,7 +194,7 @@ The RegistryGeoReplication resource accepts the following [input]({{< relref "/d
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="resource_group_python">
-<a href="#resource_group_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_group_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource<wbr>Group</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="acrloginserverout_csharp">
-<a href="#acrloginserverout_csharp" style="color: inherit; text-decoration: inherit;">Acr<wbr>Login<wbr>Server<wbr>Out</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#acrloginserverout_csharp" style="color: inherit; text-decoration: inherit;">Acr<wbr>Login<wbr>Server<wbr>Out</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -221,7 +221,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The login server url{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -229,7 +229,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="registry_csharp">
-<a href="#registry_csharp" style="color: inherit; text-decoration: inherit;">Registry</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registry_csharp" style="color: inherit; text-decoration: inherit;">Registry</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Azure<wbr>Native.<wbr>Container<wbr>Registry.<wbr>Registry</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The Registry{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replication_csharp">
-<a href="#replication_csharp" style="color: inherit; text-decoration: inherit;">Replication</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_csharp" style="color: inherit; text-decoration: inherit;">Replication</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Azure<wbr>Native.<wbr>Container<wbr>Registry.<wbr>Replication</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="acrloginserverout_go">
-<a href="#acrloginserverout_go" style="color: inherit; text-decoration: inherit;">Acr<wbr>Login<wbr>Server<wbr>Out</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#acrloginserverout_go" style="color: inherit; text-decoration: inherit;">Acr<wbr>Login<wbr>Server<wbr>Out</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -257,7 +257,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The login server url{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -265,7 +265,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="registry_go">
-<a href="#registry_go" style="color: inherit; text-decoration: inherit;">Registry</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registry_go" style="color: inherit; text-decoration: inherit;">Registry</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Registry</span>
@@ -273,7 +273,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The Registry{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replication_go">
-<a href="#replication_go" style="color: inherit; text-decoration: inherit;">Replication</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_go" style="color: inherit; text-decoration: inherit;">Replication</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Replication</span>
@@ -285,7 +285,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="acrloginserverout_nodejs">
-<a href="#acrloginserverout_nodejs" style="color: inherit; text-decoration: inherit;">acr<wbr>Login<wbr>Server<wbr>Out</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#acrloginserverout_nodejs" style="color: inherit; text-decoration: inherit;">acr<wbr>Login<wbr>Server<wbr>Out</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -293,7 +293,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The login server url{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -301,7 +301,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="registry_nodejs">
-<a href="#registry_nodejs" style="color: inherit; text-decoration: inherit;">registry</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registry_nodejs" style="color: inherit; text-decoration: inherit;">registry</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Azure<wbr>Nativecontainerregistry<wbr>Registry</span>
@@ -309,7 +309,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The Registry{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replication_nodejs">
-<a href="#replication_nodejs" style="color: inherit; text-decoration: inherit;">replication</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_nodejs" style="color: inherit; text-decoration: inherit;">replication</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Azure<wbr>Nativecontainerregistry<wbr>Replication</span>
@@ -321,7 +321,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="acr_login_server_out_python">
-<a href="#acr_login_server_out_python" style="color: inherit; text-decoration: inherit;">acr_<wbr>login_<wbr>server_<wbr>out</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#acr_login_server_out_python" style="color: inherit; text-decoration: inherit;">acr_<wbr>login_<wbr>server_<wbr>out</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -329,7 +329,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The login server url{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -337,7 +337,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="registry_python">
-<a href="#registry_python" style="color: inherit; text-decoration: inherit;">registry</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registry_python" style="color: inherit; text-decoration: inherit;">registry</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Registry</span>
@@ -345,7 +345,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The Registry{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replication_python">
-<a href="#replication_python" style="color: inherit; text-decoration: inherit;">replication</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replication_python" style="color: inherit; text-decoration: inherit;">replication</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Replication</span>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -200,7 +200,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -208,7 +208,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -220,7 +220,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -228,7 +228,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -200,7 +200,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -208,7 +208,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -220,7 +220,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -228,7 +228,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -158,7 +158,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
@@ -158,7 +158,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_csharp">
-<a href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_go">
-<a href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_nodejs">
-<a href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -111,7 +111,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_python">
-<a href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -132,7 +132,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_csharp">
-<a href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -144,7 +144,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_go">
-<a href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -156,7 +156,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_nodejs">
-<a href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_python">
-<a href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
@@ -158,7 +158,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -170,7 +170,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -182,7 +182,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -194,7 +194,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
@@ -158,7 +158,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -170,7 +170,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -182,7 +182,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -194,7 +194,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
@@ -158,7 +158,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -170,7 +170,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -182,7 +182,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -194,7 +194,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_csharp">
-<a href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_go">
-<a href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_nodejs">
-<a href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -111,7 +111,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_python">
-<a href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -132,7 +132,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_csharp">
-<a href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -144,7 +144,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_go">
-<a href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -156,7 +156,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_nodejs">
-<a href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_python">
-<a href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
@@ -159,7 +159,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Other.<wbr>Example.<wbr>Enum<wbr>Overlay</a></span>
@@ -167,7 +167,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Other.<wbr>Example.<wbr>Inputs.<wbr>Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -179,7 +179,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
@@ -187,7 +187,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
@@ -207,7 +207,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -219,7 +219,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
@@ -227,7 +227,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -306,7 +306,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_csharp">
-<a href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -318,7 +318,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_go">
-<a href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -330,7 +330,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_nodejs">
-<a href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_python">
-<a href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
@@ -158,7 +158,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
@@ -160,7 +160,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Other.<wbr>Example.<wbr>Inputs.<wbr>Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -168,7 +168,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Other.<wbr>Example.<wbr>Inputs.<wbr>Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -176,7 +176,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Other.<wbr>Example.<wbr>Inputs.<wbr>Object<wbr>Args</a></span>
@@ -188,7 +188,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -196,7 +196,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -204,7 +204,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -216,7 +216,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -224,7 +224,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -232,7 +232,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -244,7 +244,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -252,7 +252,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -260,7 +260,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -279,7 +279,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -291,7 +291,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -303,7 +303,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -315,7 +315,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -339,7 +339,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_csharp">
-<a href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -351,7 +351,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_go">
-<a href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -363,7 +363,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_nodejs">
-<a href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -375,7 +375,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_python">
-<a href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -389,7 +389,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -397,7 +397,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_csharp">
-<a href="#configs_csharp" style="color: inherit; text-decoration: inherit;">Configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_csharp" style="color: inherit; text-decoration: inherit;">Configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">List&lt;Other.<wbr>Example.<wbr>Inputs.<wbr>Config<wbr>Map&gt;</a></span>
@@ -405,7 +405,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
@@ -413,7 +413,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_csharp">
-<a href="#others_csharp" style="color: inherit; text-decoration: inherit;">Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_csharp" style="color: inherit; text-decoration: inherit;">Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">List&lt;Immutable<wbr>Array&lt;Other.<wbr>Example.<wbr>Inputs.<wbr>Some<wbr>Other<wbr>Object&gt;&gt;</a></span>
@@ -421,7 +421,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_csharp">
-<a href="#stillothers_csharp" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_csharp" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Immutable<wbr>Array&lt;Other.<wbr>Example.<wbr>Inputs.<wbr>Some<wbr>Other<wbr>Object&gt;&gt;</span>
@@ -433,7 +433,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -441,7 +441,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_go">
-<a href="#configs_go" style="color: inherit; text-decoration: inherit;">Configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_go" style="color: inherit; text-decoration: inherit;">Configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">[]Config<wbr>Map</a></span>
@@ -449,7 +449,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -457,7 +457,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_go">
-<a href="#others_go" style="color: inherit; text-decoration: inherit;">Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_go" style="color: inherit; text-decoration: inherit;">Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">[][]Some<wbr>Other<wbr>Object</a></span>
@@ -465,7 +465,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_go">
-<a href="#stillothers_go" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_go" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string][]Some<wbr>Other<wbr>Object</span>
@@ -477,7 +477,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -485,7 +485,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_nodejs">
-<a href="#configs_nodejs" style="color: inherit; text-decoration: inherit;">configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_nodejs" style="color: inherit; text-decoration: inherit;">configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">Config<wbr>Map[]</a></span>
@@ -493,7 +493,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -501,7 +501,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_nodejs">
-<a href="#others_nodejs" style="color: inherit; text-decoration: inherit;">others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_nodejs" style="color: inherit; text-decoration: inherit;">others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object[][]</a></span>
@@ -509,7 +509,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_nodejs">
-<a href="#stillothers_nodejs" style="color: inherit; text-decoration: inherit;">still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_nodejs" style="color: inherit; text-decoration: inherit;">still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Some<wbr>Other<wbr>Object[]}</span>
@@ -521,7 +521,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -529,7 +529,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_python">
-<a href="#configs_python" style="color: inherit; text-decoration: inherit;">configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_python" style="color: inherit; text-decoration: inherit;">configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">Sequence[Config<wbr>Map]</a></span>
@@ -537,7 +537,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -545,7 +545,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_python">
-<a href="#others_python" style="color: inherit; text-decoration: inherit;">others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_python" style="color: inherit; text-decoration: inherit;">others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Sequence[Sequence[Some<wbr>Other<wbr>Object]]</a></span>
@@ -553,7 +553,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="still_others_python">
-<a href="#still_others_python" style="color: inherit; text-decoration: inherit;">still_<wbr>others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#still_others_python" style="color: inherit; text-decoration: inherit;">still_<wbr>others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Sequence[Some<wbr>Other<wbr>Object]]</span>
@@ -567,7 +567,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -575,7 +575,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -587,7 +587,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -595,7 +595,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -607,7 +607,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -615,7 +615,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -627,7 +627,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -635,7 +635,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -649,7 +649,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -661,7 +661,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -673,7 +673,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -685,7 +685,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
@@ -82,7 +82,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="configurationfilters_csharp">
-<a href="#configurationfilters_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationfilters_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationfilters">List&lt;Configuration<wbr>Filters&gt;</a></span>
@@ -90,7 +90,7 @@ The following arguments are supported:
     <dd>{{% md %}}Holds details about product hierarchy information and filterable property.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customersubscriptiondetails_csharp">
-<a href="#customersubscriptiondetails_csharp" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customersubscriptiondetails_csharp" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -98,7 +98,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skiptoken_csharp">
-<a href="#skiptoken_csharp" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skiptoken_csharp" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -110,7 +110,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="configurationfilters_go">
-<a href="#configurationfilters_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationfilters_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationfilters">[]Configuration<wbr>Filters</a></span>
@@ -118,7 +118,7 @@ The following arguments are supported:
     <dd>{{% md %}}Holds details about product hierarchy information and filterable property.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customersubscriptiondetails_go">
-<a href="#customersubscriptiondetails_go" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customersubscriptiondetails_go" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -126,7 +126,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skiptoken_go">
-<a href="#skiptoken_go" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skiptoken_go" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -138,7 +138,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="configurationfilters_nodejs">
-<a href="#configurationfilters_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationfilters_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationfilters">Configuration<wbr>Filters[]</a></span>
@@ -146,7 +146,7 @@ The following arguments are supported:
     <dd>{{% md %}}Holds details about product hierarchy information and filterable property.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customersubscriptiondetails_nodejs">
-<a href="#customersubscriptiondetails_nodejs" style="color: inherit; text-decoration: inherit;">customer<wbr>Subscription<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customersubscriptiondetails_nodejs" style="color: inherit; text-decoration: inherit;">customer<wbr>Subscription<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -154,7 +154,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skiptoken_nodejs">
-<a href="#skiptoken_nodejs" style="color: inherit; text-decoration: inherit;">skip<wbr>Token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skiptoken_nodejs" style="color: inherit; text-decoration: inherit;">skip<wbr>Token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -166,7 +166,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="configuration_filters_python">
-<a href="#configuration_filters_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configuration_filters_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationfilters">Sequence[Configuration<wbr>Filters]</a></span>
@@ -174,7 +174,7 @@ The following arguments are supported:
     <dd>{{% md %}}Holds details about product hierarchy information and filterable property.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customer_subscription_details_python">
-<a href="#customer_subscription_details_python" style="color: inherit; text-decoration: inherit;">customer_<wbr>subscription_<wbr>details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customer_subscription_details_python" style="color: inherit; text-decoration: inherit;">customer_<wbr>subscription_<wbr>details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -182,7 +182,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skip_token_python">
-<a href="#skip_token_python" style="color: inherit; text-decoration: inherit;">skip_<wbr>token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skip_token_python" style="color: inherit; text-decoration: inherit;">skip_<wbr>token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -203,7 +203,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">List&lt;Configuration<wbr>Response&gt;</a></span>
@@ -211,7 +211,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nextlink_csharp">
-<a href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -223,7 +223,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">[]Configuration<wbr>Response</a></span>
@@ -231,7 +231,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nextlink_go">
-<a href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -243,7 +243,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">Configuration<wbr>Response[]</a></span>
@@ -251,7 +251,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nextlink_nodejs">
-<a href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -263,7 +263,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">Sequence[Configuration<wbr>Response]</a></span>
@@ -271,7 +271,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="next_link_python">
-<a href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -293,7 +293,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilitystage_csharp">
-<a href="#availabilitystage_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilitystage_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -301,7 +301,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreason_csharp">
-<a href="#disabledreason_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreason_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -309,7 +309,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreasonmessage_csharp">
-<a href="#disabledreasonmessage_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreasonmessage_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -321,7 +321,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilitystage_go">
-<a href="#availabilitystage_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilitystage_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -329,7 +329,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreason_go">
-<a href="#disabledreason_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreason_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -337,7 +337,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreasonmessage_go">
-<a href="#disabledreasonmessage_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreasonmessage_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -349,7 +349,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilitystage_nodejs">
-<a href="#availabilitystage_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilitystage_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -357,7 +357,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreason_nodejs">
-<a href="#disabledreason_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreason_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -365,7 +365,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreasonmessage_nodejs">
-<a href="#disabledreasonmessage_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason<wbr>Message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreasonmessage_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason<wbr>Message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -377,7 +377,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availability_stage_python">
-<a href="#availability_stage_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availability_stage_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -385,7 +385,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabled_reason_python">
-<a href="#disabled_reason_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabled_reason_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -393,7 +393,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabled_reason_message_python">
-<a href="#disabled_reason_message_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason_<wbr>message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabled_reason_message_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason_<wbr>message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -409,7 +409,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_csharp">
-<a href="#frequency_csharp" style="color: inherit; text-decoration: inherit;">Frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_csharp" style="color: inherit; text-decoration: inherit;">Frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -417,7 +417,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterdetails_csharp">
-<a href="#meterdetails_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterdetails_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -425,7 +425,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meteringtype_csharp">
-<a href="#meteringtype_csharp" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meteringtype_csharp" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -433,7 +433,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -445,7 +445,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_go">
-<a href="#frequency_go" style="color: inherit; text-decoration: inherit;">Frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_go" style="color: inherit; text-decoration: inherit;">Frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -453,7 +453,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterdetails_go">
-<a href="#meterdetails_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterdetails_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -461,7 +461,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meteringtype_go">
-<a href="#meteringtype_go" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meteringtype_go" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -469,7 +469,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -481,7 +481,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_nodejs">
-<a href="#frequency_nodejs" style="color: inherit; text-decoration: inherit;">frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_nodejs" style="color: inherit; text-decoration: inherit;">frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -489,7 +489,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterdetails_nodejs">
-<a href="#meterdetails_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterdetails_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -497,7 +497,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meteringtype_nodejs">
-<a href="#meteringtype_nodejs" style="color: inherit; text-decoration: inherit;">metering<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meteringtype_nodejs" style="color: inherit; text-decoration: inherit;">metering<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -505,7 +505,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -517,7 +517,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_python">
-<a href="#frequency_python" style="color: inherit; text-decoration: inherit;">frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_python" style="color: inherit; text-decoration: inherit;">frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -525,7 +525,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meter_details_python">
-<a href="#meter_details_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meter_details_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -533,7 +533,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="metering_type_python">
-<a href="#metering_type_python" style="color: inherit; text-decoration: inherit;">metering_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metering_type_python" style="color: inherit; text-decoration: inherit;">metering_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -541,7 +541,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -557,7 +557,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_csharp">
-<a href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformation">Hierarchy<wbr>Information</a></span>
@@ -565,7 +565,7 @@ The following output properties are available:
     <dd>{{% md %}}Product hierarchy information{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filterableproperty_csharp">
-<a href="#filterableproperty_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Property</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperty_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Property</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterableproperty">List&lt;Filterable<wbr>Property&gt;</a></span>
@@ -577,7 +577,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_go">
-<a href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformation">Hierarchy<wbr>Information</a></span>
@@ -585,7 +585,7 @@ The following output properties are available:
     <dd>{{% md %}}Product hierarchy information{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filterableproperty_go">
-<a href="#filterableproperty_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Property</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperty_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Property</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterableproperty">[]Filterable<wbr>Property</a></span>
@@ -597,7 +597,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_nodejs">
-<a href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformation">Hierarchy<wbr>Information</a></span>
@@ -605,7 +605,7 @@ The following output properties are available:
     <dd>{{% md %}}Product hierarchy information{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filterableproperty_nodejs">
-<a href="#filterableproperty_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Property</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperty_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Property</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterableproperty">Filterable<wbr>Property[]</a></span>
@@ -617,7 +617,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="hierarchy_information_python">
-<a href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformation">Hierarchy<wbr>Information</a></span>
@@ -625,7 +625,7 @@ The following output properties are available:
     <dd>{{% md %}}Product hierarchy information{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filterable_property_python">
-<a href="#filterable_property_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>property</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterable_property_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>property</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterableproperty">Sequence[Filterable<wbr>Property]</a></span>
@@ -641,7 +641,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_csharp">
-<a href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -649,7 +649,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_csharp">
-<a href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -657,7 +657,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -665,7 +665,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_csharp">
-<a href="#dimensions_csharp" style="color: inherit; text-decoration: inherit;">Dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_csharp" style="color: inherit; text-decoration: inherit;">Dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -673,7 +673,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_csharp">
-<a href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -681,7 +681,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_csharp">
-<a href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">List&lt;Filterable<wbr>Property<wbr>Response&gt;</a></span>
@@ -689,7 +689,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_csharp">
-<a href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -697,7 +697,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_csharp">
-<a href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">List&lt;Image<wbr>Information<wbr>Response&gt;</a></span>
@@ -705,7 +705,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_csharp">
-<a href="#specifications_csharp" style="color: inherit; text-decoration: inherit;">Specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_csharp" style="color: inherit; text-decoration: inherit;">Specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">List&lt;Specification<wbr>Response&gt;</a></span>
@@ -717,7 +717,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_go">
-<a href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -725,7 +725,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_go">
-<a href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -733,7 +733,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -741,7 +741,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_go">
-<a href="#dimensions_go" style="color: inherit; text-decoration: inherit;">Dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_go" style="color: inherit; text-decoration: inherit;">Dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -749,7 +749,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_go">
-<a href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -757,7 +757,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_go">
-<a href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">[]Filterable<wbr>Property<wbr>Response</a></span>
@@ -765,7 +765,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_go">
-<a href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -773,7 +773,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_go">
-<a href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">[]Image<wbr>Information<wbr>Response</a></span>
@@ -781,7 +781,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_go">
-<a href="#specifications_go" style="color: inherit; text-decoration: inherit;">Specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_go" style="color: inherit; text-decoration: inherit;">Specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">[]Specification<wbr>Response</a></span>
@@ -793,7 +793,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_nodejs">
-<a href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -801,7 +801,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_nodejs">
-<a href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -809,7 +809,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -817,7 +817,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_nodejs">
-<a href="#dimensions_nodejs" style="color: inherit; text-decoration: inherit;">dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_nodejs" style="color: inherit; text-decoration: inherit;">dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -825,7 +825,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_nodejs">
-<a href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -833,7 +833,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_nodejs">
-<a href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Filterable<wbr>Property<wbr>Response[]</a></span>
@@ -841,7 +841,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_nodejs">
-<a href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -849,7 +849,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_nodejs">
-<a href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Image<wbr>Information<wbr>Response[]</a></span>
@@ -857,7 +857,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_nodejs">
-<a href="#specifications_nodejs" style="color: inherit; text-decoration: inherit;">specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_nodejs" style="color: inherit; text-decoration: inherit;">specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">Specification<wbr>Response[]</a></span>
@@ -869,7 +869,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availability_information_python">
-<a href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -877,7 +877,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="cost_information_python">
-<a href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -885,7 +885,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -893,7 +893,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_python">
-<a href="#dimensions_python" style="color: inherit; text-decoration: inherit;">dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_python" style="color: inherit; text-decoration: inherit;">dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -901,7 +901,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="display_name_python">
-<a href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -909,7 +909,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterable_properties_python">
-<a href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Sequence[Filterable<wbr>Property<wbr>Response]</a></span>
@@ -917,7 +917,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchy_information_python">
-<a href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -925,7 +925,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="image_information_python">
-<a href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Sequence[Image<wbr>Information<wbr>Response]</a></span>
@@ -933,7 +933,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_python">
-<a href="#specifications_python" style="color: inherit; text-decoration: inherit;">specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_python" style="color: inherit; text-decoration: inherit;">specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">Sequence[Specification<wbr>Response]</a></span>
@@ -949,7 +949,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billinginfourl_csharp">
-<a href="#billinginfourl_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billinginfourl_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -957,7 +957,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billingmeterdetails_csharp">
-<a href="#billingmeterdetails_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billingmeterdetails_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">List&lt;Billing<wbr>Meter<wbr>Details<wbr>Response&gt;</a></span>
@@ -969,7 +969,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billinginfourl_go">
-<a href="#billinginfourl_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billinginfourl_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -977,7 +977,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billingmeterdetails_go">
-<a href="#billingmeterdetails_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billingmeterdetails_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">[]Billing<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -989,7 +989,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billinginfourl_nodejs">
-<a href="#billinginfourl_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Info<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billinginfourl_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Info<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -997,7 +997,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billingmeterdetails_nodejs">
-<a href="#billingmeterdetails_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billingmeterdetails_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">Billing<wbr>Meter<wbr>Details<wbr>Response[]</a></span>
@@ -1009,7 +1009,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billing_info_url_python">
-<a href="#billing_info_url_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>info_<wbr>url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billing_info_url_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>info_<wbr>url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1017,7 +1017,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billing_meter_details_python">
-<a href="#billing_meter_details_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>meter_<wbr>details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billing_meter_details_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>meter_<wbr>details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">Sequence[Billing<wbr>Meter<wbr>Details<wbr>Response]</a></span>
@@ -1033,7 +1033,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quotaid_csharp">
-<a href="#quotaid_csharp" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quotaid_csharp" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1041,7 +1041,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="locationplacementid_csharp">
-<a href="#locationplacementid_csharp" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#locationplacementid_csharp" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1049,7 +1049,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registeredfeatures_csharp">
-<a href="#registeredfeatures_csharp" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registeredfeatures_csharp" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">List&lt;Customer<wbr>Subscription<wbr>Registered<wbr>Features&gt;</a></span>
@@ -1061,7 +1061,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quotaid_go">
-<a href="#quotaid_go" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quotaid_go" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1069,7 +1069,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="locationplacementid_go">
-<a href="#locationplacementid_go" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#locationplacementid_go" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1077,7 +1077,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registeredfeatures_go">
-<a href="#registeredfeatures_go" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registeredfeatures_go" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">[]Customer<wbr>Subscription<wbr>Registered<wbr>Features</a></span>
@@ -1089,7 +1089,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quotaid_nodejs">
-<a href="#quotaid_nodejs" style="color: inherit; text-decoration: inherit;">quota<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quotaid_nodejs" style="color: inherit; text-decoration: inherit;">quota<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1097,7 +1097,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="locationplacementid_nodejs">
-<a href="#locationplacementid_nodejs" style="color: inherit; text-decoration: inherit;">location<wbr>Placement<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#locationplacementid_nodejs" style="color: inherit; text-decoration: inherit;">location<wbr>Placement<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1105,7 +1105,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registeredfeatures_nodejs">
-<a href="#registeredfeatures_nodejs" style="color: inherit; text-decoration: inherit;">registered<wbr>Features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registeredfeatures_nodejs" style="color: inherit; text-decoration: inherit;">registered<wbr>Features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">Customer<wbr>Subscription<wbr>Registered<wbr>Features[]</a></span>
@@ -1117,7 +1117,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quota_id_python">
-<a href="#quota_id_python" style="color: inherit; text-decoration: inherit;">quota_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quota_id_python" style="color: inherit; text-decoration: inherit;">quota_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1125,7 +1125,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="location_placement_id_python">
-<a href="#location_placement_id_python" style="color: inherit; text-decoration: inherit;">location_<wbr>placement_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#location_placement_id_python" style="color: inherit; text-decoration: inherit;">location_<wbr>placement_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1133,7 +1133,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registered_features_python">
-<a href="#registered_features_python" style="color: inherit; text-decoration: inherit;">registered_<wbr>features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registered_features_python" style="color: inherit; text-decoration: inherit;">registered_<wbr>features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">Sequence[Customer<wbr>Subscription<wbr>Registered<wbr>Features]</a></span>
@@ -1149,7 +1149,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1157,7 +1157,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_csharp">
-<a href="#state_csharp" style="color: inherit; text-decoration: inherit;">State</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_csharp" style="color: inherit; text-decoration: inherit;">State</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1169,7 +1169,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1177,7 +1177,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_go">
-<a href="#state_go" style="color: inherit; text-decoration: inherit;">State</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_go" style="color: inherit; text-decoration: inherit;">State</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1189,7 +1189,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1197,7 +1197,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_nodejs">
-<a href="#state_nodejs" style="color: inherit; text-decoration: inherit;">state</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_nodejs" style="color: inherit; text-decoration: inherit;">state</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1209,7 +1209,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1217,7 +1217,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_python">
-<a href="#state_python" style="color: inherit; text-decoration: inherit;">state</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_python" style="color: inherit; text-decoration: inherit;">state</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1233,7 +1233,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_csharp">
-<a href="#attributes_csharp" style="color: inherit; text-decoration: inherit;">Attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_csharp" style="color: inherit; text-decoration: inherit;">Attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1241,7 +1241,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="descriptiontype_csharp">
-<a href="#descriptiontype_csharp" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#descriptiontype_csharp" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1249,7 +1249,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_csharp">
-<a href="#keywords_csharp" style="color: inherit; text-decoration: inherit;">Keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_csharp" style="color: inherit; text-decoration: inherit;">Keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1257,7 +1257,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_csharp">
-<a href="#links_csharp" style="color: inherit; text-decoration: inherit;">Links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_csharp" style="color: inherit; text-decoration: inherit;">Links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">List&lt;Link<wbr>Response&gt;</a></span>
@@ -1265,7 +1265,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="longdescription_csharp">
-<a href="#longdescription_csharp" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#longdescription_csharp" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1273,7 +1273,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="shortdescription_csharp">
-<a href="#shortdescription_csharp" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#shortdescription_csharp" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1285,7 +1285,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_go">
-<a href="#attributes_go" style="color: inherit; text-decoration: inherit;">Attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_go" style="color: inherit; text-decoration: inherit;">Attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1293,7 +1293,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="descriptiontype_go">
-<a href="#descriptiontype_go" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#descriptiontype_go" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1301,7 +1301,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_go">
-<a href="#keywords_go" style="color: inherit; text-decoration: inherit;">Keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_go" style="color: inherit; text-decoration: inherit;">Keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1309,7 +1309,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_go">
-<a href="#links_go" style="color: inherit; text-decoration: inherit;">Links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_go" style="color: inherit; text-decoration: inherit;">Links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">[]Link<wbr>Response</a></span>
@@ -1317,7 +1317,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="longdescription_go">
-<a href="#longdescription_go" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#longdescription_go" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1325,7 +1325,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="shortdescription_go">
-<a href="#shortdescription_go" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#shortdescription_go" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1337,7 +1337,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_nodejs">
-<a href="#attributes_nodejs" style="color: inherit; text-decoration: inherit;">attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_nodejs" style="color: inherit; text-decoration: inherit;">attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1345,7 +1345,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="descriptiontype_nodejs">
-<a href="#descriptiontype_nodejs" style="color: inherit; text-decoration: inherit;">description<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#descriptiontype_nodejs" style="color: inherit; text-decoration: inherit;">description<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1353,7 +1353,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_nodejs">
-<a href="#keywords_nodejs" style="color: inherit; text-decoration: inherit;">keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_nodejs" style="color: inherit; text-decoration: inherit;">keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1361,7 +1361,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_nodejs">
-<a href="#links_nodejs" style="color: inherit; text-decoration: inherit;">links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_nodejs" style="color: inherit; text-decoration: inherit;">links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">Link<wbr>Response[]</a></span>
@@ -1369,7 +1369,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="longdescription_nodejs">
-<a href="#longdescription_nodejs" style="color: inherit; text-decoration: inherit;">long<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#longdescription_nodejs" style="color: inherit; text-decoration: inherit;">long<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1377,7 +1377,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="shortdescription_nodejs">
-<a href="#shortdescription_nodejs" style="color: inherit; text-decoration: inherit;">short<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#shortdescription_nodejs" style="color: inherit; text-decoration: inherit;">short<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1389,7 +1389,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_python">
-<a href="#attributes_python" style="color: inherit; text-decoration: inherit;">attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_python" style="color: inherit; text-decoration: inherit;">attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1397,7 +1397,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_type_python">
-<a href="#description_type_python" style="color: inherit; text-decoration: inherit;">description_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_type_python" style="color: inherit; text-decoration: inherit;">description_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1405,7 +1405,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_python">
-<a href="#keywords_python" style="color: inherit; text-decoration: inherit;">keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_python" style="color: inherit; text-decoration: inherit;">keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1413,7 +1413,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_python">
-<a href="#links_python" style="color: inherit; text-decoration: inherit;">links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_python" style="color: inherit; text-decoration: inherit;">links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">Sequence[Link<wbr>Response]</a></span>
@@ -1421,7 +1421,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="long_description_python">
-<a href="#long_description_python" style="color: inherit; text-decoration: inherit;">long_<wbr>description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#long_description_python" style="color: inherit; text-decoration: inherit;">long_<wbr>description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1429,7 +1429,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="short_description_python">
-<a href="#short_description_python" style="color: inherit; text-decoration: inherit;">short_<wbr>description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#short_description_python" style="color: inherit; text-decoration: inherit;">short_<wbr>description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1445,7 +1445,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_csharp">
-<a href="#depth_csharp" style="color: inherit; text-decoration: inherit;">Depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_csharp" style="color: inherit; text-decoration: inherit;">Depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1453,7 +1453,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_csharp">
-<a href="#height_csharp" style="color: inherit; text-decoration: inherit;">Height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_csharp" style="color: inherit; text-decoration: inherit;">Height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1461,7 +1461,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_csharp">
-<a href="#length_csharp" style="color: inherit; text-decoration: inherit;">Length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_csharp" style="color: inherit; text-decoration: inherit;">Length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1469,7 +1469,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="lengthheightunit_csharp">
-<a href="#lengthheightunit_csharp" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#lengthheightunit_csharp" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1477,7 +1477,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_csharp">
-<a href="#weight_csharp" style="color: inherit; text-decoration: inherit;">Weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_csharp" style="color: inherit; text-decoration: inherit;">Weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1485,7 +1485,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weightunit_csharp">
-<a href="#weightunit_csharp" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weightunit_csharp" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1493,7 +1493,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_csharp">
-<a href="#width_csharp" style="color: inherit; text-decoration: inherit;">Width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_csharp" style="color: inherit; text-decoration: inherit;">Width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1505,7 +1505,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_go">
-<a href="#depth_go" style="color: inherit; text-decoration: inherit;">Depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_go" style="color: inherit; text-decoration: inherit;">Depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1513,7 +1513,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_go">
-<a href="#height_go" style="color: inherit; text-decoration: inherit;">Height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_go" style="color: inherit; text-decoration: inherit;">Height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1521,7 +1521,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_go">
-<a href="#length_go" style="color: inherit; text-decoration: inherit;">Length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_go" style="color: inherit; text-decoration: inherit;">Length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1529,7 +1529,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="lengthheightunit_go">
-<a href="#lengthheightunit_go" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#lengthheightunit_go" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1537,7 +1537,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_go">
-<a href="#weight_go" style="color: inherit; text-decoration: inherit;">Weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_go" style="color: inherit; text-decoration: inherit;">Weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1545,7 +1545,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weightunit_go">
-<a href="#weightunit_go" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weightunit_go" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1553,7 +1553,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_go">
-<a href="#width_go" style="color: inherit; text-decoration: inherit;">Width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_go" style="color: inherit; text-decoration: inherit;">Width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1565,7 +1565,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_nodejs">
-<a href="#depth_nodejs" style="color: inherit; text-decoration: inherit;">depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_nodejs" style="color: inherit; text-decoration: inherit;">depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1573,7 +1573,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_nodejs">
-<a href="#height_nodejs" style="color: inherit; text-decoration: inherit;">height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_nodejs" style="color: inherit; text-decoration: inherit;">height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1581,7 +1581,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_nodejs">
-<a href="#length_nodejs" style="color: inherit; text-decoration: inherit;">length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_nodejs" style="color: inherit; text-decoration: inherit;">length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1589,7 +1589,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="lengthheightunit_nodejs">
-<a href="#lengthheightunit_nodejs" style="color: inherit; text-decoration: inherit;">length<wbr>Height<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#lengthheightunit_nodejs" style="color: inherit; text-decoration: inherit;">length<wbr>Height<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1597,7 +1597,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_nodejs">
-<a href="#weight_nodejs" style="color: inherit; text-decoration: inherit;">weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_nodejs" style="color: inherit; text-decoration: inherit;">weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1605,7 +1605,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weightunit_nodejs">
-<a href="#weightunit_nodejs" style="color: inherit; text-decoration: inherit;">weight<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weightunit_nodejs" style="color: inherit; text-decoration: inherit;">weight<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1613,7 +1613,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_nodejs">
-<a href="#width_nodejs" style="color: inherit; text-decoration: inherit;">width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_nodejs" style="color: inherit; text-decoration: inherit;">width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1625,7 +1625,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_python">
-<a href="#depth_python" style="color: inherit; text-decoration: inherit;">depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_python" style="color: inherit; text-decoration: inherit;">depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1633,7 +1633,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_python">
-<a href="#height_python" style="color: inherit; text-decoration: inherit;">height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_python" style="color: inherit; text-decoration: inherit;">height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1641,7 +1641,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_python">
-<a href="#length_python" style="color: inherit; text-decoration: inherit;">length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_python" style="color: inherit; text-decoration: inherit;">length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1649,7 +1649,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_height_unit_python">
-<a href="#length_height_unit_python" style="color: inherit; text-decoration: inherit;">length_<wbr>height_<wbr>unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_height_unit_python" style="color: inherit; text-decoration: inherit;">length_<wbr>height_<wbr>unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1657,7 +1657,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_python">
-<a href="#weight_python" style="color: inherit; text-decoration: inherit;">weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_python" style="color: inherit; text-decoration: inherit;">weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1665,7 +1665,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_unit_python">
-<a href="#weight_unit_python" style="color: inherit; text-decoration: inherit;">weight_<wbr>unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_unit_python" style="color: inherit; text-decoration: inherit;">weight_<wbr>unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1673,7 +1673,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_python">
-<a href="#width_python" style="color: inherit; text-decoration: inherit;">width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_python" style="color: inherit; text-decoration: inherit;">width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1689,7 +1689,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_csharp">
-<a href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1697,7 +1697,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_csharp">
-<a href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#supportedfiltertypes">Pulumi.<wbr>Myedgeorder.<wbr>Supported<wbr>Filter<wbr>Types</a></span>
@@ -1709,7 +1709,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_go">
-<a href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1717,7 +1717,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_go">
-<a href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#supportedfiltertypes">Supported<wbr>Filter<wbr>Types</a></span>
@@ -1729,7 +1729,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_nodejs">
-<a href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1737,7 +1737,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_nodejs">
-<a href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#supportedfiltertypes">Supported<wbr>Filter<wbr>Types</a></span>
@@ -1749,7 +1749,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supported_values_python">
-<a href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1757,7 +1757,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_python">
-<a href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str | <a href="#supportedfiltertypes">Supported<wbr>Filter<wbr>Types</a></span>
@@ -1773,7 +1773,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_csharp">
-<a href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1781,7 +1781,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_csharp">
-<a href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1793,7 +1793,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_go">
-<a href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1801,7 +1801,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_go">
-<a href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1813,7 +1813,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_nodejs">
-<a href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1821,7 +1821,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_nodejs">
-<a href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1833,7 +1833,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supported_values_python">
-<a href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1841,7 +1841,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_python">
-<a href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1857,7 +1857,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_csharp">
-<a href="#configurationname_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1865,7 +1865,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_csharp">
-<a href="#productfamilyname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1873,7 +1873,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_csharp">
-<a href="#productlinename_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1881,7 +1881,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_csharp">
-<a href="#productname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1893,7 +1893,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_go">
-<a href="#configurationname_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1901,7 +1901,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_go">
-<a href="#productfamilyname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1909,7 +1909,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_go">
-<a href="#productlinename_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1917,7 +1917,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_go">
-<a href="#productname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1929,7 +1929,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_nodejs">
-<a href="#configurationname_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1937,7 +1937,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_nodejs">
-<a href="#productfamilyname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1945,7 +1945,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_nodejs">
-<a href="#productlinename_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1953,7 +1953,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_nodejs">
-<a href="#productname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1965,7 +1965,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configuration_name_python">
-<a href="#configuration_name_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configuration_name_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1973,7 +1973,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_family_name_python">
-<a href="#product_family_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>family_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_family_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>family_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1981,7 +1981,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_line_name_python">
-<a href="#product_line_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>line_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_line_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>line_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1989,7 +1989,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_name_python">
-<a href="#product_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2005,7 +2005,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_csharp">
-<a href="#configurationname_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2013,7 +2013,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_csharp">
-<a href="#productfamilyname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2021,7 +2021,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_csharp">
-<a href="#productlinename_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2029,7 +2029,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_csharp">
-<a href="#productname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2041,7 +2041,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_go">
-<a href="#configurationname_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2049,7 +2049,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_go">
-<a href="#productfamilyname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2057,7 +2057,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_go">
-<a href="#productlinename_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2065,7 +2065,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_go">
-<a href="#productname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2077,7 +2077,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_nodejs">
-<a href="#configurationname_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2085,7 +2085,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_nodejs">
-<a href="#productfamilyname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2093,7 +2093,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_nodejs">
-<a href="#productlinename_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2101,7 +2101,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_nodejs">
-<a href="#productname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2113,7 +2113,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configuration_name_python">
-<a href="#configuration_name_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configuration_name_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2121,7 +2121,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_family_name_python">
-<a href="#product_family_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>family_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_family_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>family_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2129,7 +2129,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_line_name_python">
-<a href="#product_line_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>line_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_line_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>line_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2137,7 +2137,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_name_python">
-<a href="#product_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2153,7 +2153,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="imagetype_csharp">
-<a href="#imagetype_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imagetype_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2161,7 +2161,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageurl_csharp">
-<a href="#imageurl_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageurl_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2173,7 +2173,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="imagetype_go">
-<a href="#imagetype_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imagetype_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2181,7 +2181,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageurl_go">
-<a href="#imageurl_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageurl_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2193,7 +2193,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="imagetype_nodejs">
-<a href="#imagetype_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imagetype_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2201,7 +2201,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageurl_nodejs">
-<a href="#imageurl_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageurl_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2213,7 +2213,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="image_type_python">
-<a href="#image_type_python" style="color: inherit; text-decoration: inherit;">image_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_type_python" style="color: inherit; text-decoration: inherit;">image_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2221,7 +2221,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="image_url_python">
-<a href="#image_url_python" style="color: inherit; text-decoration: inherit;">image_<wbr>url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_url_python" style="color: inherit; text-decoration: inherit;">image_<wbr>url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2237,7 +2237,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="linktype_csharp">
-<a href="#linktype_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linktype_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2245,7 +2245,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="linkurl_csharp">
-<a href="#linkurl_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linkurl_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2257,7 +2257,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="linktype_go">
-<a href="#linktype_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linktype_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2265,7 +2265,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="linkurl_go">
-<a href="#linkurl_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linkurl_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2277,7 +2277,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="linktype_nodejs">
-<a href="#linktype_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linktype_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2285,7 +2285,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="linkurl_nodejs">
-<a href="#linkurl_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linkurl_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2297,7 +2297,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="link_type_python">
-<a href="#link_type_python" style="color: inherit; text-decoration: inherit;">link_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#link_type_python" style="color: inherit; text-decoration: inherit;">link_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2305,7 +2305,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="link_url_python">
-<a href="#link_url_python" style="color: inherit; text-decoration: inherit;">link_<wbr>url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#link_url_python" style="color: inherit; text-decoration: inherit;">link_<wbr>url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2321,7 +2321,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_csharp">
-<a href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2329,7 +2329,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterguid_csharp">
-<a href="#meterguid_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterguid_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2337,7 +2337,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_csharp">
-<a href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -2349,7 +2349,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_go">
-<a href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2357,7 +2357,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterguid_go">
-<a href="#meterguid_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterguid_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2365,7 +2365,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_go">
-<a href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -2377,7 +2377,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_nodejs">
-<a href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2385,7 +2385,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterguid_nodejs">
-<a href="#meterguid_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterguid_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2393,7 +2393,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_nodejs">
-<a href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -2405,7 +2405,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="charging_type_python">
-<a href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2413,7 +2413,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meter_guid_python">
-<a href="#meter_guid_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meter_guid_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2421,7 +2421,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_python">
-<a href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -2437,7 +2437,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_csharp">
-<a href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2445,7 +2445,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_csharp">
-<a href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -2453,7 +2453,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productid_csharp">
-<a href="#productid_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productid_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2461,7 +2461,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="skuid_csharp">
-<a href="#skuid_csharp" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skuid_csharp" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2469,7 +2469,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="termid_csharp">
-<a href="#termid_csharp" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#termid_csharp" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2481,7 +2481,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_go">
-<a href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2489,7 +2489,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_go">
-<a href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -2497,7 +2497,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productid_go">
-<a href="#productid_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productid_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2505,7 +2505,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="skuid_go">
-<a href="#skuid_go" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skuid_go" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2513,7 +2513,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="termid_go">
-<a href="#termid_go" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#termid_go" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2525,7 +2525,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_nodejs">
-<a href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2533,7 +2533,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_nodejs">
-<a href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -2541,7 +2541,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productid_nodejs">
-<a href="#productid_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productid_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2549,7 +2549,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="skuid_nodejs">
-<a href="#skuid_nodejs" style="color: inherit; text-decoration: inherit;">sku<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skuid_nodejs" style="color: inherit; text-decoration: inherit;">sku<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2557,7 +2557,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="termid_nodejs">
-<a href="#termid_nodejs" style="color: inherit; text-decoration: inherit;">term<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#termid_nodejs" style="color: inherit; text-decoration: inherit;">term<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2569,7 +2569,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="charging_type_python">
-<a href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2577,7 +2577,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_python">
-<a href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -2585,7 +2585,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="product_id_python">
-<a href="#product_id_python" style="color: inherit; text-decoration: inherit;">product_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_id_python" style="color: inherit; text-decoration: inherit;">product_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2593,7 +2593,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="sku_id_python">
-<a href="#sku_id_python" style="color: inherit; text-decoration: inherit;">sku_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sku_id_python" style="color: inherit; text-decoration: inherit;">sku_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2601,7 +2601,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="term_id_python">
-<a href="#term_id_python" style="color: inherit; text-decoration: inherit;">term_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#term_id_python" style="color: inherit; text-decoration: inherit;">term_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2617,7 +2617,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2625,7 +2625,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2637,7 +2637,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2645,7 +2645,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2657,7 +2657,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2665,7 +2665,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2677,7 +2677,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2685,7 +2685,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="filterableproperties_csharp">
-<a href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Immutable<wbr>Array&lt;Filterable<wbr>Property&gt;&gt;</span>
@@ -92,7 +92,7 @@ The following arguments are supported:
     <dd>{{% md %}}Dictionary of filterable properties on product family.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customersubscriptiondetails_csharp">
-<a href="#customersubscriptiondetails_csharp" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customersubscriptiondetails_csharp" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -100,7 +100,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_csharp">
-<a href="#expand_csharp" style="color: inherit; text-decoration: inherit;">Expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_csharp" style="color: inherit; text-decoration: inherit;">Expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -108,7 +108,7 @@ The following arguments are supported:
     <dd>{{% md %}}$expand is supported on configurations parameter for product, which provides details on the configurations for the product.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skiptoken_csharp">
-<a href="#skiptoken_csharp" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skiptoken_csharp" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -120,7 +120,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="filterableproperties_go">
-<a href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string][]Filterable<wbr>Property</span>
@@ -128,7 +128,7 @@ The following arguments are supported:
     <dd>{{% md %}}Dictionary of filterable properties on product family.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customersubscriptiondetails_go">
-<a href="#customersubscriptiondetails_go" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customersubscriptiondetails_go" style="color: inherit; text-decoration: inherit;">Customer<wbr>Subscription<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -136,7 +136,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_go">
-<a href="#expand_go" style="color: inherit; text-decoration: inherit;">Expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_go" style="color: inherit; text-decoration: inherit;">Expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -144,7 +144,7 @@ The following arguments are supported:
     <dd>{{% md %}}$expand is supported on configurations parameter for product, which provides details on the configurations for the product.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skiptoken_go">
-<a href="#skiptoken_go" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skiptoken_go" style="color: inherit; text-decoration: inherit;">Skip<wbr>Token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -156,7 +156,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="filterableproperties_nodejs">
-<a href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Filterable<wbr>Property[]}</span>
@@ -164,7 +164,7 @@ The following arguments are supported:
     <dd>{{% md %}}Dictionary of filterable properties on product family.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customersubscriptiondetails_nodejs">
-<a href="#customersubscriptiondetails_nodejs" style="color: inherit; text-decoration: inherit;">customer<wbr>Subscription<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customersubscriptiondetails_nodejs" style="color: inherit; text-decoration: inherit;">customer<wbr>Subscription<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -172,7 +172,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_nodejs">
-<a href="#expand_nodejs" style="color: inherit; text-decoration: inherit;">expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_nodejs" style="color: inherit; text-decoration: inherit;">expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following arguments are supported:
     <dd>{{% md %}}$expand is supported on configurations parameter for product, which provides details on the configurations for the product.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skiptoken_nodejs">
-<a href="#skiptoken_nodejs" style="color: inherit; text-decoration: inherit;">skip<wbr>Token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skiptoken_nodejs" style="color: inherit; text-decoration: inherit;">skip<wbr>Token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="filterable_properties_python">
-<a href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Sequence[Filterable<wbr>Property]]</span>
@@ -200,7 +200,7 @@ The following arguments are supported:
     <dd>{{% md %}}Dictionary of filterable properties on product family.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="customer_subscription_details_python">
-<a href="#customer_subscription_details_python" style="color: inherit; text-decoration: inherit;">customer_<wbr>subscription_<wbr>details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#customer_subscription_details_python" style="color: inherit; text-decoration: inherit;">customer_<wbr>subscription_<wbr>details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptiondetails">Customer<wbr>Subscription<wbr>Details</a></span>
@@ -208,7 +208,7 @@ The following arguments are supported:
     <dd>{{% md %}}Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_python">
-<a href="#expand_python" style="color: inherit; text-decoration: inherit;">expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_python" style="color: inherit; text-decoration: inherit;">expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -216,7 +216,7 @@ The following arguments are supported:
     <dd>{{% md %}}$expand is supported on configurations parameter for product, which provides details on the configurations for the product.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="skip_token_python">
-<a href="#skip_token_python" style="color: inherit; text-decoration: inherit;">skip_<wbr>token</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skip_token_python" style="color: inherit; text-decoration: inherit;">skip_<wbr>token</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -237,7 +237,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productfamilyresponse">List&lt;Product<wbr>Family<wbr>Response&gt;</a></span>
@@ -245,7 +245,7 @@ The following output properties are available:
     <dd>{{% md %}}List of product families.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nextlink_csharp">
-<a href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -257,7 +257,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productfamilyresponse">[]Product<wbr>Family<wbr>Response</a></span>
@@ -265,7 +265,7 @@ The following output properties are available:
     <dd>{{% md %}}List of product families.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nextlink_go">
-<a href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -277,7 +277,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productfamilyresponse">Product<wbr>Family<wbr>Response[]</a></span>
@@ -285,7 +285,7 @@ The following output properties are available:
     <dd>{{% md %}}List of product families.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nextlink_nodejs">
-<a href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -297,7 +297,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productfamilyresponse">Sequence[Product<wbr>Family<wbr>Response]</a></span>
@@ -305,7 +305,7 @@ The following output properties are available:
     <dd>{{% md %}}List of product families.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="next_link_python">
-<a href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -327,7 +327,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilitystage_csharp">
-<a href="#availabilitystage_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilitystage_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -335,7 +335,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreason_csharp">
-<a href="#disabledreason_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreason_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -343,7 +343,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreasonmessage_csharp">
-<a href="#disabledreasonmessage_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreasonmessage_csharp" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -355,7 +355,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilitystage_go">
-<a href="#availabilitystage_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilitystage_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -363,7 +363,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreason_go">
-<a href="#disabledreason_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreason_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -371,7 +371,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreasonmessage_go">
-<a href="#disabledreasonmessage_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreasonmessage_go" style="color: inherit; text-decoration: inherit;">Disabled<wbr>Reason<wbr>Message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -383,7 +383,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilitystage_nodejs">
-<a href="#availabilitystage_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilitystage_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -391,7 +391,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreason_nodejs">
-<a href="#disabledreason_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreason_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -399,7 +399,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabledreasonmessage_nodejs">
-<a href="#disabledreasonmessage_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason<wbr>Message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabledreasonmessage_nodejs" style="color: inherit; text-decoration: inherit;">disabled<wbr>Reason<wbr>Message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -411,7 +411,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availability_stage_python">
-<a href="#availability_stage_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>stage</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availability_stage_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>stage</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -419,7 +419,7 @@ The following output properties are available:
     <dd>{{% md %}}Current availability stage of the product. Availability stage{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabled_reason_python">
-<a href="#disabled_reason_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabled_reason_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -427,7 +427,7 @@ The following output properties are available:
     <dd>{{% md %}}Reason why the product is disabled.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="disabled_reason_message_python">
-<a href="#disabled_reason_message_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason_<wbr>message</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#disabled_reason_message_python" style="color: inherit; text-decoration: inherit;">disabled_<wbr>reason_<wbr>message</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -443,7 +443,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_csharp">
-<a href="#frequency_csharp" style="color: inherit; text-decoration: inherit;">Frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_csharp" style="color: inherit; text-decoration: inherit;">Frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -451,7 +451,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterdetails_csharp">
-<a href="#meterdetails_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterdetails_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -459,7 +459,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meteringtype_csharp">
-<a href="#meteringtype_csharp" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meteringtype_csharp" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -467,7 +467,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -479,7 +479,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_go">
-<a href="#frequency_go" style="color: inherit; text-decoration: inherit;">Frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_go" style="color: inherit; text-decoration: inherit;">Frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -487,7 +487,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterdetails_go">
-<a href="#meterdetails_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterdetails_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -495,7 +495,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meteringtype_go">
-<a href="#meteringtype_go" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meteringtype_go" style="color: inherit; text-decoration: inherit;">Metering<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -503,7 +503,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -515,7 +515,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_nodejs">
-<a href="#frequency_nodejs" style="color: inherit; text-decoration: inherit;">frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_nodejs" style="color: inherit; text-decoration: inherit;">frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -523,7 +523,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterdetails_nodejs">
-<a href="#meterdetails_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterdetails_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -531,7 +531,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meteringtype_nodejs">
-<a href="#meteringtype_nodejs" style="color: inherit; text-decoration: inherit;">metering<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meteringtype_nodejs" style="color: inherit; text-decoration: inherit;">metering<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -539,7 +539,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -551,7 +551,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="frequency_python">
-<a href="#frequency_python" style="color: inherit; text-decoration: inherit;">frequency</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#frequency_python" style="color: inherit; text-decoration: inherit;">frequency</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -559,7 +559,7 @@ The following output properties are available:
     <dd>{{% md %}}Frequency of recurrence{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meter_details_python">
-<a href="#meter_details_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meter_details_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pav2meterdetailsresponse">Pav2Meter<wbr>Details<wbr>Response</a> | <a href="#purchasemeterdetailsresponse">Purchase<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -567,7 +567,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents MeterDetails{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="metering_type_python">
-<a href="#metering_type_python" style="color: inherit; text-decoration: inherit;">metering_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metering_type_python" style="color: inherit; text-decoration: inherit;">metering_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -575,7 +575,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents Metering type (eg one-time or recurrent){{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -591,7 +591,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_csharp">
-<a href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -599,7 +599,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_csharp">
-<a href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -607,7 +607,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -615,7 +615,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_csharp">
-<a href="#dimensions_csharp" style="color: inherit; text-decoration: inherit;">Dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_csharp" style="color: inherit; text-decoration: inherit;">Dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -623,7 +623,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_csharp">
-<a href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -631,7 +631,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_csharp">
-<a href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">List&lt;Filterable<wbr>Property<wbr>Response&gt;</a></span>
@@ -639,7 +639,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_csharp">
-<a href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -647,7 +647,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_csharp">
-<a href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">List&lt;Image<wbr>Information<wbr>Response&gt;</a></span>
@@ -655,7 +655,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_csharp">
-<a href="#specifications_csharp" style="color: inherit; text-decoration: inherit;">Specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_csharp" style="color: inherit; text-decoration: inherit;">Specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">List&lt;Specification<wbr>Response&gt;</a></span>
@@ -667,7 +667,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_go">
-<a href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -675,7 +675,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_go">
-<a href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -683,7 +683,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -691,7 +691,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_go">
-<a href="#dimensions_go" style="color: inherit; text-decoration: inherit;">Dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_go" style="color: inherit; text-decoration: inherit;">Dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -699,7 +699,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_go">
-<a href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -707,7 +707,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_go">
-<a href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">[]Filterable<wbr>Property<wbr>Response</a></span>
@@ -715,7 +715,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_go">
-<a href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -723,7 +723,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_go">
-<a href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">[]Image<wbr>Information<wbr>Response</a></span>
@@ -731,7 +731,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_go">
-<a href="#specifications_go" style="color: inherit; text-decoration: inherit;">Specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_go" style="color: inherit; text-decoration: inherit;">Specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">[]Specification<wbr>Response</a></span>
@@ -743,7 +743,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_nodejs">
-<a href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -751,7 +751,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_nodejs">
-<a href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -759,7 +759,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -767,7 +767,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_nodejs">
-<a href="#dimensions_nodejs" style="color: inherit; text-decoration: inherit;">dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_nodejs" style="color: inherit; text-decoration: inherit;">dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -775,7 +775,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_nodejs">
-<a href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -783,7 +783,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_nodejs">
-<a href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Filterable<wbr>Property<wbr>Response[]</a></span>
@@ -791,7 +791,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_nodejs">
-<a href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -799,7 +799,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_nodejs">
-<a href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Image<wbr>Information<wbr>Response[]</a></span>
@@ -807,7 +807,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_nodejs">
-<a href="#specifications_nodejs" style="color: inherit; text-decoration: inherit;">specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_nodejs" style="color: inherit; text-decoration: inherit;">specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">Specification<wbr>Response[]</a></span>
@@ -819,7 +819,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availability_information_python">
-<a href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -827,7 +827,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="cost_information_python">
-<a href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -835,7 +835,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -843,7 +843,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="dimensions_python">
-<a href="#dimensions_python" style="color: inherit; text-decoration: inherit;">dimensions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#dimensions_python" style="color: inherit; text-decoration: inherit;">dimensions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#dimensionsresponse">Dimensions<wbr>Response</a></span>
@@ -851,7 +851,7 @@ The following output properties are available:
     <dd>{{% md %}}Dimensions of the configuration{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="display_name_python">
-<a href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -859,7 +859,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterable_properties_python">
-<a href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Sequence[Filterable<wbr>Property<wbr>Response]</a></span>
@@ -867,7 +867,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchy_information_python">
-<a href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -875,7 +875,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="image_information_python">
-<a href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Sequence[Image<wbr>Information<wbr>Response]</a></span>
@@ -883,7 +883,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="specifications_python">
-<a href="#specifications_python" style="color: inherit; text-decoration: inherit;">specifications</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#specifications_python" style="color: inherit; text-decoration: inherit;">specifications</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#specificationresponse">Sequence[Specification<wbr>Response]</a></span>
@@ -899,7 +899,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billinginfourl_csharp">
-<a href="#billinginfourl_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billinginfourl_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -907,7 +907,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billingmeterdetails_csharp">
-<a href="#billingmeterdetails_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billingmeterdetails_csharp" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">List&lt;Billing<wbr>Meter<wbr>Details<wbr>Response&gt;</a></span>
@@ -919,7 +919,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billinginfourl_go">
-<a href="#billinginfourl_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billinginfourl_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Info<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -927,7 +927,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billingmeterdetails_go">
-<a href="#billingmeterdetails_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billingmeterdetails_go" style="color: inherit; text-decoration: inherit;">Billing<wbr>Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">[]Billing<wbr>Meter<wbr>Details<wbr>Response</a></span>
@@ -939,7 +939,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billinginfourl_nodejs">
-<a href="#billinginfourl_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Info<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billinginfourl_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Info<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -947,7 +947,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billingmeterdetails_nodejs">
-<a href="#billingmeterdetails_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Meter<wbr>Details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billingmeterdetails_nodejs" style="color: inherit; text-decoration: inherit;">billing<wbr>Meter<wbr>Details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">Billing<wbr>Meter<wbr>Details<wbr>Response[]</a></span>
@@ -959,7 +959,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="billing_info_url_python">
-<a href="#billing_info_url_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>info_<wbr>url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billing_info_url_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>info_<wbr>url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -967,7 +967,7 @@ The following output properties are available:
     <dd>{{% md %}}Default url to display billing information{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="billing_meter_details_python">
-<a href="#billing_meter_details_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>meter_<wbr>details</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#billing_meter_details_python" style="color: inherit; text-decoration: inherit;">billing_<wbr>meter_<wbr>details</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#billingmeterdetailsresponse">Sequence[Billing<wbr>Meter<wbr>Details<wbr>Response]</a></span>
@@ -983,7 +983,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quotaid_csharp">
-<a href="#quotaid_csharp" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quotaid_csharp" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -991,7 +991,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="locationplacementid_csharp">
-<a href="#locationplacementid_csharp" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#locationplacementid_csharp" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -999,7 +999,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registeredfeatures_csharp">
-<a href="#registeredfeatures_csharp" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registeredfeatures_csharp" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">List&lt;Customer<wbr>Subscription<wbr>Registered<wbr>Features&gt;</a></span>
@@ -1011,7 +1011,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quotaid_go">
-<a href="#quotaid_go" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quotaid_go" style="color: inherit; text-decoration: inherit;">Quota<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1019,7 +1019,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="locationplacementid_go">
-<a href="#locationplacementid_go" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#locationplacementid_go" style="color: inherit; text-decoration: inherit;">Location<wbr>Placement<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1027,7 +1027,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registeredfeatures_go">
-<a href="#registeredfeatures_go" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registeredfeatures_go" style="color: inherit; text-decoration: inherit;">Registered<wbr>Features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">[]Customer<wbr>Subscription<wbr>Registered<wbr>Features</a></span>
@@ -1039,7 +1039,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quotaid_nodejs">
-<a href="#quotaid_nodejs" style="color: inherit; text-decoration: inherit;">quota<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quotaid_nodejs" style="color: inherit; text-decoration: inherit;">quota<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1047,7 +1047,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="locationplacementid_nodejs">
-<a href="#locationplacementid_nodejs" style="color: inherit; text-decoration: inherit;">location<wbr>Placement<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#locationplacementid_nodejs" style="color: inherit; text-decoration: inherit;">location<wbr>Placement<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1055,7 +1055,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registeredfeatures_nodejs">
-<a href="#registeredfeatures_nodejs" style="color: inherit; text-decoration: inherit;">registered<wbr>Features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registeredfeatures_nodejs" style="color: inherit; text-decoration: inherit;">registered<wbr>Features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">Customer<wbr>Subscription<wbr>Registered<wbr>Features[]</a></span>
@@ -1067,7 +1067,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="quota_id_python">
-<a href="#quota_id_python" style="color: inherit; text-decoration: inherit;">quota_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#quota_id_python" style="color: inherit; text-decoration: inherit;">quota_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1075,7 +1075,7 @@ The following output properties are available:
     <dd>{{% md %}}Quota ID of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="location_placement_id_python">
-<a href="#location_placement_id_python" style="color: inherit; text-decoration: inherit;">location_<wbr>placement_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#location_placement_id_python" style="color: inherit; text-decoration: inherit;">location_<wbr>placement_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1083,7 +1083,7 @@ The following output properties are available:
     <dd>{{% md %}}Location placement Id of a subscription{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="registered_features_python">
-<a href="#registered_features_python" style="color: inherit; text-decoration: inherit;">registered_<wbr>features</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#registered_features_python" style="color: inherit; text-decoration: inherit;">registered_<wbr>features</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#customersubscriptionregisteredfeatures">Sequence[Customer<wbr>Subscription<wbr>Registered<wbr>Features]</a></span>
@@ -1099,7 +1099,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1107,7 +1107,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_csharp">
-<a href="#state_csharp" style="color: inherit; text-decoration: inherit;">State</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_csharp" style="color: inherit; text-decoration: inherit;">State</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1119,7 +1119,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1127,7 +1127,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_go">
-<a href="#state_go" style="color: inherit; text-decoration: inherit;">State</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_go" style="color: inherit; text-decoration: inherit;">State</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1139,7 +1139,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1147,7 +1147,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_nodejs">
-<a href="#state_nodejs" style="color: inherit; text-decoration: inherit;">state</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_nodejs" style="color: inherit; text-decoration: inherit;">state</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1159,7 +1159,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1167,7 +1167,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of subscription registered feature{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="state_python">
-<a href="#state_python" style="color: inherit; text-decoration: inherit;">state</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_python" style="color: inherit; text-decoration: inherit;">state</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1183,7 +1183,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_csharp">
-<a href="#attributes_csharp" style="color: inherit; text-decoration: inherit;">Attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_csharp" style="color: inherit; text-decoration: inherit;">Attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1191,7 +1191,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="descriptiontype_csharp">
-<a href="#descriptiontype_csharp" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#descriptiontype_csharp" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1199,7 +1199,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_csharp">
-<a href="#keywords_csharp" style="color: inherit; text-decoration: inherit;">Keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_csharp" style="color: inherit; text-decoration: inherit;">Keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1207,7 +1207,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_csharp">
-<a href="#links_csharp" style="color: inherit; text-decoration: inherit;">Links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_csharp" style="color: inherit; text-decoration: inherit;">Links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">List&lt;Link<wbr>Response&gt;</a></span>
@@ -1215,7 +1215,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="longdescription_csharp">
-<a href="#longdescription_csharp" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#longdescription_csharp" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1223,7 +1223,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="shortdescription_csharp">
-<a href="#shortdescription_csharp" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#shortdescription_csharp" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1235,7 +1235,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_go">
-<a href="#attributes_go" style="color: inherit; text-decoration: inherit;">Attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_go" style="color: inherit; text-decoration: inherit;">Attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1243,7 +1243,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="descriptiontype_go">
-<a href="#descriptiontype_go" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#descriptiontype_go" style="color: inherit; text-decoration: inherit;">Description<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1251,7 +1251,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_go">
-<a href="#keywords_go" style="color: inherit; text-decoration: inherit;">Keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_go" style="color: inherit; text-decoration: inherit;">Keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1259,7 +1259,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_go">
-<a href="#links_go" style="color: inherit; text-decoration: inherit;">Links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_go" style="color: inherit; text-decoration: inherit;">Links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">[]Link<wbr>Response</a></span>
@@ -1267,7 +1267,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="longdescription_go">
-<a href="#longdescription_go" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#longdescription_go" style="color: inherit; text-decoration: inherit;">Long<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1275,7 +1275,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="shortdescription_go">
-<a href="#shortdescription_go" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#shortdescription_go" style="color: inherit; text-decoration: inherit;">Short<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1287,7 +1287,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_nodejs">
-<a href="#attributes_nodejs" style="color: inherit; text-decoration: inherit;">attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_nodejs" style="color: inherit; text-decoration: inherit;">attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1295,7 +1295,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="descriptiontype_nodejs">
-<a href="#descriptiontype_nodejs" style="color: inherit; text-decoration: inherit;">description<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#descriptiontype_nodejs" style="color: inherit; text-decoration: inherit;">description<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1303,7 +1303,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_nodejs">
-<a href="#keywords_nodejs" style="color: inherit; text-decoration: inherit;">keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_nodejs" style="color: inherit; text-decoration: inherit;">keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1311,7 +1311,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_nodejs">
-<a href="#links_nodejs" style="color: inherit; text-decoration: inherit;">links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_nodejs" style="color: inherit; text-decoration: inherit;">links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">Link<wbr>Response[]</a></span>
@@ -1319,7 +1319,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="longdescription_nodejs">
-<a href="#longdescription_nodejs" style="color: inherit; text-decoration: inherit;">long<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#longdescription_nodejs" style="color: inherit; text-decoration: inherit;">long<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1327,7 +1327,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="shortdescription_nodejs">
-<a href="#shortdescription_nodejs" style="color: inherit; text-decoration: inherit;">short<wbr>Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#shortdescription_nodejs" style="color: inherit; text-decoration: inherit;">short<wbr>Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1339,7 +1339,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="attributes_python">
-<a href="#attributes_python" style="color: inherit; text-decoration: inherit;">attributes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#attributes_python" style="color: inherit; text-decoration: inherit;">attributes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1347,7 +1347,7 @@ The following output properties are available:
     <dd>{{% md %}}Attributes for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_type_python">
-<a href="#description_type_python" style="color: inherit; text-decoration: inherit;">description_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_type_python" style="color: inherit; text-decoration: inherit;">description_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1355,7 +1355,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of description.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keywords_python">
-<a href="#keywords_python" style="color: inherit; text-decoration: inherit;">keywords</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keywords_python" style="color: inherit; text-decoration: inherit;">keywords</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1363,7 +1363,7 @@ The following output properties are available:
     <dd>{{% md %}}Keywords for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="links_python">
-<a href="#links_python" style="color: inherit; text-decoration: inherit;">links</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#links_python" style="color: inherit; text-decoration: inherit;">links</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#linkresponse">Sequence[Link<wbr>Response]</a></span>
@@ -1371,7 +1371,7 @@ The following output properties are available:
     <dd>{{% md %}}Links for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="long_description_python">
-<a href="#long_description_python" style="color: inherit; text-decoration: inherit;">long_<wbr>description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#long_description_python" style="color: inherit; text-decoration: inherit;">long_<wbr>description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1379,7 +1379,7 @@ The following output properties are available:
     <dd>{{% md %}}Long description of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="short_description_python">
-<a href="#short_description_python" style="color: inherit; text-decoration: inherit;">short_<wbr>description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#short_description_python" style="color: inherit; text-decoration: inherit;">short_<wbr>description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1395,7 +1395,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_csharp">
-<a href="#depth_csharp" style="color: inherit; text-decoration: inherit;">Depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_csharp" style="color: inherit; text-decoration: inherit;">Depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1403,7 +1403,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_csharp">
-<a href="#height_csharp" style="color: inherit; text-decoration: inherit;">Height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_csharp" style="color: inherit; text-decoration: inherit;">Height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1411,7 +1411,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_csharp">
-<a href="#length_csharp" style="color: inherit; text-decoration: inherit;">Length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_csharp" style="color: inherit; text-decoration: inherit;">Length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1419,7 +1419,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="lengthheightunit_csharp">
-<a href="#lengthheightunit_csharp" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#lengthheightunit_csharp" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1427,7 +1427,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_csharp">
-<a href="#weight_csharp" style="color: inherit; text-decoration: inherit;">Weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_csharp" style="color: inherit; text-decoration: inherit;">Weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1435,7 +1435,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weightunit_csharp">
-<a href="#weightunit_csharp" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weightunit_csharp" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1443,7 +1443,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_csharp">
-<a href="#width_csharp" style="color: inherit; text-decoration: inherit;">Width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_csharp" style="color: inherit; text-decoration: inherit;">Width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1455,7 +1455,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_go">
-<a href="#depth_go" style="color: inherit; text-decoration: inherit;">Depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_go" style="color: inherit; text-decoration: inherit;">Depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1463,7 +1463,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_go">
-<a href="#height_go" style="color: inherit; text-decoration: inherit;">Height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_go" style="color: inherit; text-decoration: inherit;">Height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1471,7 +1471,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_go">
-<a href="#length_go" style="color: inherit; text-decoration: inherit;">Length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_go" style="color: inherit; text-decoration: inherit;">Length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1479,7 +1479,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="lengthheightunit_go">
-<a href="#lengthheightunit_go" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#lengthheightunit_go" style="color: inherit; text-decoration: inherit;">Length<wbr>Height<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1487,7 +1487,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_go">
-<a href="#weight_go" style="color: inherit; text-decoration: inherit;">Weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_go" style="color: inherit; text-decoration: inherit;">Weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1495,7 +1495,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weightunit_go">
-<a href="#weightunit_go" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weightunit_go" style="color: inherit; text-decoration: inherit;">Weight<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1503,7 +1503,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_go">
-<a href="#width_go" style="color: inherit; text-decoration: inherit;">Width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_go" style="color: inherit; text-decoration: inherit;">Width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1515,7 +1515,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_nodejs">
-<a href="#depth_nodejs" style="color: inherit; text-decoration: inherit;">depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_nodejs" style="color: inherit; text-decoration: inherit;">depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1523,7 +1523,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_nodejs">
-<a href="#height_nodejs" style="color: inherit; text-decoration: inherit;">height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_nodejs" style="color: inherit; text-decoration: inherit;">height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1531,7 +1531,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_nodejs">
-<a href="#length_nodejs" style="color: inherit; text-decoration: inherit;">length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_nodejs" style="color: inherit; text-decoration: inherit;">length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1539,7 +1539,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="lengthheightunit_nodejs">
-<a href="#lengthheightunit_nodejs" style="color: inherit; text-decoration: inherit;">length<wbr>Height<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#lengthheightunit_nodejs" style="color: inherit; text-decoration: inherit;">length<wbr>Height<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1547,7 +1547,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_nodejs">
-<a href="#weight_nodejs" style="color: inherit; text-decoration: inherit;">weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_nodejs" style="color: inherit; text-decoration: inherit;">weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1555,7 +1555,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weightunit_nodejs">
-<a href="#weightunit_nodejs" style="color: inherit; text-decoration: inherit;">weight<wbr>Unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weightunit_nodejs" style="color: inherit; text-decoration: inherit;">weight<wbr>Unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1563,7 +1563,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_nodejs">
-<a href="#width_nodejs" style="color: inherit; text-decoration: inherit;">width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_nodejs" style="color: inherit; text-decoration: inherit;">width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1575,7 +1575,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="depth_python">
-<a href="#depth_python" style="color: inherit; text-decoration: inherit;">depth</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#depth_python" style="color: inherit; text-decoration: inherit;">depth</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1583,7 +1583,7 @@ The following output properties are available:
     <dd>{{% md %}}Depth of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="height_python">
-<a href="#height_python" style="color: inherit; text-decoration: inherit;">height</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#height_python" style="color: inherit; text-decoration: inherit;">height</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1591,7 +1591,7 @@ The following output properties are available:
     <dd>{{% md %}}Height of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_python">
-<a href="#length_python" style="color: inherit; text-decoration: inherit;">length</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_python" style="color: inherit; text-decoration: inherit;">length</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1599,7 +1599,7 @@ The following output properties are available:
     <dd>{{% md %}}Length of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="length_height_unit_python">
-<a href="#length_height_unit_python" style="color: inherit; text-decoration: inherit;">length_<wbr>height_<wbr>unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#length_height_unit_python" style="color: inherit; text-decoration: inherit;">length_<wbr>height_<wbr>unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1607,7 +1607,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of length, height and width.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_python">
-<a href="#weight_python" style="color: inherit; text-decoration: inherit;">weight</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_python" style="color: inherit; text-decoration: inherit;">weight</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1615,7 +1615,7 @@ The following output properties are available:
     <dd>{{% md %}}Weight of the device.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="weight_unit_python">
-<a href="#weight_unit_python" style="color: inherit; text-decoration: inherit;">weight_<wbr>unit</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#weight_unit_python" style="color: inherit; text-decoration: inherit;">weight_<wbr>unit</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1623,7 +1623,7 @@ The following output properties are available:
     <dd>{{% md %}}Unit for the dimensions of weight.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="width_python">
-<a href="#width_python" style="color: inherit; text-decoration: inherit;">width</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#width_python" style="color: inherit; text-decoration: inherit;">width</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1639,7 +1639,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_csharp">
-<a href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1647,7 +1647,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_csharp">
-<a href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#supportedfiltertypes">Pulumi.<wbr>Myedgeorder.<wbr>Supported<wbr>Filter<wbr>Types</a></span>
@@ -1659,7 +1659,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_go">
-<a href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1667,7 +1667,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_go">
-<a href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#supportedfiltertypes">Supported<wbr>Filter<wbr>Types</a></span>
@@ -1679,7 +1679,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_nodejs">
-<a href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1687,7 +1687,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_nodejs">
-<a href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#supportedfiltertypes">Supported<wbr>Filter<wbr>Types</a></span>
@@ -1699,7 +1699,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supported_values_python">
-<a href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1707,7 +1707,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_python">
-<a href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str | <a href="#supportedfiltertypes">Supported<wbr>Filter<wbr>Types</a></span>
@@ -1723,7 +1723,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_csharp">
-<a href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_csharp" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -1731,7 +1731,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_csharp">
-<a href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1743,7 +1743,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_go">
-<a href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_go" style="color: inherit; text-decoration: inherit;">Supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -1751,7 +1751,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_go">
-<a href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1763,7 +1763,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supportedvalues_nodejs">
-<a href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supportedvalues_nodejs" style="color: inherit; text-decoration: inherit;">supported<wbr>Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -1771,7 +1771,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_nodejs">
-<a href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1783,7 +1783,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="supported_values_python">
-<a href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#supported_values_python" style="color: inherit; text-decoration: inherit;">supported_<wbr>values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -1791,7 +1791,7 @@ The following output properties are available:
     <dd>{{% md %}}Values to be filtered.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_python">
-<a href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1807,7 +1807,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_csharp">
-<a href="#configurationname_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_csharp" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1815,7 +1815,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_csharp">
-<a href="#productfamilyname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1823,7 +1823,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_csharp">
-<a href="#productlinename_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1831,7 +1831,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_csharp">
-<a href="#productname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1843,7 +1843,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_go">
-<a href="#configurationname_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_go" style="color: inherit; text-decoration: inherit;">Configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1851,7 +1851,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_go">
-<a href="#productfamilyname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1859,7 +1859,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_go">
-<a href="#productlinename_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1867,7 +1867,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_go">
-<a href="#productname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1879,7 +1879,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configurationname_nodejs">
-<a href="#configurationname_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurationname_nodejs" style="color: inherit; text-decoration: inherit;">configuration<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1887,7 +1887,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productfamilyname_nodejs">
-<a href="#productfamilyname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Family<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productfamilyname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Family<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1895,7 +1895,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productlinename_nodejs">
-<a href="#productlinename_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Line<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlinename_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Line<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1903,7 +1903,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="productname_nodejs">
-<a href="#productname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productname_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1915,7 +1915,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="configuration_name_python">
-<a href="#configuration_name_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configuration_name_python" style="color: inherit; text-decoration: inherit;">configuration_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1923,7 +1923,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents configuration name that uniquely identifies configuration{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_family_name_python">
-<a href="#product_family_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>family_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_family_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>family_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1931,7 +1931,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product family name that uniquely identifies product family{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_line_name_python">
-<a href="#product_line_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>line_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_line_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>line_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1939,7 +1939,7 @@ The following output properties are available:
     <dd>{{% md %}}Represents product line name that uniquely identifies product line{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="product_name_python">
-<a href="#product_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_name_python" style="color: inherit; text-decoration: inherit;">product_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1955,7 +1955,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="imagetype_csharp">
-<a href="#imagetype_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imagetype_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1963,7 +1963,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageurl_csharp">
-<a href="#imageurl_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageurl_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1975,7 +1975,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="imagetype_go">
-<a href="#imagetype_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imagetype_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1983,7 +1983,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageurl_go">
-<a href="#imageurl_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageurl_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1995,7 +1995,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="imagetype_nodejs">
-<a href="#imagetype_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imagetype_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2003,7 +2003,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageurl_nodejs">
-<a href="#imageurl_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageurl_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2015,7 +2015,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="image_type_python">
-<a href="#image_type_python" style="color: inherit; text-decoration: inherit;">image_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_type_python" style="color: inherit; text-decoration: inherit;">image_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2023,7 +2023,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of the image{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="image_url_python">
-<a href="#image_url_python" style="color: inherit; text-decoration: inherit;">image_<wbr>url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_url_python" style="color: inherit; text-decoration: inherit;">image_<wbr>url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2039,7 +2039,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="linktype_csharp">
-<a href="#linktype_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linktype_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2047,7 +2047,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="linkurl_csharp">
-<a href="#linkurl_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linkurl_csharp" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2059,7 +2059,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="linktype_go">
-<a href="#linktype_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linktype_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2067,7 +2067,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="linkurl_go">
-<a href="#linkurl_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linkurl_go" style="color: inherit; text-decoration: inherit;">Link<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2079,7 +2079,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="linktype_nodejs">
-<a href="#linktype_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linktype_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2087,7 +2087,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="linkurl_nodejs">
-<a href="#linkurl_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#linkurl_nodejs" style="color: inherit; text-decoration: inherit;">link<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2099,7 +2099,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="link_type_python">
-<a href="#link_type_python" style="color: inherit; text-decoration: inherit;">link_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#link_type_python" style="color: inherit; text-decoration: inherit;">link_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2107,7 +2107,7 @@ The following output properties are available:
     <dd>{{% md %}}Type of link{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="link_url_python">
-<a href="#link_url_python" style="color: inherit; text-decoration: inherit;">link_<wbr>url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#link_url_python" style="color: inherit; text-decoration: inherit;">link_<wbr>url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2123,7 +2123,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_csharp">
-<a href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2131,7 +2131,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterguid_csharp">
-<a href="#meterguid_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterguid_csharp" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2139,7 +2139,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_csharp">
-<a href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -2151,7 +2151,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_go">
-<a href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2159,7 +2159,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterguid_go">
-<a href="#meterguid_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterguid_go" style="color: inherit; text-decoration: inherit;">Meter<wbr>Guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2167,7 +2167,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_go">
-<a href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -2179,7 +2179,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_nodejs">
-<a href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2187,7 +2187,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meterguid_nodejs">
-<a href="#meterguid_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meterguid_nodejs" style="color: inherit; text-decoration: inherit;">meter<wbr>Guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2195,7 +2195,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_nodejs">
-<a href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -2207,7 +2207,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="charging_type_python">
-<a href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2215,7 +2215,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="meter_guid_python">
-<a href="#meter_guid_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>guid</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#meter_guid_python" style="color: inherit; text-decoration: inherit;">meter_<wbr>guid</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2223,7 +2223,7 @@ The following output properties are available:
     <dd>{{% md %}}Validation status of requested data center and transport.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_python">
-<a href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -2239,7 +2239,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_csharp">
-<a href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2247,7 +2247,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_csharp">
-<a href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2255,7 +2255,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2263,7 +2263,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_csharp">
-<a href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2271,7 +2271,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_csharp">
-<a href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">List&lt;Filterable<wbr>Property<wbr>Response&gt;</a></span>
@@ -2279,7 +2279,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_csharp">
-<a href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2287,7 +2287,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_csharp">
-<a href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">List&lt;Image<wbr>Information<wbr>Response&gt;</a></span>
@@ -2295,7 +2295,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productlines_csharp">
-<a href="#productlines_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Lines</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlines_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Lines</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productlineresponse">List&lt;Product<wbr>Line<wbr>Response&gt;</a></span>
@@ -2307,7 +2307,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_go">
-<a href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2315,7 +2315,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_go">
-<a href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2323,7 +2323,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2331,7 +2331,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_go">
-<a href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2339,7 +2339,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_go">
-<a href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">[]Filterable<wbr>Property<wbr>Response</a></span>
@@ -2347,7 +2347,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_go">
-<a href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2355,7 +2355,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_go">
-<a href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">[]Image<wbr>Information<wbr>Response</a></span>
@@ -2363,7 +2363,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productlines_go">
-<a href="#productlines_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Lines</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlines_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Lines</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productlineresponse">[]Product<wbr>Line<wbr>Response</a></span>
@@ -2375,7 +2375,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_nodejs">
-<a href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2383,7 +2383,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_nodejs">
-<a href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2391,7 +2391,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2399,7 +2399,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_nodejs">
-<a href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2407,7 +2407,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_nodejs">
-<a href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Filterable<wbr>Property<wbr>Response[]</a></span>
@@ -2415,7 +2415,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_nodejs">
-<a href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2423,7 +2423,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_nodejs">
-<a href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Image<wbr>Information<wbr>Response[]</a></span>
@@ -2431,7 +2431,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productlines_nodejs">
-<a href="#productlines_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Lines</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productlines_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Lines</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productlineresponse">Product<wbr>Line<wbr>Response[]</a></span>
@@ -2443,7 +2443,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availability_information_python">
-<a href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2451,7 +2451,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="cost_information_python">
-<a href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2459,7 +2459,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2467,7 +2467,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="display_name_python">
-<a href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2475,7 +2475,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterable_properties_python">
-<a href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Sequence[Filterable<wbr>Property<wbr>Response]</a></span>
@@ -2483,7 +2483,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchy_information_python">
-<a href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2491,7 +2491,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="image_information_python">
-<a href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Sequence[Image<wbr>Information<wbr>Response]</a></span>
@@ -2499,7 +2499,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="product_lines_python">
-<a href="#product_lines_python" style="color: inherit; text-decoration: inherit;">product_<wbr>lines</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_lines_python" style="color: inherit; text-decoration: inherit;">product_<wbr>lines</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productlineresponse">Sequence[Product<wbr>Line<wbr>Response]</a></span>
@@ -2515,7 +2515,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_csharp">
-<a href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2523,7 +2523,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_csharp">
-<a href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2531,7 +2531,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2539,7 +2539,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_csharp">
-<a href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2547,7 +2547,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_csharp">
-<a href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">List&lt;Filterable<wbr>Property<wbr>Response&gt;</a></span>
@@ -2555,7 +2555,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_csharp">
-<a href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2563,7 +2563,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_csharp">
-<a href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">List&lt;Image<wbr>Information<wbr>Response&gt;</a></span>
@@ -2571,7 +2571,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="products_csharp">
-<a href="#products_csharp" style="color: inherit; text-decoration: inherit;">Products</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#products_csharp" style="color: inherit; text-decoration: inherit;">Products</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productresponse">List&lt;Product<wbr>Response&gt;</a></span>
@@ -2583,7 +2583,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_go">
-<a href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2591,7 +2591,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_go">
-<a href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2599,7 +2599,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2607,7 +2607,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_go">
-<a href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2615,7 +2615,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_go">
-<a href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">[]Filterable<wbr>Property<wbr>Response</a></span>
@@ -2623,7 +2623,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_go">
-<a href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2631,7 +2631,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_go">
-<a href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">[]Image<wbr>Information<wbr>Response</a></span>
@@ -2639,7 +2639,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="products_go">
-<a href="#products_go" style="color: inherit; text-decoration: inherit;">Products</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#products_go" style="color: inherit; text-decoration: inherit;">Products</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productresponse">[]Product<wbr>Response</a></span>
@@ -2651,7 +2651,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_nodejs">
-<a href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2659,7 +2659,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_nodejs">
-<a href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2667,7 +2667,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2675,7 +2675,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_nodejs">
-<a href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2683,7 +2683,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_nodejs">
-<a href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Filterable<wbr>Property<wbr>Response[]</a></span>
@@ -2691,7 +2691,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_nodejs">
-<a href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2699,7 +2699,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_nodejs">
-<a href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Image<wbr>Information<wbr>Response[]</a></span>
@@ -2707,7 +2707,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="products_nodejs">
-<a href="#products_nodejs" style="color: inherit; text-decoration: inherit;">products</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#products_nodejs" style="color: inherit; text-decoration: inherit;">products</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productresponse">Product<wbr>Response[]</a></span>
@@ -2719,7 +2719,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availability_information_python">
-<a href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2727,7 +2727,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="cost_information_python">
-<a href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2735,7 +2735,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2743,7 +2743,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="display_name_python">
-<a href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -2751,7 +2751,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterable_properties_python">
-<a href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Sequence[Filterable<wbr>Property<wbr>Response]</a></span>
@@ -2759,7 +2759,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchy_information_python">
-<a href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2767,7 +2767,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="image_information_python">
-<a href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Sequence[Image<wbr>Information<wbr>Response]</a></span>
@@ -2775,7 +2775,7 @@ The following output properties are available:
     <dd>{{% md %}}Image information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="products_python">
-<a href="#products_python" style="color: inherit; text-decoration: inherit;">products</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#products_python" style="color: inherit; text-decoration: inherit;">products</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#productresponse">Sequence[Product<wbr>Response]</a></span>
@@ -2791,7 +2791,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_csharp">
-<a href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_csharp" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2799,7 +2799,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="configurations_csharp">
-<a href="#configurations_csharp" style="color: inherit; text-decoration: inherit;">Configurations</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurations_csharp" style="color: inherit; text-decoration: inherit;">Configurations</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">List&lt;Configuration<wbr>Response&gt;</a></span>
@@ -2807,7 +2807,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations for the product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_csharp">
-<a href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_csharp" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2815,7 +2815,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2823,7 +2823,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_csharp">
-<a href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_csharp" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2831,7 +2831,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_csharp">
-<a href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_csharp" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">List&lt;Filterable<wbr>Property<wbr>Response&gt;</a></span>
@@ -2839,7 +2839,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_csharp">
-<a href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_csharp" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2847,7 +2847,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_csharp">
-<a href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_csharp" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">List&lt;Image<wbr>Information<wbr>Response&gt;</a></span>
@@ -2859,7 +2859,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_go">
-<a href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_go" style="color: inherit; text-decoration: inherit;">Availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2867,7 +2867,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="configurations_go">
-<a href="#configurations_go" style="color: inherit; text-decoration: inherit;">Configurations</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurations_go" style="color: inherit; text-decoration: inherit;">Configurations</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">[]Configuration<wbr>Response</a></span>
@@ -2875,7 +2875,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations for the product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_go">
-<a href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_go" style="color: inherit; text-decoration: inherit;">Cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2883,7 +2883,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2891,7 +2891,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_go">
-<a href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_go" style="color: inherit; text-decoration: inherit;">Display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2899,7 +2899,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_go">
-<a href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_go" style="color: inherit; text-decoration: inherit;">Filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">[]Filterable<wbr>Property<wbr>Response</a></span>
@@ -2907,7 +2907,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_go">
-<a href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_go" style="color: inherit; text-decoration: inherit;">Hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2915,7 +2915,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_go">
-<a href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_go" style="color: inherit; text-decoration: inherit;">Image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">[]Image<wbr>Information<wbr>Response</a></span>
@@ -2927,7 +2927,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availabilityinformation_nodejs">
-<a href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availabilityinformation_nodejs" style="color: inherit; text-decoration: inherit;">availability<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -2935,7 +2935,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="configurations_nodejs">
-<a href="#configurations_nodejs" style="color: inherit; text-decoration: inherit;">configurations</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurations_nodejs" style="color: inherit; text-decoration: inherit;">configurations</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">Configuration<wbr>Response[]</a></span>
@@ -2943,7 +2943,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations for the product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="costinformation_nodejs">
-<a href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#costinformation_nodejs" style="color: inherit; text-decoration: inherit;">cost<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -2951,7 +2951,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -2959,7 +2959,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="displayname_nodejs">
-<a href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#displayname_nodejs" style="color: inherit; text-decoration: inherit;">display<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -2967,7 +2967,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterableproperties_nodejs">
-<a href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterableproperties_nodejs" style="color: inherit; text-decoration: inherit;">filterable<wbr>Properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Filterable<wbr>Property<wbr>Response[]</a></span>
@@ -2975,7 +2975,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchyinformation_nodejs">
-<a href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchyinformation_nodejs" style="color: inherit; text-decoration: inherit;">hierarchy<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -2983,7 +2983,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="imageinformation_nodejs">
-<a href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#imageinformation_nodejs" style="color: inherit; text-decoration: inherit;">image<wbr>Information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Image<wbr>Information<wbr>Response[]</a></span>
@@ -2995,7 +2995,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="availability_information_python">
-<a href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#availability_information_python" style="color: inherit; text-decoration: inherit;">availability_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#availabilityinformationresponse">Availability<wbr>Information<wbr>Response</a></span>
@@ -3003,7 +3003,7 @@ The following output properties are available:
     <dd>{{% md %}}Availability information of the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="configurations_python">
-<a href="#configurations_python" style="color: inherit; text-decoration: inherit;">configurations</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configurations_python" style="color: inherit; text-decoration: inherit;">configurations</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configurationresponse">Sequence[Configuration<wbr>Response]</a></span>
@@ -3011,7 +3011,7 @@ The following output properties are available:
     <dd>{{% md %}}List of configurations for the product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="cost_information_python">
-<a href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#cost_information_python" style="color: inherit; text-decoration: inherit;">cost_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#costinformationresponse">Cost<wbr>Information<wbr>Response</a></span>
@@ -3019,7 +3019,7 @@ The following output properties are available:
     <dd>{{% md %}}Cost information for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#descriptionresponse">Description<wbr>Response</a></span>
@@ -3027,7 +3027,7 @@ The following output properties are available:
     <dd>{{% md %}}Description related to the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="display_name_python">
-<a href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#display_name_python" style="color: inherit; text-decoration: inherit;">display_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -3035,7 +3035,7 @@ The following output properties are available:
     <dd>{{% md %}}Display Name for the product system.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="filterable_properties_python">
-<a href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filterable_properties_python" style="color: inherit; text-decoration: inherit;">filterable_<wbr>properties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#filterablepropertyresponse">Sequence[Filterable<wbr>Property<wbr>Response]</a></span>
@@ -3043,7 +3043,7 @@ The following output properties are available:
     <dd>{{% md %}}list of filters supported for a product{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="hierarchy_information_python">
-<a href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hierarchy_information_python" style="color: inherit; text-decoration: inherit;">hierarchy_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#hierarchyinformationresponse">Hierarchy<wbr>Information<wbr>Response</a></span>
@@ -3051,7 +3051,7 @@ The following output properties are available:
     <dd>{{% md %}}Hierarchy information of a product.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="image_information_python">
-<a href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#image_information_python" style="color: inherit; text-decoration: inherit;">image_<wbr>information</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#imageinformationresponse">Sequence[Image<wbr>Information<wbr>Response]</a></span>
@@ -3067,7 +3067,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_csharp">
-<a href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_csharp" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3075,7 +3075,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_csharp">
-<a href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_csharp" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -3083,7 +3083,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productid_csharp">
-<a href="#productid_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productid_csharp" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3091,7 +3091,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="skuid_csharp">
-<a href="#skuid_csharp" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skuid_csharp" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3099,7 +3099,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="termid_csharp">
-<a href="#termid_csharp" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#termid_csharp" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3111,7 +3111,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_go">
-<a href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_go" style="color: inherit; text-decoration: inherit;">Charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3119,7 +3119,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_go">
-<a href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_go" style="color: inherit; text-decoration: inherit;">Multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -3127,7 +3127,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productid_go">
-<a href="#productid_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productid_go" style="color: inherit; text-decoration: inherit;">Product<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3135,7 +3135,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="skuid_go">
-<a href="#skuid_go" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skuid_go" style="color: inherit; text-decoration: inherit;">Sku<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3143,7 +3143,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="termid_go">
-<a href="#termid_go" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#termid_go" style="color: inherit; text-decoration: inherit;">Term<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3155,7 +3155,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="chargingtype_nodejs">
-<a href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chargingtype_nodejs" style="color: inherit; text-decoration: inherit;">charging<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3163,7 +3163,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_nodejs">
-<a href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_nodejs" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -3171,7 +3171,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="productid_nodejs">
-<a href="#productid_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#productid_nodejs" style="color: inherit; text-decoration: inherit;">product<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3179,7 +3179,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="skuid_nodejs">
-<a href="#skuid_nodejs" style="color: inherit; text-decoration: inherit;">sku<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#skuid_nodejs" style="color: inherit; text-decoration: inherit;">sku<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3187,7 +3187,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="termid_nodejs">
-<a href="#termid_nodejs" style="color: inherit; text-decoration: inherit;">term<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#termid_nodejs" style="color: inherit; text-decoration: inherit;">term<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3199,7 +3199,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="charging_type_python">
-<a href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#charging_type_python" style="color: inherit; text-decoration: inherit;">charging_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -3207,7 +3207,7 @@ The following output properties are available:
     <dd>{{% md %}}Charging type.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="multiplier_python">
-<a href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#multiplier_python" style="color: inherit; text-decoration: inherit;">multiplier</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -3215,7 +3215,7 @@ The following output properties are available:
     <dd>{{% md %}}Billing unit applicable for Pav2 billing{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="product_id_python">
-<a href="#product_id_python" style="color: inherit; text-decoration: inherit;">product_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#product_id_python" style="color: inherit; text-decoration: inherit;">product_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -3223,7 +3223,7 @@ The following output properties are available:
     <dd>{{% md %}}Product Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="sku_id_python">
-<a href="#sku_id_python" style="color: inherit; text-decoration: inherit;">sku_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sku_id_python" style="color: inherit; text-decoration: inherit;">sku_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -3231,7 +3231,7 @@ The following output properties are available:
     <dd>{{% md %}}Sku Id{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="term_id_python">
-<a href="#term_id_python" style="color: inherit; text-decoration: inherit;">term_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#term_id_python" style="color: inherit; text-decoration: inherit;">term_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -3247,7 +3247,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3255,7 +3255,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3267,7 +3267,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3275,7 +3275,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3287,7 +3287,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3295,7 +3295,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -3307,7 +3307,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -3315,7 +3315,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the specification{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
@@ -86,7 +86,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="owners_csharp">
-<a href="#owners_csharp" style="color: inherit; text-decoration: inherit;">Owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_csharp" style="color: inherit; text-decoration: inherit;">Owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -95,7 +95,7 @@ The following arguments are supported:
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="executableusers_csharp">
-<a href="#executableusers_csharp" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executableusers_csharp" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -105,7 +105,7 @@ permission on  the image. Valid items are the numeric account ID or `self`.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filters_csharp">
-<a href="#filters_csharp" style="color: inherit; text-decoration: inherit;">Filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_csharp" style="color: inherit; text-decoration: inherit;">Filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">List&lt;Get<wbr>Ami<wbr>Ids<wbr>Filter&gt;</a></span>
@@ -116,7 +116,7 @@ are several valid keys, for a full reference, check out
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="nameregex_csharp">
-<a href="#nameregex_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nameregex_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -129,7 +129,7 @@ options to narrow down the list AWS returns.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sortascending_csharp">
-<a href="#sortascending_csharp" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sortascending_csharp" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -142,7 +142,7 @@ options to narrow down the list AWS returns.
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="owners_go">
-<a href="#owners_go" style="color: inherit; text-decoration: inherit;">Owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_go" style="color: inherit; text-decoration: inherit;">Owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -151,7 +151,7 @@ options to narrow down the list AWS returns.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="executableusers_go">
-<a href="#executableusers_go" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executableusers_go" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -161,7 +161,7 @@ permission on  the image. Valid items are the numeric account ID or `self`.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filters_go">
-<a href="#filters_go" style="color: inherit; text-decoration: inherit;">Filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_go" style="color: inherit; text-decoration: inherit;">Filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">[]Get<wbr>Ami<wbr>Ids<wbr>Filter</a></span>
@@ -172,7 +172,7 @@ are several valid keys, for a full reference, check out
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="nameregex_go">
-<a href="#nameregex_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nameregex_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -185,7 +185,7 @@ options to narrow down the list AWS returns.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sortascending_go">
-<a href="#sortascending_go" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sortascending_go" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -198,7 +198,7 @@ options to narrow down the list AWS returns.
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="owners_nodejs">
-<a href="#owners_nodejs" style="color: inherit; text-decoration: inherit;">owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_nodejs" style="color: inherit; text-decoration: inherit;">owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -207,7 +207,7 @@ options to narrow down the list AWS returns.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="executableusers_nodejs">
-<a href="#executableusers_nodejs" style="color: inherit; text-decoration: inherit;">executable<wbr>Users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executableusers_nodejs" style="color: inherit; text-decoration: inherit;">executable<wbr>Users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -217,7 +217,7 @@ permission on  the image. Valid items are the numeric account ID or `self`.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filters_nodejs">
-<a href="#filters_nodejs" style="color: inherit; text-decoration: inherit;">filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_nodejs" style="color: inherit; text-decoration: inherit;">filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">Get<wbr>Ami<wbr>Ids<wbr>Filter[]</a></span>
@@ -228,7 +228,7 @@ are several valid keys, for a full reference, check out
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="nameregex_nodejs">
-<a href="#nameregex_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nameregex_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -241,7 +241,7 @@ options to narrow down the list AWS returns.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sortascending_nodejs">
-<a href="#sortascending_nodejs" style="color: inherit; text-decoration: inherit;">sort<wbr>Ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sortascending_nodejs" style="color: inherit; text-decoration: inherit;">sort<wbr>Ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -254,7 +254,7 @@ options to narrow down the list AWS returns.
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="owners_python">
-<a href="#owners_python" style="color: inherit; text-decoration: inherit;">owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_python" style="color: inherit; text-decoration: inherit;">owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -263,7 +263,7 @@ options to narrow down the list AWS returns.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="executable_users_python">
-<a href="#executable_users_python" style="color: inherit; text-decoration: inherit;">executable_<wbr>users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executable_users_python" style="color: inherit; text-decoration: inherit;">executable_<wbr>users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -273,7 +273,7 @@ permission on  the image. Valid items are the numeric account ID or `self`.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="filters_python">
-<a href="#filters_python" style="color: inherit; text-decoration: inherit;">filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_python" style="color: inherit; text-decoration: inherit;">filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">Sequence[Get<wbr>Ami<wbr>Ids<wbr>Filter]</a></span>
@@ -284,7 +284,7 @@ are several valid keys, for a full reference, check out
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_regex_python">
-<a href="#name_regex_python" style="color: inherit; text-decoration: inherit;">name_<wbr>regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_regex_python" style="color: inherit; text-decoration: inherit;">name_<wbr>regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -297,7 +297,7 @@ options to narrow down the list AWS returns.
 {{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sort_ascending_python">
-<a href="#sort_ascending_python" style="color: inherit; text-decoration: inherit;">sort_<wbr>ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sort_ascending_python" style="color: inherit; text-decoration: inherit;">sort_<wbr>ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -319,7 +319,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -328,7 +328,7 @@ The following output properties are available:
 {{% /md %}}</dd><dt class="property-"
             title="">
         <span id="ids_csharp">
-<a href="#ids_csharp" style="color: inherit; text-decoration: inherit;">Ids</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#ids_csharp" style="color: inherit; text-decoration: inherit;">Ids</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -336,7 +336,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="owners_csharp">
-<a href="#owners_csharp" style="color: inherit; text-decoration: inherit;">Owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_csharp" style="color: inherit; text-decoration: inherit;">Owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -344,7 +344,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="executableusers_csharp">
-<a href="#executableusers_csharp" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executableusers_csharp" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -352,7 +352,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="filters_csharp">
-<a href="#filters_csharp" style="color: inherit; text-decoration: inherit;">Filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_csharp" style="color: inherit; text-decoration: inherit;">Filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">List&lt;Get<wbr>Ami<wbr>Ids<wbr>Filter&gt;</a></span>
@@ -360,7 +360,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nameregex_csharp">
-<a href="#nameregex_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nameregex_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -368,7 +368,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="sortascending_csharp">
-<a href="#sortascending_csharp" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sortascending_csharp" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -380,7 +380,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -389,7 +389,7 @@ The following output properties are available:
 {{% /md %}}</dd><dt class="property-"
             title="">
         <span id="ids_go">
-<a href="#ids_go" style="color: inherit; text-decoration: inherit;">Ids</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#ids_go" style="color: inherit; text-decoration: inherit;">Ids</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -397,7 +397,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="owners_go">
-<a href="#owners_go" style="color: inherit; text-decoration: inherit;">Owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_go" style="color: inherit; text-decoration: inherit;">Owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -405,7 +405,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="executableusers_go">
-<a href="#executableusers_go" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executableusers_go" style="color: inherit; text-decoration: inherit;">Executable<wbr>Users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -413,7 +413,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="filters_go">
-<a href="#filters_go" style="color: inherit; text-decoration: inherit;">Filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_go" style="color: inherit; text-decoration: inherit;">Filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">[]Get<wbr>Ami<wbr>Ids<wbr>Filter</a></span>
@@ -421,7 +421,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nameregex_go">
-<a href="#nameregex_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nameregex_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -429,7 +429,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="sortascending_go">
-<a href="#sortascending_go" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sortascending_go" style="color: inherit; text-decoration: inherit;">Sort<wbr>Ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -441,7 +441,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -450,7 +450,7 @@ The following output properties are available:
 {{% /md %}}</dd><dt class="property-"
             title="">
         <span id="ids_nodejs">
-<a href="#ids_nodejs" style="color: inherit; text-decoration: inherit;">ids</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#ids_nodejs" style="color: inherit; text-decoration: inherit;">ids</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -458,7 +458,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="owners_nodejs">
-<a href="#owners_nodejs" style="color: inherit; text-decoration: inherit;">owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_nodejs" style="color: inherit; text-decoration: inherit;">owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -466,7 +466,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="executableusers_nodejs">
-<a href="#executableusers_nodejs" style="color: inherit; text-decoration: inherit;">executable<wbr>Users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executableusers_nodejs" style="color: inherit; text-decoration: inherit;">executable<wbr>Users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -474,7 +474,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="filters_nodejs">
-<a href="#filters_nodejs" style="color: inherit; text-decoration: inherit;">filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_nodejs" style="color: inherit; text-decoration: inherit;">filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">Get<wbr>Ami<wbr>Ids<wbr>Filter[]</a></span>
@@ -482,7 +482,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="nameregex_nodejs">
-<a href="#nameregex_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nameregex_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -490,7 +490,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="sortascending_nodejs">
-<a href="#sortascending_nodejs" style="color: inherit; text-decoration: inherit;">sort<wbr>Ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sortascending_nodejs" style="color: inherit; text-decoration: inherit;">sort<wbr>Ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -502,7 +502,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -511,7 +511,7 @@ The following output properties are available:
 {{% /md %}}</dd><dt class="property-"
             title="">
         <span id="ids_python">
-<a href="#ids_python" style="color: inherit; text-decoration: inherit;">ids</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#ids_python" style="color: inherit; text-decoration: inherit;">ids</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -519,7 +519,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="owners_python">
-<a href="#owners_python" style="color: inherit; text-decoration: inherit;">owners</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owners_python" style="color: inherit; text-decoration: inherit;">owners</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -527,7 +527,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="executable_users_python">
-<a href="#executable_users_python" style="color: inherit; text-decoration: inherit;">executable_<wbr>users</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#executable_users_python" style="color: inherit; text-decoration: inherit;">executable_<wbr>users</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -535,7 +535,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="filters_python">
-<a href="#filters_python" style="color: inherit; text-decoration: inherit;">filters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#filters_python" style="color: inherit; text-decoration: inherit;">filters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getamiidsfilter">Sequence[Get<wbr>Ami<wbr>Ids<wbr>Filter]</a></span>
@@ -543,7 +543,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_regex_python">
-<a href="#name_regex_python" style="color: inherit; text-decoration: inherit;">name_<wbr>regex</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_regex_python" style="color: inherit; text-decoration: inherit;">name_<wbr>regex</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -551,7 +551,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="sort_ascending_python">
-<a href="#sort_ascending_python" style="color: inherit; text-decoration: inherit;">sort_<wbr>ascending</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sort_ascending_python" style="color: inherit; text-decoration: inherit;">sort_<wbr>ascending</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -573,7 +573,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -581,7 +581,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="values_csharp">
-<a href="#values_csharp" style="color: inherit; text-decoration: inherit;">Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#values_csharp" style="color: inherit; text-decoration: inherit;">Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -593,7 +593,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -601,7 +601,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="values_go">
-<a href="#values_go" style="color: inherit; text-decoration: inherit;">Values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#values_go" style="color: inherit; text-decoration: inherit;">Values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -613,7 +613,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -621,7 +621,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="values_nodejs">
-<a href="#values_nodejs" style="color: inherit; text-decoration: inherit;">values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#values_nodejs" style="color: inherit; text-decoration: inherit;">values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -633,7 +633,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -641,7 +641,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="values_python">
-<a href="#values_python" style="color: inherit; text-decoration: inherit;">values</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#values_python" style="color: inherit; text-decoration: inherit;">values</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
@@ -82,7 +82,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="accountname_csharp">
-<a href="#accountname_csharp" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#accountname_csharp" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -90,7 +90,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_csharp">
-<a href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -98,7 +98,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_csharp">
-<a href="#expand_csharp" style="color: inherit; text-decoration: inherit;">Expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_csharp" style="color: inherit; text-decoration: inherit;">Expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -110,7 +110,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="accountname_go">
-<a href="#accountname_go" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#accountname_go" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -118,7 +118,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_go">
-<a href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -126,7 +126,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_go">
-<a href="#expand_go" style="color: inherit; text-decoration: inherit;">Expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_go" style="color: inherit; text-decoration: inherit;">Expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -138,7 +138,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="accountname_nodejs">
-<a href="#accountname_nodejs" style="color: inherit; text-decoration: inherit;">account<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#accountname_nodejs" style="color: inherit; text-decoration: inherit;">account<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -146,7 +146,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_nodejs">
-<a href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -154,7 +154,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_nodejs">
-<a href="#expand_nodejs" style="color: inherit; text-decoration: inherit;">expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_nodejs" style="color: inherit; text-decoration: inherit;">expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -166,7 +166,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="account_name_python">
-<a href="#account_name_python" style="color: inherit; text-decoration: inherit;">account_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#account_name_python" style="color: inherit; text-decoration: inherit;">account_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -174,7 +174,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resource_group_name_python">
-<a href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -182,7 +182,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_python">
-<a href="#expand_python" style="color: inherit; text-decoration: inherit;">expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_python" style="color: inherit; text-decoration: inherit;">expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -203,7 +203,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_csharp">
-<a href="#keys_csharp" style="color: inherit; text-decoration: inherit;">Keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_csharp" style="color: inherit; text-decoration: inherit;">Keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">List&lt;Storage<wbr>Account<wbr>Key<wbr>Response&gt;</a></span>
@@ -215,7 +215,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_go">
-<a href="#keys_go" style="color: inherit; text-decoration: inherit;">Keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_go" style="color: inherit; text-decoration: inherit;">Keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">[]Storage<wbr>Account<wbr>Key<wbr>Response</a></span>
@@ -227,7 +227,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_nodejs">
-<a href="#keys_nodejs" style="color: inherit; text-decoration: inherit;">keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_nodejs" style="color: inherit; text-decoration: inherit;">keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">Storage<wbr>Account<wbr>Key<wbr>Response[]</a></span>
@@ -239,7 +239,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_python">
-<a href="#keys_python" style="color: inherit; text-decoration: inherit;">keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_python" style="color: inherit; text-decoration: inherit;">keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">Sequence[Storage<wbr>Account<wbr>Key<wbr>Response]</a></span>
@@ -261,7 +261,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creationtime_csharp">
-<a href="#creationtime_csharp" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creationtime_csharp" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -269,7 +269,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keyname_csharp">
-<a href="#keyname_csharp" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keyname_csharp" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -277,7 +277,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_csharp">
-<a href="#permissions_csharp" style="color: inherit; text-decoration: inherit;">Permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_csharp" style="color: inherit; text-decoration: inherit;">Permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -285,7 +285,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -297,7 +297,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creationtime_go">
-<a href="#creationtime_go" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creationtime_go" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -305,7 +305,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keyname_go">
-<a href="#keyname_go" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keyname_go" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -313,7 +313,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_go">
-<a href="#permissions_go" style="color: inherit; text-decoration: inherit;">Permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_go" style="color: inherit; text-decoration: inherit;">Permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -321,7 +321,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -333,7 +333,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creationtime_nodejs">
-<a href="#creationtime_nodejs" style="color: inherit; text-decoration: inherit;">creation<wbr>Time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creationtime_nodejs" style="color: inherit; text-decoration: inherit;">creation<wbr>Time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -341,7 +341,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keyname_nodejs">
-<a href="#keyname_nodejs" style="color: inherit; text-decoration: inherit;">key<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keyname_nodejs" style="color: inherit; text-decoration: inherit;">key<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -349,7 +349,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_nodejs">
-<a href="#permissions_nodejs" style="color: inherit; text-decoration: inherit;">permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_nodejs" style="color: inherit; text-decoration: inherit;">permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -357,7 +357,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -369,7 +369,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creation_time_python">
-<a href="#creation_time_python" style="color: inherit; text-decoration: inherit;">creation_<wbr>time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creation_time_python" style="color: inherit; text-decoration: inherit;">creation_<wbr>time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -377,7 +377,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="key_name_python">
-<a href="#key_name_python" style="color: inherit; text-decoration: inherit;">key_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#key_name_python" style="color: inherit; text-decoration: inherit;">key_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -385,7 +385,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_python">
-<a href="#permissions_python" style="color: inherit; text-decoration: inherit;">permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_python" style="color: inherit; text-decoration: inherit;">permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -393,7 +393,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -107,7 +107,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -119,7 +119,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -127,7 +127,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -139,7 +139,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -147,7 +147,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_csharp">
-<a href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_go">
-<a href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_nodejs">
-<a href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_python">
-<a href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -107,7 +107,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -119,7 +119,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -127,7 +127,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -139,7 +139,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -147,7 +147,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_csharp">
-<a href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_go">
-<a href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_nodejs">
-<a href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_python">
-<a href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, string&gt;</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string]string</span>
@@ -107,7 +107,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -119,7 +119,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: string}</span>
@@ -127,7 +127,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -139,7 +139,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, str]</span>
@@ -147,7 +147,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_csharp">
-<a href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_go">
-<a href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_nodejs">
-<a href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_python">
-<a href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -107,7 +107,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -119,7 +119,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -127,7 +127,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -139,7 +139,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -147,7 +147,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_csharp">
-<a href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_go">
-<a href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_nodejs">
-<a href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_python">
-<a href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
@@ -82,7 +82,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bastionhostname_csharp">
-<a href="#bastionhostname_csharp" style="color: inherit; text-decoration: inherit;">Bastion<wbr>Host<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bastionhostname_csharp" style="color: inherit; text-decoration: inherit;">Bastion<wbr>Host<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -90,7 +90,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the Bastion Host.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_csharp">
-<a href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -98,7 +98,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="vms_csharp">
-<a href="#vms_csharp" style="color: inherit; text-decoration: inherit;">Vms</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vms_csharp" style="color: inherit; text-decoration: inherit;">Vms</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#bastionshareablelink">List&lt;Bastion<wbr>Shareable<wbr>Link&gt;</a></span>
@@ -110,7 +110,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bastionhostname_go">
-<a href="#bastionhostname_go" style="color: inherit; text-decoration: inherit;">Bastion<wbr>Host<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bastionhostname_go" style="color: inherit; text-decoration: inherit;">Bastion<wbr>Host<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -118,7 +118,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the Bastion Host.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_go">
-<a href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -126,7 +126,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="vms_go">
-<a href="#vms_go" style="color: inherit; text-decoration: inherit;">Vms</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vms_go" style="color: inherit; text-decoration: inherit;">Vms</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#bastionshareablelink">[]Bastion<wbr>Shareable<wbr>Link</a></span>
@@ -138,7 +138,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bastionhostname_nodejs">
-<a href="#bastionhostname_nodejs" style="color: inherit; text-decoration: inherit;">bastion<wbr>Host<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bastionhostname_nodejs" style="color: inherit; text-decoration: inherit;">bastion<wbr>Host<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -146,7 +146,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the Bastion Host.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_nodejs">
-<a href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -154,7 +154,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="vms_nodejs">
-<a href="#vms_nodejs" style="color: inherit; text-decoration: inherit;">vms</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vms_nodejs" style="color: inherit; text-decoration: inherit;">vms</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#bastionshareablelink">Bastion<wbr>Shareable<wbr>Link[]</a></span>
@@ -166,7 +166,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bastion_host_name_python">
-<a href="#bastion_host_name_python" style="color: inherit; text-decoration: inherit;">bastion_<wbr>host_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bastion_host_name_python" style="color: inherit; text-decoration: inherit;">bastion_<wbr>host_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -174,7 +174,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the Bastion Host.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resource_group_name_python">
-<a href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -182,7 +182,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="vms_python">
-<a href="#vms_python" style="color: inherit; text-decoration: inherit;">vms</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vms_python" style="color: inherit; text-decoration: inherit;">vms</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#bastionshareablelink">Sequence[Bastion<wbr>Shareable<wbr>Link]</a></span>
@@ -203,7 +203,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="nextlink_csharp">
-<a href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -215,7 +215,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="nextlink_go">
-<a href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -227,7 +227,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="nextlink_nodejs">
-<a href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -239,7 +239,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="next_link_python">
-<a href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -261,7 +261,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="vm_csharp">
-<a href="#vm_csharp" style="color: inherit; text-decoration: inherit;">Vm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vm_csharp" style="color: inherit; text-decoration: inherit;">Vm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -273,7 +273,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="vm_go">
-<a href="#vm_go" style="color: inherit; text-decoration: inherit;">Vm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vm_go" style="color: inherit; text-decoration: inherit;">Vm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -285,7 +285,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="vm_nodejs">
-<a href="#vm_nodejs" style="color: inherit; text-decoration: inherit;">vm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vm_nodejs" style="color: inherit; text-decoration: inherit;">vm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -297,7 +297,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="vm_python">
-<a href="#vm_python" style="color: inherit; text-decoration: inherit;">vm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#vm_python" style="color: inherit; text-decoration: inherit;">vm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
@@ -67,7 +67,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="clientid_csharp">
-<a href="#clientid_csharp" style="color: inherit; text-decoration: inherit;">Client<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#clientid_csharp" style="color: inherit; text-decoration: inherit;">Client<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -75,7 +75,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Client ID (Application Object ID).{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="objectid_csharp">
-<a href="#objectid_csharp" style="color: inherit; text-decoration: inherit;">Object<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#objectid_csharp" style="color: inherit; text-decoration: inherit;">Object<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -83,7 +83,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Object ID of the current user or service principal.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="subscriptionid_csharp">
-<a href="#subscriptionid_csharp" style="color: inherit; text-decoration: inherit;">Subscription<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#subscriptionid_csharp" style="color: inherit; text-decoration: inherit;">Subscription<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -91,7 +91,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Subscription ID{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="tenantid_csharp">
-<a href="#tenantid_csharp" style="color: inherit; text-decoration: inherit;">Tenant<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#tenantid_csharp" style="color: inherit; text-decoration: inherit;">Tenant<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -103,7 +103,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="clientid_go">
-<a href="#clientid_go" style="color: inherit; text-decoration: inherit;">Client<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#clientid_go" style="color: inherit; text-decoration: inherit;">Client<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -111,7 +111,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Client ID (Application Object ID).{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="objectid_go">
-<a href="#objectid_go" style="color: inherit; text-decoration: inherit;">Object<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#objectid_go" style="color: inherit; text-decoration: inherit;">Object<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -119,7 +119,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Object ID of the current user or service principal.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="subscriptionid_go">
-<a href="#subscriptionid_go" style="color: inherit; text-decoration: inherit;">Subscription<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#subscriptionid_go" style="color: inherit; text-decoration: inherit;">Subscription<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -127,7 +127,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Subscription ID{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="tenantid_go">
-<a href="#tenantid_go" style="color: inherit; text-decoration: inherit;">Tenant<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#tenantid_go" style="color: inherit; text-decoration: inherit;">Tenant<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -139,7 +139,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="clientid_nodejs">
-<a href="#clientid_nodejs" style="color: inherit; text-decoration: inherit;">client<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#clientid_nodejs" style="color: inherit; text-decoration: inherit;">client<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -147,7 +147,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Client ID (Application Object ID).{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="objectid_nodejs">
-<a href="#objectid_nodejs" style="color: inherit; text-decoration: inherit;">object<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#objectid_nodejs" style="color: inherit; text-decoration: inherit;">object<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -155,7 +155,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Object ID of the current user or service principal.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="subscriptionid_nodejs">
-<a href="#subscriptionid_nodejs" style="color: inherit; text-decoration: inherit;">subscription<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#subscriptionid_nodejs" style="color: inherit; text-decoration: inherit;">subscription<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -163,7 +163,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Subscription ID{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="tenantid_nodejs">
-<a href="#tenantid_nodejs" style="color: inherit; text-decoration: inherit;">tenant<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#tenantid_nodejs" style="color: inherit; text-decoration: inherit;">tenant<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -175,7 +175,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="client_id_python">
-<a href="#client_id_python" style="color: inherit; text-decoration: inherit;">client_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#client_id_python" style="color: inherit; text-decoration: inherit;">client_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -183,7 +183,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Client ID (Application Object ID).{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="object_id_python">
-<a href="#object_id_python" style="color: inherit; text-decoration: inherit;">object_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#object_id_python" style="color: inherit; text-decoration: inherit;">object_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -191,7 +191,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Object ID of the current user or service principal.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="subscription_id_python">
-<a href="#subscription_id_python" style="color: inherit; text-decoration: inherit;">subscription_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#subscription_id_python" style="color: inherit; text-decoration: inherit;">subscription_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -199,7 +199,7 @@ The following output properties are available:
     <dd>{{% md %}}Azure Subscription ID{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="tenant_id_python">
-<a href="#tenant_id_python" style="color: inherit; text-decoration: inherit;">tenant_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#tenant_id_python" style="color: inherit; text-decoration: inherit;">tenant_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="factoryname_csharp">
-<a href="#factoryname_csharp" style="color: inherit; text-decoration: inherit;">Factory<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#factoryname_csharp" style="color: inherit; text-decoration: inherit;">Factory<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -92,7 +92,7 @@ The following arguments are supported:
     <dd>{{% md %}}The factory name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="integrationruntimename_csharp">
-<a href="#integrationruntimename_csharp" style="color: inherit; text-decoration: inherit;">Integration<wbr>Runtime<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#integrationruntimename_csharp" style="color: inherit; text-decoration: inherit;">Integration<wbr>Runtime<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -100,7 +100,7 @@ The following arguments are supported:
     <dd>{{% md %}}The integration runtime name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_csharp">
-<a href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -108,7 +108,7 @@ The following arguments are supported:
     <dd>{{% md %}}The resource group name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadatapath_csharp">
-<a href="#metadatapath_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatapath_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -120,7 +120,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="factoryname_go">
-<a href="#factoryname_go" style="color: inherit; text-decoration: inherit;">Factory<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#factoryname_go" style="color: inherit; text-decoration: inherit;">Factory<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -128,7 +128,7 @@ The following arguments are supported:
     <dd>{{% md %}}The factory name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="integrationruntimename_go">
-<a href="#integrationruntimename_go" style="color: inherit; text-decoration: inherit;">Integration<wbr>Runtime<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#integrationruntimename_go" style="color: inherit; text-decoration: inherit;">Integration<wbr>Runtime<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -136,7 +136,7 @@ The following arguments are supported:
     <dd>{{% md %}}The integration runtime name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_go">
-<a href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -144,7 +144,7 @@ The following arguments are supported:
     <dd>{{% md %}}The resource group name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadatapath_go">
-<a href="#metadatapath_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatapath_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -156,7 +156,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="factoryname_nodejs">
-<a href="#factoryname_nodejs" style="color: inherit; text-decoration: inherit;">factory<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#factoryname_nodejs" style="color: inherit; text-decoration: inherit;">factory<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -164,7 +164,7 @@ The following arguments are supported:
     <dd>{{% md %}}The factory name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="integrationruntimename_nodejs">
-<a href="#integrationruntimename_nodejs" style="color: inherit; text-decoration: inherit;">integration<wbr>Runtime<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#integrationruntimename_nodejs" style="color: inherit; text-decoration: inherit;">integration<wbr>Runtime<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -172,7 +172,7 @@ The following arguments are supported:
     <dd>{{% md %}}The integration runtime name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_nodejs">
-<a href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following arguments are supported:
     <dd>{{% md %}}The resource group name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadatapath_nodejs">
-<a href="#metadatapath_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatapath_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="factory_name_python">
-<a href="#factory_name_python" style="color: inherit; text-decoration: inherit;">factory_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#factory_name_python" style="color: inherit; text-decoration: inherit;">factory_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -200,7 +200,7 @@ The following arguments are supported:
     <dd>{{% md %}}The factory name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="integration_runtime_name_python">
-<a href="#integration_runtime_name_python" style="color: inherit; text-decoration: inherit;">integration_<wbr>runtime_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#integration_runtime_name_python" style="color: inherit; text-decoration: inherit;">integration_<wbr>runtime_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -208,7 +208,7 @@ The following arguments are supported:
     <dd>{{% md %}}The integration runtime name.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resource_group_name_python">
-<a href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -216,7 +216,7 @@ The following arguments are supported:
     <dd>{{% md %}}The resource group name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_path_python">
-<a href="#metadata_path_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_path_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -237,7 +237,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="nextlink_csharp">
-<a href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_csharp" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -245,7 +245,7 @@ The following output properties are available:
     <dd>{{% md %}}The link to the next page of results, if any remaining results exist.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;object&gt;</span>
@@ -257,7 +257,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="nextlink_go">
-<a href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_go" style="color: inherit; text-decoration: inherit;">Next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -265,7 +265,7 @@ The following output properties are available:
     <dd>{{% md %}}The link to the next page of results, if any remaining results exist.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]interface{}</span>
@@ -277,7 +277,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="nextlink_nodejs">
-<a href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#nextlink_nodejs" style="color: inherit; text-decoration: inherit;">next<wbr>Link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -285,7 +285,7 @@ The following output properties are available:
     <dd>{{% md %}}The link to the next page of results, if any remaining results exist.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">(Ssis<wbr>Environment<wbr>Response | Ssis<wbr>Folder<wbr>Response | Ssis<wbr>Package<wbr>Response | Ssis<wbr>Project<wbr>Response)[]</span>
@@ -297,7 +297,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="next_link_python">
-<a href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#next_link_python" style="color: inherit; text-decoration: inherit;">next_<wbr>link</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -305,7 +305,7 @@ The following output properties are available:
     <dd>{{% md %}}The link to the next page of results, if any remaining results exist.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[Any]</span>
@@ -327,7 +327,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="environmentfoldername_csharp">
-<a href="#environmentfoldername_csharp" style="color: inherit; text-decoration: inherit;">Environment<wbr>Folder<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentfoldername_csharp" style="color: inherit; text-decoration: inherit;">Environment<wbr>Folder<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -335,7 +335,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment folder name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environmentname_csharp">
-<a href="#environmentname_csharp" style="color: inherit; text-decoration: inherit;">Environment<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentname_csharp" style="color: inherit; text-decoration: inherit;">Environment<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -343,7 +343,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -351,7 +351,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="referencetype_csharp">
-<a href="#referencetype_csharp" style="color: inherit; text-decoration: inherit;">Reference<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#referencetype_csharp" style="color: inherit; text-decoration: inherit;">Reference<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -363,7 +363,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="environmentfoldername_go">
-<a href="#environmentfoldername_go" style="color: inherit; text-decoration: inherit;">Environment<wbr>Folder<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentfoldername_go" style="color: inherit; text-decoration: inherit;">Environment<wbr>Folder<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -371,7 +371,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment folder name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environmentname_go">
-<a href="#environmentname_go" style="color: inherit; text-decoration: inherit;">Environment<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentname_go" style="color: inherit; text-decoration: inherit;">Environment<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -379,7 +379,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -387,7 +387,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="referencetype_go">
-<a href="#referencetype_go" style="color: inherit; text-decoration: inherit;">Reference<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#referencetype_go" style="color: inherit; text-decoration: inherit;">Reference<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -399,7 +399,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="environmentfoldername_nodejs">
-<a href="#environmentfoldername_nodejs" style="color: inherit; text-decoration: inherit;">environment<wbr>Folder<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentfoldername_nodejs" style="color: inherit; text-decoration: inherit;">environment<wbr>Folder<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -407,7 +407,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment folder name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environmentname_nodejs">
-<a href="#environmentname_nodejs" style="color: inherit; text-decoration: inherit;">environment<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentname_nodejs" style="color: inherit; text-decoration: inherit;">environment<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -415,7 +415,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -423,7 +423,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="referencetype_nodejs">
-<a href="#referencetype_nodejs" style="color: inherit; text-decoration: inherit;">reference<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#referencetype_nodejs" style="color: inherit; text-decoration: inherit;">reference<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -435,7 +435,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="environment_folder_name_python">
-<a href="#environment_folder_name_python" style="color: inherit; text-decoration: inherit;">environment_<wbr>folder_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environment_folder_name_python" style="color: inherit; text-decoration: inherit;">environment_<wbr>folder_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -443,7 +443,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment folder name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environment_name_python">
-<a href="#environment_name_python" style="color: inherit; text-decoration: inherit;">environment_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environment_name_python" style="color: inherit; text-decoration: inherit;">environment_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -451,7 +451,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -459,7 +459,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="reference_type_python">
-<a href="#reference_type_python" style="color: inherit; text-decoration: inherit;">reference_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#reference_type_python" style="color: inherit; text-decoration: inherit;">reference_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -475,7 +475,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -483,7 +483,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_csharp">
-<a href="#folderid_csharp" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_csharp" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -491,7 +491,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains environment.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -499,7 +499,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -507,7 +507,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variables_csharp">
-<a href="#variables_csharp" style="color: inherit; text-decoration: inherit;">Variables</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variables_csharp" style="color: inherit; text-decoration: inherit;">Variables</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisvariableresponse">List&lt;Ssis<wbr>Variable<wbr>Response&gt;</a></span>
@@ -519,7 +519,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -527,7 +527,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_go">
-<a href="#folderid_go" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_go" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -535,7 +535,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains environment.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -543,7 +543,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -551,7 +551,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variables_go">
-<a href="#variables_go" style="color: inherit; text-decoration: inherit;">Variables</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variables_go" style="color: inherit; text-decoration: inherit;">Variables</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisvariableresponse">[]Ssis<wbr>Variable<wbr>Response</a></span>
@@ -563,7 +563,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -571,7 +571,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_nodejs">
-<a href="#folderid_nodejs" style="color: inherit; text-decoration: inherit;">folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_nodejs" style="color: inherit; text-decoration: inherit;">folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -579,7 +579,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains environment.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -587,7 +587,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -595,7 +595,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variables_nodejs">
-<a href="#variables_nodejs" style="color: inherit; text-decoration: inherit;">variables</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variables_nodejs" style="color: inherit; text-decoration: inherit;">variables</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisvariableresponse">Ssis<wbr>Variable<wbr>Response[]</a></span>
@@ -607,7 +607,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -615,7 +615,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folder_id_python">
-<a href="#folder_id_python" style="color: inherit; text-decoration: inherit;">folder_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folder_id_python" style="color: inherit; text-decoration: inherit;">folder_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -623,7 +623,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains environment.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -631,7 +631,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -639,7 +639,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variables_python">
-<a href="#variables_python" style="color: inherit; text-decoration: inherit;">variables</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variables_python" style="color: inherit; text-decoration: inherit;">variables</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisvariableresponse">Sequence[Ssis<wbr>Variable<wbr>Response]</a></span>
@@ -655,7 +655,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -663,7 +663,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -671,7 +671,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -683,7 +683,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -691,7 +691,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -699,7 +699,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -711,7 +711,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -719,7 +719,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -727,7 +727,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -739,7 +739,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -747,7 +747,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -755,7 +755,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -771,7 +771,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -779,7 +779,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_csharp">
-<a href="#folderid_csharp" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_csharp" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -787,7 +787,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -795,7 +795,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -803,7 +803,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_csharp">
-<a href="#parameters_csharp" style="color: inherit; text-decoration: inherit;">Parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_csharp" style="color: inherit; text-decoration: inherit;">Parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">List&lt;Ssis<wbr>Parameter<wbr>Response&gt;</a></span>
@@ -811,7 +811,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in package{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="projectid_csharp">
-<a href="#projectid_csharp" style="color: inherit; text-decoration: inherit;">Project<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#projectid_csharp" style="color: inherit; text-decoration: inherit;">Project<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -819,7 +819,7 @@ The following output properties are available:
     <dd>{{% md %}}Project id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="projectversion_csharp">
-<a href="#projectversion_csharp" style="color: inherit; text-decoration: inherit;">Project<wbr>Version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#projectversion_csharp" style="color: inherit; text-decoration: inherit;">Project<wbr>Version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -831,7 +831,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -839,7 +839,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_go">
-<a href="#folderid_go" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_go" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -847,7 +847,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -855,7 +855,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -863,7 +863,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_go">
-<a href="#parameters_go" style="color: inherit; text-decoration: inherit;">Parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_go" style="color: inherit; text-decoration: inherit;">Parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">[]Ssis<wbr>Parameter<wbr>Response</a></span>
@@ -871,7 +871,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in package{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="projectid_go">
-<a href="#projectid_go" style="color: inherit; text-decoration: inherit;">Project<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#projectid_go" style="color: inherit; text-decoration: inherit;">Project<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -879,7 +879,7 @@ The following output properties are available:
     <dd>{{% md %}}Project id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="projectversion_go">
-<a href="#projectversion_go" style="color: inherit; text-decoration: inherit;">Project<wbr>Version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#projectversion_go" style="color: inherit; text-decoration: inherit;">Project<wbr>Version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -891,7 +891,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -899,7 +899,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_nodejs">
-<a href="#folderid_nodejs" style="color: inherit; text-decoration: inherit;">folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_nodejs" style="color: inherit; text-decoration: inherit;">folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -907,7 +907,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -915,7 +915,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -923,7 +923,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_nodejs">
-<a href="#parameters_nodejs" style="color: inherit; text-decoration: inherit;">parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_nodejs" style="color: inherit; text-decoration: inherit;">parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">Ssis<wbr>Parameter<wbr>Response[]</a></span>
@@ -931,7 +931,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in package{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="projectid_nodejs">
-<a href="#projectid_nodejs" style="color: inherit; text-decoration: inherit;">project<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#projectid_nodejs" style="color: inherit; text-decoration: inherit;">project<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -939,7 +939,7 @@ The following output properties are available:
     <dd>{{% md %}}Project id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="projectversion_nodejs">
-<a href="#projectversion_nodejs" style="color: inherit; text-decoration: inherit;">project<wbr>Version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#projectversion_nodejs" style="color: inherit; text-decoration: inherit;">project<wbr>Version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -951,7 +951,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -959,7 +959,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folder_id_python">
-<a href="#folder_id_python" style="color: inherit; text-decoration: inherit;">folder_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folder_id_python" style="color: inherit; text-decoration: inherit;">folder_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -967,7 +967,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -975,7 +975,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -983,7 +983,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_python">
-<a href="#parameters_python" style="color: inherit; text-decoration: inherit;">parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_python" style="color: inherit; text-decoration: inherit;">parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">Sequence[Ssis<wbr>Parameter<wbr>Response]</a></span>
@@ -991,7 +991,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in package{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="project_id_python">
-<a href="#project_id_python" style="color: inherit; text-decoration: inherit;">project_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#project_id_python" style="color: inherit; text-decoration: inherit;">project_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -999,7 +999,7 @@ The following output properties are available:
     <dd>{{% md %}}Project id which contains package.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="project_version_python">
-<a href="#project_version_python" style="color: inherit; text-decoration: inherit;">project_<wbr>version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#project_version_python" style="color: inherit; text-decoration: inherit;">project_<wbr>version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1015,7 +1015,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="datatype_csharp">
-<a href="#datatype_csharp" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#datatype_csharp" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1023,7 +1023,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="defaultvalue_csharp">
-<a href="#defaultvalue_csharp" style="color: inherit; text-decoration: inherit;">Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultvalue_csharp" style="color: inherit; text-decoration: inherit;">Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1031,7 +1031,7 @@ The following output properties are available:
     <dd>{{% md %}}Default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1039,7 +1039,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="designdefaultvalue_csharp">
-<a href="#designdefaultvalue_csharp" style="color: inherit; text-decoration: inherit;">Design<wbr>Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#designdefaultvalue_csharp" style="color: inherit; text-decoration: inherit;">Design<wbr>Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1047,7 +1047,7 @@ The following output properties are available:
     <dd>{{% md %}}Design default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1055,7 +1055,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1063,7 +1063,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="required_csharp">
-<a href="#required_csharp" style="color: inherit; text-decoration: inherit;">Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_csharp" style="color: inherit; text-decoration: inherit;">Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1071,7 +1071,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is required.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_csharp">
-<a href="#sensitive_csharp" style="color: inherit; text-decoration: inherit;">Sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_csharp" style="color: inherit; text-decoration: inherit;">Sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1079,7 +1079,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitivedefaultvalue_csharp">
-<a href="#sensitivedefaultvalue_csharp" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitivedefaultvalue_csharp" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1087,7 +1087,7 @@ The following output properties are available:
     <dd>{{% md %}}Default sensitive value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="valueset_csharp">
-<a href="#valueset_csharp" style="color: inherit; text-decoration: inherit;">Value<wbr>Set</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#valueset_csharp" style="color: inherit; text-decoration: inherit;">Value<wbr>Set</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1095,7 +1095,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value set.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="valuetype_csharp">
-<a href="#valuetype_csharp" style="color: inherit; text-decoration: inherit;">Value<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#valuetype_csharp" style="color: inherit; text-decoration: inherit;">Value<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1103,7 +1103,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variable_csharp">
-<a href="#variable_csharp" style="color: inherit; text-decoration: inherit;">Variable</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variable_csharp" style="color: inherit; text-decoration: inherit;">Variable</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1115,7 +1115,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="datatype_go">
-<a href="#datatype_go" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#datatype_go" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1123,7 +1123,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="defaultvalue_go">
-<a href="#defaultvalue_go" style="color: inherit; text-decoration: inherit;">Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultvalue_go" style="color: inherit; text-decoration: inherit;">Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1131,7 +1131,7 @@ The following output properties are available:
     <dd>{{% md %}}Default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1139,7 +1139,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="designdefaultvalue_go">
-<a href="#designdefaultvalue_go" style="color: inherit; text-decoration: inherit;">Design<wbr>Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#designdefaultvalue_go" style="color: inherit; text-decoration: inherit;">Design<wbr>Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1147,7 +1147,7 @@ The following output properties are available:
     <dd>{{% md %}}Design default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1155,7 +1155,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1163,7 +1163,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="required_go">
-<a href="#required_go" style="color: inherit; text-decoration: inherit;">Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_go" style="color: inherit; text-decoration: inherit;">Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1171,7 +1171,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is required.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_go">
-<a href="#sensitive_go" style="color: inherit; text-decoration: inherit;">Sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_go" style="color: inherit; text-decoration: inherit;">Sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1179,7 +1179,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitivedefaultvalue_go">
-<a href="#sensitivedefaultvalue_go" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitivedefaultvalue_go" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1187,7 +1187,7 @@ The following output properties are available:
     <dd>{{% md %}}Default sensitive value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="valueset_go">
-<a href="#valueset_go" style="color: inherit; text-decoration: inherit;">Value<wbr>Set</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#valueset_go" style="color: inherit; text-decoration: inherit;">Value<wbr>Set</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1195,7 +1195,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value set.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="valuetype_go">
-<a href="#valuetype_go" style="color: inherit; text-decoration: inherit;">Value<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#valuetype_go" style="color: inherit; text-decoration: inherit;">Value<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1203,7 +1203,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variable_go">
-<a href="#variable_go" style="color: inherit; text-decoration: inherit;">Variable</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variable_go" style="color: inherit; text-decoration: inherit;">Variable</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1215,7 +1215,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="datatype_nodejs">
-<a href="#datatype_nodejs" style="color: inherit; text-decoration: inherit;">data<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#datatype_nodejs" style="color: inherit; text-decoration: inherit;">data<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1223,7 +1223,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="defaultvalue_nodejs">
-<a href="#defaultvalue_nodejs" style="color: inherit; text-decoration: inherit;">default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultvalue_nodejs" style="color: inherit; text-decoration: inherit;">default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1231,7 +1231,7 @@ The following output properties are available:
     <dd>{{% md %}}Default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1239,7 +1239,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="designdefaultvalue_nodejs">
-<a href="#designdefaultvalue_nodejs" style="color: inherit; text-decoration: inherit;">design<wbr>Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#designdefaultvalue_nodejs" style="color: inherit; text-decoration: inherit;">design<wbr>Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1247,7 +1247,7 @@ The following output properties are available:
     <dd>{{% md %}}Design default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1255,7 +1255,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1263,7 +1263,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="required_nodejs">
-<a href="#required_nodejs" style="color: inherit; text-decoration: inherit;">required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_nodejs" style="color: inherit; text-decoration: inherit;">required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -1271,7 +1271,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is required.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_nodejs">
-<a href="#sensitive_nodejs" style="color: inherit; text-decoration: inherit;">sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_nodejs" style="color: inherit; text-decoration: inherit;">sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -1279,7 +1279,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitivedefaultvalue_nodejs">
-<a href="#sensitivedefaultvalue_nodejs" style="color: inherit; text-decoration: inherit;">sensitive<wbr>Default<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitivedefaultvalue_nodejs" style="color: inherit; text-decoration: inherit;">sensitive<wbr>Default<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1287,7 +1287,7 @@ The following output properties are available:
     <dd>{{% md %}}Default sensitive value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="valueset_nodejs">
-<a href="#valueset_nodejs" style="color: inherit; text-decoration: inherit;">value<wbr>Set</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#valueset_nodejs" style="color: inherit; text-decoration: inherit;">value<wbr>Set</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -1295,7 +1295,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value set.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="valuetype_nodejs">
-<a href="#valuetype_nodejs" style="color: inherit; text-decoration: inherit;">value<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#valuetype_nodejs" style="color: inherit; text-decoration: inherit;">value<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1303,7 +1303,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variable_nodejs">
-<a href="#variable_nodejs" style="color: inherit; text-decoration: inherit;">variable</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variable_nodejs" style="color: inherit; text-decoration: inherit;">variable</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1315,7 +1315,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="data_type_python">
-<a href="#data_type_python" style="color: inherit; text-decoration: inherit;">data_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#data_type_python" style="color: inherit; text-decoration: inherit;">data_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1323,7 +1323,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="default_value_python">
-<a href="#default_value_python" style="color: inherit; text-decoration: inherit;">default_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#default_value_python" style="color: inherit; text-decoration: inherit;">default_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1331,7 +1331,7 @@ The following output properties are available:
     <dd>{{% md %}}Default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1339,7 +1339,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="design_default_value_python">
-<a href="#design_default_value_python" style="color: inherit; text-decoration: inherit;">design_<wbr>default_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#design_default_value_python" style="color: inherit; text-decoration: inherit;">design_<wbr>default_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1347,7 +1347,7 @@ The following output properties are available:
     <dd>{{% md %}}Design default value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1355,7 +1355,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1363,7 +1363,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="required_python">
-<a href="#required_python" style="color: inherit; text-decoration: inherit;">required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_python" style="color: inherit; text-decoration: inherit;">required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1371,7 +1371,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is required.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_python">
-<a href="#sensitive_python" style="color: inherit; text-decoration: inherit;">sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_python" style="color: inherit; text-decoration: inherit;">sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1379,7 +1379,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether parameter is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_default_value_python">
-<a href="#sensitive_default_value_python" style="color: inherit; text-decoration: inherit;">sensitive_<wbr>default_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_default_value_python" style="color: inherit; text-decoration: inherit;">sensitive_<wbr>default_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1387,7 +1387,7 @@ The following output properties are available:
     <dd>{{% md %}}Default sensitive value of parameter.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="value_set_python">
-<a href="#value_set_python" style="color: inherit; text-decoration: inherit;">value_<wbr>set</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_set_python" style="color: inherit; text-decoration: inherit;">value_<wbr>set</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1395,7 +1395,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value set.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="value_type_python">
-<a href="#value_type_python" style="color: inherit; text-decoration: inherit;">value_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_type_python" style="color: inherit; text-decoration: inherit;">value_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1403,7 +1403,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameter value type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="variable_python">
-<a href="#variable_python" style="color: inherit; text-decoration: inherit;">variable</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#variable_python" style="color: inherit; text-decoration: inherit;">variable</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1419,7 +1419,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1427,7 +1427,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environmentrefs_csharp">
-<a href="#environmentrefs_csharp" style="color: inherit; text-decoration: inherit;">Environment<wbr>Refs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentrefs_csharp" style="color: inherit; text-decoration: inherit;">Environment<wbr>Refs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisenvironmentreferenceresponse">List&lt;Ssis<wbr>Environment<wbr>Reference<wbr>Response&gt;</a></span>
@@ -1435,7 +1435,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_csharp">
-<a href="#folderid_csharp" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_csharp" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1443,7 +1443,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains project.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1451,7 +1451,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1459,7 +1459,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_csharp">
-<a href="#parameters_csharp" style="color: inherit; text-decoration: inherit;">Parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_csharp" style="color: inherit; text-decoration: inherit;">Parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">List&lt;Ssis<wbr>Parameter<wbr>Response&gt;</a></span>
@@ -1467,7 +1467,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="version_csharp">
-<a href="#version_csharp" style="color: inherit; text-decoration: inherit;">Version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#version_csharp" style="color: inherit; text-decoration: inherit;">Version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1479,7 +1479,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1487,7 +1487,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environmentrefs_go">
-<a href="#environmentrefs_go" style="color: inherit; text-decoration: inherit;">Environment<wbr>Refs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentrefs_go" style="color: inherit; text-decoration: inherit;">Environment<wbr>Refs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisenvironmentreferenceresponse">[]Ssis<wbr>Environment<wbr>Reference<wbr>Response</a></span>
@@ -1495,7 +1495,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_go">
-<a href="#folderid_go" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_go" style="color: inherit; text-decoration: inherit;">Folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1503,7 +1503,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains project.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1511,7 +1511,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1519,7 +1519,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_go">
-<a href="#parameters_go" style="color: inherit; text-decoration: inherit;">Parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_go" style="color: inherit; text-decoration: inherit;">Parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">[]Ssis<wbr>Parameter<wbr>Response</a></span>
@@ -1527,7 +1527,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="version_go">
-<a href="#version_go" style="color: inherit; text-decoration: inherit;">Version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#version_go" style="color: inherit; text-decoration: inherit;">Version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1539,7 +1539,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1547,7 +1547,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environmentrefs_nodejs">
-<a href="#environmentrefs_nodejs" style="color: inherit; text-decoration: inherit;">environment<wbr>Refs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environmentrefs_nodejs" style="color: inherit; text-decoration: inherit;">environment<wbr>Refs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisenvironmentreferenceresponse">Ssis<wbr>Environment<wbr>Reference<wbr>Response[]</a></span>
@@ -1555,7 +1555,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folderid_nodejs">
-<a href="#folderid_nodejs" style="color: inherit; text-decoration: inherit;">folder<wbr>Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folderid_nodejs" style="color: inherit; text-decoration: inherit;">folder<wbr>Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1563,7 +1563,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains project.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1571,7 +1571,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1579,7 +1579,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_nodejs">
-<a href="#parameters_nodejs" style="color: inherit; text-decoration: inherit;">parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_nodejs" style="color: inherit; text-decoration: inherit;">parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">Ssis<wbr>Parameter<wbr>Response[]</a></span>
@@ -1587,7 +1587,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="version_nodejs">
-<a href="#version_nodejs" style="color: inherit; text-decoration: inherit;">version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#version_nodejs" style="color: inherit; text-decoration: inherit;">version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1599,7 +1599,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1607,7 +1607,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="environment_refs_python">
-<a href="#environment_refs_python" style="color: inherit; text-decoration: inherit;">environment_<wbr>refs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#environment_refs_python" style="color: inherit; text-decoration: inherit;">environment_<wbr>refs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisenvironmentreferenceresponse">Sequence[Ssis<wbr>Environment<wbr>Reference<wbr>Response]</a></span>
@@ -1615,7 +1615,7 @@ The following output properties are available:
     <dd>{{% md %}}Environment reference in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="folder_id_python">
-<a href="#folder_id_python" style="color: inherit; text-decoration: inherit;">folder_<wbr>id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#folder_id_python" style="color: inherit; text-decoration: inherit;">folder_<wbr>id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1623,7 +1623,7 @@ The following output properties are available:
     <dd>{{% md %}}Folder id which contains project.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1631,7 +1631,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1639,7 +1639,7 @@ The following output properties are available:
     <dd>{{% md %}}Metadata name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="parameters_python">
-<a href="#parameters_python" style="color: inherit; text-decoration: inherit;">parameters</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#parameters_python" style="color: inherit; text-decoration: inherit;">parameters</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#ssisparameterresponse">Sequence[Ssis<wbr>Parameter<wbr>Response]</a></span>
@@ -1647,7 +1647,7 @@ The following output properties are available:
     <dd>{{% md %}}Parameters in project{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="version_python">
-<a href="#version_python" style="color: inherit; text-decoration: inherit;">version</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#version_python" style="color: inherit; text-decoration: inherit;">version</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1663,7 +1663,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="datatype_csharp">
-<a href="#datatype_csharp" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#datatype_csharp" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1671,7 +1671,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_csharp">
-<a href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_csharp" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1679,7 +1679,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -1687,7 +1687,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1695,7 +1695,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_csharp">
-<a href="#sensitive_csharp" style="color: inherit; text-decoration: inherit;">Sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_csharp" style="color: inherit; text-decoration: inherit;">Sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1703,7 +1703,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether variable is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitivevalue_csharp">
-<a href="#sensitivevalue_csharp" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitivevalue_csharp" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1711,7 +1711,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable sensitive value.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1723,7 +1723,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="datatype_go">
-<a href="#datatype_go" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#datatype_go" style="color: inherit; text-decoration: inherit;">Data<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1731,7 +1731,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_go">
-<a href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_go" style="color: inherit; text-decoration: inherit;">Description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1739,7 +1739,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -1747,7 +1747,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1755,7 +1755,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_go">
-<a href="#sensitive_go" style="color: inherit; text-decoration: inherit;">Sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_go" style="color: inherit; text-decoration: inherit;">Sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1763,7 +1763,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether variable is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitivevalue_go">
-<a href="#sensitivevalue_go" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitivevalue_go" style="color: inherit; text-decoration: inherit;">Sensitive<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1771,7 +1771,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable sensitive value.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1783,7 +1783,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="datatype_nodejs">
-<a href="#datatype_nodejs" style="color: inherit; text-decoration: inherit;">data<wbr>Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#datatype_nodejs" style="color: inherit; text-decoration: inherit;">data<wbr>Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1791,7 +1791,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_nodejs">
-<a href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_nodejs" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1799,7 +1799,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -1807,7 +1807,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1815,7 +1815,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_nodejs">
-<a href="#sensitive_nodejs" style="color: inherit; text-decoration: inherit;">sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_nodejs" style="color: inherit; text-decoration: inherit;">sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -1823,7 +1823,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether variable is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitivevalue_nodejs">
-<a href="#sensitivevalue_nodejs" style="color: inherit; text-decoration: inherit;">sensitive<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitivevalue_nodejs" style="color: inherit; text-decoration: inherit;">sensitive<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1831,7 +1831,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable sensitive value.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -1843,7 +1843,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="data_type_python">
-<a href="#data_type_python" style="color: inherit; text-decoration: inherit;">data_<wbr>type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#data_type_python" style="color: inherit; text-decoration: inherit;">data_<wbr>type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1851,7 +1851,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable type.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="description_python">
-<a href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#description_python" style="color: inherit; text-decoration: inherit;">description</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1859,7 +1859,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable description.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -1867,7 +1867,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable id.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1875,7 +1875,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable name.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_python">
-<a href="#sensitive_python" style="color: inherit; text-decoration: inherit;">sensitive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_python" style="color: inherit; text-decoration: inherit;">sensitive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -1883,7 +1883,7 @@ The following output properties are available:
     <dd>{{% md %}}Whether variable is sensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sensitive_value_python">
-<a href="#sensitive_value_python" style="color: inherit; text-decoration: inherit;">sensitive_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sensitive_value_python" style="color: inherit; text-decoration: inherit;">sensitive_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -1891,7 +1891,7 @@ The following output properties are available:
     <dd>{{% md %}}Variable sensitive value.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
@@ -82,7 +82,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="accountname_csharp">
-<a href="#accountname_csharp" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#accountname_csharp" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -90,7 +90,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_csharp">
-<a href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_csharp" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -98,7 +98,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_csharp">
-<a href="#expand_csharp" style="color: inherit; text-decoration: inherit;">Expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_csharp" style="color: inherit; text-decoration: inherit;">Expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -110,7 +110,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="accountname_go">
-<a href="#accountname_go" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#accountname_go" style="color: inherit; text-decoration: inherit;">Account<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -118,7 +118,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_go">
-<a href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_go" style="color: inherit; text-decoration: inherit;">Resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -126,7 +126,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_go">
-<a href="#expand_go" style="color: inherit; text-decoration: inherit;">Expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_go" style="color: inherit; text-decoration: inherit;">Expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -138,7 +138,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="accountname_nodejs">
-<a href="#accountname_nodejs" style="color: inherit; text-decoration: inherit;">account<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#accountname_nodejs" style="color: inherit; text-decoration: inherit;">account<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -146,7 +146,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resourcegroupname_nodejs">
-<a href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resourcegroupname_nodejs" style="color: inherit; text-decoration: inherit;">resource<wbr>Group<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -154,7 +154,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_nodejs">
-<a href="#expand_nodejs" style="color: inherit; text-decoration: inherit;">expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_nodejs" style="color: inherit; text-decoration: inherit;">expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -166,7 +166,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="account_name_python">
-<a href="#account_name_python" style="color: inherit; text-decoration: inherit;">account_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#account_name_python" style="color: inherit; text-decoration: inherit;">account_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -174,7 +174,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="resource_group_name_python">
-<a href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#resource_group_name_python" style="color: inherit; text-decoration: inherit;">resource_<wbr>group_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -182,7 +182,7 @@ The following arguments are supported:
     <dd>{{% md %}}The name of the resource group within the user's subscription. The name is case insensitive.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="expand_python">
-<a href="#expand_python" style="color: inherit; text-decoration: inherit;">expand</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#expand_python" style="color: inherit; text-decoration: inherit;">expand</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -203,7 +203,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_csharp">
-<a href="#keys_csharp" style="color: inherit; text-decoration: inherit;">Keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_csharp" style="color: inherit; text-decoration: inherit;">Keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">List&lt;Storage<wbr>Account<wbr>Key<wbr>Response&gt;</a></span>
@@ -215,7 +215,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_go">
-<a href="#keys_go" style="color: inherit; text-decoration: inherit;">Keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_go" style="color: inherit; text-decoration: inherit;">Keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">[]Storage<wbr>Account<wbr>Key<wbr>Response</a></span>
@@ -227,7 +227,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_nodejs">
-<a href="#keys_nodejs" style="color: inherit; text-decoration: inherit;">keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_nodejs" style="color: inherit; text-decoration: inherit;">keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">Storage<wbr>Account<wbr>Key<wbr>Response[]</a></span>
@@ -239,7 +239,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="keys_python">
-<a href="#keys_python" style="color: inherit; text-decoration: inherit;">keys</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keys_python" style="color: inherit; text-decoration: inherit;">keys</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#storageaccountkeyresponse">Sequence[Storage<wbr>Account<wbr>Key<wbr>Response]</a></span>
@@ -261,7 +261,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creationtime_csharp">
-<a href="#creationtime_csharp" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creationtime_csharp" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -269,7 +269,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keyname_csharp">
-<a href="#keyname_csharp" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keyname_csharp" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -277,7 +277,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_csharp">
-<a href="#permissions_csharp" style="color: inherit; text-decoration: inherit;">Permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_csharp" style="color: inherit; text-decoration: inherit;">Permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -285,7 +285,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_csharp">
-<a href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_csharp" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -297,7 +297,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creationtime_go">
-<a href="#creationtime_go" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creationtime_go" style="color: inherit; text-decoration: inherit;">Creation<wbr>Time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -305,7 +305,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keyname_go">
-<a href="#keyname_go" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keyname_go" style="color: inherit; text-decoration: inherit;">Key<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -313,7 +313,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_go">
-<a href="#permissions_go" style="color: inherit; text-decoration: inherit;">Permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_go" style="color: inherit; text-decoration: inherit;">Permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -321,7 +321,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_go">
-<a href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_go" style="color: inherit; text-decoration: inherit;">Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -333,7 +333,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creationtime_nodejs">
-<a href="#creationtime_nodejs" style="color: inherit; text-decoration: inherit;">creation<wbr>Time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creationtime_nodejs" style="color: inherit; text-decoration: inherit;">creation<wbr>Time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -341,7 +341,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="keyname_nodejs">
-<a href="#keyname_nodejs" style="color: inherit; text-decoration: inherit;">key<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#keyname_nodejs" style="color: inherit; text-decoration: inherit;">key<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -349,7 +349,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_nodejs">
-<a href="#permissions_nodejs" style="color: inherit; text-decoration: inherit;">permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_nodejs" style="color: inherit; text-decoration: inherit;">permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -357,7 +357,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_nodejs">
-<a href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_nodejs" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -369,7 +369,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="creation_time_python">
-<a href="#creation_time_python" style="color: inherit; text-decoration: inherit;">creation_<wbr>time</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#creation_time_python" style="color: inherit; text-decoration: inherit;">creation_<wbr>time</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -377,7 +377,7 @@ The following output properties are available:
     <dd>{{% md %}}Creation time of the key, in round trip date format.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="key_name_python">
-<a href="#key_name_python" style="color: inherit; text-decoration: inherit;">key_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#key_name_python" style="color: inherit; text-decoration: inherit;">key_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -385,7 +385,7 @@ The following output properties are available:
     <dd>{{% md %}}Name of the key.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="permissions_python">
-<a href="#permissions_python" style="color: inherit; text-decoration: inherit;">permissions</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#permissions_python" style="color: inherit; text-decoration: inherit;">permissions</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -393,7 +393,7 @@ The following output properties are available:
     <dd>{{% md %}}Permissions for the key -- read-only or full permissions.{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="value_python">
-<a href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#value_python" style="color: inherit; text-decoration: inherit;">value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
@@ -171,7 +171,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="plain_required_bool_csharp">
-<a href="#plain_required_bool_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -179,7 +179,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_number_csharp">
-<a href="#plain_required_number_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -187,7 +187,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_string_csharp">
-<a href="#plain_required_string_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -195,7 +195,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_bool_csharp">
-<a href="#required_bool_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -203,7 +203,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_enum_csharp">
-<a href="#required_enum_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Enum<wbr>Thing</a></span>
@@ -211,7 +211,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_number_csharp">
-<a href="#required_number_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -219,7 +219,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_string_csharp">
-<a href="#required_string_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_csharp" style="color: inherit; text-decoration: inherit;">Required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -227,7 +227,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_bool_csharp">
-<a href="#optional_bool_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -235,7 +235,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_enum_csharp">
-<a href="#optional_enum_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Enum<wbr>Thing</a></span>
@@ -243,7 +243,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_number_csharp">
-<a href="#optional_number_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -251,7 +251,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_string_csharp">
-<a href="#optional_string_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -259,7 +259,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_bool_csharp">
-<a href="#plain_optional_bool_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -267,7 +267,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_number_csharp">
-<a href="#plain_optional_number_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -275,7 +275,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_string_csharp">
-<a href="#plain_optional_string_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_csharp" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -287,7 +287,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="plain_required_bool_go">
-<a href="#plain_required_bool_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -295,7 +295,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_number_go">
-<a href="#plain_required_number_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -303,7 +303,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_string_go">
-<a href="#plain_required_string_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -311,7 +311,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_bool_go">
-<a href="#required_bool_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -319,7 +319,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_enum_go">
-<a href="#required_enum_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
@@ -327,7 +327,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_number_go">
-<a href="#required_number_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -335,7 +335,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_string_go">
-<a href="#required_string_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_go" style="color: inherit; text-decoration: inherit;">Required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -343,7 +343,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_bool_go">
-<a href="#optional_bool_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -351,7 +351,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_enum_go">
-<a href="#optional_enum_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
@@ -359,7 +359,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_number_go">
-<a href="#optional_number_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -367,7 +367,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_string_go">
-<a href="#optional_string_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -375,7 +375,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_bool_go">
-<a href="#plain_optional_bool_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -383,7 +383,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_number_go">
-<a href="#plain_optional_number_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -391,7 +391,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_string_go">
-<a href="#plain_optional_string_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_go" style="color: inherit; text-decoration: inherit;">Plain_<wbr>optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -403,7 +403,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="plain_required_bool_nodejs">
-<a href="#plain_required_bool_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -411,7 +411,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_number_nodejs">
-<a href="#plain_required_number_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -419,7 +419,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_string_nodejs">
-<a href="#plain_required_string_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -427,7 +427,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_bool_nodejs">
-<a href="#required_bool_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -435,7 +435,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_enum_nodejs">
-<a href="#required_enum_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
@@ -443,7 +443,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_number_nodejs">
-<a href="#required_number_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -451,7 +451,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_string_nodejs">
-<a href="#required_string_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_nodejs" style="color: inherit; text-decoration: inherit;">required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -459,7 +459,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_bool_nodejs">
-<a href="#optional_bool_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -467,7 +467,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_enum_nodejs">
-<a href="#optional_enum_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
@@ -475,7 +475,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_number_nodejs">
-<a href="#optional_number_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -483,7 +483,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_string_nodejs">
-<a href="#optional_string_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -491,7 +491,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_bool_nodejs">
-<a href="#plain_optional_bool_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -499,7 +499,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_number_nodejs">
-<a href="#plain_optional_number_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -507,7 +507,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_string_nodejs">
-<a href="#plain_optional_string_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_nodejs" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -519,7 +519,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="plain_required_bool_python">
-<a href="#plain_required_bool_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_bool_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -527,7 +527,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_number_python">
-<a href="#plain_required_number_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_number_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -535,7 +535,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="plain_required_string_python">
-<a href="#plain_required_string_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_required_string_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -543,7 +543,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_bool_python">
-<a href="#required_bool_python" style="color: inherit; text-decoration: inherit;">required_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_bool_python" style="color: inherit; text-decoration: inherit;">required_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -551,7 +551,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_enum_python">
-<a href="#required_enum_python" style="color: inherit; text-decoration: inherit;">required_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_enum_python" style="color: inherit; text-decoration: inherit;">required_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
@@ -559,7 +559,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_number_python">
-<a href="#required_number_python" style="color: inherit; text-decoration: inherit;">required_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_number_python" style="color: inherit; text-decoration: inherit;">required_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -567,7 +567,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="required_string_python">
-<a href="#required_string_python" style="color: inherit; text-decoration: inherit;">required_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_string_python" style="color: inherit; text-decoration: inherit;">required_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -575,7 +575,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_bool_python">
-<a href="#optional_bool_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -583,7 +583,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_enum_python">
-<a href="#optional_enum_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
@@ -591,7 +591,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_number_python">
-<a href="#optional_number_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -599,7 +599,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="optional_string_python">
-<a href="#optional_string_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -607,7 +607,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_bool_python">
-<a href="#plain_optional_bool_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>bool</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_bool_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -615,7 +615,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_number_python">
-<a href="#plain_optional_number_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>number</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_number_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -623,7 +623,7 @@ The ModuleResource resource accepts the following [input]({{< relref "/docs/intr
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_optional_string_python">
-<a href="#plain_optional_string_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>string</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_optional_string_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -642,7 +642,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -654,7 +654,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -666,7 +666,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -678,7 +678,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
@@ -163,7 +163,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backupkubeclientsettings_csharp">
-<a href="#backupkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backupkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -171,7 +171,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_csharp">
-<a href="#argument_csharp" style="color: inherit; text-decoration: inherit;">Argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_csharp" style="color: inherit; text-decoration: inherit;">Argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -179,7 +179,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kubeclientsettings_csharp">
-<a href="#kubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -187,7 +187,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_csharp">
-<a href="#settings_csharp" style="color: inherit; text-decoration: inherit;">Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_csharp" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backupkubeclientsettings_go">
-<a href="#backupkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backupkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -207,7 +207,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_go">
-<a href="#argument_go" style="color: inherit; text-decoration: inherit;">Argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_go" style="color: inherit; text-decoration: inherit;">Argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -215,7 +215,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kubeclientsettings_go">
-<a href="#kubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -223,7 +223,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_go">
-<a href="#settings_go" style="color: inherit; text-decoration: inherit;">Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_go" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -235,7 +235,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backupkubeclientsettings_nodejs">
-<a href="#backupkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">backup<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backupkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">backup<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -243,7 +243,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_nodejs">
-<a href="#argument_nodejs" style="color: inherit; text-decoration: inherit;">argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_nodejs" style="color: inherit; text-decoration: inherit;">argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -251,7 +251,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kubeclientsettings_nodejs">
-<a href="#kubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -259,7 +259,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_nodejs">
-<a href="#settings_nodejs" style="color: inherit; text-decoration: inherit;">settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_nodejs" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -271,7 +271,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backup_kube_client_settings_python">
-<a href="#backup_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">backup_<wbr>kube_<wbr>client_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backup_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">backup_<wbr>kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -279,7 +279,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_python">
-<a href="#argument_python" style="color: inherit; text-decoration: inherit;">argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_python" style="color: inherit; text-decoration: inherit;">argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -287,7 +287,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kube_client_settings_python">
-<a href="#kube_client_settings_python" style="color: inherit; text-decoration: inherit;">kube_<wbr>client_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kube_client_settings_python" style="color: inherit; text-decoration: inherit;">kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -295,7 +295,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_python">
-<a href="#settings_python" style="color: inherit; text-decoration: inherit;">settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_python" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -314,7 +314,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -322,7 +322,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="defaultkubeclientsettings_csharp">
-<a href="#defaultkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -334,7 +334,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="defaultkubeclientsettings_go">
-<a href="#defaultkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -362,7 +362,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="defaultkubeclientsettings_nodejs">
-<a href="#defaultkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">default<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">default<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -374,7 +374,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -382,7 +382,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="default_kube_client_settings_python">
-<a href="#default_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">default_<wbr>kube_<wbr>client_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#default_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">default_<wbr>kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -406,7 +406,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_csharp">
-<a href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -414,7 +414,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_csharp">
-<a href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -422,7 +422,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
-<a href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -434,7 +434,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_go">
-<a href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -442,7 +442,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_go">
-<a href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -450,7 +450,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
-<a href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -462,7 +462,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_nodejs">
-<a href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -470,7 +470,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_nodejs">
-<a href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -478,7 +478,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
-<a href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -490,7 +490,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_arg_python">
-<a href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -498,7 +498,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_python">
-<a href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -506,7 +506,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
-<a href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -520,7 +520,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_csharp">
-<a href="#burst_csharp" style="color: inherit; text-decoration: inherit;">Burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_csharp" style="color: inherit; text-decoration: inherit;">Burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -528,7 +528,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_csharp">
-<a href="#qps_csharp" style="color: inherit; text-decoration: inherit;">Qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_csharp" style="color: inherit; text-decoration: inherit;">Qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -536,7 +536,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rectest_csharp">
-<a href="#rectest_csharp" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rectest_csharp" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -548,7 +548,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_go">
-<a href="#burst_go" style="color: inherit; text-decoration: inherit;">Burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_go" style="color: inherit; text-decoration: inherit;">Burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -556,7 +556,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_go">
-<a href="#qps_go" style="color: inherit; text-decoration: inherit;">Qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_go" style="color: inherit; text-decoration: inherit;">Qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -564,7 +564,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rectest_go">
-<a href="#rectest_go" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rectest_go" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -576,7 +576,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_nodejs">
-<a href="#burst_nodejs" style="color: inherit; text-decoration: inherit;">burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_nodejs" style="color: inherit; text-decoration: inherit;">burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -584,7 +584,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_nodejs">
-<a href="#qps_nodejs" style="color: inherit; text-decoration: inherit;">qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_nodejs" style="color: inherit; text-decoration: inherit;">qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -592,7 +592,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rectest_nodejs">
-<a href="#rectest_nodejs" style="color: inherit; text-decoration: inherit;">rec<wbr>Test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rectest_nodejs" style="color: inherit; text-decoration: inherit;">rec<wbr>Test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -604,7 +604,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_python">
-<a href="#burst_python" style="color: inherit; text-decoration: inherit;">burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_python" style="color: inherit; text-decoration: inherit;">burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -612,7 +612,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_python">
-<a href="#qps_python" style="color: inherit; text-decoration: inherit;">qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_python" style="color: inherit; text-decoration: inherit;">qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -620,7 +620,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rec_test_python">
-<a href="#rec_test_python" style="color: inherit; text-decoration: inherit;">rec_<wbr>test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_test_python" style="color: inherit; text-decoration: inherit;">rec_<wbr>test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -634,7 +634,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_csharp">
-<a href="#other_csharp" style="color: inherit; text-decoration: inherit;">Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_csharp" style="color: inherit; text-decoration: inherit;">Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -642,7 +642,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_csharp">
-<a href="#thinker_csharp" style="color: inherit; text-decoration: inherit;">Thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_csharp" style="color: inherit; text-decoration: inherit;">Thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -650,7 +650,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_csharp">
-<a href="#answer_csharp" style="color: inherit; text-decoration: inherit;">Answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_csharp" style="color: inherit; text-decoration: inherit;">Answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -658,7 +658,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plainother_csharp">
-<a href="#plainother_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainother_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -666,7 +666,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_csharp">
-<a href="#question_csharp" style="color: inherit; text-decoration: inherit;">Question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_csharp" style="color: inherit; text-decoration: inherit;">Question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -674,7 +674,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_csharp">
-<a href="#recursive_csharp" style="color: inherit; text-decoration: inherit;">Recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_csharp" style="color: inherit; text-decoration: inherit;">Recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>
@@ -686,7 +686,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_go">
-<a href="#other_go" style="color: inherit; text-decoration: inherit;">Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_go" style="color: inherit; text-decoration: inherit;">Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -694,7 +694,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_go">
-<a href="#thinker_go" style="color: inherit; text-decoration: inherit;">Thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_go" style="color: inherit; text-decoration: inherit;">Thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -702,7 +702,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_go">
-<a href="#answer_go" style="color: inherit; text-decoration: inherit;">Answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_go" style="color: inherit; text-decoration: inherit;">Answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -710,7 +710,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plainother_go">
-<a href="#plainother_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainother_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -718,7 +718,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_go">
-<a href="#question_go" style="color: inherit; text-decoration: inherit;">Question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_go" style="color: inherit; text-decoration: inherit;">Question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -726,7 +726,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_go">
-<a href="#recursive_go" style="color: inherit; text-decoration: inherit;">Recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_go" style="color: inherit; text-decoration: inherit;">Recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>
@@ -738,7 +738,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_nodejs">
-<a href="#other_nodejs" style="color: inherit; text-decoration: inherit;">other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_nodejs" style="color: inherit; text-decoration: inherit;">other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -746,7 +746,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_nodejs">
-<a href="#thinker_nodejs" style="color: inherit; text-decoration: inherit;">thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_nodejs" style="color: inherit; text-decoration: inherit;">thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -754,7 +754,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_nodejs">
-<a href="#answer_nodejs" style="color: inherit; text-decoration: inherit;">answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_nodejs" style="color: inherit; text-decoration: inherit;">answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -762,7 +762,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plainother_nodejs">
-<a href="#plainother_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainother_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -770,7 +770,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_nodejs">
-<a href="#question_nodejs" style="color: inherit; text-decoration: inherit;">question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_nodejs" style="color: inherit; text-decoration: inherit;">question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -778,7 +778,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_nodejs">
-<a href="#recursive_nodejs" style="color: inherit; text-decoration: inherit;">recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_nodejs" style="color: inherit; text-decoration: inherit;">recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>
@@ -790,7 +790,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_python">
-<a href="#other_python" style="color: inherit; text-decoration: inherit;">other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_python" style="color: inherit; text-decoration: inherit;">other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -798,7 +798,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_python">
-<a href="#thinker_python" style="color: inherit; text-decoration: inherit;">thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_python" style="color: inherit; text-decoration: inherit;">thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -806,7 +806,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_python">
-<a href="#answer_python" style="color: inherit; text-decoration: inherit;">answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_python" style="color: inherit; text-decoration: inherit;">answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -814,7 +814,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_other_python">
-<a href="#plain_other_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_other_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -822,7 +822,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_python">
-<a href="#question_python" style="color: inherit; text-decoration: inherit;">question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_python" style="color: inherit; text-decoration: inherit;">question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -830,7 +830,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_python">
-<a href="#recursive_python" style="color: inherit; text-decoration: inherit;">recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_python" style="color: inherit; text-decoration: inherit;">recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -87,7 +87,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -107,7 +107,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -119,7 +119,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -127,7 +127,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -139,7 +139,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -147,7 +147,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_csharp">
-<a href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_go">
-<a href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_nodejs">
-<a href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_python">
-<a href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -226,7 +226,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_csharp">
-<a href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -234,7 +234,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_csharp">
-<a href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -242,7 +242,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
-<a href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -254,7 +254,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_go">
-<a href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -262,7 +262,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_go">
-<a href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
-<a href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_nodejs">
-<a href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -290,7 +290,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_nodejs">
-<a href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -298,7 +298,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
-<a href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -310,7 +310,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_arg_python">
-<a href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -318,7 +318,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_python">
-<a href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -326,7 +326,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
-<a href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
@@ -159,7 +159,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_csharp">
-<a href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ<wbr>Args</a></span>
@@ -167,7 +167,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -179,7 +179,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_go">
-<a href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -187,7 +187,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_nodejs">
-<a href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod1Typ<wbr>Args</a></span>
@@ -207,7 +207,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -219,7 +219,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_python">
-<a href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -227,7 +227,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -306,7 +306,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_csharp">
-<a href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ</a></span>
@@ -314,7 +314,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_csharp">
-<a href="#mod2_csharp" style="color: inherit; text-decoration: inherit;">Mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_csharp" style="color: inherit; text-decoration: inherit;">Mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod2.<wbr>Inputs.<wbr>Typ</a></span>
@@ -322,7 +322,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -334,7 +334,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_go">
-<a href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_go">
-<a href="#mod2_go" style="color: inherit; text-decoration: inherit;">Mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_go" style="color: inherit; text-decoration: inherit;">Mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -350,7 +350,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -362,7 +362,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_nodejs">
-<a href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod1Typ</a></span>
@@ -370,7 +370,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_nodejs">
-<a href="#mod2_nodejs" style="color: inherit; text-decoration: inherit;">mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_nodejs" style="color: inherit; text-decoration: inherit;">mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod2Typ</a></span>
@@ -378,7 +378,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -390,7 +390,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_python">
-<a href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -398,7 +398,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_python">
-<a href="#mod2_python" style="color: inherit; text-decoration: inherit;">mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_python" style="color: inherit; text-decoration: inherit;">mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -406,7 +406,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -420,7 +420,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -432,7 +432,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -444,7 +444,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -456,7 +456,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -470,7 +470,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_csharp">
-<a href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ</a></span>
@@ -478,7 +478,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -490,7 +490,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_go">
-<a href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -498,7 +498,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -510,7 +510,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_nodejs">
-<a href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod1Typ</a></span>
@@ -518,7 +518,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -530,7 +530,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_python">
-<a href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -538,7 +538,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
@@ -160,7 +160,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helmreleasesettings_csharp">
-<a href="#helmreleasesettings_csharp" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_csharp" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -172,7 +172,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helmreleasesettings_go">
-<a href="#helmreleasesettings_go" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_go" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -184,7 +184,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helmreleasesettings_nodejs">
-<a href="#helmreleasesettings_nodejs" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_nodejs" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -196,7 +196,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helm_release_settings_python">
-<a href="#helm_release_settings_python" style="color: inherit; text-decoration: inherit;">helm_<wbr>release_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helm_release_settings_python" style="color: inherit; text-decoration: inherit;">helm_<wbr>release_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -215,7 +215,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -227,7 +227,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -239,7 +239,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -251,7 +251,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -275,7 +275,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_csharp">
-<a href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -283,7 +283,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_csharp">
-<a href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -291,7 +291,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
-<a href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -303,7 +303,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_go">
-<a href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -311,7 +311,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_go">
-<a href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -319,7 +319,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
-<a href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -331,7 +331,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_nodejs">
-<a href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -339,7 +339,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_nodejs">
-<a href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -347,7 +347,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
-<a href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_arg_python">
-<a href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -367,7 +367,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_python">
-<a href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -375,7 +375,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
-<a href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
@@ -163,7 +163,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backupkubeclientsettings_csharp">
-<a href="#backupkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backupkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -171,7 +171,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_csharp">
-<a href="#argument_csharp" style="color: inherit; text-decoration: inherit;">Argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_csharp" style="color: inherit; text-decoration: inherit;">Argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -179,7 +179,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kubeclientsettings_csharp">
-<a href="#kubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -187,7 +187,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_csharp">
-<a href="#settings_csharp" style="color: inherit; text-decoration: inherit;">Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_csharp" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backupkubeclientsettings_go">
-<a href="#backupkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backupkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Backup<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -207,7 +207,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_go">
-<a href="#argument_go" style="color: inherit; text-decoration: inherit;">Argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_go" style="color: inherit; text-decoration: inherit;">Argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -215,7 +215,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kubeclientsettings_go">
-<a href="#kubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -223,7 +223,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_go">
-<a href="#settings_go" style="color: inherit; text-decoration: inherit;">Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_go" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -235,7 +235,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backupkubeclientsettings_nodejs">
-<a href="#backupkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">backup<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backupkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">backup<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -243,7 +243,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_nodejs">
-<a href="#argument_nodejs" style="color: inherit; text-decoration: inherit;">argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_nodejs" style="color: inherit; text-decoration: inherit;">argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -251,7 +251,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kubeclientsettings_nodejs">
-<a href="#kubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -259,7 +259,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_nodejs">
-<a href="#settings_nodejs" style="color: inherit; text-decoration: inherit;">settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_nodejs" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -271,7 +271,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="backup_kube_client_settings_python">
-<a href="#backup_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">backup_<wbr>kube_<wbr>client_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backup_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">backup_<wbr>kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -279,7 +279,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="argument_python">
-<a href="#argument_python" style="color: inherit; text-decoration: inherit;">argument</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#argument_python" style="color: inherit; text-decoration: inherit;">argument</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -287,7 +287,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="kube_client_settings_python">
-<a href="#kube_client_settings_python" style="color: inherit; text-decoration: inherit;">kube_<wbr>client_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kube_client_settings_python" style="color: inherit; text-decoration: inherit;">kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
@@ -295,7 +295,7 @@ The Foo resource accepts the following [input]({{< relref "/docs/intro/concepts/
     <dd>{{% md %}}Options for tuning the Kubernetes client used by a Provider.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="settings_python">
-<a href="#settings_python" style="color: inherit; text-decoration: inherit;">settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_python" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
@@ -314,7 +314,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -322,7 +322,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="defaultkubeclientsettings_csharp">
-<a href="#defaultkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultkubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -334,7 +334,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="defaultkubeclientsettings_go">
-<a href="#defaultkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultkubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Default<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -362,7 +362,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="defaultkubeclientsettings_nodejs">
-<a href="#defaultkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">default<wbr>Kube<wbr>Client<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#defaultkubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">default<wbr>Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -374,7 +374,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -382,7 +382,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="default_kube_client_settings_python">
-<a href="#default_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">default_<wbr>kube_<wbr>client_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#default_kube_client_settings_python" style="color: inherit; text-decoration: inherit;">default_<wbr>kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -406,7 +406,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_csharp">
-<a href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -414,7 +414,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_csharp">
-<a href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -422,7 +422,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
-<a href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -434,7 +434,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_go">
-<a href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -442,7 +442,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_go">
-<a href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -450,7 +450,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
-<a href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -462,7 +462,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_nodejs">
-<a href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -470,7 +470,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_nodejs">
-<a href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -478,7 +478,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
-<a href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -490,7 +490,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_arg_python">
-<a href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -498,7 +498,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_python">
-<a href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -506,7 +506,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
-<a href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -520,7 +520,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_csharp">
-<a href="#burst_csharp" style="color: inherit; text-decoration: inherit;">Burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_csharp" style="color: inherit; text-decoration: inherit;">Burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -528,7 +528,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_csharp">
-<a href="#qps_csharp" style="color: inherit; text-decoration: inherit;">Qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_csharp" style="color: inherit; text-decoration: inherit;">Qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -536,7 +536,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rectest_csharp">
-<a href="#rectest_csharp" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rectest_csharp" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -548,7 +548,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_go">
-<a href="#burst_go" style="color: inherit; text-decoration: inherit;">Burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_go" style="color: inherit; text-decoration: inherit;">Burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -556,7 +556,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_go">
-<a href="#qps_go" style="color: inherit; text-decoration: inherit;">Qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_go" style="color: inherit; text-decoration: inherit;">Qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -564,7 +564,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rectest_go">
-<a href="#rectest_go" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rectest_go" style="color: inherit; text-decoration: inherit;">Rec<wbr>Test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -576,7 +576,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_nodejs">
-<a href="#burst_nodejs" style="color: inherit; text-decoration: inherit;">burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_nodejs" style="color: inherit; text-decoration: inherit;">burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -584,7 +584,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_nodejs">
-<a href="#qps_nodejs" style="color: inherit; text-decoration: inherit;">qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_nodejs" style="color: inherit; text-decoration: inherit;">qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -592,7 +592,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rectest_nodejs">
-<a href="#rectest_nodejs" style="color: inherit; text-decoration: inherit;">rec<wbr>Test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rectest_nodejs" style="color: inherit; text-decoration: inherit;">rec<wbr>Test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -604,7 +604,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="burst_python">
-<a href="#burst_python" style="color: inherit; text-decoration: inherit;">burst</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#burst_python" style="color: inherit; text-decoration: inherit;">burst</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -612,7 +612,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum burst for throttle. Default value is 10.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qps_python">
-<a href="#qps_python" style="color: inherit; text-decoration: inherit;">qps</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qps_python" style="color: inherit; text-decoration: inherit;">qps</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -620,7 +620,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Maximum queries per second (QPS) to the API server from this client. Default value is 5.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="rec_test_python">
-<a href="#rec_test_python" style="color: inherit; text-decoration: inherit;">rec_<wbr>test</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_test_python" style="color: inherit; text-decoration: inherit;">rec_<wbr>test</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings</a></span>
@@ -634,7 +634,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_csharp">
-<a href="#other_csharp" style="color: inherit; text-decoration: inherit;">Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_csharp" style="color: inherit; text-decoration: inherit;">Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -642,7 +642,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_csharp">
-<a href="#thinker_csharp" style="color: inherit; text-decoration: inherit;">Thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_csharp" style="color: inherit; text-decoration: inherit;">Thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -650,7 +650,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_csharp">
-<a href="#answer_csharp" style="color: inherit; text-decoration: inherit;">Answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_csharp" style="color: inherit; text-decoration: inherit;">Answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -658,7 +658,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plainother_csharp">
-<a href="#plainother_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainother_csharp" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -666,7 +666,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_csharp">
-<a href="#question_csharp" style="color: inherit; text-decoration: inherit;">Question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_csharp" style="color: inherit; text-decoration: inherit;">Question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -674,7 +674,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_csharp">
-<a href="#recursive_csharp" style="color: inherit; text-decoration: inherit;">Recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_csharp" style="color: inherit; text-decoration: inherit;">Recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>
@@ -686,7 +686,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_go">
-<a href="#other_go" style="color: inherit; text-decoration: inherit;">Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_go" style="color: inherit; text-decoration: inherit;">Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -694,7 +694,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_go">
-<a href="#thinker_go" style="color: inherit; text-decoration: inherit;">Thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_go" style="color: inherit; text-decoration: inherit;">Thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -702,7 +702,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_go">
-<a href="#answer_go" style="color: inherit; text-decoration: inherit;">Answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_go" style="color: inherit; text-decoration: inherit;">Answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -710,7 +710,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plainother_go">
-<a href="#plainother_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainother_go" style="color: inherit; text-decoration: inherit;">Plain<wbr>Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -718,7 +718,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_go">
-<a href="#question_go" style="color: inherit; text-decoration: inherit;">Question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_go" style="color: inherit; text-decoration: inherit;">Question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -726,7 +726,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_go">
-<a href="#recursive_go" style="color: inherit; text-decoration: inherit;">Recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_go" style="color: inherit; text-decoration: inherit;">Recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>
@@ -738,7 +738,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_nodejs">
-<a href="#other_nodejs" style="color: inherit; text-decoration: inherit;">other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_nodejs" style="color: inherit; text-decoration: inherit;">other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -746,7 +746,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_nodejs">
-<a href="#thinker_nodejs" style="color: inherit; text-decoration: inherit;">thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_nodejs" style="color: inherit; text-decoration: inherit;">thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -754,7 +754,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_nodejs">
-<a href="#answer_nodejs" style="color: inherit; text-decoration: inherit;">answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_nodejs" style="color: inherit; text-decoration: inherit;">answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -762,7 +762,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plainother_nodejs">
-<a href="#plainother_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plainother_nodejs" style="color: inherit; text-decoration: inherit;">plain<wbr>Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -770,7 +770,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_nodejs">
-<a href="#question_nodejs" style="color: inherit; text-decoration: inherit;">question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_nodejs" style="color: inherit; text-decoration: inherit;">question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -778,7 +778,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_nodejs">
-<a href="#recursive_nodejs" style="color: inherit; text-decoration: inherit;">recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_nodejs" style="color: inherit; text-decoration: inherit;">recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>
@@ -790,7 +790,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="other_python">
-<a href="#other_python" style="color: inherit; text-decoration: inherit;">other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_python" style="color: inherit; text-decoration: inherit;">other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -798,7 +798,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="thinker_python">
-<a href="#thinker_python" style="color: inherit; text-decoration: inherit;">thinker</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thinker_python" style="color: inherit; text-decoration: inherit;">thinker</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -806,7 +806,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}To ask and answer{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="answer_python">
-<a href="#answer_python" style="color: inherit; text-decoration: inherit;">answer</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#answer_python" style="color: inherit; text-decoration: inherit;">answer</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -814,7 +814,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The answer to the question{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plain_other_python">
-<a href="#plain_other_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plain_other_python" style="color: inherit; text-decoration: inherit;">plain_<wbr>other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -822,7 +822,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}Test how plain types interact{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="question_python">
-<a href="#question_python" style="color: inherit; text-decoration: inherit;">question</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#question_python" style="color: inherit; text-decoration: inherit;">question</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -830,7 +830,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The question already answered{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="recursive_python">
-<a href="#recursive_python" style="color: inherit; text-decoration: inherit;">recursive</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#recursive_python" style="color: inherit; text-decoration: inherit;">recursive</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#layeredtype">Layered<wbr>Type</a></span>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -87,7 +87,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -107,7 +107,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -119,7 +119,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -127,7 +127,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -139,7 +139,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings</a></span>
@@ -147,7 +147,7 @@ The following arguments are supported:
     <dd>{{% md %}}Property A{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_csharp">
-<a href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_csharp" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -180,7 +180,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_go">
-<a href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_go" style="color: inherit; text-decoration: inherit;">R</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_nodejs">
-<a href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_nodejs" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="r_python">
-<a href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#r_python" style="color: inherit; text-decoration: inherit;">r</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -226,7 +226,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_csharp">
-<a href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -234,7 +234,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_csharp">
-<a href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -242,7 +242,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
-<a href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -254,7 +254,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_go">
-<a href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -262,7 +262,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_go">
-<a href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
-<a href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_nodejs">
-<a href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -290,7 +290,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_nodejs">
-<a href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -298,7 +298,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
-<a href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -310,7 +310,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_arg_python">
-<a href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -318,7 +318,7 @@ The following output properties are available:
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_python">
-<a href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -326,7 +326,7 @@ The following output properties are available:
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
-<a href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -159,7 +159,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_csharp">
-<a href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ<wbr>Args</a></span>
@@ -167,7 +167,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -179,7 +179,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_go">
-<a href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -187,7 +187,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_nodejs">
-<a href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod1Typ<wbr>Args</a></span>
@@ -207,7 +207,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -219,7 +219,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_python">
-<a href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -227,7 +227,7 @@ The ModuleTest resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -306,7 +306,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_csharp">
-<a href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ</a></span>
@@ -314,7 +314,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_csharp">
-<a href="#mod2_csharp" style="color: inherit; text-decoration: inherit;">Mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_csharp" style="color: inherit; text-decoration: inherit;">Mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod2.<wbr>Inputs.<wbr>Typ</a></span>
@@ -322,7 +322,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -334,7 +334,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_go">
-<a href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_go">
-<a href="#mod2_go" style="color: inherit; text-decoration: inherit;">Mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_go" style="color: inherit; text-decoration: inherit;">Mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -350,7 +350,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -362,7 +362,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_nodejs">
-<a href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod1Typ</a></span>
@@ -370,7 +370,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_nodejs">
-<a href="#mod2_nodejs" style="color: inherit; text-decoration: inherit;">mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_nodejs" style="color: inherit; text-decoration: inherit;">mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod2Typ</a></span>
@@ -378,7 +378,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -390,7 +390,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_python">
-<a href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -398,7 +398,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="mod2_python">
-<a href="#mod2_python" style="color: inherit; text-decoration: inherit;">mod2</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod2_python" style="color: inherit; text-decoration: inherit;">mod2</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -406,7 +406,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -420,7 +420,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -432,7 +432,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -444,7 +444,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -456,7 +456,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -470,7 +470,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_csharp">
-<a href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ</a></span>
@@ -478,7 +478,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_csharp">
-<a href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -490,7 +490,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_go">
-<a href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -498,7 +498,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_go">
-<a href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -510,7 +510,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_nodejs">
-<a href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">mod1Typ</a></span>
@@ -518,7 +518,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_nodejs">
-<a href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -530,7 +530,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="mod1_python">
-<a href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#typ">Typ</a></span>
@@ -538,7 +538,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="val_python">
-<a href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
@@ -160,7 +160,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helmreleasesettings_csharp">
-<a href="#helmreleasesettings_csharp" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_csharp" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -172,7 +172,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helmreleasesettings_go">
-<a href="#helmreleasesettings_go" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_go" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -184,7 +184,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helmreleasesettings_nodejs">
-<a href="#helmreleasesettings_nodejs" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_nodejs" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -196,7 +196,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="helm_release_settings_python">
-<a href="#helm_release_settings_python" style="color: inherit; text-decoration: inherit;">helm_<wbr>release_<wbr>settings</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helm_release_settings_python" style="color: inherit; text-decoration: inherit;">helm_<wbr>release_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
@@ -215,7 +215,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -227,7 +227,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -239,7 +239,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -251,7 +251,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -275,7 +275,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_csharp">
-<a href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -283,7 +283,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_csharp">
-<a href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_csharp" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -291,7 +291,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_csharp">
-<a href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_csharp" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -303,7 +303,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_go">
-<a href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -311,7 +311,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_go">
-<a href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_go" style="color: inherit; text-decoration: inherit;">Driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -319,7 +319,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_go">
-<a href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_go" style="color: inherit; text-decoration: inherit;">Plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -331,7 +331,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="requiredarg_nodejs">
-<a href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#requiredarg_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -339,7 +339,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_nodejs">
-<a href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_nodejs" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -347,7 +347,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pluginspath_nodejs">
-<a href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pluginspath_nodejs" style="color: inherit; text-decoration: inherit;">plugins<wbr>Path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="required_arg_python">
-<a href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#required_arg_python" style="color: inherit; text-decoration: inherit;">required_<wbr>arg</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -367,7 +367,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}to test required args{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="driver_python">
-<a href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#driver_python" style="color: inherit; text-decoration: inherit;">driver</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -375,7 +375,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The backend storage driver for Helm. Values are: configmap, secret, memory, sql.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="plugins_path_python">
-<a href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#plugins_path_python" style="color: inherit; text-decoration: inherit;">plugins_<wbr>path</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
@@ -159,7 +159,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="indexcontent_csharp">
-<a href="#indexcontent_csharp" style="color: inherit; text-decoration: inherit;">Index<wbr>Content</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#indexcontent_csharp" style="color: inherit; text-decoration: inherit;">Index<wbr>Content</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -167,7 +167,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}The HTML content for index.html.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -179,7 +179,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="indexcontent_go">
-<a href="#indexcontent_go" style="color: inherit; text-decoration: inherit;">Index<wbr>Content</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#indexcontent_go" style="color: inherit; text-decoration: inherit;">Index<wbr>Content</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -187,7 +187,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}The HTML content for index.html.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="indexcontent_nodejs">
-<a href="#indexcontent_nodejs" style="color: inherit; text-decoration: inherit;">index<wbr>Content</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#indexcontent_nodejs" style="color: inherit; text-decoration: inherit;">index<wbr>Content</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -207,7 +207,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}The HTML content for index.html.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -219,7 +219,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="index_content_python">
-<a href="#index_content_python" style="color: inherit; text-decoration: inherit;">index_<wbr>content</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#index_content_python" style="color: inherit; text-decoration: inherit;">index_<wbr>content</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -227,7 +227,7 @@ The StaticPage resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}The HTML content for index.html.{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bucket_csharp">
-<a href="#bucket_csharp" style="color: inherit; text-decoration: inherit;">Bucket</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bucket_csharp" style="color: inherit; text-decoration: inherit;">Bucket</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Aws.<wbr>S3.<wbr>Bucket</span>
@@ -254,7 +254,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The bucket resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -262,7 +262,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="websiteurl_csharp">
-<a href="#websiteurl_csharp" style="color: inherit; text-decoration: inherit;">Website<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_csharp" style="color: inherit; text-decoration: inherit;">Website<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -274,7 +274,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bucket_go">
-<a href="#bucket_go" style="color: inherit; text-decoration: inherit;">Bucket</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bucket_go" style="color: inherit; text-decoration: inherit;">Bucket</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Bucket</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The bucket resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -290,7 +290,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="websiteurl_go">
-<a href="#websiteurl_go" style="color: inherit; text-decoration: inherit;">Website<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_go" style="color: inherit; text-decoration: inherit;">Website<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -302,7 +302,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bucket_nodejs">
-<a href="#bucket_nodejs" style="color: inherit; text-decoration: inherit;">bucket</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bucket_nodejs" style="color: inherit; text-decoration: inherit;">bucket</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Awss3Bucket</span>
@@ -310,7 +310,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The bucket resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -318,7 +318,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="websiteurl_nodejs">
-<a href="#websiteurl_nodejs" style="color: inherit; text-decoration: inherit;">website<wbr>Url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#websiteurl_nodejs" style="color: inherit; text-decoration: inherit;">website<wbr>Url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -330,7 +330,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bucket_python">
-<a href="#bucket_python" style="color: inherit; text-decoration: inherit;">bucket</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bucket_python" style="color: inherit; text-decoration: inherit;">bucket</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Bucket</span>
@@ -338,7 +338,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The bucket resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -346,7 +346,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="website_url_python">
-<a href="#website_url_python" style="color: inherit; text-decoration: inherit;">website_<wbr>url</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#website_url_python" style="color: inherit; text-decoration: inherit;">website_<wbr>url</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -370,7 +370,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -382,7 +382,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -394,7 +394,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -406,7 +406,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
@@ -158,7 +158,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="favoritecolor_csharp">
-<a href="#favoritecolor_csharp" style="color: inherit; text-decoration: inherit;">Favorite<wbr>Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_csharp" style="color: inherit; text-decoration: inherit;">Favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#color">Pulumi.<wbr>Configstation.<wbr>Color</a></span>
@@ -170,7 +170,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="favoritecolor_go">
-<a href="#favoritecolor_go" style="color: inherit; text-decoration: inherit;">Favorite<wbr>Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_go" style="color: inherit; text-decoration: inherit;">Favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#color">Color</a></span>
@@ -182,7 +182,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="favoritecolor_nodejs">
-<a href="#favoritecolor_nodejs" style="color: inherit; text-decoration: inherit;">favorite<wbr>Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_nodejs" style="color: inherit; text-decoration: inherit;">favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string | <a href="#color">Color</a></span>
@@ -194,7 +194,7 @@ The Provider resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="favorite_color_python">
-<a href="#favorite_color_python" style="color: inherit; text-decoration: inherit;">favorite_<wbr>color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favorite_color_python" style="color: inherit; text-decoration: inherit;">favorite_<wbr>color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str | <a href="#color">Color</a></span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
@@ -86,7 +86,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_csharp">
-<a href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getcustomdbrolesresult">Get<wbr>Custom<wbr>Db<wbr>Roles<wbr>Result</a></span>
@@ -98,7 +98,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_go">
-<a href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getcustomdbrolesresult">Get<wbr>Custom<wbr>Db<wbr>Roles<wbr>Result</a></span>
@@ -110,7 +110,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_nodejs">
-<a href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getcustomdbrolesresult">Get<wbr>Custom<wbr>Db<wbr>Roles<wbr>Result</a></span>
@@ -122,7 +122,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_python">
-<a href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#getcustomdbrolesresult">Get<wbr>Custom<wbr>Db<wbr>Roles<wbr>Result</a></span>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
@@ -62,7 +62,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="enums_csharp">
-<a href="#enums_csharp" style="color: inherit; text-decoration: inherit;">Enums</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#enums_csharp" style="color: inherit; text-decoration: inherit;">Enums</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;Union&lt;string, Pulumi.<wbr>My8110.<wbr>My<wbr>Enum&gt;&gt;</span>
@@ -74,7 +74,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="enums_go">
-<a href="#enums_go" style="color: inherit; text-decoration: inherit;">Enums</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#enums_go" style="color: inherit; text-decoration: inherit;">Enums</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -86,7 +86,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="enums_nodejs">
-<a href="#enums_nodejs" style="color: inherit; text-decoration: inherit;">enums</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#enums_nodejs" style="color: inherit; text-decoration: inherit;">enums</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">(string | My<wbr>Enum)[]</span>
@@ -98,7 +98,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="enums_python">
-<a href="#enums_python" style="color: inherit; text-decoration: inherit;">enums</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#enums_python" style="color: inherit; text-decoration: inherit;">enums</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[Union[str, My<wbr>Enum]]</span>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="foes_csharp">
-<a href="#foes_csharp" style="color: inherit; text-decoration: inherit;">Foes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foes_csharp" style="color: inherit; text-decoration: inherit;">Foes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Toy&gt;</span>
@@ -196,7 +196,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="friends_csharp">
-<a href="#friends_csharp" style="color: inherit; text-decoration: inherit;">Friends</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#friends_csharp" style="color: inherit; text-decoration: inherit;">Friends</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">List&lt;Toy&gt;</a></span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -212,7 +212,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="other_csharp">
-<a href="#other_csharp" style="color: inherit; text-decoration: inherit;">Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_csharp" style="color: inherit; text-decoration: inherit;">Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>God</span>
@@ -220,7 +220,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="toy_csharp">
-<a href="#toy_csharp" style="color: inherit; text-decoration: inherit;">Toy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#toy_csharp" style="color: inherit; text-decoration: inherit;">Toy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -232,7 +232,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="foes_go">
-<a href="#foes_go" style="color: inherit; text-decoration: inherit;">Foes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foes_go" style="color: inherit; text-decoration: inherit;">Foes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string]Toy</span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="friends_go">
-<a href="#friends_go" style="color: inherit; text-decoration: inherit;">Friends</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#friends_go" style="color: inherit; text-decoration: inherit;">Friends</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">[]Toy</a></span>
@@ -256,7 +256,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -264,7 +264,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="other_go">
-<a href="#other_go" style="color: inherit; text-decoration: inherit;">Other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_go" style="color: inherit; text-decoration: inherit;">Other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">God</span>
@@ -272,7 +272,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="toy_go">
-<a href="#toy_go" style="color: inherit; text-decoration: inherit;">Toy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#toy_go" style="color: inherit; text-decoration: inherit;">Toy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -284,7 +284,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -292,7 +292,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="foes_nodejs">
-<a href="#foes_nodejs" style="color: inherit; text-decoration: inherit;">foes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foes_nodejs" style="color: inherit; text-decoration: inherit;">foes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Toy}</span>
@@ -300,7 +300,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="friends_nodejs">
-<a href="#friends_nodejs" style="color: inherit; text-decoration: inherit;">friends</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#friends_nodejs" style="color: inherit; text-decoration: inherit;">friends</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy[]</a></span>
@@ -308,7 +308,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -316,7 +316,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="other_nodejs">
-<a href="#other_nodejs" style="color: inherit; text-decoration: inherit;">other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_nodejs" style="color: inherit; text-decoration: inherit;">other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">God</span>
@@ -324,7 +324,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="toy_nodejs">
-<a href="#toy_nodejs" style="color: inherit; text-decoration: inherit;">toy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#toy_nodejs" style="color: inherit; text-decoration: inherit;">toy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -336,7 +336,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -344,7 +344,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="foes_python">
-<a href="#foes_python" style="color: inherit; text-decoration: inherit;">foes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foes_python" style="color: inherit; text-decoration: inherit;">foes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Toy]</span>
@@ -352,7 +352,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="friends_python">
-<a href="#friends_python" style="color: inherit; text-decoration: inherit;">friends</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#friends_python" style="color: inherit; text-decoration: inherit;">friends</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Sequence[Toy]</a></span>
@@ -360,7 +360,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -368,7 +368,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="other_python">
-<a href="#other_python" style="color: inherit; text-decoration: inherit;">other</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#other_python" style="color: inherit; text-decoration: inherit;">other</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">God</span>
@@ -376,7 +376,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="toy_python">
-<a href="#toy_python" style="color: inherit; text-decoration: inherit;">toy</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#toy_python" style="color: inherit; text-decoration: inherit;">toy</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -400,7 +400,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_csharp">
-<a href="#associated_csharp" style="color: inherit; text-decoration: inherit;">Associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_csharp" style="color: inherit; text-decoration: inherit;">Associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_csharp">
-<a href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -416,7 +416,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_csharp">
-<a href="#wear_csharp" style="color: inherit; text-decoration: inherit;">Wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_csharp" style="color: inherit; text-decoration: inherit;">Wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -428,7 +428,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_go">
-<a href="#associated_go" style="color: inherit; text-decoration: inherit;">Associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_go" style="color: inherit; text-decoration: inherit;">Associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -436,7 +436,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_go">
-<a href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -444,7 +444,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_go">
-<a href="#wear_go" style="color: inherit; text-decoration: inherit;">Wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_go" style="color: inherit; text-decoration: inherit;">Wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -456,7 +456,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_nodejs">
-<a href="#associated_nodejs" style="color: inherit; text-decoration: inherit;">associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_nodejs" style="color: inherit; text-decoration: inherit;">associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -464,7 +464,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_nodejs">
-<a href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -472,7 +472,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_nodejs">
-<a href="#wear_nodejs" style="color: inherit; text-decoration: inherit;">wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_nodejs" style="color: inherit; text-decoration: inherit;">wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -484,7 +484,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_python">
-<a href="#associated_python" style="color: inherit; text-decoration: inherit;">associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_python" style="color: inherit; text-decoration: inherit;">associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -492,7 +492,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_python">
-<a href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -500,7 +500,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_python">
-<a href="#wear_python" style="color: inherit; text-decoration: inherit;">wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_python" style="color: inherit; text-decoration: inherit;">wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bone_csharp">
-<a href="#bone_csharp" style="color: inherit; text-decoration: inherit;">Bone</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bone_csharp" style="color: inherit; text-decoration: inherit;">Bone</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -200,7 +200,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -208,7 +208,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bone_go">
-<a href="#bone_go" style="color: inherit; text-decoration: inherit;">Bone</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bone_go" style="color: inherit; text-decoration: inherit;">Bone</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -220,7 +220,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -228,7 +228,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bone_nodejs">
-<a href="#bone_nodejs" style="color: inherit; text-decoration: inherit;">bone</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bone_nodejs" style="color: inherit; text-decoration: inherit;">bone</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="bone_python">
-<a href="#bone_python" style="color: inherit; text-decoration: inherit;">bone</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bone_python" style="color: inherit; text-decoration: inherit;">bone</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="backwards_csharp">
-<a href="#backwards_csharp" style="color: inherit; text-decoration: inherit;">Backwards</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backwards_csharp" style="color: inherit; text-decoration: inherit;">Backwards</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Dog</span>
@@ -200,7 +200,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -208,7 +208,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="backwards_go">
-<a href="#backwards_go" style="color: inherit; text-decoration: inherit;">Backwards</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backwards_go" style="color: inherit; text-decoration: inherit;">Backwards</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dog</span>
@@ -220,7 +220,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -228,7 +228,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="backwards_nodejs">
-<a href="#backwards_nodejs" style="color: inherit; text-decoration: inherit;">backwards</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backwards_nodejs" style="color: inherit; text-decoration: inherit;">backwards</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dog</span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="backwards_python">
-<a href="#backwards_python" style="color: inherit; text-decoration: inherit;">backwards</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#backwards_python" style="color: inherit; text-decoration: inherit;">backwards</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dog</span>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_csharp">
-<a href="#rec_csharp" style="color: inherit; text-decoration: inherit;">Rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_csharp" style="color: inherit; text-decoration: inherit;">Rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>
@@ -196,7 +196,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replace_csharp">
-<a href="#replace_csharp" style="color: inherit; text-decoration: inherit;">Replace</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_csharp" style="color: inherit; text-decoration: inherit;">Replace</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -208,7 +208,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_go">
-<a href="#rec_go" style="color: inherit; text-decoration: inherit;">Rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_go" style="color: inherit; text-decoration: inherit;">Rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>
@@ -224,7 +224,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replace_go">
-<a href="#replace_go" style="color: inherit; text-decoration: inherit;">Replace</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_go" style="color: inherit; text-decoration: inherit;">Replace</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -236,7 +236,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -244,7 +244,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_nodejs">
-<a href="#rec_nodejs" style="color: inherit; text-decoration: inherit;">rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_nodejs" style="color: inherit; text-decoration: inherit;">rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>
@@ -252,7 +252,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replace_nodejs">
-<a href="#replace_nodejs" style="color: inherit; text-decoration: inherit;">replace</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_nodejs" style="color: inherit; text-decoration: inherit;">replace</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -264,7 +264,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -272,7 +272,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_python">
-<a href="#rec_python" style="color: inherit; text-decoration: inherit;">rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_python" style="color: inherit; text-decoration: inherit;">rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>
@@ -280,7 +280,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="replace_python">
-<a href="#replace_python" style="color: inherit; text-decoration: inherit;">replace</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#replace_python" style="color: inherit; text-decoration: inherit;">replace</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -304,7 +304,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="rec1_csharp">
-<a href="#rec1_csharp" style="color: inherit; text-decoration: inherit;">Rec1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec1_csharp" style="color: inherit; text-decoration: inherit;">Rec1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>
@@ -316,7 +316,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="rec1_go">
-<a href="#rec1_go" style="color: inherit; text-decoration: inherit;">Rec1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec1_go" style="color: inherit; text-decoration: inherit;">Rec1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>
@@ -328,7 +328,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="rec1_nodejs">
-<a href="#rec1_nodejs" style="color: inherit; text-decoration: inherit;">rec1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec1_nodejs" style="color: inherit; text-decoration: inherit;">rec1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>
@@ -340,7 +340,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="rec1_python">
-<a href="#rec1_python" style="color: inherit; text-decoration: inherit;">rec1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec1_python" style="color: inherit; text-decoration: inherit;">rec1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rec">Rec</a></span>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="chew_csharp">
-<a href="#chew_csharp" style="color: inherit; text-decoration: inherit;">Chew</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chew_csharp" style="color: inherit; text-decoration: inherit;">Chew</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#chew">Chew</a></span>
@@ -196,7 +196,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="laser_csharp">
-<a href="#laser_csharp" style="color: inherit; text-decoration: inherit;">Laser</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#laser_csharp" style="color: inherit; text-decoration: inherit;">Laser</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#laser">Laser</a></span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="stuff_csharp">
-<a href="#stuff_csharp" style="color: inherit; text-decoration: inherit;">Stuff</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stuff_csharp" style="color: inherit; text-decoration: inherit;">Stuff</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">List&lt;Toy&gt;</a></span>
@@ -212,7 +212,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="wanted_csharp">
-<a href="#wanted_csharp" style="color: inherit; text-decoration: inherit;">Wanted</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wanted_csharp" style="color: inherit; text-decoration: inherit;">Wanted</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">List&lt;Toy&gt;</a></span>
@@ -224,7 +224,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -232,7 +232,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="chew_go">
-<a href="#chew_go" style="color: inherit; text-decoration: inherit;">Chew</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chew_go" style="color: inherit; text-decoration: inherit;">Chew</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#chew">Chew</a></span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="laser_go">
-<a href="#laser_go" style="color: inherit; text-decoration: inherit;">Laser</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#laser_go" style="color: inherit; text-decoration: inherit;">Laser</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#laser">Laser</a></span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="stuff_go">
-<a href="#stuff_go" style="color: inherit; text-decoration: inherit;">Stuff</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stuff_go" style="color: inherit; text-decoration: inherit;">Stuff</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">[]Toy</a></span>
@@ -256,7 +256,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="wanted_go">
-<a href="#wanted_go" style="color: inherit; text-decoration: inherit;">Wanted</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wanted_go" style="color: inherit; text-decoration: inherit;">Wanted</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">[]Toy</a></span>
@@ -268,7 +268,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -276,7 +276,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="chew_nodejs">
-<a href="#chew_nodejs" style="color: inherit; text-decoration: inherit;">chew</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chew_nodejs" style="color: inherit; text-decoration: inherit;">chew</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#chew">Chew</a></span>
@@ -284,7 +284,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="laser_nodejs">
-<a href="#laser_nodejs" style="color: inherit; text-decoration: inherit;">laser</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#laser_nodejs" style="color: inherit; text-decoration: inherit;">laser</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#laser">Laser</a></span>
@@ -292,7 +292,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="stuff_nodejs">
-<a href="#stuff_nodejs" style="color: inherit; text-decoration: inherit;">stuff</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stuff_nodejs" style="color: inherit; text-decoration: inherit;">stuff</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy[]</a></span>
@@ -300,7 +300,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="wanted_nodejs">
-<a href="#wanted_nodejs" style="color: inherit; text-decoration: inherit;">wanted</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wanted_nodejs" style="color: inherit; text-decoration: inherit;">wanted</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy[]</a></span>
@@ -312,7 +312,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -320,7 +320,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="chew_python">
-<a href="#chew_python" style="color: inherit; text-decoration: inherit;">chew</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#chew_python" style="color: inherit; text-decoration: inherit;">chew</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#chew">Chew</a></span>
@@ -328,7 +328,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="laser_python">
-<a href="#laser_python" style="color: inherit; text-decoration: inherit;">laser</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#laser_python" style="color: inherit; text-decoration: inherit;">laser</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#laser">Laser</a></span>
@@ -336,7 +336,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="stuff_python">
-<a href="#stuff_python" style="color: inherit; text-decoration: inherit;">stuff</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stuff_python" style="color: inherit; text-decoration: inherit;">stuff</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Sequence[Toy]</a></span>
@@ -344,7 +344,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="wanted_python">
-<a href="#wanted_python" style="color: inherit; text-decoration: inherit;">wanted</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wanted_python" style="color: inherit; text-decoration: inherit;">wanted</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Sequence[Toy]</a></span>
@@ -368,7 +368,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="owner_csharp">
-<a href="#owner_csharp" style="color: inherit; text-decoration: inherit;">Owner</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owner_csharp" style="color: inherit; text-decoration: inherit;">Owner</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Dog</span>
@@ -380,7 +380,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="owner_go">
-<a href="#owner_go" style="color: inherit; text-decoration: inherit;">Owner</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owner_go" style="color: inherit; text-decoration: inherit;">Owner</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dog</span>
@@ -392,7 +392,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="owner_nodejs">
-<a href="#owner_nodejs" style="color: inherit; text-decoration: inherit;">owner</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owner_nodejs" style="color: inherit; text-decoration: inherit;">owner</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dog</span>
@@ -404,7 +404,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="owner_python">
-<a href="#owner_python" style="color: inherit; text-decoration: inherit;">owner</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#owner_python" style="color: inherit; text-decoration: inherit;">owner</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dog</span>
@@ -418,7 +418,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="animal_csharp">
-<a href="#animal_csharp" style="color: inherit; text-decoration: inherit;">Animal</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#animal_csharp" style="color: inherit; text-decoration: inherit;">Animal</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Cat</span>
@@ -426,7 +426,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="batteries_csharp">
-<a href="#batteries_csharp" style="color: inherit; text-decoration: inherit;">Batteries</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#batteries_csharp" style="color: inherit; text-decoration: inherit;">Batteries</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -434,7 +434,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="light_csharp">
-<a href="#light_csharp" style="color: inherit; text-decoration: inherit;">Light</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#light_csharp" style="color: inherit; text-decoration: inherit;">Light</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -446,7 +446,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="animal_go">
-<a href="#animal_go" style="color: inherit; text-decoration: inherit;">Animal</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#animal_go" style="color: inherit; text-decoration: inherit;">Animal</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Cat</span>
@@ -454,7 +454,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="batteries_go">
-<a href="#batteries_go" style="color: inherit; text-decoration: inherit;">Batteries</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#batteries_go" style="color: inherit; text-decoration: inherit;">Batteries</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -462,7 +462,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="light_go">
-<a href="#light_go" style="color: inherit; text-decoration: inherit;">Light</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#light_go" style="color: inherit; text-decoration: inherit;">Light</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -474,7 +474,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="animal_nodejs">
-<a href="#animal_nodejs" style="color: inherit; text-decoration: inherit;">animal</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#animal_nodejs" style="color: inherit; text-decoration: inherit;">animal</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Cat</span>
@@ -482,7 +482,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="batteries_nodejs">
-<a href="#batteries_nodejs" style="color: inherit; text-decoration: inherit;">batteries</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#batteries_nodejs" style="color: inherit; text-decoration: inherit;">batteries</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -490,7 +490,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="light_nodejs">
-<a href="#light_nodejs" style="color: inherit; text-decoration: inherit;">light</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#light_nodejs" style="color: inherit; text-decoration: inherit;">light</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -502,7 +502,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="animal_python">
-<a href="#animal_python" style="color: inherit; text-decoration: inherit;">animal</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#animal_python" style="color: inherit; text-decoration: inherit;">animal</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Cat</span>
@@ -510,7 +510,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="batteries_python">
-<a href="#batteries_python" style="color: inherit; text-decoration: inherit;">batteries</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#batteries_python" style="color: inherit; text-decoration: inherit;">batteries</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -518,7 +518,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="light_python">
-<a href="#light_python" style="color: inherit; text-decoration: inherit;">light</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#light_python" style="color: inherit; text-decoration: inherit;">light</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>
@@ -532,7 +532,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_csharp">
-<a href="#associated_csharp" style="color: inherit; text-decoration: inherit;">Associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_csharp" style="color: inherit; text-decoration: inherit;">Associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -540,7 +540,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_csharp">
-<a href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -548,7 +548,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_csharp">
-<a href="#wear_csharp" style="color: inherit; text-decoration: inherit;">Wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_csharp" style="color: inherit; text-decoration: inherit;">Wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">double</span>
@@ -560,7 +560,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_go">
-<a href="#associated_go" style="color: inherit; text-decoration: inherit;">Associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_go" style="color: inherit; text-decoration: inherit;">Associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -568,7 +568,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_go">
-<a href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -576,7 +576,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_go">
-<a href="#wear_go" style="color: inherit; text-decoration: inherit;">Wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_go" style="color: inherit; text-decoration: inherit;">Wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float64</span>
@@ -588,7 +588,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_nodejs">
-<a href="#associated_nodejs" style="color: inherit; text-decoration: inherit;">associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_nodejs" style="color: inherit; text-decoration: inherit;">associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -596,7 +596,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_nodejs">
-<a href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -604,7 +604,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_nodejs">
-<a href="#wear_nodejs" style="color: inherit; text-decoration: inherit;">wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_nodejs" style="color: inherit; text-decoration: inherit;">wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -616,7 +616,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="associated_python">
-<a href="#associated_python" style="color: inherit; text-decoration: inherit;">associated</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#associated_python" style="color: inherit; text-decoration: inherit;">associated</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#toy">Toy</a></span>
@@ -624,7 +624,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_python">
-<a href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -632,7 +632,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="wear_python">
-<a href="#wear_python" style="color: inherit; text-decoration: inherit;">wear</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#wear_python" style="color: inherit; text-decoration: inherit;">wear</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">float</span>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
@@ -159,7 +159,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -167,7 +167,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_csharp">
-<a href="#pets_csharp" style="color: inherit; text-decoration: inherit;">Pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_csharp" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">List&lt;Pet<wbr>Args&gt;</a></span>
@@ -179,7 +179,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -187,7 +187,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_go">
-<a href="#pets_go" style="color: inherit; text-decoration: inherit;">Pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_go" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">[]Pet<wbr>Type<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -207,7 +207,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_nodejs">
-<a href="#pets_nodejs" style="color: inherit; text-decoration: inherit;">pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_nodejs" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Pet<wbr>Args[]</a></span>
@@ -219,7 +219,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -227,7 +227,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_python">
-<a href="#pets_python" style="color: inherit; text-decoration: inherit;">pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_python" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Sequence[Pet<wbr>Args]</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -306,7 +306,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -318,7 +318,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -330,7 +330,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -158,7 +158,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
@@ -159,7 +159,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -167,7 +167,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_csharp">
-<a href="#pets_csharp" style="color: inherit; text-decoration: inherit;">Pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_csharp" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">List&lt;Pet<wbr>Args&gt;</a></span>
@@ -179,7 +179,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -187,7 +187,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_go">
-<a href="#pets_go" style="color: inherit; text-decoration: inherit;">Pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_go" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">[]Pet<wbr>Type<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -207,7 +207,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_nodejs">
-<a href="#pets_nodejs" style="color: inherit; text-decoration: inherit;">pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_nodejs" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Pet<wbr>Args[]</a></span>
@@ -219,7 +219,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -227,7 +227,7 @@ The Person resource accepts the following [input]({{< relref "/docs/intro/concep
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="pets_python">
-<a href="#pets_python" style="color: inherit; text-decoration: inherit;">pets</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_python" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#pet">Sequence[Pet<wbr>Args]</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -306,7 +306,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -318,7 +318,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -330,7 +330,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
@@ -158,7 +158,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_csharp">
-<a href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_go">
-<a href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_nodejs">
-<a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Pet resource accepts the following [input]({{< relref "/docs/intro/concepts/
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="name_python">
-<a href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -188,7 +188,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_csharp">
-<a href="#rec_csharp" style="color: inherit; text-decoration: inherit;">Rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_csharp" style="color: inherit; text-decoration: inherit;">Rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Rec</span>
@@ -200,7 +200,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -208,7 +208,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_go">
-<a href="#rec_go" style="color: inherit; text-decoration: inherit;">Rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_go" style="color: inherit; text-decoration: inherit;">Rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Rec</span>
@@ -220,7 +220,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -228,7 +228,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_nodejs">
-<a href="#rec_nodejs" style="color: inherit; text-decoration: inherit;">rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_nodejs" style="color: inherit; text-decoration: inherit;">rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Rec</span>
@@ -240,7 +240,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -248,7 +248,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="rec_python">
-<a href="#rec_python" style="color: inherit; text-decoration: inherit;">rec</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#rec_python" style="color: inherit; text-decoration: inherit;">rec</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Rec</span>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -159,7 +159,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_csharp">
-<a href="#varieties_csharp" style="color: inherit; text-decoration: inherit;">Varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_csharp" style="color: inherit; text-decoration: inherit;">Varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">List&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Rubber<wbr>Tree<wbr>Variety&gt;</a></span>
@@ -167,7 +167,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_csharp">
-<a href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;</span>
@@ -179,7 +179,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_go">
-<a href="#varieties_go" style="color: inherit; text-decoration: inherit;">Varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_go" style="color: inherit; text-decoration: inherit;">Varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">[]Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -187,7 +187,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_go">
-<a href="#sizes_go" style="color: inherit; text-decoration: inherit;">Sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_go" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string]Tree<wbr>Size</span>
@@ -199,7 +199,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_nodejs">
-<a href="#varieties_nodejs" style="color: inherit; text-decoration: inherit;">varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_nodejs" style="color: inherit; text-decoration: inherit;">varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety[]</a></span>
@@ -207,7 +207,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_nodejs">
-<a href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Tree<wbr>Size}</span>
@@ -219,7 +219,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="varieties_python">
-<a href="#varieties_python" style="color: inherit; text-decoration: inherit;">varieties</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#varieties_python" style="color: inherit; text-decoration: inherit;">varieties</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Sequence[Rubber<wbr>Tree<wbr>Variety]</a></span>
@@ -227,7 +227,7 @@ The Nursery resource accepts the following [input]({{< relref "/docs/intro/conce
     <dd>{{% md %}}The varieties available{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="sizes_python">
-<a href="#sizes_python" style="color: inherit; text-decoration: inherit;">sizes</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_python" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Tree<wbr>Size]</span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -162,7 +162,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_csharp">
-<a href="#diameter_csharp" style="color: inherit; text-decoration: inherit;">Diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_csharp" style="color: inherit; text-decoration: inherit;">Diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Diameter</a></span>
@@ -170,7 +170,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_csharp">
-<a href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_csharp" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -178,7 +178,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_csharp">
-<a href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args</a></span>
@@ -186,7 +186,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_csharp">
-<a href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
@@ -194,7 +194,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_csharp">
-<a href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size</a></span>
@@ -206,7 +206,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_go">
-<a href="#diameter_go" style="color: inherit; text-decoration: inherit;">Diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_go" style="color: inherit; text-decoration: inherit;">Diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -214,7 +214,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_go">
-<a href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_go" style="color: inherit; text-decoration: inherit;">Type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -222,7 +222,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_go">
-<a href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -230,7 +230,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_go">
-<a href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -238,7 +238,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_go">
-<a href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -250,7 +250,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_nodejs">
-<a href="#diameter_nodejs" style="color: inherit; text-decoration: inherit;">diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_nodejs" style="color: inherit; text-decoration: inherit;">diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -258,7 +258,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_nodejs">
-<a href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_nodejs" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -266,7 +266,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_nodejs">
-<a href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -274,7 +274,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_nodejs">
-<a href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -282,7 +282,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_nodejs">
-<a href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -294,7 +294,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="diameter_python">
-<a href="#diameter_python" style="color: inherit; text-decoration: inherit;">diameter</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#diameter_python" style="color: inherit; text-decoration: inherit;">diameter</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#diameter">Diameter</a></span>
@@ -302,7 +302,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="type_python">
-<a href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#type_python" style="color: inherit; text-decoration: inherit;">type</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -310,7 +310,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="container_python">
-<a href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
@@ -318,7 +318,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="farm_python">
-<a href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | str</span>
@@ -326,7 +326,7 @@ The RubberTree resource accepts the following [input]({{< relref "/docs/intro/co
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="size_python">
-<a href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
@@ -345,7 +345,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -357,7 +357,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -369,7 +369,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -381,7 +381,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -519,7 +519,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_csharp">
-<a href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
@@ -531,7 +531,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_go">
-<a href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -543,7 +543,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_nodejs">
-<a href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | string</span>
@@ -555,7 +555,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="state_farm_python">
-<a href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#farm">Farm</a> | str</span>
@@ -578,7 +578,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_csharp">
-<a href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Pulumi.<wbr>Plant.<wbr>Container<wbr>Size</a></span>
@@ -586,7 +586,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_csharp">
-<a href="#brightness_csharp" style="color: inherit; text-decoration: inherit;">Brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_csharp" style="color: inherit; text-decoration: inherit;">Brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Pulumi.<wbr>Plant.<wbr>Container<wbr>Brightness</a></span>
@@ -594,7 +594,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_csharp">
-<a href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_csharp" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Pulumi.<wbr>Plant.<wbr>Container<wbr>Color</a> | string</span>
@@ -602,7 +602,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_csharp">
-<a href="#material_csharp" style="color: inherit; text-decoration: inherit;">Material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_csharp" style="color: inherit; text-decoration: inherit;">Material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -614,7 +614,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_go">
-<a href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -622,7 +622,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_go">
-<a href="#brightness_go" style="color: inherit; text-decoration: inherit;">Brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_go" style="color: inherit; text-decoration: inherit;">Brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -630,7 +630,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_go">
-<a href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_go" style="color: inherit; text-decoration: inherit;">Color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | string</span>
@@ -638,7 +638,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_go">
-<a href="#material_go" style="color: inherit; text-decoration: inherit;">Material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_go" style="color: inherit; text-decoration: inherit;">Material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -650,7 +650,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_nodejs">
-<a href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -658,7 +658,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_nodejs">
-<a href="#brightness_nodejs" style="color: inherit; text-decoration: inherit;">brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_nodejs" style="color: inherit; text-decoration: inherit;">brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -666,7 +666,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_nodejs">
-<a href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_nodejs" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | string</span>
@@ -674,7 +674,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_nodejs">
-<a href="#material_nodejs" style="color: inherit; text-decoration: inherit;">material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_nodejs" style="color: inherit; text-decoration: inherit;">material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -686,7 +686,7 @@ The following state arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="size_python">
-<a href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containersize">Container<wbr>Size</a></span>
@@ -694,7 +694,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="brightness_python">
-<a href="#brightness_python" style="color: inherit; text-decoration: inherit;">brightness</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#brightness_python" style="color: inherit; text-decoration: inherit;">brightness</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containerbrightness">Container<wbr>Brightness</a></span>
@@ -702,7 +702,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="color_python">
-<a href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#color_python" style="color: inherit; text-decoration: inherit;">color</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#containercolor">Container<wbr>Color</a> | str</span>
@@ -710,7 +710,7 @@ The following state arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="material_python">
-<a href="#material_python" style="color: inherit; text-decoration: inherit;">material</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#material_python" style="color: inherit; text-decoration: inherit;">material</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -267,7 +267,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_profilename_csharp">
-<a href="#getKubeconfig_arg_profilename_csharp" style="color: inherit; text-decoration: inherit;">Profile<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_profilename_csharp" style="color: inherit; text-decoration: inherit;">Profile<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -275,7 +275,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_rolearn_csharp">
-<a href="#getKubeconfig_arg_rolearn_csharp" style="color: inherit; text-decoration: inherit;">Role<wbr>Arn</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_rolearn_csharp" style="color: inherit; text-decoration: inherit;">Role<wbr>Arn</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -287,7 +287,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_profilename_go">
-<a href="#getKubeconfig_arg_profilename_go" style="color: inherit; text-decoration: inherit;">Profile<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_profilename_go" style="color: inherit; text-decoration: inherit;">Profile<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -295,7 +295,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_rolearn_go">
-<a href="#getKubeconfig_arg_rolearn_go" style="color: inherit; text-decoration: inherit;">Role<wbr>Arn</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_rolearn_go" style="color: inherit; text-decoration: inherit;">Role<wbr>Arn</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -307,7 +307,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_profilename_nodejs">
-<a href="#getKubeconfig_arg_profilename_nodejs" style="color: inherit; text-decoration: inherit;">profile<wbr>Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_profilename_nodejs" style="color: inherit; text-decoration: inherit;">profile<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -315,7 +315,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_rolearn_nodejs">
-<a href="#getKubeconfig_arg_rolearn_nodejs" style="color: inherit; text-decoration: inherit;">role<wbr>Arn</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_rolearn_nodejs" style="color: inherit; text-decoration: inherit;">role<wbr>Arn</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -327,7 +327,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_profile_name_python">
-<a href="#getKubeconfig_arg_profile_name_python" style="color: inherit; text-decoration: inherit;">profile_<wbr>name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_profile_name_python" style="color: inherit; text-decoration: inherit;">profile_<wbr>name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -335,7 +335,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="getKubeconfig_arg_role_arn_python">
-<a href="#getKubeconfig_arg_role_arn_python" style="color: inherit; text-decoration: inherit;">role_<wbr>arn</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_arg_role_arn_python" style="color: inherit; text-decoration: inherit;">role_<wbr>arn</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -352,7 +352,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="getKubeconfig_result_kubeconfig_csharp">
-<a href="#getKubeconfig_result_kubeconfig_csharp" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_result_kubeconfig_csharp" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -364,7 +364,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="getKubeconfig_result_kubeconfig_go">
-<a href="#getKubeconfig_result_kubeconfig_go" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_result_kubeconfig_go" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -376,7 +376,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="getKubeconfig_result_kubeconfig_nodejs">
-<a href="#getKubeconfig_result_kubeconfig_nodejs" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_result_kubeconfig_nodejs" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -388,7 +388,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="getKubeconfig_result_kubeconfig_python">
-<a href="#getKubeconfig_result_kubeconfig_python" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#getKubeconfig_result_kubeconfig_python" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -279,7 +279,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bar_arg_bazrequired_csharp">
-<a href="#bar_arg_bazrequired_csharp" style="color: inherit; text-decoration: inherit;">Baz<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bazrequired_csharp" style="color: inherit; text-decoration: inherit;">Baz<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Pulumi.<wbr>Example.<wbr>Nested.<wbr>Inputs.<wbr>Baz</a></span>
@@ -287,7 +287,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_boolvaluerequired_csharp">
-<a href="#bar_arg_boolvaluerequired_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvaluerequired_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -295,7 +295,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_namerequired_csharp">
-<a href="#bar_arg_namerequired_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_namerequired_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
@@ -303,7 +303,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_csharp">
-<a href="#bar_arg_stringvaluerequired_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -311,7 +311,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_baz_csharp">
-<a href="#bar_arg_baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Pulumi.<wbr>Example.<wbr>Nested.<wbr>Inputs.<wbr>Baz</a></span>
@@ -319,7 +319,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_bazplain_csharp">
-<a href="#bar_arg_bazplain_csharp" style="color: inherit; text-decoration: inherit;">Baz<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bazplain_csharp" style="color: inherit; text-decoration: inherit;">Baz<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Pulumi.<wbr>Example.<wbr>Nested.<wbr>Inputs.<wbr>Baz</a></span>
@@ -327,7 +327,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_boolvalue_csharp">
-<a href="#bar_arg_boolvalue_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvalue_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -335,7 +335,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_boolvalueplain_csharp">
-<a href="#bar_arg_boolvalueplain_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvalueplain_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -343,7 +343,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_name_csharp">
-<a href="#bar_arg_name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
@@ -351,7 +351,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_csharp">
-<a href="#bar_arg_nameplain_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
@@ -359,7 +359,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_csharp">
-<a href="#bar_arg_stringvalue_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -367,7 +367,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalueplain_csharp">
-<a href="#bar_arg_stringvalueplain_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalueplain_csharp" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -379,7 +379,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bar_arg_bazrequired_go">
-<a href="#bar_arg_bazrequired_go" style="color: inherit; text-decoration: inherit;">Baz<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bazrequired_go" style="color: inherit; text-decoration: inherit;">Baz<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Baz</a></span>
@@ -387,7 +387,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_boolvaluerequired_go">
-<a href="#bar_arg_boolvaluerequired_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvaluerequired_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -395,7 +395,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_namerequired_go">
-<a href="#bar_arg_namerequired_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_namerequired_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -403,7 +403,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_go">
-<a href="#bar_arg_stringvaluerequired_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -411,7 +411,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_baz_go">
-<a href="#bar_arg_baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Baz</a></span>
@@ -419,7 +419,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_bazplain_go">
-<a href="#bar_arg_bazplain_go" style="color: inherit; text-decoration: inherit;">Baz<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bazplain_go" style="color: inherit; text-decoration: inherit;">Baz<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Baz</a></span>
@@ -427,7 +427,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_boolvalue_go">
-<a href="#bar_arg_boolvalue_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvalue_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -435,7 +435,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_boolvalueplain_go">
-<a href="#bar_arg_boolvalueplain_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvalueplain_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -443,7 +443,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_name_go">
-<a href="#bar_arg_name_go" style="color: inherit; text-decoration: inherit;">Name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_name_go" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -451,7 +451,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_go">
-<a href="#bar_arg_nameplain_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -459,7 +459,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_go">
-<a href="#bar_arg_stringvalue_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -467,7 +467,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalueplain_go">
-<a href="#bar_arg_stringvalueplain_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalueplain_go" style="color: inherit; text-decoration: inherit;">String<wbr>Value<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -479,7 +479,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bar_arg_bazrequired_nodejs">
-<a href="#bar_arg_bazrequired_nodejs" style="color: inherit; text-decoration: inherit;">baz<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bazrequired_nodejs" style="color: inherit; text-decoration: inherit;">baz<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">nested<wbr>Baz</a></span>
@@ -487,7 +487,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_boolvaluerequired_nodejs">
-<a href="#bar_arg_boolvaluerequired_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvaluerequired_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -495,7 +495,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_namerequired_nodejs">
-<a href="#bar_arg_namerequired_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_namerequired_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
@@ -503,7 +503,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_stringvaluerequired_nodejs">
-<a href="#bar_arg_stringvaluerequired_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value<wbr>Required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvaluerequired_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value<wbr>Required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -511,7 +511,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_baz_nodejs">
-<a href="#bar_arg_baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">nested<wbr>Baz</a></span>
@@ -519,7 +519,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_bazplain_nodejs">
-<a href="#bar_arg_bazplain_nodejs" style="color: inherit; text-decoration: inherit;">baz<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bazplain_nodejs" style="color: inherit; text-decoration: inherit;">baz<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">nested<wbr>Baz</a></span>
@@ -527,7 +527,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_boolvalue_nodejs">
-<a href="#bar_arg_boolvalue_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvalue_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -535,7 +535,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_boolvalueplain_nodejs">
-<a href="#bar_arg_boolvalueplain_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_boolvalueplain_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -543,7 +543,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_name_nodejs">
-<a href="#bar_arg_name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
@@ -551,7 +551,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_nameplain_nodejs">
-<a href="#bar_arg_nameplain_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_nameplain_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
@@ -559,7 +559,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalue_nodejs">
-<a href="#bar_arg_stringvalue_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalue_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -567,7 +567,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_stringvalueplain_nodejs">
-<a href="#bar_arg_stringvalueplain_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value<wbr>Plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_stringvalueplain_nodejs" style="color: inherit; text-decoration: inherit;">string<wbr>Value<wbr>Plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -579,7 +579,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="bar_arg_baz_required_python">
-<a href="#bar_arg_baz_required_python" style="color: inherit; text-decoration: inherit;">baz_<wbr>required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_baz_required_python" style="color: inherit; text-decoration: inherit;">baz_<wbr>required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Baz</a></span>
@@ -587,7 +587,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_bool_value_required_python">
-<a href="#bar_arg_bool_value_required_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value_<wbr>required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bool_value_required_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value_<wbr>required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -595,7 +595,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_name_required_python">
-<a href="#bar_arg_name_required_python" style="color: inherit; text-decoration: inherit;">name_<wbr>required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_name_required_python" style="color: inherit; text-decoration: inherit;">name_<wbr>required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -603,7 +603,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="bar_arg_string_value_required_python">
-<a href="#bar_arg_string_value_required_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value_<wbr>required</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_string_value_required_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value_<wbr>required</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -611,7 +611,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_baz_python">
-<a href="#bar_arg_baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Baz</a></span>
@@ -619,7 +619,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_baz_plain_python">
-<a href="#bar_arg_baz_plain_python" style="color: inherit; text-decoration: inherit;">baz_<wbr>plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_baz_plain_python" style="color: inherit; text-decoration: inherit;">baz_<wbr>plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#baz">Baz</a></span>
@@ -627,7 +627,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_bool_value_python">
-<a href="#bar_arg_bool_value_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bool_value_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -635,7 +635,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_bool_value_plain_python">
-<a href="#bar_arg_bool_value_plain_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value_<wbr>plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_bool_value_plain_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value_<wbr>plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -643,7 +643,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_name_python">
-<a href="#bar_arg_name_python" style="color: inherit; text-decoration: inherit;">name</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -651,7 +651,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_name_plain_python">
-<a href="#bar_arg_name_plain_python" style="color: inherit; text-decoration: inherit;">name_<wbr>plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_name_plain_python" style="color: inherit; text-decoration: inherit;">name_<wbr>plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
@@ -659,7 +659,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_string_value_python">
-<a href="#bar_arg_string_value_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_string_value_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -667,7 +667,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_arg_string_value_plain_python">
-<a href="#bar_arg_string_value_plain_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value_<wbr>plain</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_arg_string_value_plain_python" style="color: inherit; text-decoration: inherit;">string_<wbr>value_<wbr>plain</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -684,7 +684,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bar_result_somevalue_csharp">
-<a href="#bar_result_somevalue_csharp" style="color: inherit; text-decoration: inherit;">Some<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_result_somevalue_csharp" style="color: inherit; text-decoration: inherit;">Some<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -696,7 +696,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bar_result_somevalue_go">
-<a href="#bar_result_somevalue_go" style="color: inherit; text-decoration: inherit;">Some<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_result_somevalue_go" style="color: inherit; text-decoration: inherit;">Some<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -708,7 +708,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bar_result_somevalue_nodejs">
-<a href="#bar_result_somevalue_nodejs" style="color: inherit; text-decoration: inherit;">some<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_result_somevalue_nodejs" style="color: inherit; text-decoration: inherit;">some<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -720,7 +720,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="bar_result_some_value_python">
-<a href="#bar_result_some_value_python" style="color: inherit; text-decoration: inherit;">some_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_result_some_value_python" style="color: inherit; text-decoration: inherit;">some_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -803,7 +803,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="generateKubeconfig_arg_boolvalue_csharp">
-<a href="#generateKubeconfig_arg_boolvalue_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_arg_boolvalue_csharp" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -815,7 +815,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="generateKubeconfig_arg_boolvalue_go">
-<a href="#generateKubeconfig_arg_boolvalue_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_arg_boolvalue_go" style="color: inherit; text-decoration: inherit;">Bool<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -827,7 +827,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="generateKubeconfig_arg_boolvalue_nodejs">
-<a href="#generateKubeconfig_arg_boolvalue_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_arg_boolvalue_nodejs" style="color: inherit; text-decoration: inherit;">bool<wbr>Value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -839,7 +839,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="generateKubeconfig_arg_bool_value_python">
-<a href="#generateKubeconfig_arg_bool_value_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_arg_bool_value_python" style="color: inherit; text-decoration: inherit;">bool_<wbr>value</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -856,7 +856,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="generateKubeconfig_result_kubeconfig_csharp">
-<a href="#generateKubeconfig_result_kubeconfig_csharp" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_result_kubeconfig_csharp" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -868,7 +868,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="generateKubeconfig_result_kubeconfig_go">
-<a href="#generateKubeconfig_result_kubeconfig_go" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_result_kubeconfig_go" style="color: inherit; text-decoration: inherit;">Kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -880,7 +880,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="generateKubeconfig_result_kubeconfig_nodejs">
-<a href="#generateKubeconfig_result_kubeconfig_nodejs" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_result_kubeconfig_nodejs" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -892,7 +892,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="generateKubeconfig_result_kubeconfig_python">
-<a href="#generateKubeconfig_result_kubeconfig_python" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#generateKubeconfig_result_kubeconfig_python" style="color: inherit; text-decoration: inherit;">kubeconfig</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -917,7 +917,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="hello_csharp">
-<a href="#hello_csharp" style="color: inherit; text-decoration: inherit;">Hello</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hello_csharp" style="color: inherit; text-decoration: inherit;">Hello</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -925,7 +925,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="world_csharp">
-<a href="#world_csharp" style="color: inherit; text-decoration: inherit;">World</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#world_csharp" style="color: inherit; text-decoration: inherit;">World</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -937,7 +937,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="hello_go">
-<a href="#hello_go" style="color: inherit; text-decoration: inherit;">Hello</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hello_go" style="color: inherit; text-decoration: inherit;">Hello</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -945,7 +945,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="world_go">
-<a href="#world_go" style="color: inherit; text-decoration: inherit;">World</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#world_go" style="color: inherit; text-decoration: inherit;">World</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -957,7 +957,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="hello_nodejs">
-<a href="#hello_nodejs" style="color: inherit; text-decoration: inherit;">hello</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hello_nodejs" style="color: inherit; text-decoration: inherit;">hello</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -965,7 +965,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="world_nodejs">
-<a href="#world_nodejs" style="color: inherit; text-decoration: inherit;">world</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#world_nodejs" style="color: inherit; text-decoration: inherit;">world</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -977,7 +977,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="hello_python">
-<a href="#hello_python" style="color: inherit; text-decoration: inherit;">hello</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#hello_python" style="color: inherit; text-decoration: inherit;">hello</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -985,7 +985,7 @@ The following arguments are supported:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="world_python">
-<a href="#world_python" style="color: inherit; text-decoration: inherit;">world</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#world_python" style="color: inherit; text-decoration: inherit;">world</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -166,7 +166,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -174,7 +174,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_csharp">
-<a href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -182,7 +182,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_csharp">
-<a href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -190,7 +190,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -198,7 +198,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -206,7 +206,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">List&lt;Foo<wbr>Args&gt;</a></span>
@@ -214,7 +214,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_csharp">
-<a href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -222,7 +222,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_csharp">
-<a href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -230,7 +230,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -242,7 +242,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -250,7 +250,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_go">
-<a href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -258,7 +258,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_go">
-<a href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -266,7 +266,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -274,7 +274,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -282,7 +282,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">[]Foo<wbr>Args</a></span>
@@ -290,7 +290,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_go">
-<a href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -298,7 +298,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_go">
-<a href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -306,7 +306,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -318,7 +318,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -326,7 +326,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_nodejs">
-<a href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -334,7 +334,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_nodejs">
-<a href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -342,7 +342,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -350,7 +350,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -358,7 +358,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args[]</a></span>
@@ -366,7 +366,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_nodejs">
-<a href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -374,7 +374,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_nodejs">
-<a href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -382,7 +382,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -394,7 +394,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -402,7 +402,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_python">
-<a href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -410,7 +410,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_python">
-<a href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -418,7 +418,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -426,7 +426,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -434,7 +434,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Sequence[Foo<wbr>Args]</a></span>
@@ -442,7 +442,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_python">
-<a href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -450,7 +450,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_python">
-<a href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -458,7 +458,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -477,7 +477,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -489,7 +489,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -501,7 +501,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -513,7 +513,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -537,7 +537,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -545,7 +545,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_csharp">
-<a href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -553,7 +553,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_csharp">
-<a href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -561,7 +561,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -569,7 +569,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_csharp">
-<a href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -577,7 +577,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_csharp">
-<a href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -589,7 +589,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -597,7 +597,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_go">
-<a href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -605,7 +605,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_go">
-<a href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -613,7 +613,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -621,7 +621,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_go">
-<a href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -629,7 +629,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_go">
-<a href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -641,7 +641,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -649,7 +649,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_nodejs">
-<a href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -657,7 +657,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_nodejs">
-<a href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -665,7 +665,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -673,7 +673,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_nodejs">
-<a href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -681,7 +681,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_nodejs">
-<a href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -693,7 +693,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -701,7 +701,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_python">
-<a href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -709,7 +709,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_python">
-<a href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -717,7 +717,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -725,7 +725,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_python">
-<a href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -733,7 +733,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_python">
-<a href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
@@ -167,7 +167,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -175,7 +175,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_csharp">
-<a href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -183,7 +183,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_csharp">
-<a href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -191,7 +191,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -199,7 +199,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -207,7 +207,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">List&lt;Foo<wbr>Args&gt;</a></span>
@@ -215,7 +215,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bazmap_csharp">
-<a href="#bazmap_csharp" style="color: inherit; text-decoration: inherit;">Baz<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bazmap_csharp" style="color: inherit; text-decoration: inherit;">Baz<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Foo<wbr>Args&gt;</span>
@@ -223,7 +223,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_csharp">
-<a href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -231,7 +231,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_csharp">
-<a href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -239,7 +239,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -251,7 +251,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -259,7 +259,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_go">
-<a href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -267,7 +267,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_go">
-<a href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -275,7 +275,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -283,7 +283,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -291,7 +291,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">[]Foo<wbr>Args</a></span>
@@ -299,7 +299,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bazmap_go">
-<a href="#bazmap_go" style="color: inherit; text-decoration: inherit;">Baz<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bazmap_go" style="color: inherit; text-decoration: inherit;">Baz<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string]Foo<wbr>Args</span>
@@ -307,7 +307,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_go">
-<a href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -315,7 +315,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_go">
-<a href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -323,7 +323,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -335,7 +335,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -343,7 +343,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_nodejs">
-<a href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -351,7 +351,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_nodejs">
-<a href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -359,7 +359,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -367,7 +367,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -375,7 +375,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args[]</a></span>
@@ -383,7 +383,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bazmap_nodejs">
-<a href="#bazmap_nodejs" style="color: inherit; text-decoration: inherit;">baz<wbr>Map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bazmap_nodejs" style="color: inherit; text-decoration: inherit;">baz<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Foo<wbr>Args}</span>
@@ -391,7 +391,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_nodejs">
-<a href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -399,7 +399,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_nodejs">
-<a href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -407,7 +407,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -419,7 +419,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -427,7 +427,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_python">
-<a href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -435,7 +435,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_python">
-<a href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -443,7 +443,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -451,7 +451,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -459,7 +459,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Sequence[Foo<wbr>Args]</a></span>
@@ -467,7 +467,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_map_python">
-<a href="#baz_map_python" style="color: inherit; text-decoration: inherit;">baz_<wbr>map</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_map_python" style="color: inherit; text-decoration: inherit;">baz_<wbr>map</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Foo<wbr>Args]</span>
@@ -475,7 +475,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_python">
-<a href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -483,7 +483,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_python">
-<a href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -491,7 +491,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
@@ -510,7 +510,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -522,7 +522,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -534,7 +534,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -546,7 +546,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -570,7 +570,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -578,7 +578,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_csharp">
-<a href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -586,7 +586,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_csharp">
-<a href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -594,7 +594,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -602,7 +602,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_csharp">
-<a href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -610,7 +610,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_csharp">
-<a href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -622,7 +622,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -630,7 +630,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_go">
-<a href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -638,7 +638,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_go">
-<a href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -646,7 +646,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -654,7 +654,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_go">
-<a href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -662,7 +662,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_go">
-<a href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -674,7 +674,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -682,7 +682,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_nodejs">
-<a href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -690,7 +690,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_nodejs">
-<a href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -698,7 +698,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -706,7 +706,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_nodejs">
-<a href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -714,7 +714,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_nodejs">
-<a href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -726,7 +726,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -734,7 +734,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_python">
-<a href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -742,7 +742,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_python">
-<a href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -750,7 +750,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -758,7 +758,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_python">
-<a href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -766,7 +766,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_python">
-<a href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
@@ -62,7 +62,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo</a></span>
@@ -74,7 +74,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo</a></span>
@@ -86,7 +86,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo</a></span>
@@ -98,7 +98,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Foo</a></span>
@@ -129,7 +129,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_csharp">
-<a href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_csharp" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -137,7 +137,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_csharp">
-<a href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_csharp" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -145,7 +145,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_csharp">
-<a href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_csharp" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -153,7 +153,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_csharp">
-<a href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_csharp" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -161,7 +161,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_csharp">
-<a href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -169,7 +169,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_csharp">
-<a href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_csharp" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -181,7 +181,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_go">
-<a href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_go" style="color: inherit; text-decoration: inherit;">A</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -189,7 +189,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_go">
-<a href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_go" style="color: inherit; text-decoration: inherit;">C</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -197,7 +197,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_go">
-<a href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_go" style="color: inherit; text-decoration: inherit;">E</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -205,7 +205,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_go">
-<a href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_go" style="color: inherit; text-decoration: inherit;">B</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -213,7 +213,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_go">
-<a href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_go" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -221,7 +221,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_go">
-<a href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_go" style="color: inherit; text-decoration: inherit;">F</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -233,7 +233,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_nodejs">
-<a href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_nodejs" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -241,7 +241,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_nodejs">
-<a href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_nodejs" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -249,7 +249,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_nodejs">
-<a href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_nodejs" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -257,7 +257,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_nodejs">
-<a href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_nodejs" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">boolean</span>
@@ -265,7 +265,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_nodejs">
-<a href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -273,7 +273,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_nodejs">
-<a href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_nodejs" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -285,7 +285,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="a_python">
-<a href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#a_python" style="color: inherit; text-decoration: inherit;">a</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -293,7 +293,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="c_python">
-<a href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#c_python" style="color: inherit; text-decoration: inherit;">c</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -301,7 +301,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
         <span id="e_python">
-<a href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#e_python" style="color: inherit; text-decoration: inherit;">e</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -309,7 +309,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="b_python">
-<a href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#b_python" style="color: inherit; text-decoration: inherit;">b</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
@@ -317,7 +317,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="d_python">
-<a href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#d_python" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -325,7 +325,7 @@ The following output properties are available:
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="f_python">
-<a href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#f_python" style="color: inherit; text-decoration: inherit;">f</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_csharp">
-<a href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_go">
-<a href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_nodejs">
-<a href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -111,7 +111,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_python">
-<a href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -132,7 +132,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_csharp">
-<a href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -144,7 +144,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_go">
-<a href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -156,7 +156,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_nodejs">
-<a href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_python">
-<a href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -158,7 +158,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -170,7 +170,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -182,7 +182,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -194,7 +194,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -158,7 +158,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_csharp">
-<a href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_go">
-<a href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_nodejs">
-<a href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -111,7 +111,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_python">
-<a href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -132,7 +132,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_csharp">
-<a href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -144,7 +144,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_go">
-<a href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -156,7 +156,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_nodejs">
-<a href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_python">
-<a href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
@@ -158,7 +158,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -170,7 +170,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -182,7 +182,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -194,7 +194,7 @@ The BarResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
@@ -158,7 +158,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -170,7 +170,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -182,7 +182,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -194,7 +194,7 @@ The FooResource resource accepts the following [input]({{< relref "/docs/intro/c
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
@@ -158,7 +158,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -170,7 +170,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -182,7 +182,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -194,7 +194,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_csharp">
-<a href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -87,7 +87,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_go">
-<a href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -99,7 +99,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_nodejs">
-<a href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -111,7 +111,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_python">
-<a href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -132,7 +132,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_csharp">
-<a href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -144,7 +144,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_go">
-<a href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -156,7 +156,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_nodejs">
-<a href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -168,7 +168,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_python">
-<a href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
@@ -159,7 +159,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Pulumi.<wbr>Example.<wbr>Enum<wbr>Overlay</a></span>
@@ -167,7 +167,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -179,7 +179,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
@@ -187,7 +187,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -199,7 +199,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
@@ -207,7 +207,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -219,7 +219,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
@@ -227,7 +227,7 @@ The OverlayResource resource accepts the following [input]({{< relref "/docs/int
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -306,7 +306,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_csharp">
-<a href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -318,7 +318,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_go">
-<a href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -330,7 +330,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_nodejs">
-<a href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -342,7 +342,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_python">
-<a href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
@@ -158,7 +158,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -221,7 +221,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -233,7 +233,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -241,7 +241,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -253,7 +253,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -261,7 +261,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -273,7 +273,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -281,7 +281,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
@@ -160,7 +160,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -168,7 +168,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -176,7 +176,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -188,7 +188,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -196,7 +196,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -204,7 +204,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -216,7 +216,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -224,7 +224,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -232,7 +232,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -244,7 +244,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -252,7 +252,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -260,7 +260,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -279,7 +279,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -291,7 +291,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -303,7 +303,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -315,7 +315,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -339,7 +339,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_csharp">
-<a href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -351,7 +351,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_go">
-<a href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -363,7 +363,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_nodejs">
-<a href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -375,7 +375,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_python">
-<a href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -389,7 +389,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -397,7 +397,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_csharp">
-<a href="#configs_csharp" style="color: inherit; text-decoration: inherit;">Configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_csharp" style="color: inherit; text-decoration: inherit;">Configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">List&lt;Config<wbr>Map&gt;</a></span>
@@ -405,7 +405,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -413,7 +413,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_csharp">
-<a href="#others_csharp" style="color: inherit; text-decoration: inherit;">Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_csharp" style="color: inherit; text-decoration: inherit;">Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">List&lt;Immutable<wbr>Array&lt;Some<wbr>Other<wbr>Object&gt;&gt;</a></span>
@@ -421,7 +421,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_csharp">
-<a href="#stillothers_csharp" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_csharp" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Immutable<wbr>Array&lt;Some<wbr>Other<wbr>Object&gt;&gt;</span>
@@ -433,7 +433,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -441,7 +441,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_go">
-<a href="#configs_go" style="color: inherit; text-decoration: inherit;">Configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_go" style="color: inherit; text-decoration: inherit;">Configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">[]Config<wbr>Map</a></span>
@@ -449,7 +449,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -457,7 +457,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_go">
-<a href="#others_go" style="color: inherit; text-decoration: inherit;">Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_go" style="color: inherit; text-decoration: inherit;">Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">[][]Some<wbr>Other<wbr>Object</a></span>
@@ -465,7 +465,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_go">
-<a href="#stillothers_go" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_go" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string][]Some<wbr>Other<wbr>Object</span>
@@ -477,7 +477,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -485,7 +485,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_nodejs">
-<a href="#configs_nodejs" style="color: inherit; text-decoration: inherit;">configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_nodejs" style="color: inherit; text-decoration: inherit;">configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">Config<wbr>Map[]</a></span>
@@ -493,7 +493,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -501,7 +501,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_nodejs">
-<a href="#others_nodejs" style="color: inherit; text-decoration: inherit;">others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_nodejs" style="color: inherit; text-decoration: inherit;">others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object[][]</a></span>
@@ -509,7 +509,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_nodejs">
-<a href="#stillothers_nodejs" style="color: inherit; text-decoration: inherit;">still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_nodejs" style="color: inherit; text-decoration: inherit;">still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Some<wbr>Other<wbr>Object[]}</span>
@@ -521,7 +521,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -529,7 +529,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_python">
-<a href="#configs_python" style="color: inherit; text-decoration: inherit;">configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_python" style="color: inherit; text-decoration: inherit;">configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">Sequence[Config<wbr>Map]</a></span>
@@ -537,7 +537,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -545,7 +545,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_python">
-<a href="#others_python" style="color: inherit; text-decoration: inherit;">others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_python" style="color: inherit; text-decoration: inherit;">others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Sequence[Sequence[Some<wbr>Other<wbr>Object]]</a></span>
@@ -553,7 +553,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="still_others_python">
-<a href="#still_others_python" style="color: inherit; text-decoration: inherit;">still_<wbr>others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#still_others_python" style="color: inherit; text-decoration: inherit;">still_<wbr>others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Sequence[Some<wbr>Other<wbr>Object]]</span>
@@ -567,7 +567,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -575,7 +575,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -587,7 +587,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -595,7 +595,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -607,7 +607,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -615,7 +615,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -627,7 +627,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -635,7 +635,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -649,7 +649,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -661,7 +661,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -673,7 +673,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -685,7 +685,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
@@ -73,7 +73,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_csharp">
-<a href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_csharp" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -85,7 +85,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_go">
-<a href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_go" style="color: inherit; text-decoration: inherit;">Arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -97,7 +97,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_nodejs">
-<a href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_nodejs" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -109,7 +109,7 @@ The following arguments are supported:
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="arg1_python">
-<a href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#arg1_python" style="color: inherit; text-decoration: inherit;">arg1</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -130,7 +130,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_csharp">
-<a href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_csharp" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -142,7 +142,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_go">
-<a href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_go" style="color: inherit; text-decoration: inherit;">Result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -154,7 +154,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_nodejs">
-<a href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_nodejs" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -166,7 +166,7 @@ The following output properties are available:
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="result_python">
-<a href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#result_python" style="color: inherit; text-decoration: inherit;">result</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
@@ -159,7 +159,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">List&lt;string&gt;</span>
@@ -167,7 +167,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -179,7 +179,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">[]string</span>
@@ -187,7 +187,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -199,7 +199,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string[]</span>
@@ -207,7 +207,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -219,7 +219,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Sequence[str]</span>
@@ -227,7 +227,7 @@ The OtherResource resource accepts the following [input]({{< relref "/docs/intro
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -246,7 +246,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -258,7 +258,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -270,7 +270,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -282,7 +282,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
@@ -180,7 +180,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -192,7 +192,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -204,7 +204,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -216,7 +216,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
@@ -158,7 +158,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -170,7 +170,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -182,7 +182,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -194,7 +194,7 @@ The Resource resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -213,7 +213,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -225,7 +225,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -237,7 +237,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -249,7 +249,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
@@ -161,7 +161,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -169,7 +169,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -177,7 +177,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -185,7 +185,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qux_csharp">
-<a href="#qux_csharp" style="color: inherit; text-decoration: inherit;">Qux</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_csharp" style="color: inherit; text-decoration: inherit;">Qux</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Pulumi.<wbr>Example.<wbr>Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -197,7 +197,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -205,7 +205,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -213,7 +213,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -221,7 +221,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qux_go">
-<a href="#qux_go" style="color: inherit; text-decoration: inherit;">Qux</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_go" style="color: inherit; text-decoration: inherit;">Qux</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -233,7 +233,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -241,7 +241,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -249,7 +249,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -257,7 +257,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qux_nodejs">
-<a href="#qux_nodejs" style="color: inherit; text-decoration: inherit;">qux</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_nodejs" style="color: inherit; text-decoration: inherit;">qux</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -269,7 +269,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
@@ -277,7 +277,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
@@ -285,7 +285,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
@@ -293,7 +293,7 @@ The TypeUses resource accepts the following [input]({{< relref "/docs/intro/conc
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="qux_python">
-<a href="#qux_python" style="color: inherit; text-decoration: inherit;">qux</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_python" style="color: inherit; text-decoration: inherit;">qux</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
@@ -312,7 +312,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_csharp">
-<a href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_csharp" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -320,7 +320,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="alpha_csharp">
-<a href="#alpha_csharp" style="color: inherit; text-decoration: inherit;">Alpha</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#alpha_csharp" style="color: inherit; text-decoration: inherit;">Alpha</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyenumtype">Pulumi.<wbr>Example.<wbr>Output<wbr>Only<wbr>Enum<wbr>Type</a></span>
@@ -328,7 +328,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="beta_csharp">
-<a href="#beta_csharp" style="color: inherit; text-decoration: inherit;">Beta</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#beta_csharp" style="color: inherit; text-decoration: inherit;">Beta</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">List&lt;Output<wbr>Only<wbr>Object<wbr>Type&gt;</a></span>
@@ -336,7 +336,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="gamma_csharp">
-<a href="#gamma_csharp" style="color: inherit; text-decoration: inherit;">Gamma</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#gamma_csharp" style="color: inherit; text-decoration: inherit;">Gamma</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Example.<wbr>Output<wbr>Only<wbr>Enum<wbr>Type&gt;</span>
@@ -344,7 +344,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="zed_csharp">
-<a href="#zed_csharp" style="color: inherit; text-decoration: inherit;">Zed</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#zed_csharp" style="color: inherit; text-decoration: inherit;">Zed</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">Output<wbr>Only<wbr>Object<wbr>Type</a></span>
@@ -356,7 +356,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_go">
-<a href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_go" style="color: inherit; text-decoration: inherit;">Id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -364,7 +364,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="alpha_go">
-<a href="#alpha_go" style="color: inherit; text-decoration: inherit;">Alpha</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#alpha_go" style="color: inherit; text-decoration: inherit;">Alpha</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyenumtype">Output<wbr>Only<wbr>Enum<wbr>Type</a></span>
@@ -372,7 +372,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="beta_go">
-<a href="#beta_go" style="color: inherit; text-decoration: inherit;">Beta</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#beta_go" style="color: inherit; text-decoration: inherit;">Beta</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">[]Output<wbr>Only<wbr>Object<wbr>Type</a></span>
@@ -380,7 +380,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="gamma_go">
-<a href="#gamma_go" style="color: inherit; text-decoration: inherit;">Gamma</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#gamma_go" style="color: inherit; text-decoration: inherit;">Gamma</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string]Output<wbr>Only<wbr>Enum<wbr>Type</span>
@@ -388,7 +388,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="zed_go">
-<a href="#zed_go" style="color: inherit; text-decoration: inherit;">Zed</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#zed_go" style="color: inherit; text-decoration: inherit;">Zed</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">Output<wbr>Only<wbr>Object<wbr>Type</a></span>
@@ -400,7 +400,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_nodejs">
-<a href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_nodejs" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="alpha_nodejs">
-<a href="#alpha_nodejs" style="color: inherit; text-decoration: inherit;">alpha</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#alpha_nodejs" style="color: inherit; text-decoration: inherit;">alpha</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyenumtype">Output<wbr>Only<wbr>Enum<wbr>Type</a></span>
@@ -416,7 +416,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="beta_nodejs">
-<a href="#beta_nodejs" style="color: inherit; text-decoration: inherit;">beta</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#beta_nodejs" style="color: inherit; text-decoration: inherit;">beta</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">Output<wbr>Only<wbr>Object<wbr>Type[]</a></span>
@@ -424,7 +424,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="gamma_nodejs">
-<a href="#gamma_nodejs" style="color: inherit; text-decoration: inherit;">gamma</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#gamma_nodejs" style="color: inherit; text-decoration: inherit;">gamma</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Output<wbr>Only<wbr>Enum<wbr>Type}</span>
@@ -432,7 +432,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="zed_nodejs">
-<a href="#zed_nodejs" style="color: inherit; text-decoration: inherit;">zed</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#zed_nodejs" style="color: inherit; text-decoration: inherit;">zed</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">Output<wbr>Only<wbr>Object<wbr>Type</a></span>
@@ -444,7 +444,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-"
             title="">
         <span id="id_python">
-<a href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#id_python" style="color: inherit; text-decoration: inherit;">id</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -452,7 +452,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="alpha_python">
-<a href="#alpha_python" style="color: inherit; text-decoration: inherit;">alpha</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#alpha_python" style="color: inherit; text-decoration: inherit;">alpha</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyenumtype">Output<wbr>Only<wbr>Enum<wbr>Type</a></span>
@@ -460,7 +460,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="beta_python">
-<a href="#beta_python" style="color: inherit; text-decoration: inherit;">beta</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#beta_python" style="color: inherit; text-decoration: inherit;">beta</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">Sequence[Output<wbr>Only<wbr>Object<wbr>Type]</a></span>
@@ -468,7 +468,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="gamma_python">
-<a href="#gamma_python" style="color: inherit; text-decoration: inherit;">gamma</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#gamma_python" style="color: inherit; text-decoration: inherit;">gamma</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Output<wbr>Only<wbr>Enum<wbr>Type]</span>
@@ -476,7 +476,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
         <span id="zed_python">
-<a href="#zed_python" style="color: inherit; text-decoration: inherit;">zed</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#zed_python" style="color: inherit; text-decoration: inherit;">zed</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#outputonlyobjecttype">Output<wbr>Only<wbr>Object<wbr>Type</a></span>
@@ -500,7 +500,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_csharp">
-<a href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -512,7 +512,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_go">
-<a href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -524,7 +524,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_nodejs">
-<a href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -536,7 +536,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="config_python">
-<a href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -550,7 +550,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -558,7 +558,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_csharp">
-<a href="#configs_csharp" style="color: inherit; text-decoration: inherit;">Configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_csharp" style="color: inherit; text-decoration: inherit;">Configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">List&lt;Config<wbr>Map&gt;</a></span>
@@ -566,7 +566,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
@@ -574,7 +574,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_csharp">
-<a href="#others_csharp" style="color: inherit; text-decoration: inherit;">Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_csharp" style="color: inherit; text-decoration: inherit;">Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">List&lt;Immutable<wbr>Array&lt;Some<wbr>Other<wbr>Object&gt;&gt;</a></span>
@@ -582,7 +582,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_csharp">
-<a href="#stillothers_csharp" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_csharp" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Dictionary&lt;string, Immutable<wbr>Array&lt;Some<wbr>Other<wbr>Object&gt;&gt;</span>
@@ -594,7 +594,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -602,7 +602,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_go">
-<a href="#configs_go" style="color: inherit; text-decoration: inherit;">Configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_go" style="color: inherit; text-decoration: inherit;">Configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">[]Config<wbr>Map</a></span>
@@ -610,7 +610,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -618,7 +618,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_go">
-<a href="#others_go" style="color: inherit; text-decoration: inherit;">Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_go" style="color: inherit; text-decoration: inherit;">Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">[][]Some<wbr>Other<wbr>Object</a></span>
@@ -626,7 +626,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_go">
-<a href="#stillothers_go" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_go" style="color: inherit; text-decoration: inherit;">Still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">map[string][]Some<wbr>Other<wbr>Object</span>
@@ -638,7 +638,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -646,7 +646,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_nodejs">
-<a href="#configs_nodejs" style="color: inherit; text-decoration: inherit;">configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_nodejs" style="color: inherit; text-decoration: inherit;">configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">Config<wbr>Map[]</a></span>
@@ -654,7 +654,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -662,7 +662,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_nodejs">
-<a href="#others_nodejs" style="color: inherit; text-decoration: inherit;">others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_nodejs" style="color: inherit; text-decoration: inherit;">others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object[][]</a></span>
@@ -670,7 +670,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="stillothers_nodejs">
-<a href="#stillothers_nodejs" style="color: inherit; text-decoration: inherit;">still<wbr>Others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#stillothers_nodejs" style="color: inherit; text-decoration: inherit;">still<wbr>Others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">{[key: string]: Some<wbr>Other<wbr>Object[]}</span>
@@ -682,7 +682,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -690,7 +690,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="configs_python">
-<a href="#configs_python" style="color: inherit; text-decoration: inherit;">configs</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#configs_python" style="color: inherit; text-decoration: inherit;">configs</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#configmap">Sequence[Config<wbr>Map]</a></span>
@@ -698,7 +698,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Resource</span>
@@ -706,7 +706,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="others_python">
-<a href="#others_python" style="color: inherit; text-decoration: inherit;">others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#others_python" style="color: inherit; text-decoration: inherit;">others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#someotherobject">Sequence[Sequence[Some<wbr>Other<wbr>Object]]</a></span>
@@ -714,7 +714,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}List of lists of other objects{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="still_others_python">
-<a href="#still_others_python" style="color: inherit; text-decoration: inherit;">still_<wbr>others</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#still_others_python" style="color: inherit; text-decoration: inherit;">still_<wbr>others</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Mapping[str, Sequence[Some<wbr>Other<wbr>Object]]</span>
@@ -728,7 +728,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -736,7 +736,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_csharp">
-<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -748,7 +748,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -756,7 +756,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_go">
-<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -768,7 +768,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -776,7 +776,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_nodejs">
-<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">number</span>
@@ -788,7 +788,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-required"
             title="Required">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -796,7 +796,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="bar_python">
-<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">int</span>
@@ -836,7 +836,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_csharp">
-<a href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -848,7 +848,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_go">
-<a href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -860,7 +860,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_nodejs">
-<a href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -872,7 +872,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="foo_python">
-<a href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>
@@ -916,7 +916,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_csharp">
-<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -928,7 +928,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_go">
-<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -940,7 +940,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_nodejs">
-<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">string</span>
@@ -952,7 +952,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <dl class="resources-properties"><dt class="property-optional"
             title="Optional">
         <span id="baz_python">
-<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+<a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">str</span>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Add swifttype data attribute tags to resource properties, so that those can be more effectively returned as search results.  Example of where this is changing the markup: https://www.pulumi.com/registry/packages/confluent/api-docs/serviceaccount/#properties 

Fixes https://github.com/pulumi/pulumi-hugo/issues/1158

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
