### PR TITLE
Fix backupTarget

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,3 +28,6 @@
 
 - [auto/go] Fixed a race condition that could cause `Preview` to fail with "failed to get preview summary".
   [#9467](https://github.com/pulumi/pulumi/pull/9467)
+
+- [backend/filestate] - Fix a bug creating `stack.json.bak` files.
+  [#9476](https://github.com/pulumi/pulumi/pull/9476)

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -263,7 +263,7 @@ func backupTarget(bucket Bucket, file string, keepOriginal bool) string {
 	contract.Require(file != "", "file")
 	bck := file + ".bak"
 
-	err := bucket.Copy(context.TODO(), file, bck, nil)
+	err := bucket.Copy(context.TODO(), bck, file, nil)
 	if err != nil {
 		logging.V(5).Infof("error copying %s to %s: %s", file, bck, err)
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

src and dst arguments to bucket.Copy were the wrong way round.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
