### PR TITLE
Add internal abstractions in backend/httpstate/client

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -127,9 +127,37 @@ func intPtr(i int) *int {
 	return &i
 }
 
+// httpClient is an HTTP client abstraction, used by defaultRESTClient.
+type httpClient interface {
+	Do(req *http.Request, retryAllMethods bool) (*http.Response, error)
+}
+
+// defaultHTTPClient is an implementation of httpClient that provides a basic implementation of Do
+// using the specified *http.Client, with retry support.
+type defaultHTTPClient struct {
+	client *http.Client
+}
+
+func (c *defaultHTTPClient) Do(req *http.Request, retryAllMethods bool) (*http.Response, error) {
+	if req.Method == "GET" || retryAllMethods {
+		// Wait 1s before retrying on failure. Then increase by 2x until the
+		// maximum delay is reached. Stop after maxRetryCount requests have
+		// been made.
+		opts := httputil.RetryOpts{
+			Delay:    durationPtr(time.Second),
+			Backoff:  float64Ptr(2.0),
+			MaxDelay: durationPtr(30 * time.Second),
+
+			MaxRetryCount: intPtr(4),
+		}
+		return httputil.DoWithRetryOpts(req, c.client, opts)
+	}
+	return c.client.Do(req)
+}
+
 // pulumiAPICall makes an HTTP request to the Pulumi API.
-func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path string, body []byte, tok accessToken,
-	opts httpCallOptions) (string, *http.Response, error) {
+func pulumiAPICall(ctx context.Context, d diag.Sink, client httpClient, cloudAPI, method, path string, body []byte,
+	tok accessToken, opts httpCallOptions) (string, *http.Response, error) {
 
 	// Normalize URL components
 	cloudAPI = strings.TrimSuffix(cloudAPI, "/")
@@ -215,24 +243,12 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 			"Pulumi API call details (%s): headers=%v; body=%v", url, req.Header, string(body))
 	}
 
-	var resp *http.Response
-	if req.Method == "GET" || opts.RetryAllMethods {
-		// Wait 1s before retrying on failure. Then increase by 2x until the
-		// maximum delay is reached. Stop after maxRetryCount requests have
-		// been made.
-		opts := httputil.RetryOpts{
-			Delay:    durationPtr(time.Second),
-			Backoff:  float64Ptr(2.0),
-			MaxDelay: durationPtr(30 * time.Second),
-
-			MaxRetryCount: intPtr(4),
-		}
-		resp, err = httputil.DoWithRetryOpts(req, http.DefaultClient, opts)
-	} else {
-		resp, err = http.DefaultClient.Do(req)
-	}
-
+	resp, err := client.Do(req, opts.RetryAllMethods)
 	if err != nil {
+		// Don't wrap *apitype.ErrorResponse.
+		if _, ok := err.(*apitype.ErrorResponse); ok {
+			return "", nil, err
+		}
 		return "", nil, fmt.Errorf("performing HTTP request: %w", err)
 	}
 	logging.V(apiRequestLogLevel).Infof("Pulumi API call response code (%s): %v", url, resp.Status)
@@ -275,11 +291,22 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 	return url, resp, nil
 }
 
-// pulumiRESTCall calls the Pulumi REST API marshalling reqObj to JSON and using that as
+// restClient is an abstraction for calling the Pulumi REST API.
+type restClient interface {
+	Call(ctx context.Context, diag diag.Sink, cloudAPI, method, path string, queryObj, reqObj,
+		respObj interface{}, tok accessToken, opts httpCallOptions) error
+}
+
+// defaultRESTClient is the default implementation for calling the Pulumi REST API.
+type defaultRESTClient struct {
+	client httpClient
+}
+
+// Call calls the Pulumi REST API marshalling reqObj to JSON and using that as
 // the request body (use nil for GETs), and if successful, marshalling the responseObj
 // as JSON and storing it in respObj (use nil for NoContent). The error return type might
 // be an instance of apitype.ErrorResponse, in which case will have the response code.
