### PR TITLE
Change BulkDecrypt to not rely on type tests

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,3 +14,5 @@
 
 ### Bug Fixes
 
+- [cli] - StackReferences will now correctly use the service bulk decryption end point.
+  [#9373](https://github.com/pulumi/pulumi/pull/9373)

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -338,6 +338,10 @@ func (b brokenDecrypter) DecryptValue(_ string) (string, error) {
 	return "", fmt.Errorf(b.ErrorMessage)
 }
 
+func (b brokenDecrypter) BulkDecrypt(_ []string) (map[string]string, error) {
+	return nil, fmt.Errorf(b.ErrorMessage)
+}
+
 // Tests that the engine presents a reasonable error message when a decrypter fails to decrypt a config value.
 func TestBrokenDecrypter(t *testing.T) {
 	t.Parallel()

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -244,7 +244,7 @@ func DeserializeDeploymentV3(deployment apitype.DeploymentV3, secretsProv Secret
 		}
 
 		// Decrypt the collected secrets and create a decrypter that will use the result as a cache.
-		cache, err := config.BulkDecrypt(d, ciphertexts)
+		cache, err := d.BulkDecrypt(ciphertexts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -46,6 +46,10 @@ func (t *testSecretsManager) DecryptValue(ciphertext string) (string, error) {
 	return ciphertext[i+1:], nil
 }
 
+func (t *testSecretsManager) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	return config.DefaultBulkDecrypt(t, ciphertexts)
+}
+
 func deserializeProperty(v interface{}, dec config.Decrypter) (resource.PropertyValue, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -228,7 +232,7 @@ func (t *mapTestDecrypter) DecryptValue(ciphertext string) (string, error) {
 
 func (t *mapTestDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
 	t.bulkDecryptCalls++
-	return config.BulkDecrypt(t.d, ciphertexts)
+	return config.DefaultBulkDecrypt(t.d, ciphertexts)
 }
 
 func TestMapCrypter(t *testing.T) {

--- a/pkg/secrets/b64/manager.go
+++ b/pkg/secrets/b64/manager.go
@@ -48,3 +48,7 @@ func (c *base64Crypter) DecryptValue(s string) (string, error) {
 	}
 	return string(b), nil
 }
+
+func (c *base64Crypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	return config.DefaultBulkDecrypt(c, ciphertexts)
+}

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -323,3 +323,8 @@ func (ec *errorCrypter) DecryptValue(_ string) (string, error) {
 	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
+
+func (ec *errorCrypter) BulkDecrypt(_ []string) (map[string]string, error) {
+	return nil, errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
+		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
+}

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -33,8 +33,6 @@ import (
 
 const Type = "service"
 
-var _ config.BulkDecrypter = (*serviceCrypter)(nil)
-
 // serviceCrypter is an encrypter/decrypter that uses the Pulumi servce to encrypt/decrypt a stack's secrets.
 type serviceCrypter struct {
 	client *client.Client

--- a/sdk/go/common/resource/config/value_test.go
+++ b/sdk/go/common/resource/config/value_test.go
@@ -219,6 +219,10 @@ func (d passThroughDecrypter) DecryptValue(ciphertext string) (string, error) {
 	return ciphertext, nil
 }
 
+func (d passThroughDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	return DefaultBulkDecrypt(d, ciphertexts)
+}
+
 func TestSecureValues(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

`BulkDecrypt` only made use of the bulk decryption if the `Decrypter` passed in was itself a `BulkDecrypter`. Only the `serviceCrypter` implemented this interface but most of the time it's wrapped with a `cachingCrypter`.

Rather than just adding BulkDecrypt to `cachingCrypter` I've just moved it to the `Decrypter` interface and ensured that every  implementation either does something efficient if it can, or calls `DefaultBulkDecrypt` to just loop over 1-by-1. 

Fixes https://github.com/pulumi/pulumi/issues/9350

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
