### PR TITLE
Revert "Strip Aliases from state (#9275)"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,11 +23,6 @@
 
 ### Bug Fixes
 
-- [cli/engine] - Stops storing aliases in state due to the impact on file size and upload time. Due
-  to [#8627](https://github.com/pulumi/pulumi/pull/8627), the number of aliases stored in state
-  increases combinatorially with the number of type aliases of a resource and of each of its
-  ancestors. [#9089](https://github.com/pulumi/pulumi/issues/9089)
-
 - [sdk/nodejs] - Fix uncaught error "ENOENT: no such file or directory" when an error occurs during the stack up.
   [#9065](https://github.com/pulumi/pulumi/issues/9065)
 

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -86,7 +86,7 @@ func stateForJSONOutput(s *resource.State, opts Options) *resource.State {
 
 	return resource.NewState(s.Type, s.URN, s.Custom, s.Delete, s.ID, inputs,
 		outputs, s.Parent, s.Protect, s.External, s.Dependencies, s.InitErrors, s.Provider,
-		s.PropertyDependencies, s.PendingReplacement, s.AdditionalSecretOutputs, &s.CustomTimeouts,
+		s.PropertyDependencies, s.PendingReplacement, s.AdditionalSecretOutputs, s.Aliases, &s.CustomTimeouts,
 		s.ImportID, s.SequenceNumber, s.RetainOnDelete)
 }
 

--- a/pkg/engine/lifeycletest/golang_sdk_test.go
+++ b/pkg/engine/lifeycletest/golang_sdk_test.go
@@ -275,6 +275,7 @@ func TestSingleResourceDefaultProviderGolangTransformations(t *testing.T) {
 				if res.URN.Name() == "res3" {
 					foundRes3 = true
 					assert.Equal(t, "baz", res.Inputs["foo"].StringValue())
+					assert.Len(t, res.Aliases, 0)
 				}
 				// "res4" is impacted by two component parent transformations which set
 				// Foo to "baz1" and then "baz2" and also a global stack

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -1476,6 +1476,26 @@ func TestAliases(t *testing.T) {
 		},
 	}}, []deploy.StepOp{deploy.OpSame, deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced})
 
+	// ensure failure when different resources use duplicate aliases
+	snap = updateProgramWithResource(nil, []Resource{{
+		t:    "pkgA:index:t1",
+		name: "n1",
+		aliases: []resource.URN{
+			"urn:pulumi:test::test::pkgA:index:t1::n1",
+		},
+	}, {
+		t:    "pkgA:index:t2",
+		name: "n2",
+		aliases: []resource.URN{
+			"urn:pulumi:test::test::pkgA:index:t1::n1",
+		},
+	}}, []deploy.StepOp{deploy.OpCreate})
+
+	err := snap.NormalizeURNReferences()
+	assert.Equal(t, err.Error(),
+		"Two resources ('urn:pulumi:test::test::pkgA:index:t1::n1'"+
+			" and 'urn:pulumi:test::test::pkgA:index:t2::n2') aliased to the same: 'urn:pulumi:test::test::pkgA:index:t1::n1'")
+
 	// ensure different resources can use different aliases
 	snap = updateProgramWithResource(nil, []Resource{{
 		t:    "pkgA:index:t1",
@@ -1491,7 +1511,7 @@ func TestAliases(t *testing.T) {
 		},
 	}}, []deploy.StepOp{deploy.OpCreate})
 
-	err := snap.NormalizeURNReferences()
+	err = snap.NormalizeURNReferences()
 	assert.Nil(t, err)
 }
 

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -168,7 +168,7 @@ func (i *importer) getOrCreateStackResource(ctx context.Context) (resource.URN, 
 	typ, name := resource.RootStackType, fmt.Sprintf("%s-%s", projectName, stackName)
 	urn := resource.NewURN(stackName.Q(), projectName, "", typ, tokens.QName(name))
 	state := resource.NewState(typ, urn, false, false, "", resource.PropertyMap{}, nil, "", false, false, nil, nil, "",
-		nil, false, nil, nil, "", 0, false)
+		nil, false, nil, nil, nil, "", 0, false)
 	// TODO(seqnum) should stacks be created with 1? When do they ever get recreated/replaced?
 	if !i.executeSerial(ctx, NewCreateStep(i.deployment, noopEvent(0), state)) {
 		return "", false, false
@@ -254,7 +254,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		}
 
 		state := resource.NewState(typ, urn, true, false, "", inputs, nil, "", false, false, nil, nil, "", nil, false,
-			nil, nil, "", 0, false)
+			nil, nil, nil, "", 0, false)
 		// TODO(seqnum) should default providers be created with 1? When do they ever get recreated/replaced?
 		if issueCheckErrors(i.deployment, state, urn, failures) {
 			return nil, nil, false
@@ -341,7 +341,7 @@ func (i *importer) importResources(ctx context.Context) result.Result {
 
 		// Create the new desired state. Note that the resource is protected.
 		new := resource.NewState(urn.Type(), urn, true, false, imp.ID, resource.PropertyMap{}, nil, parent, imp.Protect,
-			false, nil, nil, provider, nil, false, nil, nil, "", 1, false)
+			false, nil, nil, provider, nil, false, nil, nil, nil, "", 1, false)
 		steps = append(steps, newImportDeploymentStep(i.deployment, new))
 	}
 

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -291,7 +291,7 @@ func checkMissingPlan(
 		DeleteBeforeReplace:     nil,
 		IgnoreChanges:           nil,
 		AdditionalSecretOutputs: oldState.AdditionalSecretOutputs,
-		Aliases:                 nil,
+		Aliases:                 oldState.Aliases,
 		ID:                      "",
 		CustomTimeouts:          oldState.CustomTimeouts,
 	}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -83,6 +83,17 @@ func (snap *Snapshot) NormalizeURNReferences() error {
 				contract.AssertNoError(err)
 				state.Provider = ref.String()
 			}