-func pulumiRESTCall(ctx context.Context, diag diag.Sink, cloudAPI, method, path string, queryObj, reqObj,
+func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, method, path string, queryObj, reqObj,
 	respObj interface{}, tok accessToken, opts httpCallOptions) error {
 
 	// Compute query string from query object
@@ -306,7 +333,8 @@ func pulumiRESTCall(ctx context.Context, diag diag.Sink, cloudAPI, method, path 
 	}
 
 	// Make API call
-	url, resp, err := pulumiAPICall(ctx, diag, cloudAPI, method, path+querystring, reqBody, tok, opts)
+	url, resp, err := pulumiAPICall(
+		ctx, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -47,15 +47,27 @@ type Client struct {
 	apiToken apiAccessToken
 	apiUser  string
 	diag     diag.Sink
+	client   restClient
 }
 
-// NewClient creates a new Pulumi API client with the given URL and API token.
-func NewClient(apiURL, apiToken string, d diag.Sink) *Client {
+// newClient creates a new Pulumi API client with the given URL and API token. It is a variable instead of a regular
+// function so it can be set to a different implementation at runtime, if necessary.
+var newClient = func(apiURL, apiToken string, d diag.Sink) *Client {
 	return &Client{
 		apiURL:   apiURL,
 		apiToken: apiAccessToken(apiToken),
 		diag:     d,
+		client: &defaultRESTClient{
+			client: &defaultHTTPClient{
+				client: http.DefaultClient,
+			},
+		},
 	}
+}
+
+// NewClient creates a new Pulumi API client with the given URL and API token.
+func NewClient(apiURL, apiToken string, d diag.Sink) *Client {
+	return newClient(apiURL, apiToken, d)
 }
 
 // URL returns the URL of the API endpoint this client interacts with
@@ -66,14 +78,15 @@ func (pc *Client) URL() string {
 // restCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
 // object. If a response object is provided, the server's response is deserialized into that object.
 func (pc *Client) restCall(ctx context.Context, method, path string, queryObj, reqObj, respObj interface{}) error {
-	return pulumiRESTCall(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, httpCallOptions{})
+	return pc.client.Call(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken,
+		httpCallOptions{})
 }
 
 // restCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
 // object. If a response object is provided, the server's response is deserialized into that object.
 func (pc *Client) restCallWithOptions(ctx context.Context, method, path string, queryObj, reqObj,
 	respObj interface{}, opts httpCallOptions) error {
-	return pulumiRESTCall(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, opts)
+	return pc.client.Call(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, opts)
 }
 
 // updateRESTCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
@@ -82,7 +95,7 @@ func (pc *Client) restCallWithOptions(ctx context.Context, method, path string, 
 func (pc *Client) updateRESTCall(ctx context.Context, method, path string, queryObj, reqObj, respObj interface{},
 	token updateAccessToken, httpOptions httpCallOptions) error {
 
-	return pulumiRESTCall(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, token, httpOptions)
+	return pc.client.Call(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, token, httpOptions)
 }
 
 // getProjectPath returns the API path for the given owner and the given project name joined with path separators
@@ -156,12 +169,14 @@ func getUpdatePath(update UpdateIdentifier, components ...string) string {
 	return getStackPath(update.StackIdentifier, components...)
 }
 
+type getUserResponse struct {
+	GitHubLogin string `json:"githubLogin"`
+}
+
 // GetPulumiAccountName returns the user implied by the API token associated with this client.
 func (pc *Client) GetPulumiAccountName(ctx context.Context) (string, error) {
 	if pc.apiUser == "" {
-		resp := struct {
-			GitHubLogin string `json:"githubLogin"`
-		}{}
+		resp := getUserResponse{}
 		if err := pc.restCall(ctx, "GET", "/api/user", nil, nil, &resp); err != nil {
 			return "", err
 		}
@@ -236,12 +251,13 @@ var (
 	ErrNoPreviousDeployment = errors.New("no previous deployment")
 )
 
+type getLatestConfigurationResponse struct {
+	Info apitype.UpdateInfo `json:"info,omitempty"`
+}
+
 // GetLatestConfiguration returns the configuration for the latest deployment of a given stack.
 func (pc *Client) GetLatestConfiguration(ctx context.Context, stackID StackIdentifier) (config.Map, error) {
-	latest := struct {
-		Info apitype.UpdateInfo `json:"info,omitempty"`
-	}{}
-
+	latest := getLatestConfigurationResponse{}
 	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "updates", "latest"), nil, nil, &latest); err != nil {
 		if restErr, ok := err.(*apitype.ErrorResponse); ok {
 			if restErr.Code == http.StatusNotFound {
@@ -317,11 +333,9 @@ func (pc *Client) CreateStack(
 		Tags:      tags,
 	}
 
-	var createStackResp apitype.CreateStackResponse
-
 	endpoint := fmt.Sprintf("/api/stacks/%s/%s", stackID.Owner, stackID.Project)
 	if err := pc.restCall(
-		ctx, "POST", endpoint, nil, &createStackReq, &createStackResp); err != nil {
+		ctx, "POST", endpoint, nil, &createStackReq, nil); err != nil {
 		return apitype.Stack{}, err
 	}
 
@@ -541,9 +555,7 @@ func (pc *Client) RenameStack(ctx context.Context, currentID, newID StackIdentif
 		NewName:    newID.Stack,
 		NewProject: newID.Project,
 	}
-	var resp apitype.ImportStackResponse
-
-	return pc.restCall(ctx, "POST", getStackPath(currentID, "rename"), nil, &req, &resp)
+	return pc.restCall(ctx, "POST", getStackPath(currentID, "rename"), nil, &req, nil)
 }
 
 // StartUpdate starts the indicated update. It returns the new version of the update's target stack and the token used

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -39,6 +39,11 @@ func newMockClient(server *httptest.Server) *Client {
 		apiToken: "",
 		apiUser:  "",
 		diag:     nil,
+		client: &defaultRESTClient{
+			client: &defaultHTTPClient{
+				client: http.DefaultClient,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
This change introduces internal `httpClient` and `restClient` abstractions in the `httpstate` backend, along with a `newClient` function variable that can be used to customize the `*Client` returned from `NewClient`.