### PR TITLE
Warn users when there are pending operations but proceed with deployment

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - Clear pending operations during `pulumi refresh` or `pulumi up -r`.
   [#8435](https://github.com/pulumi/pulumi/pull/8435)
 
+- [cli] Warn users when there are pending operations but proceed with deployment
+  [#9293](https://github.com/pulumi/pulumi/pull/9293)
+
 ### Bug Fixes
 
 - [codegen/go] - Fix Go SDK function output to check for errors

--- a/pkg/cmd/pulumi/errors.go
+++ b/pkg/cmd/pulumi/errors.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -26,10 +25,6 @@ func PrintEngineResult(res result.Result) result.Result {
 	err := res.Error()
 
 	switch e := err.(type) {
-	case deploy.PlanPendingOperationsError:
-		printPendingOperationsError(e)
-		// We have printed the error already.  Should just bail at this point.
-		return result.Bail()
 	case engine.DecryptError:
 		printDecryptError(e)
 		// We have printed the error already.  Should just bail at this point.
@@ -38,33 +33,6 @@ func PrintEngineResult(res result.Result) result.Result {
 		// Caller will handle printing of this true error in a generalized fashion.
 		return res
 	}
-}
-
-func printPendingOperationsError(e deploy.PlanPendingOperationsError) {
-	var buf bytes.Buffer
-	writer := bufio.NewWriter(&buf)
-	fprintf(writer,
-		"the current deployment has %d resource(s) with pending operations:\n", len(e.Operations))
-
-	for _, op := range e.Operations {
-		fprintf(writer, "  * %s, interrupted while %s\n", op.Resource.URN, op.Type)
-	}
-
-	fprintf(writer, `
-These resources are in an unknown state because the Pulumi CLI was interrupted while
-waiting for changes to these resources to complete. You should confirm whether or not the
-operations listed completed successfully by checking the state of the appropriate provider.
-For example, if you are using AWS, you can confirm using the AWS Console.
-
-Once you have confirmed the status of the interrupted operations, you can repair your stack
-using 'pulumi stack export' to export your stack to a file. For each operation that succeeded,
-remove that operation from the "pending_operations" section of the file. Once this is complete,
-use 'pulumi stack import' to import the repaired stack.
-
-refusing to proceed`)
-	contract.IgnoreError(writer.Flush())
-
-	cmdutil.Diag().Errorf(diag.RawMessage("" /*urn*/, buf.String()))
 }
 
 func printDecryptError(e engine.DecryptError) {

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -616,7 +616,9 @@ func TestRefreshWithPendingOperations(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-// Test to make sure that if we pulumi refresh while having pending CREATE operations, that these are preserved after the refresh.
+// Test to make sure that if we pulumi refresh
+// while having pending CREATE operations,
+// that these are preserved after the refresh.
 func TestRefreshPreservesPendingCreateOperations(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -738,15 +738,15 @@ func TestUpdateShowsWarningWithPendingoOperations(t *testing.T) {
 	project, target := p.GetProject(), p.GetTarget(t, old)
 
 	// The update should succeed but give a warning
+	initialPartOfMessage := "Attempting to deploy or update resources with 1 pending operations from previous deployment."
 	validate := func(
 		project workspace.Project, target deploy.Target,
 		entries JournalEntries, events []Event,
 		res result.Result) result.Result {
-
 		for i := range events {
 			if events[i].Type == "diag" {
 				payload := events[i].Payload().(engine.DiagEventPayload)
-				initialPartOfMessage := "Attempting to deploy or update resources with 1 pending operations from previous deployment."
+
 				if payload.Severity == "warning" && strings.Contains(payload.Message, initialPartOfMessage) {
 					return nil
 				}

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -550,11 +550,6 @@ func TestPreviewWithPendingOperations(t *testing.T) {
 	// A preview should succeed despite the pending operations.
 	_, res := op.Run(project, target, options, true, nil, nil)
 	assert.Nil(t, res)
-
-	// But an update should fail.
-	_, res = op.Run(project, target, options, false, nil, nil)
-	assertIsErrorOrBailResult(t, res)
-	assert.EqualError(t, res.Error(), deploy.PlanPendingOperationsError{}.Error())
 }
 
 // Tests that a refresh works for a stack with pending operations.
@@ -604,11 +599,6 @@ func TestRefreshWithPendingOperations(t *testing.T) {
 	op := TestOp(Update)
 	options := UpdateOptions{Host: deploytest.NewPluginHost(nil, nil, program, loaders...)}
 	project, target := p.GetProject(), p.GetTarget(t, old)
-
-	// Without refreshing, an update should fail.
-	_, res := op.Run(project, target, options, false, nil, nil)
-	assertIsErrorOrBailResult(t, res)
-	assert.EqualError(t, res.Error(), deploy.PlanPendingOperationsError{}.Error())
 
 	// With a refresh, the update should succeed.
 	withRefresh := options

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -98,17 +98,6 @@ type Events interface {
 	PolicyEvents
 }
 
-// PlanPendingOperationsError is an error returned from `NewPlan` if there exist pending operations in the
-// snapshot that we are preparing to operate upon. The engine does not allow any operations to be pending
-// when operating on a snapshot.
-type PlanPendingOperationsError struct {
-	Operations []resource.Operation
-}
-
-func (p PlanPendingOperationsError) Error() string {
-	return "one or more operations are currently pending"
-}
-
 type goalMap struct {
 	m sync.Map
 }

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -97,9 +97,9 @@ func (ex *deploymentExecutor) checkTargets(targets []resource.URN, op StepOp) re
 	return nil
 }
 
-func (executer *deploymentExecutor) printPendingOperationsWarning() {
+func (ex *deploymentExecutor) printPendingOperationsWarning() {
 	pendingOperations := ""
-	for _, op := range executer.deployment.prev.PendingOperations {
+	for _, op := range ex.deployment.prev.PendingOperations {
 		pendingOperations = pendingOperations + fmt.Sprintf("  * %s, interrupted while %s\n", op.Resource.URN, op.Type)
 	}
 
@@ -112,18 +112,18 @@ Once you have confirmed the status of the interrupted operations, you can repair
 using 'pulumi refresh' which will refresh the state from the provider you are using and 
 clear the pending operations if there are any.
 
-Not that 'pulumi refresh' will not clear pending CREATE operations since those could have resulted in resources which are
-not tracked by pulumi. To repair the stack and remove pending CREATE operation, use 'pulumi stack export' which will 
-export your stack to a file. For each operation that succeeded,
+Note that 'pulumi refresh' will not clear pending CREATE operations since those could have resulted in resources 
+which are not tracked by pulumi. To repair the stack and remove pending CREATE operation, 
+use 'pulumi stack export' which will  export your stack to a file. For each operation that succeeded,
 remove that operation from the "pending_operations" section of the file. Once this is complete,
 use 'pulumi stack import' to import the repaired stack.`
 
 	warning := "Attempting to deploy or update resources " +
-		fmt.Sprintf("with %d pending operations from previous deployment.\n", len(executer.deployment.prev.PendingOperations)) +
+		fmt.Sprintf("with %d pending operations from previous deployment.\n", len(ex.deployment.prev.PendingOperations)) +
 		pendingOperations +
 		resolutionMessage
 
-	executer.deployment.Diag().Warningf(diag.RawMessage("" /*urn*/, warning))
+	ex.deployment.Diag().Warningf(diag.RawMessage("" /*urn*/, warning))
 }
 
 // reportExecResult issues an appropriate diagnostic depending on went wrong.

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -123,8 +123,7 @@ use 'pulumi stack import' to import the repaired stack.`
 		pendingOperations +
 		resolutionMessage
 
-	var irrelevantUrn resource.URN = ""
-	executer.deployment.Diag().Warningf(diag.RawMessage(irrelevantUrn, warning))
+	executer.deployment.Diag().Warningf(diag.RawMessage("" /*urn*/, warning))
 }
 
 // reportExecResult issues an appropriate diagnostic depending on went wrong.

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -97,6 +97,36 @@ func (ex *deploymentExecutor) checkTargets(targets []resource.URN, op StepOp) re
 	return nil
 }
 
+func (executer *deploymentExecutor) printPendingOperationsWarning() {
+	pendingOperations := ""
+	for _, op := range executer.deployment.prev.PendingOperations {
+		pendingOperations = pendingOperations + fmt.Sprintf("  * %s, interrupted while %s\n", op.Resource.URN, op.Type)
+	}
+
+	resolutionMessage := `These resources are in an unknown state because the Pulumi CLI was interrupted while
+waiting for changes to these resources to complete. You should confirm whether or not the
+operations listed completed successfully by checking the state of the appropriate provider.
+For example, if you are using AWS, you can confirm using the AWS Console.
+	
+Once you have confirmed the status of the interrupted operations, you can repair your stack
+using 'pulumi refresh' which will refresh the state from the provider you are using and 
+clear the pending operations if there are any.
+
+Not that 'pulumi refresh' will not clear pending CREATE operations since those could have resulted in resources which are
+not tracked by pulumi. To repair the stack and remove pending CREATE operation, use 'pulumi stack export' which will 
+export your stack to a file. For each operation that succeeded,
+remove that operation from the "pending_operations" section of the file. Once this is complete,
+use 'pulumi stack import' to import the repaired stack.`
+
+	warning := "Attempting to deploy or update resources " +
+		fmt.Sprintf("with %d pending operations from previous deployment.\n", len(executer.deployment.prev.PendingOperations)) +
+		pendingOperations +
+		resolutionMessage
+
+	var irrelevantUrn resource.URN = ""
+	executer.deployment.Diag().Warningf(diag.RawMessage(irrelevantUrn, warning))
+}
+
 // reportExecResult issues an appropriate diagnostic depending on went wrong.
 func (ex *deploymentExecutor) reportExecResult(message string, preview bool) {
 	kind := "update"
@@ -150,14 +180,7 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context, opts Options, p
 		// Print a warning for users that there are pending operations.
 		// Explain that these operations can be cleared using pulumi refresh (except for CREATE operations)
 		// since these require user intevention:
-		warning := "Warning: attempting to deploy or update resources " +
-			fmt.Sprintf("with %d pending operations from previous deployment.\n", len(ex.deployment.prev.PendingOperations)) +
-			"Use pulumi refresh or pulumi up -r to clear those pending operations.\n" +
-			"Note that pending CREATE operations from previous will not be cleared since those could have resulted in resources " +
-			"that are not tracked by pulumi and will need to be manually resolved (for example by editing the stack file)"
-
-		var irrelevantUrn resource.URN = ""
-		ex.deployment.Diag().Warningf(diag.RawMessage(irrelevantUrn, warning))
+		ex.printPendingOperationsWarning()
 	}
 
 	// The set of -t targets provided on the command line.  'nil' means 'update everything'.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #4265

This PR changes the deployment execution such that it no longer errors out when there are pending operations. Instead, it only warns the users and explains that they can use `pulumi refresh` to clear the operations and they will no longer see the warning (unless there are pending `create` operations)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