+
+			// Add to aliased maps
+			for _, alias := range state.Aliases {
+				// For ease of implementation, some SDKs may end up creating the same alias to the
+				// same resource multiple times.  That's fine, only error if we see the same alias,
+				// but it maps to *different* resources.
+				if otherUrn, has := aliased[alias]; has && otherUrn != state.URN {
+					return fmt.Errorf("Two resources ('%s' and '%s') aliased to the same: '%s'", otherUrn, state.URN, alias)
+				}
+				aliased[alias] = state.URN
+			}
 		}
 	}
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -70,7 +70,7 @@ func fixedProgram(steps []RegisterResourceEvent) deploytest.ProgramFunc {
 			}
 			s.Done(&RegisterResult{
 				State: resource.NewState(g.Type, urn, g.Custom, false, id, g.Properties, outs, g.Parent, g.Protect,
-					false, g.Dependencies, nil, g.Provider, g.PropertyDependencies, false, nil, nil,
+					false, g.Dependencies, nil, g.Provider, g.PropertyDependencies, false, nil, nil, nil,
 					"", 0, false),
 			})
 		}
@@ -236,7 +236,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 		reg.Done(&RegisterResult{
 			State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
 				goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
-				false, nil, nil, "", 0, false),
+				false, nil, nil, nil, "", 0, false),
 		})
 
 		processed++
@@ -330,7 +330,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 		reg.Done(&RegisterResult{
 			State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
 				goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
-				false, nil, nil, "", 0, false),
+				false, nil, nil, nil, "", 0, false),
 		})
 
 		processed++
@@ -422,7 +422,7 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 		read.Done(&ReadResult{
 			State: resource.NewState(read.Type(), urn, true, false, read.ID(), read.Properties(),
 				resource.PropertyMap{}, read.Parent(), false, false, read.Dependencies(), nil, read.Provider(), nil,
-				false, nil, nil, "", 0, false),
+				false, nil, nil, nil, "", 0, false),
 		})
 		reads++
 	}
@@ -509,7 +509,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 			e.Done(&RegisterResult{
 				State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
 					goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
-					false, nil, nil, "", 0, false),
+					false, nil, nil, nil, "", 0, false),
 			})
 			registers++
 
@@ -518,7 +518,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 			e.Done(&ReadResult{
 				State: resource.NewState(e.Type(), urn, true, false, e.ID(), e.Properties(),
 					resource.PropertyMap{}, e.Parent(), false, false, e.Dependencies(), nil, e.Provider(), nil, false,
-					nil, nil, "", 0, false),
+					nil, nil, nil, "", 0, false),
 			})
 			reads++
 		}
