### PR TITLE
Escape deprecation messages before interpolating into source text

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,3 +14,5 @@
 
 ### Bug Fixes
 
+- [codegen/node] - Fix an issue with escaping deprecation messages.
+  [#9371](https://github.com/pulumi/pulumi/pull/9371)

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -64,17 +64,6 @@ func title(s string) string {
 	return string(append([]rune{unicode.ToUpper(runes[0])}, runes[1:]...))
 }
 
-// escape returns the string escaped for a JS string literal
-func escape(s string) string {
-	// Seems the most fool-proof way of doing this is by using the JSON marshaler and then stripping the surrounding quotes
-	escaped, err := json.Marshal(s)
-	contract.AssertNoError(err)
-	contract.Assertf(len(escaped) >= 2, "JSON(%s) expected a quoted string but returned %s", s, escaped)
-	contract.Assertf(escaped[0] == byte('"') && escaped[len(escaped)-1] == byte('"'), "JSON(%s) expected a quoted string but returned %s", s, escaped)
-
-	return string(escaped)[1:(len(escaped) - 1)]
-}
-
 // camel converts s to camel case.
 //
 // Examples:

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -218,3 +218,27 @@ func Test_isStringType(t *testing.T) {
 		})
 	}
 }
+
+func TestEscape(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"test", "test"},
+		{"sub\"string\"", "sub\\\"string\\\""},
+		{"slash\\s", "slash\\\\s"},
+		{"N\\A \"bad data\"", "N\\\\A \\\"bad data\\\""},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := escape(tt.input)
+			if tt.expected != got {
+				t.Errorf("escape(%s) was %s want %s", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -218,27 +218,3 @@ func Test_isStringType(t *testing.T) {
 		})
 	}
 }
-
-func TestEscape(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"test", "test"},
-		{"sub\"string\"", "sub\\\"string\\\""},
-		{"slash\\s", "slash\\\\s"},
-		{"N\\A \"bad data\"", "N\\\\A \\\"bad data\\\""},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.input, func(t *testing.T) {
-			t.Parallel()
-
-			got := escape(tt.input)
-			if tt.expected != got {
-				t.Errorf("escape(%s) was %s want %s", tt.input, got, tt.expected)
-			}
-		})
-	}
-}

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -15,6 +15,7 @@
 package nodejs
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -22,6 +23,7 @@ import (
 	"unicode"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // isReservedWord returns true if s is a reserved word as per ECMA-262.
@@ -125,4 +127,15 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 	}
 
 	return safeName, nil
+}
+
+// escape returns the string escaped for a JS string literal
+func escape(s string) string {
+	// Seems the most fool-proof way of doing this is by using the JSON marshaler and then stripping the surrounding quotes
+	escaped, err := json.Marshal(s)
+	contract.AssertNoError(err)
+	contract.Assertf(len(escaped) >= 2, "JSON(%s) expected a quoted string but returned %s", s, escaped)
+	contract.Assertf(escaped[0] == byte('"') && escaped[len(escaped)-1] == byte('"'), "JSON(%s) expected a quoted string but returned %s", s, escaped)
+
+	return string(escaped)[1:(len(escaped) - 1)]
 }

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -135,7 +135,9 @@ func escape(s string) string {
 	escaped, err := json.Marshal(s)
 	contract.AssertNoError(err)
 	contract.Assertf(len(escaped) >= 2, "JSON(%s) expected a quoted string but returned %s", s, escaped)
-	contract.Assertf(escaped[0] == byte('"') && escaped[len(escaped)-1] == byte('"'), "JSON(%s) expected a quoted string but returned %s", s, escaped)
+	contract.Assertf(
+		escaped[0] == byte('"') && escaped[len(escaped)-1] == byte('"'),
+		"JSON(%s) expected a quoted string but returned %s", s, escaped)
 
 	return string(escaped)[1:(len(escaped) - 1)]
 }

--- a/pkg/codegen/nodejs/utilities_test.go
+++ b/pkg/codegen/nodejs/utilities_test.go
@@ -43,3 +43,27 @@ func TestMakeSafeEnumName(t *testing.T) {
 		})
 	}
 }
+
+func TestEscape(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"test", "test"},
+		{"sub\"string\"", "sub\\\"string\\\""},
+		{"slash\\s", "slash\\\\s"},
+		{"N\\A \"bad data\"", "N\\\\A \\\"bad data\\\""},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := escape(tt.input)
+			if tt.expected != got {
+				t.Errorf("escape(%s) was %s want %s", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/9342

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
