### PR TITLE
[cli] Add a replay-events debug command.

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -236,7 +236,7 @@ func createDiff(updateKind apitype.UpdateKind, events []engine.Event, displayOpt
 	displayOpts.SummaryDiff = true
 
 	for _, e := range events {
-		msg := display.RenderDiffEvent(updateKind, e, seen, displayOpts)
+		msg := display.RenderDiffEvent(e, seen, displayOpts)
 		if msg != "" && e.Type != engine.SummaryEvent {
 			_, err := buff.WriteString(msg)
 			contract.IgnoreError(err)

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -36,8 +35,7 @@ import (
 )
 
 // ShowDiffEvents displays the engine events with the diff view.
-func ShowDiffEvents(op string, action apitype.UpdateKind,
-	events <-chan engine.Event, done chan<- bool, opts Options) {
+func ShowDiffEvents(op string, events <-chan engine.Event, done chan<- bool, opts Options) {
 
 	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op)
 
@@ -82,7 +80,7 @@ func ShowDiffEvents(op string, action apitype.UpdateKind,
 				}
 			}
 
-			msg := RenderDiffEvent(action, event, seen, opts)
+			msg := RenderDiffEvent(event, seen, opts)
 			if msg != "" && out != nil {
 				fprintIgnoreError(out, msg)
 			}
@@ -94,8 +92,7 @@ func ShowDiffEvents(op string, action apitype.UpdateKind,
 	}
 }
 
-func RenderDiffEvent(action apitype.UpdateKind, event engine.Event,
-	seen map[resource.URN]engine.StepEventMetadata, opts Options) string {
+func RenderDiffEvent(event engine.Event, seen map[resource.URN]engine.StepEventMetadata, opts Options) string {
 
 	switch event.Type {
 	case engine.CancelEvent:
@@ -107,7 +104,7 @@ func RenderDiffEvent(action apitype.UpdateKind, event engine.Event,
 		return renderPreludeEvent(event.Payload().(engine.PreludeEventPayload), opts)
 	case engine.SummaryEvent:
 		const wroteDiagnosticHeader = false
-		return renderSummaryEvent(action, event.Payload().(engine.SummaryEventPayload), wroteDiagnosticHeader, opts)
+		return renderSummaryEvent(event.Payload().(engine.SummaryEventPayload), wroteDiagnosticHeader, opts)
 	case engine.StdoutColorEvent:
 		return renderStdoutColorEvent(event.Payload().(engine.StdoutEventPayload), opts)
 
@@ -146,8 +143,7 @@ func renderStdoutColorEvent(payload engine.StdoutEventPayload, opts Options) str
 	return opts.Color.Colorize(payload.Message)
 }
 
-func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayload,
-	wroteDiagnosticHeader bool, opts Options) string {
+func renderSummaryEvent(event engine.SummaryEventPayload, wroteDiagnosticHeader bool, opts Options) string {
 
 	changes := event.ResourceChanges
 

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -56,21 +56,21 @@ func ShowEvents(
 
 	switch opts.Type {
 	case DisplayDiff:
-		ShowDiffEvents(op, action, events, done, opts)
+		ShowDiffEvents(op, events, done, opts)
 	case DisplayProgress:
 		ShowProgressEvents(op, action, stack, proj, events, done, opts, isPreview)
 	case DisplayQuery:
 		contract.Failf("DisplayQuery can only be used in query mode, which should be invoked " +
 			"directly instead of through ShowEvents")
 	case DisplayWatch:
-		ShowWatchEvents(op, action, events, done, opts)
+		ShowWatchEvents(op, events, done, opts)
 	default:
 		contract.Failf("Unknown display type %d", opts.Type)
 	}
 }
 
 func logJSONEvent(encoder *json.Encoder, event engine.Event, opts Options, seq int) error {
-	apiEvent, err := ConvertEngineEvent(event)
+	apiEvent, err := ConvertEngineEvent(event, false /* showSecrets */)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -1,13 +1,20 @@
 package display
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -17,7 +24,7 @@ import (
 //
 // IMPORTANT: Any resource secret data stored in the engine event will be encrypted using the
 // blinding encrypter, and unrecoverable. So this operation is inherently lossy.
-func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
+func ConvertEngineEvent(e engine.Event, showSecrets bool) (apitype.EngineEvent, error) {
 	var apiEvent apitype.EngineEvent
 
 	// Error to return if the payload doesn't match expected.
@@ -104,7 +111,7 @@ func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
 			return apiEvent, eventTypePayloadMismatch
 		}
 		apiEvent.ResourcePreEvent = &apitype.ResourcePreEvent{
-			Metadata: convertStepEventMetadata(p.Metadata),
+			Metadata: convertStepEventMetadata(p.Metadata, showSecrets),
 			Planning: p.Planning,
 		}
 
@@ -114,7 +121,7 @@ func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
 			return apiEvent, eventTypePayloadMismatch
 		}
 		apiEvent.ResOutputsEvent = &apitype.ResOutputsEvent{
-			Metadata: convertStepEventMetadata(p.Metadata),
+			Metadata: convertStepEventMetadata(p.Metadata, showSecrets),
 			Planning: p.Planning,
 		}
 
@@ -124,7 +131,7 @@ func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
 			return apiEvent, eventTypePayloadMismatch
 		}
 		apiEvent.ResOpFailedEvent = &apitype.ResOpFailedEvent{
-			Metadata: convertStepEventMetadata(p.Metadata),
+			Metadata: convertStepEventMetadata(p.Metadata, showSecrets),
 			Status:   int(p.Status),
 			Steps:    p.Steps,
 		}
@@ -136,7 +143,7 @@ func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
 	return apiEvent, nil
 }
 
-func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMetadata {
+func convertStepEventMetadata(md engine.StepEventMetadata, showSecrets bool) apitype.StepEventMetadata {
 	keys := make([]string, len(md.Keys))
 	for i, v := range md.Keys {
 		keys[i] = string(v)
@@ -178,8 +185,8 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 		URN:  string(md.URN),
 		Type: string(md.Type),
 
-		Old: convertStepEventStateMetadata(md.Old),
-		New: convertStepEventStateMetadata(md.New),
+		Old: convertStepEventStateMetadata(md.Old, showSecrets),
+		New: convertStepEventStateMetadata(md.New, showSecrets),
 
 		Keys:         keys,
 		Diffs:        diffs,
@@ -194,16 +201,18 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 //
 // IMPORTANT: Any secret values are encrypted using the blinding encrypter. So any secret data
 // in the resource state will be lost and unrecoverable.
-func convertStepEventStateMetadata(md *engine.StepEventStateMetadata) *apitype.StepEventStateMetadata {
+func convertStepEventStateMetadata(md *engine.StepEventStateMetadata,
+	showSecrets bool) *apitype.StepEventStateMetadata {
+
 	if md == nil {
 		return nil
 	}
 
 	encrypter := config.BlindingCrypter
-	inputs, err := stack.SerializeProperties(md.Inputs, encrypter, false /* showSecrets */)
+	inputs, err := stack.SerializeProperties(md.Inputs, encrypter, showSecrets)
 	contract.IgnoreError(err)
 
-	outputs, err := stack.SerializeProperties(md.Outputs, encrypter, false /* showSecrets */)
+	outputs, err := stack.SerializeProperties(md.Outputs, encrypter, showSecrets)
 	contract.IgnoreError(err)
 
 	return &apitype.StepEventStateMetadata{
@@ -214,6 +223,193 @@ func convertStepEventStateMetadata(md *engine.StepEventStateMetadata) *apitype.S
 		Delete:     md.Delete,
 		ID:         string(md.ID),
 		Parent:     string(md.Parent),
+		Protect:    md.Protect,
+		Inputs:     inputs,
+		Outputs:    outputs,
+		InitErrors: md.InitErrors,
+	}
+}
+
+// ConvertJSONEvent converts an apitype.EngineEvent from the Pulumi REST API into a raw engine.Event
+// Returns an error if the engine event is unknown or not in an expected format.
+//
+// IMPORTANT: Any resource secret data stored in the engine event will be encrypted using the
+// blinding encrypter, and unrecoverable. So this operation is inherently lossy.
+func ConvertJSONEvent(apiEvent apitype.EngineEvent) (engine.Event, error) {
+	var event engine.Event
+
+	switch {
+	case apiEvent.CancelEvent != nil:
+		event = engine.NewEvent(engine.CancelEvent, nil)
+
+	case apiEvent.StdoutEvent != nil:
+		p := apiEvent.StdoutEvent
+		event = engine.NewEvent(engine.StdoutColorEvent, engine.StdoutEventPayload{
+			Message: p.Message,
+			Color:   colors.Colorization(p.Color),
+		})
+
+	case apiEvent.DiagnosticEvent != nil:
+		p := apiEvent.DiagnosticEvent
+		event = engine.NewEvent(engine.DiagEvent, engine.DiagEventPayload{
+			URN:       resource.URN(p.URN),
+			Prefix:    p.Prefix,
+			Message:   p.Message,
+			Color:     colors.Colorization(p.Color),
+			Severity:  diag.Severity(p.Severity),
+			Ephemeral: p.Ephemeral,
+		})
+		apiEvent.DiagnosticEvent = &apitype.DiagnosticEvent{}
+
+	case apiEvent.PolicyEvent != nil:
+		p := apiEvent.PolicyEvent
+		event = engine.NewEvent(engine.PolicyViolationEvent, engine.PolicyViolationEventPayload{
+			ResourceURN:       resource.URN(p.ResourceURN),
+			Message:           p.Message,
+			Color:             colors.Colorization(p.Color),
+			PolicyName:        p.PolicyName,
+			PolicyPackName:    p.PolicyPackName,
+			PolicyPackVersion: p.PolicyPackVersion,
+			EnforcementLevel:  apitype.EnforcementLevel(p.EnforcementLevel),
+		})
+
+	case apiEvent.PreludeEvent != nil:
+		p := apiEvent.PreludeEvent
+
+		// Convert the config bag.
+		event = engine.NewEvent(engine.PreludeEvent, engine.PreludeEventPayload{
+			Config: p.Config,
+		})
+
+	case apiEvent.SummaryEvent != nil:
+		p := apiEvent.SummaryEvent
+		// Convert the resource changes.
+		changes := engine.ResourceChanges{}
+		for op, count := range p.ResourceChanges {
+			changes[deploy.StepOp(op)] = count
+		}
+		event = engine.NewEvent(engine.SummaryEvent, engine.SummaryEventPayload{
+			MaybeCorrupt:    p.MaybeCorrupt,
+			Duration:        time.Duration(p.DurationSeconds) * time.Second,
+			ResourceChanges: changes,
+			PolicyPacks:     p.PolicyPacks,
+		})
+
+	case apiEvent.ResourcePreEvent != nil:
+		p := apiEvent.ResourcePreEvent
+		event = engine.NewEvent(engine.ResourcePreEvent, engine.ResourcePreEventPayload{
+			Metadata: convertJSONStepEventMetadata(p.Metadata),
+			Planning: p.Planning,
+		})
+
+	case apiEvent.ResOutputsEvent != nil:
+		p := apiEvent.ResOutputsEvent
+		event = engine.NewEvent(engine.ResourceOutputsEvent, engine.ResourceOutputsEventPayload{
+			Metadata: convertJSONStepEventMetadata(p.Metadata),
+			Planning: p.Planning,
+		})
+
+	case apiEvent.ResOpFailedEvent != nil:
+		p := apiEvent.ResOpFailedEvent
+		event = engine.NewEvent(engine.ResourceOperationFailed, engine.ResourceOperationFailedPayload{
+			Metadata: convertJSONStepEventMetadata(p.Metadata),
+			Status:   resource.Status(p.Status),
+			Steps:    p.Steps,
+		})
+
+	default:
+		return event, errors.New("unknown event type")
+	}
+
+	return event, nil
+}
+
+func convertJSONStepEventMetadata(md apitype.StepEventMetadata) engine.StepEventMetadata {
+	keys := make([]resource.PropertyKey, len(md.Keys))
+	for i, v := range md.Keys {
+		keys[i] = resource.PropertyKey(v)
+	}
+	var diffs []resource.PropertyKey
+	for _, v := range md.Diffs {
+		diffs = append(diffs, resource.PropertyKey(v))
+	}
+	var detailedDiff map[string]plugin.PropertyDiff
+	if md.DetailedDiff != nil {
+		detailedDiff = make(map[string]plugin.PropertyDiff)
+		for k, v := range md.DetailedDiff {
+			var d plugin.DiffKind
+			switch v.Kind {
+			case apitype.DiffAdd:
+				d = plugin.DiffAdd
+			case apitype.DiffAddReplace:
+				d = plugin.DiffAddReplace
+			case apitype.DiffDelete:
+				d = plugin.DiffDelete
+			case apitype.DiffDeleteReplace:
+				d = plugin.DiffDeleteReplace
+			case apitype.DiffUpdate:
+				d = plugin.DiffUpdate
+			case apitype.DiffUpdateReplace:
+				d = plugin.DiffUpdateReplace
+			default:
+				contract.Failf("unrecognized diff kind %v", v)
+			}
+			detailedDiff[k] = plugin.PropertyDiff{
+				Kind:      d,
+				InputDiff: v.InputDiff,
+			}
+		}
+	}
+
+	old, new := convertJSONStepEventStateMetadata(md.Old), convertJSONStepEventStateMetadata(md.New)
+
+	res := old
+	if new != nil {
+		res = new
+	}
+
+	return engine.StepEventMetadata{
+		Op:   deploy.StepOp(md.Op),
+		URN:  resource.URN(md.URN),
+		Type: tokens.Type(md.Type),
+
+		Old: old,
+		New: new,
+		Res: res,
+
+		Keys:         keys,
+		Diffs:        diffs,
+		DetailedDiff: detailedDiff,
+		Logical:      md.Logical,
+		Provider:     md.Provider,
+	}
+}
+
+// convertJSONStepEventStateMetadata converts the internal StepEventStateMetadata to the API type
+// we send over the wire.
+//
+// IMPORTANT: Any secret values are encrypted using the blinding encrypter. So any secret data
+// in the resource state will be lost and unrecoverable.
+func convertJSONStepEventStateMetadata(md *apitype.StepEventStateMetadata) *engine.StepEventStateMetadata {
+	if md == nil {
+		return nil
+	}
+
+	crypter := config.BlindingCrypter
+	inputs, err := stack.DeserializeProperties(md.Inputs, crypter, crypter)
+	contract.IgnoreError(err)
+
+	outputs, err := stack.DeserializeProperties(md.Outputs, crypter, crypter)
+	contract.IgnoreError(err)
+
+	return &engine.StepEventStateMetadata{
+		Type: tokens.Type(md.Type),
+		URN:  resource.URN(md.URN),
+
+		Custom:     md.Custom,
+		Delete:     md.Delete,
+		ID:         resource.ID(md.ID),
+		Parent:     resource.URN(md.Parent),
 		Protect:    md.Protect,
 		Inputs:     inputs,
 		Outputs:    outputs,

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -914,7 +914,7 @@ func (display *ProgressDisplay) printSummary(wroteDiagnosticHeader bool) {
 		return
 	}
 
-	msg := renderSummaryEvent(display.action, *display.summaryEventPayload, wroteDiagnosticHeader, display.opts)
+	msg := renderSummaryEvent(*display.summaryEventPayload, wroteDiagnosticHeader, display.opts)
 	display.writeSimpleMessage(msg)
 }
 

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -35,7 +34,7 @@ import (
 const timeFormat = "15:04:05.000"
 
 // ShowWatchEvents renders incoming engine events for display in Watch Mode.
-func ShowWatchEvents(op string, action apitype.UpdateKind, events <-chan engine.Event, done chan<- bool, opts Options) {
+func ShowWatchEvents(op string, events <-chan engine.Event, done chan<- bool, opts Options) {
 	// Ensure we close the done channel before exiting.
 	defer func() { close(done) }()
 	for e := range events {

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -168,7 +168,7 @@ func (u *cloudUpdate) recordEngineEvents(startingSeqNumber int, events []engine.
 
 	var apiEvents apitype.EngineEventBatch
 	for idx, event := range events {
-		apiEvent, convErr := display.ConvertEngineEvent(event)
+		apiEvent, convErr := display.ConvertEngineEvent(event, false /* showSecrets */)
 		if convErr != nil {
 			return fmt.Errorf("converting engine event: %w", convErr)
 		}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -230,6 +230,8 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.AddCommand(newViewTraceCmd())
 	cmd.AddCommand(newConvertTraceCmd())
 
+	cmd.AddCommand(newReplayEventsCmd())
+
 	if !hasDebugCommands() {
 		err := cmd.PersistentFlags().MarkHidden("tracing-header")
 		contract.IgnoreError(err)

--- a/pkg/cmd/pulumi/replay_events.go
+++ b/pkg/cmd/pulumi/replay_events.go
@@ -1,0 +1,187 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func newReplayEventsCmd() *cobra.Command {
+	var preview bool
+
+	var jsonDisplay bool
+	var diffDisplay bool
+	var showConfig bool
+	var showReplacementSteps bool
+	var showSames bool
+	var showReads bool
+	var suppressOutputs bool
+	var debug bool
+
+	var delay time.Duration
+
+	var cmd = &cobra.Command{
+		Use:   "replay-events [kind] [events-file]",
+		Short: "Replay events from a prior update, refresh, or destroy",
+		Long: "Replay events from a prior update, refresh, or destroy.\n" +
+			"\n" +
+			"This command is used to replay events emitted by a prior\n" +
+			"invocation of the Pulumi CLI (e.g. `pulumi up --event-log [file]`).\n" +
+			"\n" +
+			"This command loads events from the indicated file and renders them\n" +
+			"using either the progress view or the diff view.\n",
+		Args:   cmdutil.ExactArgs(2),
+		Hidden: !hasDebugCommands(),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			var action apitype.UpdateKind
+			switch args[0] {
+			case "update":
+				if preview {
+					action = apitype.PreviewUpdate
+				} else {
+					action = apitype.UpdateUpdate
+				}
+			case "refresh":
+				action = apitype.RefreshUpdate
+			case "destroy":
+				action = apitype.DestroyUpdate
+			case "import":
+				action = apitype.ResourceImportUpdate
+			default:
+				return fmt.Errorf("unrecognized update kind '%v'", args[0])
+			}
+
+			var displayType = display.DisplayProgress
+			if diffDisplay {
+				displayType = display.DisplayDiff
+			}
+
+			displayOpts := display.Options{
+				Color:                cmdutil.GetGlobalColorization(),
+				ShowConfig:           showConfig,
+				ShowReplacementSteps: showReplacementSteps,
+				ShowSameResources:    showSames,
+				ShowReads:            showReads,
+				SuppressOutputs:      suppressOutputs,
+				IsInteractive:        cmdutil.Interactive(),
+				Type:                 displayType,
+				JSONDisplay:          jsonDisplay,
+				Debug:                debug,
+			}
+
+			events, err := loadEvents(args[1])
+			if err != nil {
+				return fmt.Errorf("error reading events: %w", err)
+			}
+
+			eventChannel, doneChannel := make(chan engine.Event), make(chan bool)
+
+			if delay != 0 {
+				time.Sleep(delay)
+			}
+
+			go display.ShowEvents(
+				"replay", action, "replay", "replay",
+				eventChannel, doneChannel, displayOpts, preview)
+
+			for _, e := range events {
+				eventChannel <- e
+			}
+			<-doneChannel
+
+			return nil
+		}),
+	}
+
+	cmd.PersistentFlags().BoolVarP(
+		&preview, "preview", "p", false,
+		"Must be set for events from a `pulumi preview`.")
+
+	cmd.PersistentFlags().BoolVarP(
+		&debug, "debug", "d", false,
+		"Print detailed debugging output during resource operations")
+	cmd.PersistentFlags().BoolVar(
+		&diffDisplay, "diff", false,
+		"Display operation as a rich diff showing the overall change")
+	cmd.Flags().BoolVarP(
+		&jsonDisplay, "json", "j", false,
+		"Serialize the preview diffs, operations, and overall output as JSON")
+	cmd.PersistentFlags().BoolVar(
+		&showConfig, "show-config", false,
+		"Show configuration keys and variables")
+	cmd.PersistentFlags().BoolVar(
+		&showReplacementSteps, "show-replacement-steps", false,
+		"Show detailed resource replacement creates and deletes instead of a single step")
+	cmd.PersistentFlags().BoolVar(
+		&showSames, "show-sames", false,
+		"Show resources that needn't be updated because they haven't changed, alongside those that do")
+	cmd.PersistentFlags().BoolVar(
+		&showReads, "show-reads", false,
+		"Show resources that are being read in, alongside those being managed directly in the stack")
+	cmd.PersistentFlags().BoolVar(
+		&suppressOutputs, "suppress-outputs", false,
+		"Suppress display of stack outputs (in case they contain sensitive values)")
+
+	cmd.PersistentFlags().DurationVar(&delay, "delay", time.Duration(0),
+		"Delay display by the given duration. Useful for attaching a debugger.")
+
+	return cmd
+}
+
+func loadEvents(path string) ([]engine.Event, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening '%v': %w", path, err)
+	}
+	defer contract.IgnoreClose(f)
+
+	var events []engine.Event
+	dec := json.NewDecoder(f)
+	for {
+		var jsonEvent apitype.EngineEvent
+		if err = dec.Decode(&jsonEvent); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decoding event: %w", err)
+		}
+
+		event, err := display.ConvertJSONEvent(jsonEvent)
+		if err != nil {
+			return nil, fmt.Errorf("decoding event: %w", err)
+		}
+		events = append(events, event)
+	}
+
+	// If there are no events or if the event stream does not terminate with a cancel event,
+	// synthesize one here.
+	if len(events) == 0 || events[len(events)-1].Type != engine.CancelEvent {
+		events = append(events, engine.NewEvent(engine.CancelEvent, nil))
+	}
+
+	return events, nil
+}


### PR DESCRIPTION
This command renders a recorded stream of engine events using either the
progress or diff renderer. This is useful for debugging problems with
these renderers.