@@ -673,7 +673,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 					event.Done(&ReadResult{
 						State: resource.NewState(event.Type(), urn, true, false, event.ID(), event.Properties(),
 							resource.PropertyMap{}, event.Parent(), false, false, event.Dependencies(), nil, event.Provider(), nil,
-							false, nil, nil, "", 0, false),
+							false, nil, nil, nil, "", 0, false),
 					})
 					reads++
 				case RegisterResourceEvent:
@@ -681,7 +681,7 @@ func TestDisableDefaultProviders(t *testing.T) {
 					event.Done(&RegisterResult{
 						State: resource.NewState(event.Goal().Type, urn, true, false, event.Goal().ID, event.Goal().Properties,
 							resource.PropertyMap{}, event.Goal().Parent, false, false, event.Goal().Dependencies, nil,
-							event.Goal().Provider, nil, false, nil, nil, "", 0, false),
+							event.Goal().Provider, nil, false, nil, nil, nil, "", 0, false),
 					})
 					registers++
 				default:

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -782,7 +782,7 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 
 		s.new = resource.NewState(s.old.Type, s.old.URN, s.old.Custom, s.old.Delete, resourceID, inputs, outputs,
 			s.old.Parent, s.old.Protect, s.old.External, s.old.Dependencies, initErrors, s.old.Provider,
-			s.old.PropertyDependencies, s.old.PendingReplacement, s.old.AdditionalSecretOutputs,
+			s.old.PropertyDependencies, s.old.PendingReplacement, s.old.AdditionalSecretOutputs, s.old.Aliases,
 			&s.old.CustomTimeouts, s.old.ImportID, s.old.SequenceNumber, s.old.RetainOnDelete)
 	} else {
 		s.new = nil
@@ -925,7 +925,7 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	// differences between the old and new states are between the inputs and outputs.
 	s.old = resource.NewState(s.new.Type, s.new.URN, s.new.Custom, false, s.new.ID, read.Inputs, read.Outputs,
 		s.new.Parent, s.new.Protect, false, s.new.Dependencies, s.new.InitErrors, s.new.Provider,
-		s.new.PropertyDependencies, false, nil, &s.new.CustomTimeouts, s.new.ImportID,
+		s.new.PropertyDependencies, false, nil, nil, &s.new.CustomTimeouts, s.new.ImportID,
 		s.new.SequenceNumber, s.new.RetainOnDelete)
 
 	// If this step came from an import deployment, we need to fetch any required inputs from the state.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -129,6 +129,7 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, res
 		nil,   /* propertyDependencies */
 		false, /* deleteBeforeCreate */
 		event.AdditionalSecretOutputs(),
+		nil,   /* aliases */
 		nil,   /* customTimeouts */
 		"",    /* importID */
 		1,     /* sequenceNumber */
@@ -324,7 +325,7 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 	// get serialized into the checkpoint file.
 	new := resource.NewState(goal.Type, urn, goal.Custom, false, "", inputs, nil, goal.Parent, goal.Protect, false,
 		goal.Dependencies, goal.InitErrors, goal.Provider, goal.PropertyDependencies, false,
-		goal.AdditionalSecretOutputs, &goal.CustomTimeouts, "", 1, goal.RetainOnDelete)
+		goal.AdditionalSecretOutputs, goal.Aliases, &goal.CustomTimeouts, "", 1, goal.RetainOnDelete)
 	if hasOld {
 		new.SequenceNumber = old.SequenceNumber
 	}
@@ -491,7 +492,7 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 				IgnoreChanges:           goal.IgnoreChanges,
 				DeleteBeforeReplace:     goal.DeleteBeforeReplace,
 				AdditionalSecretOutputs: new.AdditionalSecretOutputs,
-				Aliases:                 goal.Aliases,
+				Aliases:                 new.Aliases,
 				CustomTimeouts:          new.CustomTimeouts,
 			},
 		}
@@ -1689,7 +1690,7 @@ func (sg *stepGenerator) AnalyzeResources() result.Result {
 					IgnoreChanges:           goal.IgnoreChanges,
 					DeleteBeforeReplace:     goal.DeleteBeforeReplace,
 					AdditionalSecretOutputs: v.AdditionalSecretOutputs,
-					Aliases:                 goal.Aliases,
+					Aliases:                 v.Aliases,
 					CustomTimeouts:          v.CustomTimeouts,
 				},
 			},

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -319,6 +319,7 @@ func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bo
 		PropertyDependencies:    res.PropertyDependencies,
 		PendingReplacement:      res.PendingReplacement,
 		AdditionalSecretOutputs: res.AdditionalSecretOutputs,
