### PR TITLE
Use exising module name infrastrucure

### DIFF
--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -242,9 +242,16 @@ func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics)
 		pkg, module, member = member, "", "Provider"
 	}
 
-	// Normalize module.
 	if r.Schema != nil {
-		pkg := r.Schema.Package
+		module = moduleName(module, r.Schema.Package)
+	}
+
+	return makeValidIdentifier(pkg), module, title(member), diagnostics
+}
+
+func moduleName(module string, pkg *schema.Package) string {
+	// Normalize module.
+	if pkg != nil {
 		if lang, ok := pkg.Language["nodejs"]; ok {
 			pkgInfo := lang.(NodePackageInfo)
 			if m, ok := pkgInfo.ModuleToPackage[module]; ok {
@@ -252,9 +259,7 @@ func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics)
 			}
 		}
 	}
-
-	module = strings.ToLower(strings.Replace(module, "/", ".", -1))
-	return makeValidIdentifier(pkg), module, title(member), diagnostics
+	return strings.ToLower(strings.ReplaceAll(module, "/", "."))
 }
 
 // makeResourceName returns the expression that should be emitted for a resource's "name" parameter given its base name

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -296,11 +296,7 @@ func enumName(enum *model.EnumType) (string, error) {
 	components := strings.Split(enum.Token, ":")
 	contract.Assertf(len(components) == 3, "malformed token %v", enum.Token)
 	name := tokenToName(enum.Token)
-	module := func(m string) string {
-		pkg := strings.ToLower(m)
-		return strings.ReplaceAll(pkg, "-", "_")
-	}
-	pkg := components[0]
+	pkg := makeValidIdentifier(components[0])
 	e, ok := pcl.GetSchemaForType(enum)
 	if !ok {
 		return "", fmt.Errorf("Could not get associated enum")
@@ -308,9 +304,11 @@ func enumName(enum *model.EnumType) (string, error) {
 	if name := e.(*schema.EnumType).Package.Language["nodejs"].(NodePackageInfo).PackageName; name != "" {
 		pkg = name
 	}
-	pkg = module(pkg)
-	if components[1] != "" && components[1] != "index" {
-		pkg += "." + module(components[1])
+	if mod := components[1]; mod != "" && mod != "index" {
+		if pkg := e.(*schema.EnumType).Package; pkg != nil {
+			mod = moduleName(mod, pkg)
+		}
+		pkg += "." + mod
 	}
 	return fmt.Sprintf("%s.%s", pkg, name), nil
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Generate module names correctly (same way as `resourceTypeName`). 

I was unable to create an independent test for this (copying the offending PCL from `azure-native` does not reproduce the bug), but have verified that the fix works by running the failing `azure-native` test with a `replace` statement pointing to my local `pulumi/pulumi`. I propose we merge this now to unblock `azure-native` and add a repro test as followup. 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9485

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
