### PR TITLE
Fix generated code panic on *nil

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,3 +34,6 @@
 
 - [cli/engine] - Fix a panic due to `Check` failing while using update plans.
   [#9254](https://github.com/pulumi/pulumi/pull/9254)
+
+- [codegen/go] - Fix Go SDK function output to check for errors
+  [pulumi-aws#1872](https://github.com/pulumi/pulumi-aws/issues/1872)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2073,11 +2073,18 @@ func ${fn}Output(ctx *pulumi.Context, args ${fn}OutputArgs, opts ...pulumi.Invok
 		ApplyT(func(v interface{}) (${fn}Result, error) {
 			args := v.(${fn}Args)
 			r, err := ${fn}(ctx, &args, opts...)
+			if err != nil {
+				return nil, err
+			}
+			if r == nil {
+				return nil, fmt.Errorf("expected either result or error to be nil, not both")
+			}
 			return *r, err
 		}).(${outputType})
 }
 
 `
+
 	code = strings.ReplaceAll(code, "${fn}", originalName)
 	code = strings.ReplaceAll(code, "${outputType}", resultTypeName)
 	fmt.Fprintf(w, code)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2073,13 +2073,11 @@ func ${fn}Output(ctx *pulumi.Context, args ${fn}OutputArgs, opts ...pulumi.Invok
 		ApplyT(func(v interface{}) (${fn}Result, error) {
 			args := v.(${fn}Args)
 			r, err := ${fn}(ctx, &args, opts...)
-			if err != nil {
-				return nil, err
-			}
-			if r == nil {
-				return nil, fmt.Errorf("expected either result or error to be nil, not both")
-			}
-			return *r, err
+                        var s ${fn}Result
+                        if r != nil {
+                                s = *r
+                        }
+			return s, err
 		}).(${outputType})
 }
 

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/argFunction.go
@@ -33,7 +33,11 @@ func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...
 		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
 			args := v.(ArgFunctionArgs)
 			r, err := ArgFunction(ctx, &args, opts...)
-			return *r, err
+			var s ArgFunctionResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(ArgFunctionResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
@@ -43,7 +43,11 @@ func ListConfigurationsOutput(ctx *pulumi.Context, args ListConfigurationsOutput
 		ApplyT(func(v interface{}) (ListConfigurationsResult, error) {
 			args := v.(ListConfigurationsArgs)
 			r, err := ListConfigurations(ctx, &args, opts...)
-			return *r, err
+			var s ListConfigurationsResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(ListConfigurationsResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
@@ -45,7 +45,11 @@ func ListProductFamiliesOutput(ctx *pulumi.Context, args ListProductFamiliesOutp
 		ApplyT(func(v interface{}) (ListProductFamiliesResult, error) {
 			args := v.(ListProductFamiliesArgs)
 			r, err := ListProductFamilies(ctx, &args, opts...)
-			return *r, err
+			var s ListProductFamiliesResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(ListProductFamiliesResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
@@ -60,7 +60,11 @@ func GetAmiIdsOutput(ctx *pulumi.Context, args GetAmiIdsOutputArgs, opts ...pulu
 		ApplyT(func(v interface{}) (GetAmiIdsResult, error) {
 			args := v.(GetAmiIdsArgs)
 			r, err := GetAmiIds(ctx, &args, opts...)
-			return *r, err
+			var s GetAmiIdsResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(GetAmiIdsResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
@@ -41,7 +41,11 @@ func ListStorageAccountKeysOutput(ctx *pulumi.Context, args ListStorageAccountKe
 		ApplyT(func(v interface{}) (ListStorageAccountKeysResult, error) {
 			args := v.(ListStorageAccountKeysArgs)
 			r, err := ListStorageAccountKeys(ctx, &args, opts...)
-			return *r, err
+			var s ListStorageAccountKeysResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(ListStorageAccountKeysResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
@@ -36,7 +36,11 @@ func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOption
 		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResult, error) {
 			args := v.(FuncWithAllOptionalInputsArgs)
 			r, err := FuncWithAllOptionalInputs(ctx, &args, opts...)
-			return *r, err
+			var s FuncWithAllOptionalInputsResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(FuncWithAllOptionalInputsResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDefaultValue.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDefaultValue.go
@@ -47,7 +47,11 @@ func FuncWithDefaultValueOutput(ctx *pulumi.Context, args FuncWithDefaultValueOu
 		ApplyT(func(v interface{}) (FuncWithDefaultValueResult, error) {
 			args := v.(FuncWithDefaultValueArgs)
 			r, err := FuncWithDefaultValue(ctx, &args, opts...)
-			return *r, err
+			var s FuncWithDefaultValueResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(FuncWithDefaultValueResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDictParam.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDictParam.go
@@ -34,7 +34,11 @@ func FuncWithDictParamOutput(ctx *pulumi.Context, args FuncWithDictParamOutputAr
 		ApplyT(func(v interface{}) (FuncWithDictParamResult, error) {
 			args := v.(FuncWithDictParamArgs)
 			r, err := FuncWithDictParam(ctx, &args, opts...)
-			return *r, err
+			var s FuncWithDictParamResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(FuncWithDictParamResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithListParam.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithListParam.go
@@ -34,7 +34,11 @@ func FuncWithListParamOutput(ctx *pulumi.Context, args FuncWithListParamOutputAr
 		ApplyT(func(v interface{}) (FuncWithListParamResult, error) {
 			args := v.(FuncWithListParamArgs)
 			r, err := FuncWithListParam(ctx, &args, opts...)
-			return *r, err
+			var s FuncWithListParamResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(FuncWithListParamResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getBastionShareableLink.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getBastionShareableLink.go
@@ -41,7 +41,11 @@ func GetBastionShareableLinkOutput(ctx *pulumi.Context, args GetBastionShareable
 		ApplyT(func(v interface{}) (GetBastionShareableLinkResult, error) {
 			args := v.(GetBastionShareableLinkArgs)
 			r, err := GetBastionShareableLink(ctx, &args, opts...)
-			return *r, err
+			var s GetBastionShareableLinkResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(GetBastionShareableLinkResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
@@ -45,7 +45,11 @@ func GetIntegrationRuntimeObjectMetadatumOutput(ctx *pulumi.Context, args GetInt
 		ApplyT(func(v interface{}) (GetIntegrationRuntimeObjectMetadatumResult, error) {
 			args := v.(GetIntegrationRuntimeObjectMetadatumArgs)
 			r, err := GetIntegrationRuntimeObjectMetadatum(ctx, &args, opts...)
-			return *r, err
+			var s GetIntegrationRuntimeObjectMetadatumResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(GetIntegrationRuntimeObjectMetadatumResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/listStorageAccountKeys.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/listStorageAccountKeys.go
@@ -41,7 +41,11 @@ func ListStorageAccountKeysOutput(ctx *pulumi.Context, args ListStorageAccountKe
 		ApplyT(func(v interface{}) (ListStorageAccountKeysResult, error) {
 			args := v.(ListStorageAccountKeysArgs)
 			r, err := ListStorageAccountKeys(ctx, &args, opts...)
-			return *r, err
+			var s ListStorageAccountKeysResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(ListStorageAccountKeysResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
@@ -51,7 +51,11 @@ func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOption
 		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResult, error) {
 			args := v.(FuncWithAllOptionalInputsArgs)
 			r, err := FuncWithAllOptionalInputs(ctx, &args, opts...)
-			return *r, err
+			var s FuncWithAllOptionalInputsResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(FuncWithAllOptionalInputsResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
@@ -36,7 +36,11 @@ func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOption
 		ApplyT(func(v interface{}) (FuncWithAllOptionalInputsResult, error) {
 			args := v.(FuncWithAllOptionalInputsArgs)
 			r, err := FuncWithAllOptionalInputs(ctx, &args, opts...)
-			return *r, err
+			var s FuncWithAllOptionalInputsResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(FuncWithAllOptionalInputsResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
@@ -32,7 +32,11 @@ func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...
 		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
 			args := v.(ArgFunctionArgs)
 			r, err := ArgFunction(ctx, &args, opts...)
-			return *r, err
+			var s ArgFunctionResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(ArgFunctionResultOutput)
 }
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/argFunction.go
@@ -33,7 +33,11 @@ func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...
 		ApplyT(func(v interface{}) (ArgFunctionResult, error) {
 			args := v.(ArgFunctionArgs)
 			r, err := ArgFunction(ctx, &args, opts...)
-			return *r, err
+			var s ArgFunctionResult
+			if r != nil {
+				s = *r
+			}
+			return s, err
 		}).(ArgFunctionResultOutput)
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

@guineveresaenger how about this version? The `fmt.Errorf()` ran into some issues with having to import `fmt` which unfortunately are still really pesky in our go codegen, we need to work out automatic `import()` section fixup. The alternate version simply coerces `nil` to empty struct. I don't think it's much of a problem as this should not arise really in practice - the underlying code should `err` or else return non-nil. The original error is fixed in this version by guarding `*r` by a nil check.

I've then auto-updated the test cases to match:

```
cd pkg/codegen/go
PULUMI_ACCEPT=1 go test -test.v
```

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
