### PR TITLE
[area/nodejs] Take engines property into account when engine-strict appear in .npmrc file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,9 @@
 - [cli/plugins] - Improved error message for missing plugins.
   [#5208](https://github.com/pulumi/pulumi/pull/5208)
 
+- [sdk/nodejs] - Take engines property into account when engine-strict appear in npmrc file 
+  [#9249](https://github.com/pulumi/pulumi/pull/9249)
+
 ### Bug Fixes
 
 - [sdk/nodejs] - Fix uncaught error "ENOENT: no such file or directory" when an error occurs during the stack up.

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -17,6 +17,8 @@ import * as url from "url";
 import * as minimist from "minimist";
 import * as path from "path";
 import * as tsnode from "ts-node";
+import * as ini from "ini";
+import * as semver from "semver";
 import { parseConfigFileTextToJson } from "typescript";
 import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
@@ -56,6 +58,28 @@ function packageObjectFromProjectRoot(projectRoot: string): Record<string, any> 
         // This is all best-effort so if we can't load the package.json file, that's
         // fine.
         return {};
+    }
+}
+
+// Reads and parses the contents of .npmrc file if it exists under the project root
+// This assumes that .npmrc is a sibling to package.json
+function npmRcFromProjectRoot(projectRoot: string) : Record<string, any>  {
+    const emptyConfig = {};
+    try {
+        const npmRcPath = path.join(projectRoot, ".npmrc");
+        if (!fs.existsSync(npmRcPath)) {
+            return emptyConfig;
+        }
+        // file .npmrc exists, read its contents
+        const npmRc = fs.readFileSync(npmRcPath, "utf-8");
+        // Use ini to parse the contents of the .npmrc file
+        // This is what node does as described in the npm docs
+        // https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#comments
+        return ini.parse(npmRc);
+    } catch {
+        // .npmrc file exists but we couldn't read or parse it
+        // user out of luck here
+        return emptyConfig;
     }
 }
 
@@ -262,7 +286,8 @@ ${defaultMessage}`);
         // Now go ahead and execute the code. The process will remain alive until the message loop empties.
         log.debug(`Running program '${program}' in pwd '${process.cwd()}' w/ args: ${programArgs}`);
         try {
-            const packageObject = packageObjectFromProjectRoot(projectRootFromProgramPath(program));
+            const projectRoot = projectRootFromProgramPath(program);
+            const packageObject = packageObjectFromProjectRoot(projectRoot);
 
             let programExport: any;
 
@@ -294,6 +319,33 @@ ${defaultMessage}`);
             } else {
                 // It's a CommonJS module, so require the module and capture any module outputs it exported.
                 programExport = require(program);
+            }
+
+            // Check compatible engines before running the program:
+            const npmRc = npmRcFromProjectRoot(projectRoot);
+            // Reads a boolean key from the npm rc file. Can be true or "true" (quoted string)
+            const readBool = (key: string) : boolean => npmRc[key] && new Boolean(npmRc[key]);
+
+            const engineStrict = readBool("engine-strict");
+
+            if (engineStrict && packageObject.engines && packageObject.engines.node) {
+                // found:
+                //   - { engines: { node: "<version>" } } in package.json
+                //   - engine-strict=true in .npmrc
+                // 
+                // Check that current node version satistfies the required version
+                const requiredNodeVersion = packageObject.engines.node;
+                const currentNodeVersion = process.versions.node;
+                if (!semver.satisfies(currentNodeVersion, requiredNodeVersion)) {
+                    const errorMessage = [
+                        `Your current Node version is incompatible to run ${projectRoot}`,
+                        `Expected version: ${requiredNodeVersion} as found in package.json > engines > node`,
+                        `Actual Node version: ${currentNodeVersion}`,
+                        `To fix issue, install a Node version that is compatible with ${requiredNodeVersion}`
+                    ]
+
+                    throw new Error(errorMessage.join("\n"));
+                }
             }
 
             // If the exported value was itself a Function, then just execute it.  This allows for

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -63,7 +63,7 @@ function packageObjectFromProjectRoot(projectRoot: string): Record<string, any> 
 
 // Reads and parses the contents of .npmrc file if it exists under the project root
 // This assumes that .npmrc is a sibling to package.json
-function npmRcFromProjectRoot(projectRoot: string) : Record<string, any>  {
+function npmRcFromProjectRoot(projectRoot: string): Record<string, any>  {
     const emptyConfig = {};
     try {
         const npmRcPath = path.join(projectRoot, ".npmrc");
@@ -327,7 +327,7 @@ ${defaultMessage}`);
                 // found:
                 //   - { engines: { node: "<version>" } } in package.json
                 //   - engine-strict=true in .npmrc
-                // 
+                //
                 // Check that current node version satistfies the required version
                 const requiredNodeVersion = packageObject.engines.node;
                 const currentNodeVersion = process.versions.node;
@@ -336,8 +336,8 @@ ${defaultMessage}`);
                         `Your current Node version is incompatible to run ${projectRoot}`,
                         `Expected version: ${requiredNodeVersion} as found in package.json > engines > node`,
                         `Actual Node version: ${currentNodeVersion}`,
-                        `To fix issue, install a Node version that is compatible with ${requiredNodeVersion}`
-                    ]
+                        `To fix issue, install a Node version that is compatible with ${requiredNodeVersion}`,
+                    ];
 
                     throw new Error(errorMessage.join("\n"));
                 }

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -323,12 +323,7 @@ ${defaultMessage}`);
 
             // Check compatible engines before running the program:
             const npmRc = npmRcFromProjectRoot(projectRoot);
-            // Reads a boolean key from the npm rc file. Can be true or "true" (quoted string)
-            const readBool = (key: string) : boolean => npmRc[key] && new Boolean(npmRc[key]);
-
-            const engineStrict = readBool("engine-strict");
-
-            if (engineStrict && packageObject.engines && packageObject.engines.node) {
+            if (npmRc["engine-strict"] && packageObject.engines && packageObject.engines.node) {
                 // found:
                 //   - { engines: { node: "<version>" } } in package.json
                 //   - engine-strict=true in .npmrc

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,6 +13,7 @@
         "@logdna/tail-file": "^2.0.6",
         "@pulumi/query": "^0.3.0",
         "google-protobuf": "^3.5.0",
+        "ini": "^2.0.0",
         "js-yaml": "^3.14.0",
         "minimist": "^1.2.0",
         "normalize-package-data": "^2.4.0",
@@ -26,6 +27,7 @@
         "upath": "^1.1.0"
     },
     "devDependencies": {
+        "@types/ini": "^1.3.31",
         "@types/js-yaml": "^3.12.5",
         "@types/minimist": "^1.2.0",
         "@types/mocha": "^2.2.42",
@@ -36,12 +38,12 @@
         "@types/split2": "^2.1.6",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
-        "mockpackage": "file:tests/mockpackage",
         "eslint": "^7.32.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.23.4",
-        "nyc": "^15.1.0",
-        "mocha": "^9.0.0"
+        "mocha": "^9.0.0",
+        "mockpackage": "file:tests/mockpackage",
+        "nyc": "^15.1.0"
     },
     "pulumi": {
         "comment": "Do not remove. Marks this as as a deployment-time-only package"
@@ -53,6 +55,6 @@
         "require": ["ts-node/register", "source-map-support/register"]
     },
     "//": [
-       "NOTE: @types/node is pinned due to grpc/grpc-node#2002"
+        "NOTE: @types/node is pinned due to grpc/grpc-node#2002"
     ]
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9201

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
