### PR TITLE
Input map may be nil

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,6 @@
 
 - [codegen/go] - Fix Go SDK function output to check for errors
   [pulumi-aws#1872](https://github.com/pulumi/pulumi-aws/issues/1872)
+
+- [cli/engine] - Fix a panic due to `Check` returning nil while using update plans.
+  [#9304](https://github.com/pulumi/pulumi/pull/9304)

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -476,7 +476,6 @@ func (rp *ResourcePlan) checkGoal(
 	programGoal *resource.Goal) error {
 
 	contract.Assert(programGoal != nil)
-	contract.Assert(newInputs != nil)
 	// rp.Goal may be nil, but if it isn't Type and Name should match
 	contract.Assert(rp.Goal == nil || rp.Goal.Type == programGoal.Type)
 	contract.Assert(rp.Goal == nil || rp.Goal.Name == programGoal.Name)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
I had assumed that we would never get a nil input map, but we don't actually constraint `Check` to return non-nil. It can return nil instead of empty.

Fixes https://github.com/pulumi/pulumi/issues/9247

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
