### PR TITLE
codegen: preserve externally visible names of a resources and outputs

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -479,8 +479,8 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 		input.Value = g.lowerExpression(input.Value, destType.(model.Type))
 	}
 
-	name := r.Name()
-	variableName := makeValidIdentifier(name)
+	name := r.UniqueName()
+	variableName := makeValidIdentifier(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
 	for _, l := range r.Definition.Tokens.GetLabels(nil) {
@@ -589,8 +589,9 @@ func (g *generator) genOutputAssignment(w io.Writer, v *pcl.OutputVariable) {
 }
 
 func (g *generator) genOutputProperty(w io.Writer, v *pcl.OutputVariable) {
+	outputID := fmt.Sprintf(`"%s"`, g.escapeString(v.UniqueName(), false, false))
 	// TODO(pdg): trivia
-	g.Fgenf(w, "%s[Output(\"%s\")]\n", g.Indent, v.Name())
+	g.Fgenf(w, "%s[Output(%s)]\n", g.Indent, outputID)
 	// TODO(msh): derive the element type of the Output from the type of its value.
 	g.Fgenf(w, "%spublic Output<string> %s { get; set; }\n", g.Indent, propertyName(v.Name()))
 }

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -479,7 +479,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 		input.Value = g.lowerExpression(input.Value, destType.(model.Type))
 	}
 
-	name := r.UniqueName()
+	name := r.LogicalName()
 	variableName := makeValidIdentifier(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
@@ -589,7 +589,7 @@ func (g *generator) genOutputAssignment(w io.Writer, v *pcl.OutputVariable) {
 }
 
 func (g *generator) genOutputProperty(w io.Writer, v *pcl.OutputVariable) {
-	outputID := fmt.Sprintf(`"%s"`, g.escapeString(v.UniqueName(), false, false))
+	outputID := fmt.Sprintf(`"%s"`, g.escapeString(v.LogicalName(), false, false))
 	// TODO(pdg): trivia
 	g.Fgenf(w, "%s[Output(%s)]\n", g.Indent, outputID)
 	// TODO(msh): derive the element type of the Output from the type of its value.

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -474,7 +474,7 @@ func (g *generator) genResourceOptions(w io.Writer, block *model.Block) {
 
 func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
-	resName, resNameVar := r.Name(), makeValidIdentifier(r.Name())
+	resName, resNameVar := r.UniqueName(), makeValidIdentifier(r.Name())
 	pkg, mod, typ, _ := r.DecomposeToken()
 	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
 		mod = pkg
@@ -562,7 +562,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 func (g *generator) genOutputAssignment(w io.Writer, v *pcl.OutputVariable) {
 	expr, temps := g.lowerExpression(v.Value, v.Type())
 	g.genTemps(w, temps)
-	g.Fgenf(w, "ctx.Export(\"%s\", %.3v)\n", v.Name(), expr)
+	g.Fgenf(w, "ctx.Export(%q, %.3v)\n", v.UniqueName(), expr)
 }
 func (g *generator) genTemps(w io.Writer, temps []interface{}) {
 	singleReturn := ""

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -474,7 +474,7 @@ func (g *generator) genResourceOptions(w io.Writer, block *model.Block) {
 
 func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
-	resName, resNameVar := r.UniqueName(), makeValidIdentifier(r.Name())
+	resName, resNameVar := r.LogicalName(), makeValidIdentifier(r.Name())
 	pkg, mod, typ, _ := r.DecomposeToken()
 	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
 		mod = pkg
@@ -562,7 +562,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 func (g *generator) genOutputAssignment(w io.Writer, v *pcl.OutputVariable) {
 	expr, temps := g.lowerExpression(v.Value, v.Type())
 	g.genTemps(w, temps)
-	g.Fgenf(w, "ctx.Export(%q, %.3v)\n", v.UniqueName(), expr)
+	g.Fgenf(w, "ctx.Export(%q, %.3v)\n", v.LogicalName(), expr)
 }
 func (g *generator) genTemps(w io.Writer, temps []interface{}) {
 	singleReturn := ""

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -65,9 +65,18 @@ func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, 
 	var index bytes.Buffer
 	g.genPreamble(&index, program, preambleHelperMethods)
 	for _, n := range nodes {
-		if r, ok := n.(*pcl.Resource); ok && requiresAsyncMain(r) {
-			g.asyncMain = true
+		if g.asyncMain {
 			break
+		}
+		switch x := n.(type) {
+		case *pcl.Resource:
+			if resourceRequiresAsyncMain(x) {
+				g.asyncMain = true
+			}
+		case *pcl.OutputVariable:
+			if outputRequiresAsyncMain(x) {
+				g.asyncMain = true
+			}
 		}
 	}
 
@@ -89,14 +98,15 @@ func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, 
 					if result == nil {
 						result = &model.ObjectConsExpression{}
 					}
-					name := makeValidIdentifier(o.Name())
+					name := o.UniqueName()
+					nameVar := makeValidIdentifier(o.Name())
 					result.Items = append(result.Items, model.ObjectConsItem{
 						Key: &model.LiteralValueExpression{Value: cty.StringVal(name)},
 						Value: &model.ScopeTraversalExpression{
-							RootName:  name,
+							RootName:  nameVar,
 							Traversal: hcl.Traversal{hcl.TraverseRoot{Name: name}},
 							Parts: []model.Traversable{&model.Variable{
-								Name:         name,
+								Name:         nameVar,
 								VariableType: o.Type(),
 							}},
 						},
@@ -226,12 +236,21 @@ func (g *generator) genNode(w io.Writer, n pcl.Node) {
 	}
 }
 
-func requiresAsyncMain(r *pcl.Resource) bool {
+func resourceRequiresAsyncMain(r *pcl.Resource) bool {
 	if r.Options == nil || r.Options.Range == nil {
 		return false
 	}
 
 	return model.ContainsPromises(r.Options.Range.Type())
+}
+
+func outputRequiresAsyncMain(ov *pcl.OutputVariable) bool {
+	outputName := ov.UniqueName()
+	if makeValidIdentifier(outputName) != outputName {
+		return true
+	}
+
+	return false
 }
 
 // resourceTypeName computes the NodeJS package, module, and type name for the given resource.
@@ -324,8 +343,8 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
 	optionsBag := g.genResourceOptions(r.Options)
 
-	name := r.Name()
-	variableName := makeValidIdentifier(name)
+	name := r.UniqueName()
+	variableName := makeValidIdentifier(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
 	for _, l := range r.Definition.Tokens.GetLabels(nil) {

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -98,7 +98,7 @@ func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, 
 					if result == nil {
 						result = &model.ObjectConsExpression{}
 					}
-					name := o.UniqueName()
+					name := o.LogicalName()
 					nameVar := makeValidIdentifier(o.Name())
 					result.Items = append(result.Items, model.ObjectConsItem{
 						Key: &model.LiteralValueExpression{Value: cty.StringVal(name)},
@@ -245,7 +245,7 @@ func resourceRequiresAsyncMain(r *pcl.Resource) bool {
 }
 
 func outputRequiresAsyncMain(ov *pcl.OutputVariable) bool {
-	outputName := ov.UniqueName()
+	outputName := ov.LogicalName()
 	if makeValidIdentifier(outputName) != outputName {
 		return true
 	}
@@ -343,7 +343,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
 	optionsBag := g.genResourceOptions(r.Options)
 
-	name := r.UniqueName()
+	name := r.LogicalName()
 	variableName := makeValidIdentifier(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -120,6 +120,16 @@ func (b *binder) bindLocalVariable(node *LocalVariable) hcl.Diagnostics {
 
 func (b *binder) bindOutputVariable(node *OutputVariable) hcl.Diagnostics {
 	block, diagnostics := model.BindBlock(node.syntax, model.StaticScope(b.root), b.tokens, b.options.modelOptions()...)
+
+	if logicalNameAttr, ok := block.Body.Attribute(LogicalNamePropertyKey); ok {
+		logicalName, lDiags := getStringAttrValue(logicalNameAttr)
+		if lDiags != nil {
+			diagnostics = diagnostics.Append(lDiags)
+		} else {
+			node.logicalName = logicalName
+		}
+	}
+
 	if value, ok := block.Body.Attribute("value"); ok {
 		node.Value = value.Value
 		if model.InputType(node.typ).ConversionFrom(node.Value.Type()) == model.NoConversion {

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -245,6 +245,15 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 	for _, item := range block.Body.Items {
 		switch item := item.(type) {
 		case *model.Attribute:
+			if item.Name == LogicalNamePropertyKey {
+				logicalName, lDiags := getStringAttrValue(item)
+				if lDiags != nil {
+					diagnostics = diagnostics.Append(lDiags)
+				} else {
+					node.logicalName = logicalName
+				}
+				continue
+			}
 			node.Inputs = append(node.Inputs, item)
 		case *model.Block:
 			switch item.Type {

--- a/pkg/codegen/pcl/diagnostics.go
+++ b/pkg/codegen/pcl/diagnostics.go
@@ -69,6 +69,6 @@ func duplicateBlock(blockType string, typeRange hcl.Range) *hcl.Diagnostic {
 	return errorf(typeRange, "duplicate block of type '%v'", blockType)
 }
 
-func stringAttributeError(attr *hclsyntax.Attribute) *hcl.Diagnostic {
-	return errorf(attr.Expr.Range(), "attribute %v must be a string literal", attr.Name)
+func stringAttributeError(attr *model.Attribute) *hcl.Diagnostic {
+	return errorf(attr.Syntax.Expr.Range(), "attribute %v must be a string literal", attr.Name)
 }

--- a/pkg/codegen/pcl/diagnostics.go
+++ b/pkg/codegen/pcl/diagnostics.go
@@ -68,3 +68,7 @@ func tokenMustBeStringLiteral(tokenExpr model.Expression) *hcl.Diagnostic {
 func duplicateBlock(blockType string, typeRange hcl.Range) *hcl.Diagnostic {
 	return errorf(typeRange, "duplicate block of type '%v'", blockType)
 }
+
+func stringAttributeError(attr *hclsyntax.Attribute) *hcl.Diagnostic {
+	return errorf(attr.Expr.Range(), "attribute %v must be a string literal", attr.Name)
+}

--- a/pkg/codegen/pcl/local.go
+++ b/pkg/codegen/pcl/local.go
@@ -47,6 +47,10 @@ func (lv *LocalVariable) Name() string {
 	return lv.Definition.Name
 }
 
+func (lv *LocalVariable) LogicalName() string {
+	return lv.Definition.Name
+}
+
 // Type returns the type of the local variable.
 func (lv *LocalVariable) Type() model.Type {
 	return lv.Definition.Type()

--- a/pkg/codegen/pcl/output.go
+++ b/pkg/codegen/pcl/output.go
@@ -27,6 +27,11 @@ type OutputVariable struct {
 	syntax *hclsyntax.Block
 	typ    model.Type
 
+	// The name visible to API calls related to the output. Used as the Name argument in stack output
+	// constructors (typically a method called "export"), and through those calls to
+	// RegisterResourceOutputs. Must not be modified during code generation to ensure that stack
+	// outputs are not renamed, breaking stack references.
+	uniqueName string
 	// The definition of the output.
 	Definition *model.Block
 	// The value of the output.
@@ -46,6 +51,7 @@ func (ov *OutputVariable) VisitExpressions(pre, post model.ExpressionVisitor) hc
 	return model.VisitExpressions(ov.Definition, pre, post)
 }
 
+// Name returns the variable or declaration name of the output.
 func (ov *OutputVariable) Name() string {
 	return ov.Definition.Labels[0]
 }
@@ -53,4 +59,14 @@ func (ov *OutputVariable) Name() string {
 // Type returns the type of the output variable.
 func (ov *OutputVariable) Type() model.Type {
 	return ov.typ
+}
+
+// Returns the ID of the output, if the output has an ID it is returned surrounded by double
+// quotes, otherwise the defaultValue is returned as is.
+func (ov *OutputVariable) UniqueName() string {
+	if ov.uniqueName != "" {
+		return ov.uniqueName
+	}
+
+	return ov.Name()
 }

--- a/pkg/codegen/pcl/output.go
+++ b/pkg/codegen/pcl/output.go
@@ -31,7 +31,7 @@ type OutputVariable struct {
 	// constructors (typically a method called "export"), and through those calls to
 	// RegisterResourceOutputs. Must not be modified during code generation to ensure that stack
 	// outputs are not renamed, breaking stack references.
-	uniqueName string
+	logicalName string
 	// The definition of the output.
 	Definition *model.Block
 	// The value of the output.
@@ -51,22 +51,21 @@ func (ov *OutputVariable) VisitExpressions(pre, post model.ExpressionVisitor) hc
 	return model.VisitExpressions(ov.Definition, pre, post)
 }
 
-// Name returns the variable or declaration name of the output.
 func (ov *OutputVariable) Name() string {
 	return ov.Definition.Labels[0]
+}
+
+// Returns the ID of the output, if the output has an ID it is returned surrounded by double
+// quotes, otherwise the defaultValue is returned as is.
+func (ov *OutputVariable) LogicalName() string {
+	if ov.logicalName != "" {
+		return ov.logicalName
+	}
+
+	return ov.Name()
 }
 
 // Type returns the type of the output variable.
 func (ov *OutputVariable) Type() model.Type {
 	return ov.typ
-}
-
-// Returns the ID of the output, if the output has an ID it is returned surrounded by double
-// quotes, otherwise the defaultValue is returned as is.
-func (ov *OutputVariable) UniqueName() string {
-	if ov.uniqueName != "" {
-		return ov.uniqueName
-	}
-
-	return ov.Name()
 }

--- a/pkg/codegen/pcl/program.go
+++ b/pkg/codegen/pcl/program.go
@@ -29,8 +29,9 @@ import (
 type Node interface {
 	model.Definition
 
-	// Name returns the name of the node.
+	// Name returns the lexical name of the node.
 	Name() string
+
 	// Type returns the type of the node.
 	Type() model.Type
 

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -50,7 +50,7 @@ type Resource struct {
 	// The name visible to API calls related to the resource. Used as the Name argument in resource
 	// constructors, and through those calls to RegisterResource. Must not be modified during code
 	// generation to ensure that resources are not renamed (deleted and recreated).
-	uniqueName string
+	logicalName string
 
 	// The definition of the resource.
 	Definition *model.Block
@@ -94,16 +94,16 @@ func (r *Resource) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Dia
 	return r.VariableType.Traverse(traverser)
 }
 
-// Name returns the variable or declaration name of the resource.
+// Deprecated: Name returns the variable or declaration name of the resource.
 func (r *Resource) Name() string {
 	return r.Definition.Labels[0]
 }
 
 // Returns the unique name of the resource; if the resource has an unique name it is formatted with
 // the format string and returned, otherwise the defaultValue is returned as is.
-func (r *Resource) UniqueName() string {
-	if r.uniqueName != "" {
-		return r.uniqueName
+func (r *Resource) LogicalName() string {
+	if r.logicalName != "" {
+		return r.logicalName
 	}
 
 	return r.Name()

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -47,6 +47,11 @@ type Resource struct {
 
 	syntax *hclsyntax.Block
 
+	// The name visible to API calls related to the resource. Used as the Name argument in resource
+	// constructors, and through those calls to RegisterResource. Must not be modified during code
+	// generation to ensure that resources are not renamed (deleted and recreated).
+	uniqueName string
+
 	// The definition of the resource.
 	Definition *model.Block
 
@@ -89,9 +94,19 @@ func (r *Resource) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Dia
 	return r.VariableType.Traverse(traverser)
 }
 
-// Name returns the name of the resource.
+// Name returns the variable or declaration name of the resource.
 func (r *Resource) Name() string {
 	return r.Definition.Labels[0]
+}
+
+// Returns the unique name of the resource; if the resource has an unique name it is formatted with
+// the format string and returned, otherwise the defaultValue is returned as is.
+func (r *Resource) UniqueName() string {
+	if r.uniqueName != "" {
+		return r.uniqueName
+	}
+
+	return r.Name()
 }
 
 // DecomposeToken attempts to decompose the resource's type token into its package, module, and type. If decomposition

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -354,7 +354,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
 	optionsBag, temps := g.lowerResourceOptions(r.Options)
 
-	name := r.UniqueName()
+	name := r.LogicalName()
 	nameVar := PyName(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
@@ -491,7 +491,7 @@ func (g *generator) genOutputVariable(w io.Writer, v *pcl.OutputVariable) {
 	g.genTemps(w, temps)
 
 	// TODO(pdg): trivia
-	g.Fgenf(w, "%spulumi.export(\"%s\", %.v)\n", g.Indent, v.UniqueName(), value)
+	g.Fgenf(w, "%spulumi.export(\"%s\", %.v)\n", g.Indent, v.LogicalName(), value)
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...interface{}) {

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -165,6 +165,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Repro for #9357",
 		Skip:        codegen.NewStringSet("go", "nodejs", "dotnet"),
 	},
+	{
+		Directory:   "logical-name",
+		Description: "Logical names",
+	},
 }
 
 // Checks that a generated program is correct

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/dotnet/logical-name.cs
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/dotnet/logical-name.cs
@@ -1,0 +1,16 @@
+using Pulumi;
+using Random = Pulumi.Random;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var resourceLexicalName = new Random.RandomPet("aA-Alpha_alpha.🤯⁉️", new Random.RandomPetArgs
+        {
+        });
+        this.OutputLexicalName = resourceLexicalName.Id;
+    }
+
+    [Output("bB-Beta_beta.💜⁉")]
+    public Output<string> OutputLexicalName { get; set; }
+}

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/go/logical-name.go
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/go/logical-name.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		resourceLexicalName, err := random.NewRandomPet(ctx, "aA-Alpha_alpha.🤯⁉️", nil)
+		if err != nil {
+			return err
+		}
+		ctx.Export("bB-Beta_beta.💜⁉", resourceLexicalName.ID())
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/logical-name.pp
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/logical-name.pp
@@ -1,0 +1,9 @@
+resource resourceLexicalName "random:index/randomPet:RandomPet" {
+  // not necessarily a valid logical name, just testing that it passes through to codegen unmodified
+  __logicalName = "aA-Alpha_alpha.🤯⁉️"
+}
+
+output outputLexicalName {
+  __logicalName = "bB-Beta_beta.💜⁉"
+  value = resourceLexicalName.id
+}

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/nodejs/logical-name.ts
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/nodejs/logical-name.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+export = async () => {
+    const resourceLexicalName = new random.RandomPet("aA-Alpha_alpha.🤯⁉️", {});
+    const outputLexicalName = resourceLexicalName.id;
+    return {
+        "bB-Beta_beta.💜⁉": outputLexicalName,
+    };
+}

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/python/logical-name.py
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/python/logical-name.py
@@ -1,0 +1,5 @@
+import pulumi
+import pulumi_random as random
+
+resource_lexical_name = random.RandomPet("aA-Alpha_alpha.🤯⁉️")
+pulumi.export("bB-Beta_beta.💜⁉", resource_lexical_name.id)


### PR DESCRIPTION
Lexical names, or variable/declaration names, are invisible to the Pulumi API at runtime. They exist for the programmer to give useful names to objects to reason about their program. Modifying lexical names to fit the target language does not change the [denotational semantics](https://en.wikibooks.org/wiki/Haskell/Denotational_semantics) of the program, e.g.: renaming the _variable name_ `myBucket` to `my_bucket` in the example below results in the same behavior on `pulumi up`. 

```ts
const myBucket = new aws.s3.Bucket("my-bucket", {website: {
//    ~~~~~~~~ lexical name        ~~~~~~~~~~~ unique name
    indexDocument: "index.html",
}});
```

By contrast, the first argument to a resource constructor and the argument to name a stack output is meaningful to the Pulumi API and can affect the resources. We'll call this name the UniqueName, and this PR maps a `__uniqueName` string attribute in our intermediate language on a resource or output to a UniqueName on their AST nodes, which is used as-is (modulo escaping) in code generation.

In codegen, we've typically used the lexical name for this argument, this PR modifies our codegen to instead use the UniqueName.
