### PR TITLE
Add missing whitespace in error string

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -543,7 +543,7 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	if qualifiedName.Project == "" {
 		currentProject, projectErr := workspace.DetectProject()
 		if projectErr != nil {
-			return nil, fmt.Errorf("If you're using the --stack flag,"+
+			return nil, fmt.Errorf("If you're using the --stack flag, "+
 				"pass the fully qualified name (org/project/stack): %w", projectErr)
 		}
 


### PR DESCRIPTION
Before:
`If you're using the --stack flag,pass the fully qualified name (org/project/stack):`

After:
`If you're using the --stack flag, pass the fully qualified name (org/project/stack):`