### PR TITLE
feat(resource): ✨  Add Composite ResourceOption

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,9 @@
 - [cli] "down" is now treated as an alias of "destroy".
   [#9458](https://github.com/pulumi/pulumi/pull/9458)
 
+- [go] Add `Composite` resource option allowing several options to be encapsulated into a "single" option.
+  [#9459](https://github.com/pulumi/pulumi/pull/9459)
+
 ### Bug Fixes
 
 - [codegen] - Ensure that plain properties are always plain.

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -383,7 +383,7 @@ func DeleteBeforeReplace(o bool) ResourceOption {
 func Composite(opts ...ResourceOption) ResourceOption {
 	return resourceOption(func(ro *resourceOptions) {
 		for _, o := range opts {
-			o(ro)
+			o.applyResourceOption(ro)
 		}
 	})
 }

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -379,6 +379,15 @@ func DeleteBeforeReplace(o bool) ResourceOption {
 	})
 }
 
+// Composite is a resource option that contains other resource options.
+func Composite(opts ...ResourceOption) ResourceOption {
+	return resourceOption(func(ro *resourceOptions) {
+		for _, o := range opts {
+			o(ro)
+		}
+	})
+}
+
 // DependsOn is an optional array of explicit dependencies on other resources.
 func DependsOn(o []Resource) ResourceOption {
 	return resourceOption(func(ro *resourceOptions) {

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -196,7 +196,7 @@ func TestResourceOptionMergingDeleteBeforeReplace(t *testing.T) {
 func TestResourceOptionComposite(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
+	tests := []struct {
 		name  string
 		input []ResourceOption
 		want  *resourceOptions
@@ -247,10 +247,13 @@ func TestResourceOptionComposite(t *testing.T) {
 				Protect:             true,
 			},
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			opts := merge(Composite(tc.input...))
-			assert.Equal(t, tc.want, opts)
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opts := merge(Composite(tt.input...))
+			assert.Equal(t, tt.want, opts)
 		})
 	}
 }

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -193,6 +193,68 @@ func TestResourceOptionMergingDeleteBeforeReplace(t *testing.T) {
 	assert.Equal(t, false, opts.DeleteBeforeReplace)
 }
 
+func TestResourceOptionComposite(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		input []ResourceOption
+		want  *resourceOptions
+	}{
+		{
+			name:  "no options",
+			input: []ResourceOption{},
+			want:  &resourceOptions{},
+		},
+		{
+			name: "single option",
+			input: []ResourceOption{
+				DeleteBeforeReplace(true),
+			},
+			want: &resourceOptions{
+				DeleteBeforeReplace: true,
+			},
+		},
+		{
+			name: "multiple conflicting options",
+			input: []ResourceOption{
+				DeleteBeforeReplace(true),
+				DeleteBeforeReplace(false),
+			},
+			want: &resourceOptions{
+				DeleteBeforeReplace: false,
+			},
+		},
+		{
+			name: "bouncing options",
+			input: []ResourceOption{
+				DeleteBeforeReplace(true),
+				DeleteBeforeReplace(false),
+				DeleteBeforeReplace(true),
+			},
+			want: &resourceOptions{
+				DeleteBeforeReplace: true,
+			},
+		},
+		{
+			name: "different options",
+			input: []ResourceOption{
+				DeleteBeforeReplace(true),
+				Protect(true),
+			},
+			want: &resourceOptions{
+				DeleteBeforeReplace: true,
+				Protect:             true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := merge(Composite(tc.input...))
+			assert.Equal(t, tc.want, opts)
+		})
+	}
+}
+
 func TestResourceOptionMergingImport(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -248,7 +248,7 @@ func TestResourceOptionComposite(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -250,6 +250,7 @@ func TestResourceOptionComposite(t *testing.T) {
 	}
 	
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			opts := merge(Composite(tt.input...))


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


Allows encapsulation of multiple options to appear as a single option. Providing some useful flexibility for callers of the code.

resolves #9455

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
