### PR TITLE
Read needs a non-empty ID

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,6 @@
 ### Improvements
 
-- [area/cli] - Implement `pulumi stack unselect`.
+- [cli] - Implement `pulumi stack unselect`.
   [#9179](https://github.com/pulumi/pulumi/pull/9179)
 
 - [language/dotnet] - Updated Pulumi dotnet packages to use grpc-dotnet instead of grpc.
@@ -15,7 +15,7 @@
 - [cli] - Speed up `pulumi stack --show-name` by skipping unneeded snapshot loading.
   [#9199](https://github.com/pulumi/pulumi/pull/9199)
 
-- Improved error message for missing plugins.
+- [cli/plugins] - Improved error message for missing plugins.
   [#5208](https://github.com/pulumi/pulumi/pull/5208)
 
 ### Bug Fixes
@@ -25,3 +25,6 @@
 
 - [sdk/go] - Fix a panic in `pulumi.All` when using pointer inputs.
   [#9197](https://github.com/pulumi/pulumi/issues/9197)
+
+- [cli/engine] - Fix a panic due to passing `""` as the ID for a resource read.
+  [#9243](https://github.com/pulumi/pulumi/pull/9243)

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -878,6 +878,7 @@ func TestRecordingReadFailureNoPreviousResource(t *testing.T) {
 	t.Parallel()
 
 	resourceA := NewResource("a")
+	resourceA.ID = "some-a"
 	resourceA.External = true
 	resourceA.Custom = true
 	snap := NewSnapshot(nil)

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -800,8 +800,8 @@ func TestRecordingDeleteFailure(t *testing.T) {
 func TestRecordingReadSuccessNoPreviousResource(t *testing.T) {
 	t.Parallel()
 
-	resourceA := NewResource("a")
-	resourceA.ID = "some-a"
+	resourceA := NewResource("b")
+	resourceA.ID = "some-b"
 	resourceA.External = true
 	resourceA.Custom = true
 	snap := NewSnapshot(nil)
@@ -833,13 +833,13 @@ func TestRecordingReadSuccessNoPreviousResource(t *testing.T) {
 func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 	t.Parallel()
 
-	resourceA := NewResource("a")
-	resourceA.ID = "some-a"
+	resourceA := NewResource("c")
+	resourceA.ID = "some-c"
 	resourceA.External = true
 	resourceA.Custom = true
 	resourceA.Inputs["key"] = resource.NewStringProperty("old")
-	resourceANew := NewResource("a")
-	resourceANew.ID = "some-other-a"
+	resourceANew := NewResource("c")
+	resourceANew.ID = "some-other-c"
 	resourceANew.External = true
 	resourceANew.Custom = true
 	resourceANew.Inputs["key"] = resource.NewStringProperty("new")
@@ -880,8 +880,8 @@ func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 func TestRecordingReadFailureNoPreviousResource(t *testing.T) {
 	t.Parallel()
 
-	resourceA := NewResource("a")
-	resourceA.ID = "some-a"
+	resourceA := NewResource("d")
+	resourceA.ID = "some-d"
 	resourceA.External = true
 	resourceA.Custom = true
 	snap := NewSnapshot(nil)
@@ -912,13 +912,13 @@ func TestRecordingReadFailureNoPreviousResource(t *testing.T) {
 func TestRecordingReadFailurePreviousResource(t *testing.T) {
 	t.Parallel()
 
-	resourceA := NewResource("a")
-	resourceA.ID = "some-a"
+	resourceA := NewResource("e")
+	resourceA.ID = "some-e"
 	resourceA.External = true
 	resourceA.Custom = true
 	resourceA.Inputs["key"] = resource.NewStringProperty("old")
-	resourceANew := NewResource("a")
-	resourceANew.ID = "some-new-a"
+	resourceANew := NewResource("e")
+	resourceANew.ID = "some-new-e"
 	resourceANew.External = true
 	resourceANew.Custom = true
 	resourceANew.Inputs["key"] = resource.NewStringProperty("new")

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -909,10 +909,12 @@ func TestRecordingReadFailurePreviousResource(t *testing.T) {
 	t.Parallel()
 
 	resourceA := NewResource("a")
+	resourceA.ID = "some-a"
 	resourceA.External = true
 	resourceA.Custom = true
 	resourceA.Inputs["key"] = resource.NewStringProperty("old")
 	resourceANew := NewResource("a")
+	resourceANew.ID = "some-new-a"
 	resourceANew.External = true
 	resourceANew.Custom = true
 	resourceANew.Inputs["key"] = resource.NewStringProperty("new")

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -801,6 +801,7 @@ func TestRecordingReadSuccessNoPreviousResource(t *testing.T) {
 	t.Parallel()
 
 	resourceA := NewResource("a")
+	resourceA.ID = "some-a"
 	resourceA.External = true
 	resourceA.Custom = true
 	snap := NewSnapshot(nil)

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -834,10 +834,12 @@ func TestRecordingReadSuccessPreviousResource(t *testing.T) {
 	t.Parallel()
 
 	resourceA := NewResource("a")
+	resourceA.ID = "some-a"
 	resourceA.External = true
 	resourceA.Custom = true
 	resourceA.Inputs["key"] = resource.NewStringProperty("old")
 	resourceANew := NewResource("a")
+	resourceANew.ID = "some-other-a"
 	resourceANew.External = true
 	resourceANew.Custom = true
 	resourceANew.Inputs["key"] = resource.NewStringProperty("new")

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -147,7 +147,8 @@ func (p *builtinProvider) Delete(urn resource.URN, id resource.ID,
 
 func (p *builtinProvider) Read(urn resource.URN, id resource.ID,
 	inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
-
+	contract.Assertf(urn != "", "Read URN was empty")
+	contract.Assertf(id != "", "Read ID was empty")
 	contract.Assert(urn.Type() == stackReferenceType)
 
 	outputs, err := p.readStackReference(state)

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -167,6 +167,8 @@ func (prov *Provider) Delete(urn resource.URN,
 
 func (prov *Provider) Read(urn resource.URN, id resource.ID,
 	inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
+	contract.Assertf(urn != "", "Read URN was empty")
+	contract.Assertf(id != "", "Read ID was empty")
 	if prov.ReadF == nil {
 		return plugin.ReadResult{
 			Outputs: resource.PropertyMap{},

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -570,6 +570,8 @@ type ReadStep struct {
 // NewReadStep creates a new Read step.
 func NewReadStep(deployment *Deployment, event ReadResourceEvent, old, new *resource.State) Step {
 	contract.Assert(new != nil)
+	contract.Assertf(new.URN != "", "Read URN was empty")
+	contract.Assertf(new.ID != "", "Read ID was empty")
 	contract.Assertf(new.External, "target of Read step must be marked External")
 	contract.Assertf(new.Custom, "target of Read step must be Custom")
 
@@ -592,6 +594,8 @@ func NewReadStep(deployment *Deployment, event ReadResourceEvent, old, new *reso
 // it will pend deletion of the "old" resource, which must not be an external resource.
 func NewReadReplacementStep(deployment *Deployment, event ReadResourceEvent, old, new *resource.State) Step {
 	contract.Assert(new != nil)
+	contract.Assertf(new.URN != "", "Read URN was empty")
+	contract.Assertf(new.ID != "", "Read ID was empty")
 	contract.Assertf(new.External, "target of ReadReplacement step must be marked External")
 	contract.Assertf(new.Custom, "target of ReadReplacement step must be Custom")
 	contract.Assert(old != nil)

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -144,6 +144,10 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, res
 		newState.SequenceNumber = old.SequenceNumber
 	}
 
+	if newState.ID == "" {
+		return nil, result.Errorf("Expected an ID for %v", urn)
+	}
+
 	// If the snapshot has an old resource for this URN and it's not external, we're going
 	// to have to delete the old resource and conceptually replace it with the resource we
 	// are about to read.

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -801,8 +801,8 @@ func (p *provider) Create(urn resource.URN, props resource.PropertyMap, timeout 
 func (p *provider) Read(urn resource.URN, id resource.ID,
 	inputs, state resource.PropertyMap) (ReadResult, resource.Status, error) {
 
-	contract.Assert(urn != "")
-	contract.Assert(id != "")
+	contract.Assertf(urn != "", "Read URN was empty")
+	contract.Assertf(id != "", "Read ID was empty")
 
 	label := fmt.Sprintf("%s.Read(%s,%s)", p.label(), id, urn)
 	logging.V(7).Infof("%s executing (#inputs=%v, #state=%v)", label, len(inputs), len(state))


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

```
I'm getting an internal assertion thrown here: https://github.com/pulumi/pulumi/blob/8b516bb05434ca8c6dac94b76a5583e855ffd0b6/sdk/go/common/resource/plugin/provider_plugin.go#L808
(Actually, it's line 807 in the stack trace, but presumably either the URN or ID is empty..)
This is in a brand new project/stack. Never been deployed. Any ideas on what I should be looking for? (edited) 
```

This was due to accidentally passing `""` as the ID in a get call. This PR fixes it so we now report an error like `Expected an ID for urn:pulumi:test::test::pkgA:m:typA::resA` rather than a panic due to an assert.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
