### PR TITLE
Ensure that FormatOptions.Color is set before use in diag.defaultSink

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "build.directoryFilters": [
             "-sdk/dotnet/Pulumi.Automation.Tests/bin",
             "-sdk/nodejs/bin",
+            "-sdk/nodejs/tests",
             "-sdk/python/env"
         ],
         // Experimental but seems to work and means we don't need a vscode instance per go.mod file.

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -155,7 +156,7 @@ func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, 
 		Project: s.Project,
 		Stack:   s.Stack,
 	}
-	c := client.NewClient(s.URL, token, diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{}))
+	c := client.NewClient(s.URL, token, diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{Color: colors.Never}))
 
 	return &serviceSecretsManager{
 		state:   s,

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -156,7 +156,8 @@ func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, 
 		Project: s.Project,
 		Stack:   s.Stack,
 	}
-	c := client.NewClient(s.URL, token, diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{Color: colors.Never}))
+	c := client.NewClient(s.URL, token, diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{
+		Color: colors.Never}))
 
 	return &serviceSecretsManager{
 		state:   s,

--- a/pkg/util/testutil/testdiagsink.go
+++ b/pkg/util/testutil/testdiagsink.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
 // TestDiagSink suppresses message output, but captures them, so that they can be compared to expected results.
@@ -31,7 +32,8 @@ func NewTestDiagSink(pwd string) *TestDiagSink {
 	return &TestDiagSink{
 		Pwd: pwd,
 		sink: diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{
-			Pwd: pwd,
+			Color: colors.Never,
+			Pwd:   pwd,
 		}),
 		messages: make(map[diag.Severity][]string),
 	}

--- a/sdk/go/common/diag/sink.go
+++ b/sdk/go/common/diag/sink.go
@@ -86,6 +86,7 @@ func newDefaultSink(opts FormatOptions, writers map[Severity]io.Writer) *default
 	contract.Assert(writers[Infoerr] != nil)
 	contract.Assert(writers[Error] != nil)
 	contract.Assert(writers[Warning] != nil)
+	contract.Assertf(opts.Color != "", "FormatOptions.Color must be set")
 	return &defaultSink{
 		opts:    opts,
 		writers: writers,


### PR DESCRIPTION
defaultSink calls `Color.Colorize` which will panic if Color isn't one of the expected options. We just trying to catch the most egregious failings here where Color has been left blank because of a default initialized `FormatOptions` struct.