### PR TITLE
Implement "pulumi state clear-pending-operations"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,6 +21,9 @@
 - [sdk/nodejs] - Take engines property into account when engine-strict appear in npmrc file 
   [#9249](https://github.com/pulumi/pulumi/pull/9249)
 
+- [cli] Implement `pulumi state clear-pending-operations`
+  [#9270](https://github.com/pulumi/pulumi/pull/9270)
+
 ### Bug Fixes
 
 - [sdk/nodejs] - Fix uncaught error "ENOENT: no such file or directory" when an error occurs during the stack up.

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -48,6 +48,7 @@ troubleshooting a stack or when performing specific edits that otherwise would r
 	cmd.AddCommand(newStateDeleteCommand())
 	cmd.AddCommand(newStateUnprotectCommand())
 	cmd.AddCommand(newStateRenameCommand())
+	cmd.AddCommand(newStateClearPendingOperationsCmd())
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/state_clear_pending_operations.go
+++ b/pkg/cmd/pulumi/state_clear_pending_operations.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/spf13/cobra"
+)
+
+func newStateClearPendingOperationsCmd() *cobra.Command {
+	var stack string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "clear-pending-operations",
+		Short: "Clears all pending operations of the checkpoint files",
+		Long:  "Clears all pending operations of the checkpoint files",
+		Args:  cmdutil.NoArgs,
+		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			showPrompt := yes || skipConfirmations()
+			return runTotalStateEdit(stack, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
+				// Clear the pending operations
+				snap.PendingOperations = make([]resource.Operation, 0)
+				return nil
+			})
+		}),
+	}
+
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	return cmd
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR implements `pulumi state clear-pending-operations` as an easier to way to clear pending operations from checkpoint files instead of exporting, editing and importing the stack files.

Fixes #4265. In that issue it is also discussed whether or not pulumi should internally and automatically decide to clear the pending operations. I am personally not sure either about the solution but for the time being at least the users will be able to easily clear the operations themselves without having to edit JSON files by hand. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
