### PR TITLE
fix: Automation API Color flag should pass unquoted string

### DIFF
--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -242,7 +242,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--exec-agent=%s", preOpts.UserAgent))
 	}
 	if preOpts.Color != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--color=%q", preOpts.Color))
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--color=%s", preOpts.Color))
 	}
 
 	kind, args := constant.ExecKindAutoLocal, []string{"preview"}


### PR DESCRIPTION
Background
---
Automation API Color flag should pass unquoted string:

```
error: unsupported color option: '\"auto\"'
```

Since we're using ["os/exec"](https://pkg.go.dev/os/exec) there is no shell, I think we should not quote arguments?

> Unlike the "system" library call from C and other languages, the os/exec package intentionally does not invoke the system shell
