### PR TITLE
Fix issue with parsing empty engine logs

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -689,19 +689,19 @@ func ProgramTestManualLifeCycle(t *testing.T, opts *ProgramTestOptions) *Program
 
 // ProgramTester contains state associated with running a single test pass.
 type ProgramTester struct {
-	t            *testing.T          // the Go tester for this run.
-	opts         *ProgramTestOptions // options that control this test run.
-	bin          string              // the `pulumi` binary we are using.
-	yarnBin      string              // the `yarn` binary we are using.
-	goBin        string              // the `go` binary we are using.
-	pythonBin    string              // the `python` binary we are using.
-	pipenvBin    string              // The `pipenv` binary we are using.
-	dotNetBin    string              // the `dotnet` binary we are using.
-	eventLog     string              // The path to the event log for this test.
-	maxStepTries int                 // The maximum number of times to retry a failed pulumi step.
-	tmpdir       string              // the temporary directory we use for our test environment
-	projdir      string              // the project directory we use for this run
-	TestFinished bool                // whether or not the test if finished
+	t              *testing.T          // the Go tester for this run.
+	opts           *ProgramTestOptions // options that control this test run.
+	bin            string              // the `pulumi` binary we are using.
+	yarnBin        string              // the `yarn` binary we are using.
+	goBin          string              // the `go` binary we are using.
+	pythonBin      string              // the `python` binary we are using.
+	pipenvBin      string              // The `pipenv` binary we are using.
+	dotNetBin      string              // the `dotnet` binary we are using.
+	updateEventLog string              // The path to the engine event log for `pulumi up` in this test.
+	maxStepTries   int                 // The maximum number of times to retry a failed pulumi step.
+	tmpdir         string              // the temporary directory we use for our test environment
+	projdir        string              // the project directory we use for this run
+	TestFinished   bool                // whether or not the test if finished
 }
 
 func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
@@ -716,10 +716,10 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
 		opts.SkipEmptyPreviewUpdate = true
 	}
 	return &ProgramTester{
-		t:            t,
-		opts:         opts,
-		eventLog:     filepath.Join(os.TempDir(), string(stackName)+"-events.json"),
-		maxStepTries: maxStepTries,
+		t:              t,
+		opts:           opts,
+		updateEventLog: filepath.Join(os.TempDir(), string(stackName)+"-events.json"),
+		maxStepTries:   maxStepTries,
 	}
 }
 
@@ -1320,7 +1320,7 @@ func (pt *ProgramTester) PreviewAndUpdate(dir string, name string, shouldFail, e
 	expectNopUpdate bool) error {
 
 	preview := []string{"preview", "--non-interactive"}
-	update := []string{"up", "--non-interactive", "--yes", "--skip-preview", "--event-log", pt.eventLog}
+	update := []string{"up", "--non-interactive", "--yes", "--skip-preview", "--event-log", pt.updateEventLog}
 	if pt.opts.GetDebugUpdates() {
 		preview = append(preview, "-d")
 		update = append(update, "-d")
@@ -1580,22 +1580,9 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 		}
 	}
 
-	// Read the event log.
-	eventsFile, err := os.Open(pt.eventLog)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("expected to be able to open event log file %s: %w", pt.eventLog, err)
-	}
-	defer contract.IgnoreClose(eventsFile)
-	decoder, events := json.NewDecoder(eventsFile), []apitype.EngineEvent{}
-	for {
-		var event apitype.EngineEvent
-		if err = decoder.Decode(&event); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return fmt.Errorf("decoding engine event: %w", err)
-		}
-		events = append(events, event)
+	events, err := pt.readUpdateEventLog()
+	if err != nil {
+		return err
 	}
 
 	// Populate stack info object with all of this data to pass to the validation function
@@ -1611,6 +1598,35 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 	extraRuntimeValidation(pt.t, stackInfo)
 	pt.t.Log("Extra runtime validation complete.")
 	return nil
+}
+
+func (pt *ProgramTester) readUpdateEventLog() ([]apitype.EngineEvent, error) {
+	events := []apitype.EngineEvent{}
+	eventsFile, err := os.Open(pt.updateEventLog)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return events, nil
+		}
+		return events, fmt.Errorf("expected to be able to open event log file %s: %w",
+			pt.updateEventLog, err)
+	}
+
+	defer contract.IgnoreClose(eventsFile)
+
+	decoder := json.NewDecoder(eventsFile)
+	for {
+		var event apitype.EngineEvent
+		if err = decoder.Decode(&event); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return events, fmt.Errorf("failed decoding engine event from log file %s: %w",
+				pt.updateEventLog, err)
+		}
+		events = append(events, event)
+	}
+
+	return events, nil
 }
 
 // copyTestToTemporaryDirectory creates a temporary directory to run the test in and copies the test to it.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

There was a small hiccup with trying to run a ProgramTest without an actual update, that is:

```go
integration.ProgramTestOptions{
				Config: map[string]string{
					"aws:region": "us-west-1",
				},
				SkipRefresh:            true,
				SkipEmptyPreviewUpdate: true,
				SkipExportImport:       true,
				SkipUpdate:             true,
			}
```

Event log is being asked only from `pulumi up` commands, consequently it's empty when there's no such commands. Then the parsing logic proceeds to ignore non-existent file, but tries to parse json events out of the resulting empty stream, and fails.

With these changes:

- eventLog field renamed to updateEventLog to highlight what it is
- parsing logic does not error out when the file does not exist but instead returns an empty log slice

And I can now run tests with these options (which is useful for preview-only checking of large cloud examples).

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