+		Aliases:                 res.Aliases,
 		ImportID:                res.ImportID,
 		SequenceNumber:          res.SequenceNumber,
 		RetainOnDelete:          res.RetainOnDelete,
@@ -502,7 +503,7 @@ func DeserializeResource(res apitype.ResourceV3, dec config.Decrypter, enc confi
 	return resource.NewState(
 		res.Type, res.URN, res.Custom, res.Delete, res.ID,
 		inputs, outputs, res.Parent, res.Protect, res.External, res.Dependencies, res.InitErrors, res.Provider,
-		res.PropertyDependencies, res.PendingReplacement, res.AdditionalSecretOutputs, res.CustomTimeouts,
+		res.PropertyDependencies, res.PendingReplacement, res.AdditionalSecretOutputs, res.Aliases, res.CustomTimeouts,
 		res.ImportID, res.SequenceNumber, res.RetainOnDelete), nil
 }
 

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -95,6 +95,7 @@ func TestDeploymentSerialization(t *testing.T) {
 		false,
 		nil,
 		nil,
+		nil,
 		"",
 		0,
 		false,

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -318,6 +318,8 @@ type ResourceV3 struct {
 	PendingReplacement bool `json:"pendingReplacement,omitempty" yaml:"pendingReplacement,omitempty"`
 	// AdditionalSecretOutputs is a list of outputs that were explicitly marked as secret when the resource was created.
 	AdditionalSecretOutputs []resource.PropertyKey `json:"additionalSecretOutputs,omitempty" yaml:"additionalSecretOutputs,omitempty"`
+	// Aliases is a list of previous URNs that this resource may have had in previous deployments.
+	Aliases []resource.URN `json:"aliases,omitempty" yaml:"aliases,omitempty"`
 	// CustomTimeouts is a configuration block that can be used to control timeouts of CRUD operations.
 	CustomTimeouts *resource.CustomTimeouts `json:"customTimeouts,omitempty" yaml:"customTimeouts,omitempty"`
 	// ImportID is the import input used for imported resources.

--- a/sdk/go/common/resource/resource_state.go
+++ b/sdk/go/common/resource/resource_state.go
@@ -40,6 +40,7 @@ type State struct {
 	PropertyDependencies    map[PropertyKey][]URN // the set of dependencies that affect each property.
 	PendingReplacement      bool                  // true if this resource was deleted and is awaiting replacement.
 	AdditionalSecretOutputs []PropertyKey         // an additional set of outputs that should be treated as secrets.
+	Aliases                 []URN                 // TODO
 	CustomTimeouts          CustomTimeouts        // A config block that will be used to configure timeouts for CRUD operations.
 	ImportID                ID                    // the resource's import id, if this was an imported resource.
 	SequenceNumber          int                   // an auto-incrementing sequence number for each time this resource gets created/replaced (0 means sequence numbers are unknown, -1 means the last replace didn't use a sequence number).
@@ -51,7 +52,7 @@ func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 	inputs PropertyMap, outputs PropertyMap, parent URN, protect bool,
 	external bool, dependencies []URN, initErrors []string, provider string,
 	propertyDependencies map[PropertyKey][]URN, pendingReplacement bool,
-	additionalSecretOutputs []PropertyKey, timeouts *CustomTimeouts,
+	additionalSecretOutputs []PropertyKey, aliases []URN, timeouts *CustomTimeouts,
 	importID ID, sequenceNumber int, retainOnDelete bool) *State {
 
 	contract.Assertf(t != "", "type was empty")
@@ -75,6 +76,7 @@ func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 		PropertyDependencies:    propertyDependencies,
 		PendingReplacement:      pendingReplacement,
 		AdditionalSecretOutputs: additionalSecretOutputs,
+		Aliases:                 aliases,
 		ImportID:                importID,
 		SequenceNumber:          sequenceNumber,
 		RetainOnDelete:          retainOnDelete,


### PR DESCRIPTION
This reverts commit 17068e9b4907cc22acc65c3f80aca2f6aa8caa9f.

Turns out NormalizeURNReferences needs this in the state to fix up URNs while the deployment is running. It feels like we should be able to either thread this information through to the snapshot manager another way but it's not obvious how. It's also tricky to test because snapshot code differs massively in unit tests compared to proper runs.