### PR TITLE
Clear CHANGELOG_PENDING.md post v3.31.0 release

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,37 +1,3 @@
 ### Improvements
 
-- [auto/*] Add `--save-plan` and `--plan` options to automation API.
-  [#9391](https://github.com/pulumi/pulumi/pull/9391)
-
-- [cli] "down" is now treated as an alias of "destroy".
-  [#9458](https://github.com/pulumi/pulumi/pull/9458)
-
-- [go] Add `Composite` resource option allowing several options to be encapsulated into a "single" option.
-  [#9459](https://github.com/pulumi/pulumi/pull/9459)
-
-- [codegen] - Support all [Asset and Archive](https://www.pulumi.com/docs/intro/concepts/assets-archives/) types.
-  [#9463](https://github.com/pulumi/pulumi/pull/9463)
-
-- [cli] Display JSON/YAML property values as objects for creates, sames, and deletes.
-  [#9484](https://github.com/pulumi/pulumi/pull/9484)
-
 ### Bug Fixes
-
-- [codegen/go] - Ensure that plain properties are plain.
-  [#9430](https://github.com/pulumi/pulumi/pull/9430)
-  [#9488](https://github.com/pulumi/pulumi/pull/9488)
-
-- [cli] Fixed some context leaks where shutdown code wasn't correctly called.
-  [#9438](https://github.com/pulumi/pulumi/pull/9438)
-
-- [cli] Do not render array diffs for unchanged elements without recorded values.
-  [#9448](https://github.com/pulumi/pulumi/pull/9448)
-
-- [auto/go] Fixed the exit code reported by `runPulumiCommandSync` to be zero if the command runs successfully. Previously it returned -2 which could lead to confusing messages if the exit code was used for other errors, such as in `Stack.Preview`.
-  [#9443](https://github.com/pulumi/pulumi/pull/9443)
-
-- [auto/go] Fixed a race condition that could cause `Preview` to fail with "failed to get preview summary".
-  [#9467](https://github.com/pulumi/pulumi/pull/9467)
-
-- [backend/filestate] - Fix a bug creating `stack.json.bak` files.
-  [#9476](https://github.com/pulumi/pulumi/pull/9476)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
