### PR TITLE
Fix lint issues

### DIFF
--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -376,9 +376,9 @@ func TestNewResourceInput(t *testing.T) {
 	t.Parallel()
 
 	var resource Resource = &testRes{foo: "abracadabra"}
-	var resourceInput ResourceInput = NewResourceInput(resource)
+	resourceInput := NewResourceInput(resource)
 
-	var resourceOutput ResourceOutput = resourceInput.ToResourceOutput()
+	resourceOutput := resourceInput.ToResourceOutput()
 
 	channel := make(chan interface{})
 	resourceOutput.ApplyT(func(res interface{}) interface{} {


### PR DESCRIPTION
Addresses linter issues I'm hitting in a PR:

```
go/pulumi/resource_test.go:379:20: var-declaration: should omit type ResourceInput from declaration of var resourceInput; it will be inferred from the right-hand side (revive)
	var resourceInput ResourceInput = NewResourceInput(resource)
	                  ^

go/pulumi/resource_test.go:381:21: var-declaration: should omit type ResourceOutput from declaration of var resourceOutput; it will be inferred from the right-hand side (revive)
	var resourceOutput ResourceOutput = resourceInput.ToResourceOutput()
	                   ^
```
