### PR TITLE
[diff] Handle YAML maps with numeric keys.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,6 @@
 
 - [cli] Empty passphrases environment variables are now treated as if the variable was not set.
   [#9490](https://github.com/pulumi/pulumi/pull/9490)
+
+- [cli] Decode YAML mappings with numeric keys during diff.
+  [#9502](https://github.com/pulumi/pulumi/pull/9503)


### PR DESCRIPTION
YAML supports mappings with arbitrarily-typed keys (unlike JSON, which
only supports string keys). These mappings decode into
`map[interface{}]interface{}` values, which are not supported by
`resource.NewPropertyValue`. These changes add a function to the display
logic that translates `map[interface{}]interface{}` values decoded from
YAML to `map[string]interface{}` values iff the keys are strings or
numeric values.

Fixes https://github.com/pulumi/pulumi/issues/9502.