### PR TITLE
updating body text of downstream resource docs prs

### DIFF
--- a/.github/workflows/run-docs-generation.yml
+++ b/.github/workflows/run-docs-generation.yml
@@ -131,8 +131,8 @@ jobs:
           title: Preview resource docs changes for pulumi/pulumi#${{ steps.regenerate-resource-docs.outputs.prNumber }}
           body: |
             This PR was auto-generated from pulumi/pulumi#${{ steps.regenerate-resource-docs.outputs.prNumber }}.
-
             By default, this PR contains regenerated docs for AWS and Kubernetes only.
+            After review, this PR should be manually closed.
           # Assign the draft PR to the author of the current PR.
           assignees: ${{ github.event.pull_request.user.login }}
           branch: ${{ steps.regenerate-resource-docs.outputs.branchName }}


### PR DESCRIPTION
the body text on the prs that get auto-opened over in docs
don't mention that they need to be manually closed
this adds a note about it

preview of the msg can be seen here: https://github.com/pulumi/docs/pull/7360#issue-1206176566