### PR TITLE
Fix typo in `pulumi about`

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -146,7 +146,7 @@ func getSummaryAbout(transitiveDependencies bool) summaryAbout {
 			result.Runtime = &runtime
 		}
 		if deps, err := getProgramDependenciesAbout(proj, pwd, transitiveDependencies); err != nil {
-			addError(err, "Failed to get information about the Puluimi program's plugins")
+			addError(err, "Failed to get information about the Pulumi program's plugins")
 		} else {
 			result.Dependencies = deps
 		}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fix typo in `pulumi about` ([pkg/cmd/pulumi/about.go](https://github.com/pulumi/pulumi/compare/master...aetheryx:patch-1#diff-0e269f8c30430af0c9555b9bf13c3940d3befb38488a55dd36e330e990dd6b0e)): `Puluimi` -> `Pulumi`

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
  Reason: shouldn't need a test
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
  Reason: I don't think typo fixes make it into the changelog, but can update the pending changelog if they should
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
