### PR TITLE
Fix panic in snapshot.go

### DIFF
--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -603,9 +603,11 @@ func (sm *SnapshotManager) snap() *deploy.Snapshot {
 	// Track pending create operations from the base snapshot
 	// and propagate them to the new snapshot: we don't want to clear pending CREATE operations
 	// because these must require user intervention to be cleared or resolved.
-	for _, pendingOperation := range sm.baseSnapshot.PendingOperations {
-		if pendingOperation.Type == resource.OperationTypeCreating {
-			operations = append(operations, pendingOperation)
+	if base := sm.baseSnapshot; base != nil {
+		for _, pendingOperation := range base.PendingOperations {
+			if pendingOperation.Type == resource.OperationTypeCreating {
+				operations = append(operations, pendingOperation)
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds a defensive nil check matching the one shortly before in the same function.