### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -749,7 +749,7 @@ function getFunctionName(loc: FunctionLocation): string {
         // the entire lambda if it's lots of statements.
         const semicolonIndex = funcString.indexOf(";");
         if (semicolonIndex >= 0) {
-            funcString = funcString.substr(0, semicolonIndex + 1) + " ...";
+            funcString = funcString.slice(0, semicolonIndex + 1) + " ...";
         }
 
         // squash all whitespace to single spaces.

--- a/sdk/nodejs/runtime/closure/package.ts
+++ b/sdk/nodejs/runtime/closure/package.ts
@@ -202,9 +202,9 @@ class ModuleMap {
 
         const rules: [string, string[]][] = [];
         for (const [modPath, objectOrPath] of Object.entries(exports)) {
-            const modName: string = name + modPath.substr(1);
+            const modName: string = name + modPath.slice(1);
             const leaves = getAllLeafStrings(objectOrPath, opts);
-            rules.push([modName, leaves.map(leaf => name + leaf.substr(1))]);
+            rules.push([modName, leaves.map(leaf => name + leaf.slice(1))]);
         }
         this.wildcardMap = new WildcardMap(rules);
     }

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -203,21 +203,21 @@ function parseFunctionCode(funcString: string): [string, ParsedFunctionCode] {
     let isAsync = false;
     if (funcString.startsWith("async ")) {
         isAsync = true;
-        funcString = funcString.substr("async".length).trimLeft();
+        funcString = funcString.slice("async".length).trimLeft();
     }
 
     if (funcString.startsWith("function get ") || funcString.startsWith("function set ")) {
-        const trimmed = funcString.substr("function get".length);
+        const trimmed = funcString.slice("function get".length);
         return makeFunctionDeclaration(trimmed, isAsync, /*isFunctionDeclaration: */ false);
     }
 
     if (funcString.startsWith("get ") || funcString.startsWith("set ")) {
-        const trimmed = funcString.substr("get ".length);
+        const trimmed = funcString.slice("get ".length);
         return makeFunctionDeclaration(trimmed, isAsync, /*isFunctionDeclaration: */ false);
     }
 
     if (funcString.startsWith("function")) {
-        const trimmed = funcString.substr("function".length);
+        const trimmed = funcString.slice("function".length);
         return makeFunctionDeclaration(trimmed, isAsync, /*isFunctionDeclaration: */ true);
     }
 
@@ -247,7 +247,7 @@ function makeFunctionDeclaration(
     v = v.trimLeft();
 
     if (v.startsWith("*")) {
-        v = v.substr(1).trimLeft();
+        v = v.slice(1).trimLeft();
         prefix = "function* ";
     }
 
@@ -257,7 +257,7 @@ function makeFunctionDeclaration(
     }
 
     if (isComputed(v, openParenIndex)) {
-        v = v.substr(openParenIndex);
+        v = v.slice(openParenIndex);
         return ["", {
             funcExprWithoutName: prefix + v,
             funcExprWithName: prefix + "__computed" + v,
@@ -266,12 +266,12 @@ function makeFunctionDeclaration(
         }];
     }
 
-    const nameChunk = v.substr(0, openParenIndex);
+    const nameChunk = v.slice(0, openParenIndex);
     const funcName = utils.isLegalMemberName(nameChunk)
         ? utils.isLegalFunctionName(nameChunk) ? nameChunk : "/*" + nameChunk + "*/"
         : "";
     const commentedName = utils.isLegalMemberName(nameChunk) ? "/*" + nameChunk + "*/" : "";
-    v = v.substr(openParenIndex).trimLeft();
+    v = v.slice(openParenIndex).trimLeft();
 
     return ["", {
         funcExprWithoutName: prefix + commentedName + v,


### PR DESCRIPTION
# Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with functions which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
