### PR TITLE
[display] Refactor diff translation and display.

### DIFF
--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -309,21 +309,21 @@ func renderDiff(
 	seen map[resource.URN]engine.StepEventMetadata,
 	opts Options) {
 
-	indent := engine.GetIndent(metadata, seen)
-	summary := engine.GetResourcePropertiesSummary(metadata, indent)
+	indent := GetIndent(metadata, seen)
+	summary := GetResourcePropertiesSummary(metadata, indent)
 
 	var details string
 	if metadata.DetailedDiff != nil {
 		var buf bytes.Buffer
-		if diff := translateDetailedDiff(metadata); diff != nil {
-			engine.PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1, opts.SummaryDiff, debug)
+		if diff := engine.TranslateDetailedDiff(&metadata); diff != nil {
+			PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1, opts.SummaryDiff, debug)
 		} else {
-			engine.PrintObject(
+			PrintObject(
 				&buf, metadata.Old.Inputs, planning, indent+1, deploy.OpSame, true /*prefix*/, debug)
 		}
 		details = buf.String()
 	} else {
-		details = engine.GetResourcePropertiesDetails(
+		details = GetResourcePropertiesDetails(
 			metadata, indent, planning, opts.SummaryDiff, debug)
 	}
 
@@ -362,24 +362,24 @@ func renderDiffResourceOutputsEvent(
 			return out.String()
 		}
 
-		indent := engine.GetIndent(payload.Metadata, seen)
+		indent := GetIndent(payload.Metadata, seen)
 
 		refresh := false // are these outputs from a refresh?
 		if m, has := seen[payload.Metadata.URN]; has && m.Op == deploy.OpRefresh {
 			refresh = true
-			summary := engine.GetResourcePropertiesSummary(payload.Metadata, indent)
+			summary := GetResourcePropertiesSummary(payload.Metadata, indent)
 			fprintIgnoreError(out, opts.Color.Colorize(summary))
 		}
 
 		if !opts.SuppressOutputs {
 			// We want to hide same outputs if we're doing a read and the user didn't ask to see
 			// things that are the same.
-			text := engine.GetResourceOutputsPropertiesString(
+			text := GetResourceOutputsPropertiesString(
 				payload.Metadata, indent+1, payload.Planning,
 				payload.Debug, refresh, opts.ShowSameResources)
 			if text != "" {
 				header := fmt.Sprintf("%v%v--outputs:--%v\n",
-					payload.Metadata.Op.Color(), engine.GetIndentationString(indent+1), colors.Reset)
+					payload.Metadata.Op.Color(), GetIndentationString(indent+1), colors.Reset)
 				fprintfIgnoreError(out, opts.Color.Colorize(header))
 				fprintIgnoreError(out, opts.Color.Colorize(text))
 			}

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package engine
+package display
 
 import (
 	"bytes"
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -33,7 +34,7 @@ import (
 )
 
 // GetIndent computes a step's parent indentation.
-func GetIndent(step StepEventMetadata, seen map[resource.URN]StepEventMetadata) int {
+func GetIndent(step engine.StepEventMetadata, seen map[resource.URN]engine.StepEventMetadata) int {
 	indent := 0
 	for p := step.Res.Parent; p != ""; {
 		if par, has := seen[p]; !has {
@@ -49,7 +50,7 @@ func GetIndent(step StepEventMetadata, seen map[resource.URN]StepEventMetadata) 
 	return indent
 }
 
-func printStepHeader(b io.StringWriter, step StepEventMetadata) {
+func printStepHeader(b io.StringWriter, step engine.StepEventMetadata) {
 	var extra string
 	old := step.Old
 	new := step.New
@@ -113,7 +114,7 @@ func writeVerbatim(b io.StringWriter, op deploy.StepOp, value string) {
 	writeWithIndentNoPrefix(b, 0, op, "%s", value)
 }
 
-func GetResourcePropertiesSummary(step StepEventMetadata, indent int) string {
+func GetResourcePropertiesSummary(step engine.StepEventMetadata, indent int) string {
 	var b bytes.Buffer
 
 	op := step.Op
@@ -176,7 +177,7 @@ func GetResourcePropertiesSummary(step StepEventMetadata, indent int) string {
 }
 
 func GetResourcePropertiesDetails(
-	step StepEventMetadata, indent int, planning bool, summary bool, debug bool) string {
+	step engine.StepEventMetadata, indent int, planning bool, summary bool, debug bool) string {
 	var b bytes.Buffer
 
 	// indent everything an additional level, like other properties.
@@ -312,7 +313,7 @@ func massageStackPreviewOutputDiff(diff *resource.ObjectDiff, inResource bool) {
 // GetResourceOutputsPropertiesString prints only those properties that either differ from the input properties or, if
 // there is an old snapshot of the resource, differ from the prior old snapshot's output properties.
 func GetResourceOutputsPropertiesString(
-	step StepEventMetadata, indent int, planning, debug, refresh, showSames bool) string {
+	step engine.StepEventMetadata, indent int, planning, debug, refresh, showSames bool) string {
 
 	// During the actual update we always show all the outputs for the stack, even if they are unchanged.
 	if !showSames && !planning && step.URN.Type() == resource.RootStackType {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -18,7 +18,6 @@ package display
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"math"
 	"os"
 	"sort"
@@ -898,7 +897,7 @@ func (display *ProgressDisplay) printOutputs() {
 
 	stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 
-	props := engine.GetResourceOutputsPropertiesString(
+	props := GetResourceOutputsPropertiesString(
 		stackStep, 1, display.isPreview, display.opts.Debug,
 		false /* refresh */, display.opts.ShowSameResources)
 	if props != "" {
@@ -1443,9 +1442,4 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		return ""
 	}
 	return op.ColorProgress() + getDescription() + colors.Reset
-}
-
-func writeString(b io.StringWriter, s string) {
-	_, err := b.WriteString(s)
-	contract.IgnoreError(err)
 }

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -406,7 +406,7 @@ func getDiffInfo(step engine.StepEventMetadata, action apitype.UpdateKind) strin
 	if step.Old != nil && step.New != nil {
 		var diff *resource.ObjectDiff
 		if step.DetailedDiff != nil {
-			diff = translateDetailedDiff(step)
+			diff = engine.TranslateDetailedDiff(&step)
 		} else if diffOutputs {
 			if step.Old.Outputs != nil && step.New.Outputs != nil {
 				diff = step.Old.Outputs.Diff(step.New.Outputs)

--- a/pkg/engine/detailedDiff.go
+++ b/pkg/engine/detailedDiff.go
@@ -1,7 +1,6 @@
-package display
+package engine
 
 import (
-	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -130,9 +129,9 @@ func addDiff(path resource.PropertyPath, kind plugin.DiffKind, parent *resource.
 	}
 }
 
-// translateDetailedDiff converts the detailed diff stored in the step event into an ObjectDiff that is appropriate
+// TranslateDetailedDiff converts the detailed diff stored in the step event into an ObjectDiff that is appropriate
 // for display.
-func translateDetailedDiff(step engine.StepEventMetadata) *resource.ObjectDiff {
+func TranslateDetailedDiff(step *StepEventMetadata) *resource.ObjectDiff {
 	contract.Assert(step.DetailedDiff != nil)
 
 	// The rich diff is presented as a list of simple JS property paths and corresponding diffs. We translate this to

--- a/pkg/engine/detailedDiff_test.go
+++ b/pkg/engine/detailedDiff_test.go
@@ -730,7 +730,7 @@ func TestTranslateDetailedDiff(t *testing.T) {
 		oldInputs := resource.NewPropertyMapFromMap(c.oldInputs)
 		state := resource.NewPropertyMapFromMap(c.state)
 		inputs := resource.NewPropertyMapFromMap(c.inputs)
-		diff := translateDetailedDiff(StepEventMetadata{
+		diff := TranslateDetailedDiff(&StepEventMetadata{
 			Old:          &StepEventStateMetadata{Inputs: oldInputs, Outputs: state},
 			New:          &StepEventStateMetadata{Inputs: inputs},
 			DetailedDiff: c.detailedDiff,

--- a/pkg/engine/detailedDiff_test.go
+++ b/pkg/engine/detailedDiff_test.go
@@ -1,11 +1,10 @@
-package display
+package engine
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
@@ -731,9 +730,9 @@ func TestTranslateDetailedDiff(t *testing.T) {
 		oldInputs := resource.NewPropertyMapFromMap(c.oldInputs)
 		state := resource.NewPropertyMapFromMap(c.state)
 		inputs := resource.NewPropertyMapFromMap(c.inputs)
-		diff := translateDetailedDiff(engine.StepEventMetadata{
-			Old:          &engine.StepEventStateMetadata{Inputs: oldInputs, Outputs: state},
-			New:          &engine.StepEventStateMetadata{Inputs: inputs},
+		diff := translateDetailedDiff(StepEventMetadata{
+			Old:          &StepEventStateMetadata{Inputs: oldInputs, Outputs: state},
+			New:          &StepEventStateMetadata{Inputs: inputs},
 			DetailedDiff: c.detailedDiff,
 		})
 		assert.Equal(t, c.expected, diff)


### PR DESCRIPTION
- Move the code that deals in translating detailed diffs into object
  diffs out of package `backend/display` and into package `engine`
- Move the code that deals in displaying diffs out of package `engine`
  and into package `backend/display`