### PR TITLE
[cli] Do not render missing sames in arrays.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,6 @@
 
 - [cli] Fixed some context leaks where shutdown code wasn't correctly called.
   [#9438](https://github.com/pulumi/pulumi/pull/9438)
+
+- [cli] Do not render array diffs for unchanged elements without recorded values.
+  [#9448](https://github.com/pulumi/pulumi/pull/9448)

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -743,10 +743,10 @@ func (p *propertyPrinter) printPropertyValueDiff(titleFunc func(*propertyPrinter
 				elemPrinter.printDelete(delete, elemTitleFunc)
 			} else if update, isupdate := a.Updates[i]; isupdate {
 				elemPrinter.printPropertyValueDiff(elemTitleFunc, update)
-			} else if !p.summary {
+			} else if same, issame := a.Sames[i]; issame && !p.summary {
 				elemPrinter = elemPrinter.withOp(deploy.OpSame).withPrefix(false)
 				elemTitleFunc(elemPrinter)
-				elemPrinter.printPropertyValue(a.Sames[i])
+				elemPrinter.printPropertyValue(same)
 			}
 		}
 		p.writeWithIndentNoPrefix("]\n")

--- a/pkg/backend/display/testdata/up-4.json.stdout.txt
+++ b/pkg/backend/display/testdata/up-4.json.stdout.txt
@@ -42,7 +42,6 @@
 <{%reset%}><{%reset%}>        [urn=urn:pulumi:dev::eks::aws:ec2/securityGroup:SecurityGroup::eks-sg]
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
 <{%reset%}><{%fg 3%}>      ~ ingress: <{%reset%}><{%fg 3%}>[
-<{%reset%}><{%reset%}>            [0]: <{%reset%}><{%reset%}><null><{%reset%}><{%reset%}>
 <{%reset%}><{%fg 2%}>          + [1]: <{%reset%}><{%fg 2%}>{
 <{%reset%}><{%fg 2%}>                  + cidrBlocks: <{%reset%}><{%fg 2%}>[
 <{%reset%}><{%fg 2%}>                  +     [0]: <{%reset%}><{%fg 2%}>"0.0.0.0/0"<{%reset%}><{%fg 2%}>


### PR DESCRIPTION
When rendering an array diff, do not render an unchanged element if we
do not have a value for the element.

Fixes #9365.