### PR TITLE
[cli] Render JSON/YAML encoded values as objects.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,9 @@
 - [codegen] - Support all [Asset and Archive](https://www.pulumi.com/docs/intro/concepts/assets-archives/) types.
   [#9463](https://github.com/pulumi/pulumi/pull/9463)
 
+- [cli] Display JSON/YAML property values as objects for creates, sames, and deletes.
+  [#9484](https://github.com/pulumi/pulumi/pull/9484)
+
 ### Bug Fixes
 
 - [codegen] - Ensure that plain properties are always plain.

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -309,8 +309,8 @@ func renderDiff(
 	seen map[resource.URN]engine.StepEventMetadata,
 	opts Options) {
 
-	indent := GetIndent(metadata, seen)
-	summary := GetResourcePropertiesSummary(metadata, indent)
+	indent := getIndent(metadata, seen)
+	summary := getResourcePropertiesSummary(metadata, indent)
 
 	var details string
 	if metadata.DetailedDiff != nil {
@@ -323,7 +323,7 @@ func renderDiff(
 		}
 		details = buf.String()
 	} else {
-		details = GetResourcePropertiesDetails(
+		details = getResourcePropertiesDetails(
 			metadata, indent, planning, opts.SummaryDiff, debug)
 	}
 
@@ -362,24 +362,24 @@ func renderDiffResourceOutputsEvent(
 			return out.String()
 		}
 
-		indent := GetIndent(payload.Metadata, seen)
+		indent := getIndent(payload.Metadata, seen)
 
 		refresh := false // are these outputs from a refresh?
 		if m, has := seen[payload.Metadata.URN]; has && m.Op == deploy.OpRefresh {
 			refresh = true
-			summary := GetResourcePropertiesSummary(payload.Metadata, indent)
+			summary := getResourcePropertiesSummary(payload.Metadata, indent)
 			fprintIgnoreError(out, opts.Color.Colorize(summary))
 		}
 
 		if !opts.SuppressOutputs {
 			// We want to hide same outputs if we're doing a read and the user didn't ask to see
 			// things that are the same.
-			text := GetResourceOutputsPropertiesString(
+			text := getResourceOutputsPropertiesString(
 				payload.Metadata, indent+1, payload.Planning,
 				payload.Debug, refresh, opts.ShowSameResources)
 			if text != "" {
 				header := fmt.Sprintf("%v%v--outputs:--%v\n",
-					payload.Metadata.Op.Color(), GetIndentationString(indent+1), colors.Reset)
+					payload.Metadata.Op.Color(), getIndentationString(indent+1, payload.Metadata.Op, false), colors.Reset)
 				fprintfIgnoreError(out, opts.Color.Colorize(header))
 				fprintIgnoreError(out, opts.Color.Colorize(text))
 			}

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -897,7 +897,7 @@ func (display *ProgressDisplay) printOutputs() {
 
 	stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 
-	props := GetResourceOutputsPropertiesString(
+	props := getResourceOutputsPropertiesString(
 		stackStep, 1, display.isPreview, display.opts.Debug,
 		false /* refresh */, display.opts.ShowSameResources)
 	if props != "" {

--- a/pkg/backend/display/testdata/template-body.json.stdout.txt
+++ b/pkg/backend/display/testdata/template-body.json.stdout.txt
@@ -69,7 +69,23 @@
 <{%reset%}>                [id=cluster-eksRole-role-262a7fa]
 <{%reset%}><{%reset%}>                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/role:Role::cluster-eksRole-role]
 <{%reset%}><{%reset%}>                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
-<{%reset%}><{%reset%}>                assumeRolePolicy   : <{%reset%}><{%reset%}>"{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"eks.amazonaws.com\"]}}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                    Statement: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                        [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            Action   : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                                [0]: <{%reset%}><{%reset%}>"sts:AssumeRole"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            Effect   : <{%reset%}><{%reset%}>"Allow"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            Principal: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                                Service: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                                    [0]: <{%reset%}><{%reset%}>"eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Version  : <{%reset%}><{%reset%}>"2012-10-17"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>                description        : <{%reset%}><{%reset%}>"Allows EKS to manage clusters on your behalf."<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>                forceDetachPolicies: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>                maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
@@ -79,7 +95,23 @@
 <{%reset%}>                [id=cluster-instanceRole-role-f970009]
 <{%reset%}><{%reset%}>                [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:ServiceRole$aws:iam/role:Role::cluster-instanceRole-role]
 <{%reset%}><{%reset%}>                [provider=urn:pulumi:dev::aws-ts-eks::pulumi:providers:aws::default_4_38_1::9a24a173-1489-4d55-9224-f01ff9dee91f]
-<{%reset%}><{%reset%}>                assumeRolePolicy   : <{%reset%}><{%reset%}>"{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]}}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                    Statement: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                        [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            Action   : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                                [0]: <{%reset%}><{%reset%}>"sts:AssumeRole"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            Effect   : <{%reset%}><{%reset%}>"Allow"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            Principal: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                                Service: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                                    [0]: <{%reset%}><{%reset%}>"ec2.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Version  : <{%reset%}><{%reset%}>"2012-10-17"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>                forceDetachPolicies: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>                maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>                name               : <{%reset%}><{%reset%}>"cluster-instanceRole-role-f970009"<{%reset%}><{%reset%}>
@@ -356,7 +388,47 @@
 <{%reset%}><{%reset%}>        <{%reset%}>  eks:index:VpcCni: (same)
 <{%reset%}>            [id=1d530726ede55308]
 <{%reset%}><{%reset%}>            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$eks:index:VpcCni::cluster-vpc-cni]
-<{%reset%}><{%reset%}>            kubeconfig: <{%reset%}><{%reset%}>"{\"apiVersion\":\"v1\",\"clusters\":[{\"cluster\":{\"server\":\"https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com\",\"certificate-authority-data\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\"},\"name\":\"kubernetes\"}],\"contexts\":[{\"context\":{\"cluster\":\"kubernetes\",\"user\":\"aws\"},\"name\":\"aws\"}],\"current-context\":\"aws\",\"kind\":\"Config\",\"users\":[{\"name\":\"aws\",\"user\":{\"exec\":{\"apiVersion\":\"client.authentication.k8s.io/v1alpha1\",\"command\":\"aws\",\"args\":[\"eks\",\"get-token\",\"--cluster-name\",\"cluster-eksCluster-932639f\"]}}}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            kubeconfig: <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                apiVersion     : <{%reset%}><{%reset%}>"v1"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                clusters       : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        cluster: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            certificate-authority-data: <{%reset%}><{%reset%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            server                    : <{%reset%}><{%reset%}>"https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        name   : <{%reset%}><{%reset%}>"kubernetes"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                contexts       : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        context: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            cluster: <{%reset%}><{%reset%}>"kubernetes"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            user   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        name   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                current-context: <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                kind           : <{%reset%}><{%reset%}>"Config"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                users          : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        name: <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        user: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            exec: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                                apiVersion: <{%reset%}><{%reset%}>"client.authentication.k8s.io/v1alpha1"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                args      : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                                    [0]: <{%reset%}><{%reset%}>"eks"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [1]: <{%reset%}><{%reset%}>"get-token"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [2]: <{%reset%}><{%reset%}>"--cluster-name"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [3]: <{%reset%}><{%reset%}>"cluster-eksCluster-932639f"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                command   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        <{%reset%}>  aws:ec2/securityGroup:SecurityGroup: (same)
 <{%reset%}>            [id=sg-0377eac317c3aef31]
 <{%reset%}><{%reset%}>            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$aws:ec2/securityGroup:SecurityGroup::cluster-nodeSecurityGroup]
@@ -372,7 +444,47 @@
 <{%reset%}><{%reset%}>        <{%reset%}>  pulumi:providers:kubernetes: (same)
 <{%reset%}>            [id=fac1319d-5ae2-4480-96a2-f702fb3e2c92]
 <{%reset%}><{%reset%}>            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$pulumi:providers:kubernetes::cluster-eks-k8s]
-<{%reset%}><{%reset%}>            kubeconfig: <{%reset%}><{%reset%}>"{\"apiVersion\":\"v1\",\"clusters\":[{\"cluster\":{\"server\":\"https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com\",\"certificate-authority-data\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\"},\"name\":\"kubernetes\"}],\"contexts\":[{\"context\":{\"cluster\":\"kubernetes\",\"user\":\"aws\"},\"name\":\"aws\"}],\"current-context\":\"aws\",\"kind\":\"Config\",\"users\":[{\"name\":\"aws\",\"user\":{\"exec\":{\"apiVersion\":\"client.authentication.k8s.io/v1alpha1\",\"command\":\"aws\",\"args\":[\"eks\",\"get-token\",\"--cluster-name\",\"cluster-eksCluster-932639f\"]}}}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            kubeconfig: <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                apiVersion     : <{%reset%}><{%reset%}>"v1"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                clusters       : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        cluster: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            certificate-authority-data: <{%reset%}><{%reset%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            server                    : <{%reset%}><{%reset%}>"https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        name   : <{%reset%}><{%reset%}>"kubernetes"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                contexts       : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        context: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            cluster: <{%reset%}><{%reset%}>"kubernetes"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            user   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        name   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                current-context: <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                kind           : <{%reset%}><{%reset%}>"Config"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                users          : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        name: <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        user: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            exec: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                                apiVersion: <{%reset%}><{%reset%}>"client.authentication.k8s.io/v1alpha1"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                args      : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                                    [0]: <{%reset%}><{%reset%}>"eks"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [1]: <{%reset%}><{%reset%}>"get-token"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [2]: <{%reset%}><{%reset%}>"--cluster-name"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [3]: <{%reset%}><{%reset%}>"cluster-eksCluster-932639f"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                command   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            version   : <{%reset%}><{%reset%}>"3.18.2"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        <{%reset%}>  aws:ec2/securityGroupRule:SecurityGroupRule: (same)
 <{%reset%}>            [id=sgrule-607663483]
@@ -437,7 +549,17 @@
 <{%reset%}><{%reset%}>            [provider=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$pulumi:providers:kubernetes::cluster-eks-k8s::fac1319d-5ae2-4480-96a2-f702fb3e2c92]
 <{%reset%}><{%reset%}>            apiVersion: <{%reset%}><{%reset%}>"v1"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            data      : <{%reset%}><{%reset%}>{
-<{%reset%}><{%reset%}>                mapRoles: <{%reset%}><{%reset%}>"- rolearn: 'arn:aws:iam::616138583583:role/cluster-instanceRole-role-f970009'\n  username: 'system:node:{{EC2PrivateDNSName}}'\n  groups:\n    - 'system:bootstrappers'\n    - 'system:nodes'\n"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                mapRoles: <{%reset%}><{%reset%}>(yaml) <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        groups  : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                            [0]: <{%reset%}><{%reset%}>"system:bootstrappers"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            [1]: <{%reset%}><{%reset%}>"system:nodes"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        rolearn : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/cluster-instanceRole-role-f970009"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        username: <{%reset%}><{%reset%}>"system:node:{{EC2PrivateDNSName}}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            }<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            kind      : <{%reset%}><{%reset%}>"ConfigMap"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            metadata  : <{%reset%}><{%reset%}>{
@@ -514,7 +636,47 @@
 <{%reset%}><{%reset%}>        <{%reset%}>  pulumi:providers:kubernetes: (same)
 <{%reset%}>            [id=e99e4ebc-d3ed-445c-80f8-e7be504678d4]
 <{%reset%}><{%reset%}>            [urn=urn:pulumi:dev::aws-ts-eks::eks:index:Cluster$pulumi:providers:kubernetes::cluster-provider]
-<{%reset%}><{%reset%}>            kubeconfig: <{%reset%}><{%reset%}>"{\"apiVersion\":\"v1\",\"clusters\":[{\"cluster\":{\"server\":\"https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com\",\"certificate-authority-data\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\"},\"name\":\"kubernetes\"}],\"contexts\":[{\"context\":{\"cluster\":\"kubernetes\",\"user\":\"aws\"},\"name\":\"aws\"}],\"current-context\":\"aws\",\"kind\":\"Config\",\"users\":[{\"name\":\"aws\",\"user\":{\"exec\":{\"apiVersion\":\"client.authentication.k8s.io/v1alpha1\",\"command\":\"aws\",\"args\":[\"eks\",\"get-token\",\"--cluster-name\",\"cluster-eksCluster-932639f\"]}}}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            kubeconfig: <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                apiVersion     : <{%reset%}><{%reset%}>"v1"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                clusters       : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        cluster: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            certificate-authority-data: <{%reset%}><{%reset%}>"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXdPREEyTWpjMU5Wb1hEVE15TURRd05UQTJNamMxTlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2M5Ck9FSTNSLzltTnpWZy9nS284V3dmb3R6dHk5T2F5Y2hadkpXVStjWUJLVzVrUS9jc0lIVWk0M3pGWk52VjdRd2sKSkR5elFwZXI3R29CM3ZrSUlXNlpzZjdIRUVIU2h0QUxvRHJrOTlwU1ltcDJvNEhzMkx2aC9WSHkwZG4zRE9IcwpwSFkxWU9mSmUyK25UcUJ2NHhseTVDWjEzUTV3MGRVMUY1bm56b1RsS1ppTkdmYWhHNEN2QStsS3FPWFZ3dHZiCkcxRmJkVThBQXRDUnZPSmg5eTN6eDN1b0pPWVc0QkU0VDNsM0dpTlk4TVl3eGVRd3JvU0hseE1GbGJQUmQ2YXMKOUEyczNxK1RJZ2VKZzBxNFIrK3Z1QVlBcG5DRzFIbEpieU9kT3d3aldlUHZIVDhMZTJXN283NEFsNSt6bEFXdQptVm9VbE82WUlxc1h3YUl3QUY4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZFV2xRdERXbllFVEs2M0xBd2JSRUQ2TTJtM0ZNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDVjFFOUVucWhUbkNQZVZEQmxXMURXMTBwdzdVMG9sdk5TWjA0cU9RRVkwNE5oZ29tTgprWC9GeDhQenBnT1h4SWlOYlBZYTdIYVVNZ0RPMHJ1bVNPQjc5ZThtbjNIZ055dlEyM3NOUkpsMnlaUUVDKzBXCllJcXhSM2pwMkV1MG40YkxDQzRyM2UweFRITldwbGd6Z1FkcUpNLzg0NmUxRTR0alV5Ry92V09VV3RGSzRjemoKTS85SXJZWnJRVFRVL1pISDVtMmtFYjRUcmYwZ1hyL2E3UmJWUG91Uzk2dmJpdjdoSE12YVptclpzeTN3bDBYYQpFUDdwMERHdWxCdnh1K3BjUkxVdkZMZUdLODFLY3JRZmpFU2ZqSldSWVYwTERGWnQ4YnlMT0J6V2MvU0Ywd0ZoCkt4ekFLWXkvZHhTNksySCtqeFY1amF2cXNTR1dzSGZ6Q0Q2MQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            server                    : <{%reset%}><{%reset%}>"https://8AE853AAF6BD7DFED415A3D30AD938E2.gr7.us-west-2.eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        name   : <{%reset%}><{%reset%}>"kubernetes"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                contexts       : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        context: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            cluster: <{%reset%}><{%reset%}>"kubernetes"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            user   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        name   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                current-context: <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                kind           : <{%reset%}><{%reset%}>"Config"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                users          : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                    [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        name: <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        user: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                            exec: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                                apiVersion: <{%reset%}><{%reset%}>"client.authentication.k8s.io/v1alpha1"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                args      : <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                                    [0]: <{%reset%}><{%reset%}>"eks"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [1]: <{%reset%}><{%reset%}>"get-token"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [2]: <{%reset%}><{%reset%}>"--cluster-name"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                    [3]: <{%reset%}><{%reset%}>"cluster-eksCluster-932639f"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                                command   : <{%reset%}><{%reset%}>"aws"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>            version   : <{%reset%}><{%reset%}>"3.18.2"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>    --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
 <{%reset%}>    kubeconfig: <{%reset%}><{%reset%}>{

--- a/pkg/backend/display/testdata/up-2.json.stdout.txt
+++ b/pkg/backend/display/testdata/up-2.json.stdout.txt
@@ -6,14 +6,38 @@
 <{%reset%}>        [id=eks-role-24b1266]
 <{%reset%}><{%reset%}>        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::7b99a6ae-83b6-49d1-a82d-3f9f7cf83d42]
-<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>"{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2008-10-17\"}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                    Action   : <{%reset%}><{%reset%}>"sts:AssumeRole"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Effect   : <{%reset%}><{%reset%}>"Allow"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Principal: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        Service: <{%reset%}><{%reset%}>"eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            Version  : <{%reset%}><{%reset%}>"2008-10-17"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        forceDetachPolicies: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>"{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                    Action   : <{%reset%}><{%reset%}>"sts:AssumeRole"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Effect   : <{%reset%}><{%reset%}>"Allow"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Principal: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        Service: <{%reset%}><{%reset%}>"eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            Version  : <{%reset%}><{%reset%}>"2008-10-17"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        createDate         : <{%reset%}><{%reset%}>"2022-02-09T23:14:50Z"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        id                 : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        inlinePolicies     : <{%reset%}><{%reset%}>[

--- a/pkg/backend/display/testdata/up-3.json.stdout.txt
+++ b/pkg/backend/display/testdata/up-3.json.stdout.txt
@@ -5,7 +5,19 @@
 <{%reset%}><{%reset%}>    <{%fg 2%}>+ aws:iam/role:Role: (create)
 <{%fg 2%}>        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
 <{%reset%}><{%fg 2%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-<{%reset%}><{%fg 2%}>        assumeRolePolicy   : <{%reset%}><{%fg 2%}>"{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2008-10-17\"}"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>        assumeRolePolicy   : <{%reset%}><{%fg 2%}>(json) <{%reset%}><{%fg 2%}>{
+<{%reset%}><{%fg 2%}>            Statement: <{%reset%}><{%fg 2%}>[
+<{%reset%}><{%fg 2%}>                [0]: <{%reset%}><{%fg 2%}>{
+<{%reset%}><{%fg 2%}>                    Action   : <{%reset%}><{%fg 2%}>"sts:AssumeRole"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                    Effect   : <{%reset%}><{%fg 2%}>"Allow"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                    Principal: <{%reset%}><{%fg 2%}>{
+<{%reset%}><{%fg 2%}>                        Service: <{%reset%}><{%fg 2%}>"eks.amazonaws.com"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                    }<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                }<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>            ]<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>            Version  : <{%reset%}><{%fg 2%}>"2008-10-17"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>        }<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        forceDetachPolicies: <{%reset%}><{%fg 2%}>false<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        maxSessionDuration : <{%reset%}><{%fg 2%}>3600<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        name               : <{%reset%}><{%fg 2%}>"eks-role-be36613"<{%reset%}><{%fg 2%}>
@@ -41,7 +53,19 @@
 <{%reset%}><{%fg 2%}>        vpcId              : <{%reset%}><{%fg 2%}>"vpc-4b82e033"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%reset%}><{%!f(MISSING)g 2%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
 <{%fg 2%}>        arn                : <{%reset%}><{%fg 2%}>"arn:aws:iam::616138583583:role/eks-role-be36613"<{%reset%}><{%fg 2%}>
-<{%reset%}><{%fg 2%}>        assumeRolePolicy   : <{%reset%}><{%fg 2%}>"{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>        assumeRolePolicy   : <{%reset%}><{%fg 2%}>(json) <{%reset%}><{%fg 2%}>{
+<{%reset%}><{%fg 2%}>            Statement: <{%reset%}><{%fg 2%}>[
+<{%reset%}><{%fg 2%}>                [0]: <{%reset%}><{%fg 2%}>{
+<{%reset%}><{%fg 2%}>                    Action   : <{%reset%}><{%fg 2%}>"sts:AssumeRole"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                    Effect   : <{%reset%}><{%fg 2%}>"Allow"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                    Principal: <{%reset%}><{%fg 2%}>{
+<{%reset%}><{%fg 2%}>                        Service: <{%reset%}><{%fg 2%}>"eks.amazonaws.com"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                    }<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>                }<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>            ]<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>            Version  : <{%reset%}><{%fg 2%}>"2008-10-17"<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>        }<{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        createDate         : <{%reset%}><{%fg 2%}>"2022-04-01T07:30:56Z"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        id                 : <{%reset%}><{%fg 2%}>"eks-role-be36613"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%fg 2%}>        inlinePolicies     : <{%reset%}><{%fg 2%}>[

--- a/pkg/backend/display/testdata/up-4.json.stdout.txt
+++ b/pkg/backend/display/testdata/up-4.json.stdout.txt
@@ -6,14 +6,38 @@
 <{%reset%}>        [id=eks-role-be36613]
 <{%reset%}><{%reset%}>        [urn=urn:pulumi:dev::eks::aws:iam/role:Role::eks-role]
 <{%reset%}><{%reset%}>        [provider=urn:pulumi:dev::eks::pulumi:providers:aws::default_4_36_0::0ec0509c-c2e3-422d-aec6-ea54de8d499b]
-<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>"{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2008-10-17\"}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                    Action   : <{%reset%}><{%reset%}>"sts:AssumeRole"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Effect   : <{%reset%}><{%reset%}>"Allow"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Principal: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        Service: <{%reset%}><{%reset%}>"eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            Version  : <{%reset%}><{%reset%}>"2008-10-17"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        forceDetachPolicies: <{%reset%}><{%reset%}>false<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        maxSessionDuration : <{%reset%}><{%reset%}>3600<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        name               : <{%reset%}><{%reset%}>"eks-role-be36613"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-be36613"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>"{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                    Action   : <{%reset%}><{%reset%}>"sts:AssumeRole"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Effect   : <{%reset%}><{%reset%}>"Allow"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Principal: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        Service: <{%reset%}><{%reset%}>"eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            Version  : <{%reset%}><{%reset%}>"2008-10-17"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        createDate         : <{%reset%}><{%reset%}>"2022-04-01T07:30:56Z"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        id                 : <{%reset%}><{%reset%}>"eks-role-be36613"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        inlinePolicies     : <{%reset%}><{%reset%}>[

--- a/pkg/backend/display/testdata/up.json.stdout.txt
+++ b/pkg/backend/display/testdata/up.json.stdout.txt
@@ -24,7 +24,19 @@
 <{%reset%}><{%reset%}>        path               : <{%reset%}><{%reset%}>"/"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}><{%!r(MISSING)eset%!}(MISSING)>        --outputs:--<{%!r(MISSING)eset%!}(MISSING)>
 <{%reset%}>        arn                : <{%reset%}><{%reset%}>"arn:aws:iam::616138583583:role/eks-role-24b1266"<{%reset%}><{%reset%}>
-<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>"{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        assumeRolePolicy   : <{%reset%}><{%reset%}>(json) <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>            Statement: <{%reset%}><{%reset%}>[
+<{%reset%}><{%reset%}>                [0]: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                    Action   : <{%reset%}><{%reset%}>"sts:AssumeRole"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Effect   : <{%reset%}><{%reset%}>"Allow"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    Principal: <{%reset%}><{%reset%}>{
+<{%reset%}><{%reset%}>                        Service: <{%reset%}><{%reset%}>"eks.amazonaws.com"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                    }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>                }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            ]<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>            Version  : <{%reset%}><{%reset%}>"2008-10-17"<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>        }<{%reset%}><{%reset%}>
+<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        createDate         : <{%reset%}><{%reset%}>"2022-02-09T23:14:50Z"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        id                 : <{%reset%}><{%reset%}>"eks-role-24b1266"<{%reset%}><{%reset%}>
 <{%reset%}><{%reset%}>        inlinePolicies     : <{%reset%}><{%reset%}>[


### PR DESCRIPTION
Reuse the support for decoding JSON/YAML strings into objects to display
such values as objects during create, same, and delete operations (we
already do this for updates).

These changes also unexport a number of methods that should be internal
to the display package.