### PR TITLE
cli: Make "down" an alias of "destroy"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - [auto/*] Add `--save-plan` and `--plan` options to automation API.
   [#9391](https://github.com/pulumi/pulumi/pull/9391)
 
+- [cli] "down" is now treated as an alias of "destroy".
+  [#9458](https://github.com/pulumi/pulumi/pull/9458)
+
 ### Bug Fixes
 
 - [codegen] - Ensure that plain properties are always plain.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -58,7 +58,8 @@ func newDestroyCmd() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:        "destroy",
-		SuggestFor: []string{"delete", "down", "kill", "remove", "rm", "stop"},
+		Aliases:    []string{"down"},
+		SuggestFor: []string{"delete", "kill", "remove", "rm", "stop"},
 		Short:      "Destroy an existing stack and its resources",
 		Long: "Destroy an existing stack and its resources\n" +
 			"\n" +


### PR DESCRIPTION
# Description

Previously, "down" was a suggestion for "destroy". This commit makes it an alias instead, to give symmetry of "up" => "down".

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

No test coverage of command aliases, assumed to work by virtue of Cobra upstream testing.

- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

No changes.
