### PR TITLE
Add deps to unsafe unknown outputs API

### DIFF
--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -506,9 +506,9 @@ func ToSecret(input interface{}) Output {
 
 // Creates an unknown output. This is a low level API and should not be used in programs as this
 // will cause "pulumi up" to fail if called and used during a non-dryrun deployment.
-func UnsafeUnknownOutput() Output {
+func UnsafeUnknownOutput(deps []Resource) Output {
 	output, _, _ := NewOutput()
-	output.getState().resolve(nil, false, false, nil)
+	output.getState().resolve(nil, false, false, deps)
 	return output
 }
 


### PR DESCRIPTION
This resolves an issue where running `pulumi destroy` lost information on sequencing the deletes when using this API.