### PR TITLE
Don't disable ambient providers during tests

### DIFF
--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -40,7 +40,6 @@ func RunCommand(t *testing.T, name string, args []string, wd string, opts *Progr
 	env = append(env, "PULUMI_DEBUG_COMMANDS=true")
 	env = append(env, "PULUMI_RETAIN_CHECKPOINTS=true")
 	env = append(env, "PULUMI_CONFIG_PASSPHRASE=correct horse battery staple")
-	env = append(env, "PULUMI_IGNORE_AMBIENT_PLUGINS=true")
 
 	cmd := exec.Cmd{
 		Path: path,


### PR DESCRIPTION
I had wanted this to ensure that dynamic providers were working correctly, but we also have test providers that we don't install as proper plugins.
