### PR TITLE
Add version to runtime in Pulumi.yaml

### DIFF
--- a/pkg/cmd/pulumi/about_test.go
+++ b/pkg/cmd/pulumi/about_test.go
@@ -48,7 +48,7 @@ func TestProjectRuntime(t *testing.T) {
 	var runtime projectRuntimeAbout
 	runtime, err = getProjectRuntimeAbout(&workspace.Project{
 		Name:    "TestProject",
-		Runtime: workspace.NewProjectRuntimeInfo("python", make(map[string]interface{})),
+		Runtime: workspace.NewProjectRuntimeInfo("python", nil, make(map[string]interface{})),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, runtime.Language, "python")

--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -29,7 +29,7 @@ func TestPrettyKeyForProject(t *testing.T) {
 
 	proj := &workspace.Project{
 		Name:    tokens.PackageName("test-package"),
-		Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
+		Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil, nil),
 	}
 
 	assert.Equal(t, "foo", prettyKeyForProject(config.MustMakeKey("test-package", "foo"), proj))

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -457,7 +457,7 @@ func readProjectForUpdate(clientAddress string) (*workspace.Project, string, err
 		return nil, "", err
 	}
 	if clientAddress != "" {
-		proj.Runtime = workspace.NewProjectRuntimeInfo("client", map[string]interface{}{
+		proj.Runtime = workspace.NewProjectRuntimeInfo("client", nil, map[string]interface{}{
 			"address": clientAddress,
 		})
 	}

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -194,7 +194,7 @@ func (p *TestPlan) GetProject() workspace.Project {
 
 	return workspace.Project{
 		Name:    projectName,
-		Runtime: workspace.NewProjectRuntimeInfo(runtime, p.RuntimeOptions),
+		Runtime: workspace.NewProjectRuntimeInfo(runtime, nil, p.RuntimeOptions),
 	}
 }
 

--- a/sdk/go/auto/example_test.go
+++ b/sdk/go/auto/example_test.go
@@ -195,7 +195,7 @@ func ExampleGitRepo() {
 	// an override to the project file in the git repo, specifying our pre-built executable
 	project := workspace.Project{
 		Name: tokens.PackageName(pName),
-		Runtime: workspace.NewProjectRuntimeInfo("go", map[string]interface{}{
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, map[string]interface{}{
 			"binary": binName,
 		}),
 	}
@@ -378,7 +378,7 @@ func ExampleNewLocalWorkspace() {
 	// Project provides ProjectSettings to set once the workspace is created.
 	proj := Project(workspace.Project{
 		Name:    tokens.PackageName("myproject"),
-		Runtime: workspace.NewProjectRuntimeInfo("go", nil),
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, nil),
 		Backend: &workspace.ProjectBackend{
 			URL: "https://url.to.custom.saas.backend.com",
 		},
@@ -396,7 +396,7 @@ func ExampleLocalWorkspace_secretsProvider() {
 	// Project provides ProjectSettings to set once the workspace is created.
 	proj := Project(workspace.Project{
 		Name:    tokens.PackageName("myproject"),
-		Runtime: workspace.NewProjectRuntimeInfo("go", nil),
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, nil),
 		Backend: &workspace.ProjectBackend{
 			URL: "https://url.to.custom.saas.backend.com",
 		},
@@ -439,7 +439,7 @@ func ExampleLocalWorkspace_ProjectSettings() {
 		// no Pulumi.yaml was found, so create a default
 		ps = &workspace.Project{
 			Name:    tokens.PackageName("myproject"),
-			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
+			Runtime: workspace.NewProjectRuntimeInfo("go", nil, nil),
 		}
 	}
 	// make some changes
@@ -459,7 +459,7 @@ func ExampleLocalWorkspace_SaveProjectSettings() {
 		// no Pulumi.yaml was found, so create a default
 		ps = &workspace.Project{
 			Name:    tokens.PackageName("myproject"),
-			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
+			Runtime: workspace.NewProjectRuntimeInfo("go", nil, nil),
 		}
 	}
 	// make some changes
@@ -865,7 +865,7 @@ func ExampleNewStackRemoteSource() {
 	// an override to the project file in the git repo, specifying our pre-built executable
 	project := workspace.Project{
 		Name: tokens.PackageName(pName),
-		Runtime: workspace.NewProjectRuntimeInfo("go", map[string]interface{}{
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, map[string]interface{}{
 			"binary": binName,
 		}),
 	}
@@ -896,7 +896,7 @@ func ExampleUpsertStackRemoteSource() {
 	// an override to the project file in the git repo, specifying our pre-built executable
 	project := workspace.Project{
 		Name: tokens.PackageName(pName),
-		Runtime: workspace.NewProjectRuntimeInfo("go", map[string]interface{}{
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, map[string]interface{}{
 			"binary": binName,
 		}),
 	}
@@ -927,7 +927,7 @@ func ExampleSelectStackRemoteSource() {
 	// an override to the project file in the git repo, specifying our pre-built executable
 	project := workspace.Project{
 		Name: tokens.PackageName(pName),
-		Runtime: workspace.NewProjectRuntimeInfo("go", map[string]interface{}{
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, map[string]interface{}{
 			"binary": binName,
 		}),
 	}

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -993,7 +993,7 @@ func defaultInlineProject(projectName string) (workspace.Project, error) {
 	}
 	proj = workspace.Project{
 		Name:    tokens.PackageName(projectName),
-		Runtime: workspace.NewProjectRuntimeInfo("go", nil),
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, nil),
 		Main:    cwd,
 	}
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -662,7 +662,7 @@ func TestNewStackRemoteSourceWithSetup(t *testing.T) {
 	}
 	project := workspace.Project{
 		Name: tokens.PackageName(pName),
-		Runtime: workspace.NewProjectRuntimeInfo("go", map[string]interface{}{
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, map[string]interface{}{
 			"binary": binName,
 		}),
 	}
@@ -772,7 +772,7 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 	}
 	project := workspace.Project{
 		Name: tokens.PackageName(pName),
-		Runtime: workspace.NewProjectRuntimeInfo("go", map[string]interface{}{
+		Runtime: workspace.NewProjectRuntimeInfo("go", nil, map[string]interface{}{
 			"binary": binName,
 		}),
 	}

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
@@ -12,7 +13,8 @@ func TestProjectRuntimeInfoRoundtripYAML(t *testing.T) {
 	t.Parallel()
 
 	doTest := func(marshal func(interface{}) ([]byte, error), unmarshal func([]byte, interface{}) error) {
-		ri := NewProjectRuntimeInfo("nodejs", nil)
+		// Just name
+		ri := NewProjectRuntimeInfo("nodejs", nil, nil)
 		byts, err := marshal(ri)
 		assert.NoError(t, err)
 
@@ -20,17 +22,53 @@ func TestProjectRuntimeInfoRoundtripYAML(t *testing.T) {
 		err = unmarshal(byts, &riRountrip)
 		assert.NoError(t, err)
 		assert.Equal(t, "nodejs", riRountrip.Name())
+		assert.Nil(t, riRountrip.Version())
 		assert.Nil(t, riRountrip.Options())
 
-		ri = NewProjectRuntimeInfo("nodejs", map[string]interface{}{
+		// Name and version
+		vers := semver.MustParse("1.0.0")
+		ri = NewProjectRuntimeInfo("nodejs", &vers, nil)
+		byts, err = marshal(ri)
+		assert.NoError(t, err)
+
+		riRountrip = ProjectRuntimeInfo{}
+		err = unmarshal(byts, &riRountrip)
+		assert.NoError(t, err)
+		assert.Equal(t, "nodejs", riRountrip.Name())
+		assert.Nil(t, riRountrip.Options())
+		assert.NotNil(t, riRountrip.Version())
+		assert.Equal(t, vers, *riRountrip.Version())
+
+		// Name and options
+		ri = NewProjectRuntimeInfo("nodejs", nil, map[string]interface{}{
 			"typescript":   true,
 			"stringOption": "hello",
 		})
 		byts, err = marshal(ri)
 		assert.NoError(t, err)
+
+		riRountrip = ProjectRuntimeInfo{}
 		err = unmarshal(byts, &riRountrip)
 		assert.NoError(t, err)
 		assert.Equal(t, "nodejs", riRountrip.Name())
+		assert.Nil(t, riRountrip.Version())
+		assert.Equal(t, true, riRountrip.Options()["typescript"])
+		assert.Equal(t, "hello", riRountrip.Options()["stringOption"])
+
+		// Name, version and options
+		ri = NewProjectRuntimeInfo("nodejs", &vers, map[string]interface{}{
+			"typescript":   true,
+			"stringOption": "hello",
+		})
+		byts, err = marshal(ri)
+		assert.NoError(t, err)
+
+		riRountrip = ProjectRuntimeInfo{}
+		err = unmarshal(byts, &riRountrip)
+		assert.NoError(t, err)
+		assert.Equal(t, "nodejs", riRountrip.Name())
+		assert.NotNil(t, riRountrip.Version())
+		assert.Equal(t, vers, *riRountrip.Version())
 		assert.Equal(t, true, riRountrip.Options()["typescript"])
 		assert.Equal(t, "hello", riRountrip.Options()["stringOption"])
 	}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -162,7 +162,7 @@ func TestConfigSave(t *testing.T) {
 	path := filepath.Join(e.RootPath, "Pulumi.yaml")
 	err := (&workspace.Project{
 		Name:    "testing-config",
-		Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
+		Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil, nil),
 	}).Save(path)
 	assert.NoError(t, err)
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -238,7 +238,7 @@ func TestConfigPaths(t *testing.T) {
 	path := filepath.Join(e.RootPath, "Pulumi.yaml")
 	err := (&workspace.Project{
 		Name:    "testing-config",
-		Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
+		Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil, nil),
 	}).Save(path)
 	assert.NoError(t, err)
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())


### PR DESCRIPTION
Nothing uses this yet, but as we support real plugins for languages we'll need some way to specify the version.

This supports the version by either adding "@vX.Y.Z" to the runtime string (e.g. `runtime: dotnet@v1.0.0`) or by using the version key:
```
runtime:
  name: dotnet
  version: v1.0.0
```