### PR TITLE
gosdk: add API to retrieve raw property map of outputs

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1158,6 +1158,7 @@ func (state *resourceState) resolve(ctx *Context, err error, inputs *resourceInp
 		for _, output := range state.outputs {
 			output.getState().reject(err)
 		}
+		state.rawOutputs.getState().reject(err)
 		return
 	}
 

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -40,6 +40,7 @@ type ResourceState struct {
 
 	urn URNOutput `pulumi:"urn"`
 
+	rawOutputs        Output
 	children          resourceSet
 	providers         map[string]ProviderResource
 	provider          ProviderResource
@@ -58,6 +59,15 @@ func (s *ResourceState) URN() URNOutput {
 
 func (s *ResourceState) GetProvider(token string) ProviderResource {
 	return s.providers[getPackage(token)]
+}
+
+// This is an internal method and future versions of the sdk may not support this API.
+//
+// InternalGetRawOutputs obtains the full PropertyMap returned during resource registration,
+// allowing a caller of RegisterResource to obtain directly information about the outputs and their
+// known and secret attributes.
+func InternalGetRawOutputs(ctx *Context, res *ResourceState) Output {
+	return res.rawOutputs
 }
 
 func (s *ResourceState) getChildren() []Resource {

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -66,7 +66,7 @@ func (s *ResourceState) GetProvider(token string) ProviderResource {
 // InternalGetRawOutputs obtains the full PropertyMap returned during resource registration,
 // allowing a caller of RegisterResource to obtain directly information about the outputs and their
 // known and secret attributes.
-func InternalGetRawOutputs(ctx *Context, res *ResourceState) Output {
+func InternalGetRawOutputs(res *ResourceState) Output {
 	return res.rawOutputs
 }
 

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -188,7 +188,7 @@ func TestRegisterResource(t *testing.T) {
 		}, &res3)
 		assert.NoError(t, err)
 		assert.NotNil(t, res3.rawOutputs)
-		output := InternalGetRawOutputs(ctx, &res3.ResourceState)
+		output := InternalGetRawOutputs(&res3.ResourceState)
 		rawOutputsTmp, _, _, _, err := await(output)
 		assert.NoError(t, err)
 		rawOutputs, ok := rawOutputsTmp.(resource.PropertyMap)

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -78,19 +78,39 @@ func TestRegisterResource(t *testing.T) {
 
 	mocks := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
+			switch args.TypeToken {
+			case "test:resource:type":
+				assert.Equal(t, "resA", args.Name)
+				assert.True(t, args.Inputs.DeepEquals(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"foo":  "oof",
+					"bar":  "rab",
+					"baz":  "zab",
+					"bang": "gnab",
+				})))
+				assert.Equal(t, "", args.Provider)
+				assert.Equal(t, "", args.ID)
 
-			assert.Equal(t, "test:resource:type", args.TypeToken)
-			assert.Equal(t, "resA", args.Name)
-			assert.True(t, args.Inputs.DeepEquals(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"foo":  "oof",
-				"bar":  "rab",
-				"baz":  "zab",
-				"bang": "gnab",
-			})))
-			assert.Equal(t, "", args.Provider)
-			assert.Equal(t, "", args.ID)
+				return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+			case "test:resource:complextype":
+				assert.Equal(t, "resB", args.Name)
+				assert.True(t, args.Inputs.DeepEquals(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"foo":  "oof",
+					"bar":  "rab",
+					"baz":  "zab",
+					"bang": "gnab",
+				})))
+				assert.Equal(t, "", args.Provider)
+				assert.Equal(t, "", args.ID)
 
-			return "someID", resource.PropertyMap{"foo": resource.NewStringProperty("qux")}, nil
+				return "someID", resource.PropertyMap{
+					"foo":    resource.NewStringProperty("qux"),
+					"secret": resource.MakeSecret(resource.NewStringProperty("shh")),
+					"output": resource.MakeOutput(resource.NewStringProperty("known unknown")),
+				}, nil
+			default:
+				assert.Fail(t, "Expected a valid resource type, got %v", args.TypeToken)
+				return "someID", nil, nil
+			}
 		},
 	}
 
@@ -135,6 +155,7 @@ func TestRegisterResource(t *testing.T) {
 			"bang": String("gnab"),
 		}, &res2)
 		assert.NoError(t, err)
+		assert.NotNil(t, res2.rawOutputs)
 
 		id, known, secret, deps, err = await(res2.ID())
 		assert.NoError(t, err)
@@ -156,6 +177,25 @@ func TestRegisterResource(t *testing.T) {
 		assert.False(t, secret)
 		assert.Equal(t, []Resource{&res2}, deps)
 		assert.Equal(t, map[string]interface{}{"foo": "qux"}, outputs)
+
+		// Test raw access to property values:
+		var res3 testResource3
+		err = ctx.RegisterResource("test:resource:complextype", "resB", Map{
+			"foo":  String("oof"),
+			"bar":  String("rab"),
+			"baz":  String("zab"),
+			"bang": String("gnab"),
+		}, &res3)
+		assert.NoError(t, err)
+		assert.NotNil(t, res3.rawOutputs)
+		output := InternalGetRawOutputs(ctx, &res3.ResourceState)
+		rawOutputsTmp, _, _, _, err := await(output)
+		assert.NoError(t, err)
+		rawOutputs, ok := rawOutputsTmp.(resource.PropertyMap)
+		assert.True(t, ok)
+		assert.True(t, rawOutputs.HasValue("foo"))
+		assert.True(t, rawOutputs.HasValue("secret"))
+		assert.True(t, rawOutputs.ContainsSecrets())
 
 		return nil
 	}, WithMocks("project", "stack", mocks))

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -504,6 +504,14 @@ func ToSecret(input interface{}) Output {
 	return ToSecretWithContext(context.Background(), input)
 }
 
+// Creates an unknown output. This is a low level API and should not be used in programs as this
+// will cause "pulumi up" to fail if called and used during a non-dryrun deployment.
+func UnsafeUnknownOutput() Output {
+	output, _, _ := NewOutput()
+	output.getState().resolve(nil, false, false, nil)
+	return output
+}
+
 // ToSecretWithContext wraps the input in an Output marked as secret
 // that will resolve when all Inputs contained in the given value have resolved.
 func ToSecretWithContext(ctx context.Context, input interface{}) Output {


### PR DESCRIPTION
This enables a Pulumi program in Go that directly constructs resources by type tokens to get access to the full property map, including querying the known-ness and secret-ness of properties without needing to marshal them into an appropriately tagged data structure.

For example, in a Go program where we wish to dynamically access properties of a resource, we might perform this step while evaluating keys at each level:

```go
rawOutputs := x.GetRawOutputs(ctx.ctx)
return evaluateAccessF(rawOutputs, accessors)
```

Is there a better way to plumb this API, and are we satisfied with the naming?