### PR TITLE
[sdk/go] Enable obtaining resource outputs off a ResourceOutput

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,9 @@
 
 ### Bug Fixes
 
+- [codegen/go] Enable obtaining resource outputs off a ResourceOutput.
+  [#9513](https://github.com/pulumi/pulumi/pull/9513)
+
 - [codegen/go] Ensure that "plain" generates shallowly plain types.
   [#9512](https://github.com/pulumi/pulumi/pull/9512)
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/go/azure/documentdb/sqlResourceSqlContainer.go
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/go/azure/documentdb/sqlResourceSqlContainer.go
@@ -184,6 +184,10 @@ func (o SqlResourceSqlContainerOutput) ToSqlResourceSqlContainerOutputWithContex
 	return o
 }
 
+func (o SqlResourceSqlContainerOutput) Resource() SqlContainerGetPropertiesResponseResourcePtrOutput {
+	return o.ApplyT(func(v *SqlResourceSqlContainer) SqlContainerGetPropertiesResponseResourcePtrOutput { return v.Resource }).(SqlContainerGetPropertiesResponseResourcePtrOutput)
+}
+
 func init() {
 	pulumi.RegisterOutputType(SqlResourceSqlContainerOutput{})
 }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
@@ -101,6 +101,10 @@ func (o ModuleResourceOutput) ToModuleResourceOutputWithContext(ctx context.Cont
 	return o
 }
 
+func (o ModuleResourceOutput) Thing() foo.TopLevelPtrOutput {
+	return o.ApplyT(func(v *ModuleResource) foo.TopLevelPtrOutput { return v.Thing }).(foo.TopLevelPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ModuleResourceInput)(nil)).Elem(), &ModuleResource{})
 	pulumi.RegisterOutputType(ModuleResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
@@ -131,6 +131,26 @@ func (o RubberTreeOutput) ToRubberTreeOutputWithContext(ctx context.Context) Rub
 	return o
 }
 
+func (o RubberTreeOutput) Container() plantprovider.ContainerPtrOutput {
+	return o.ApplyT(func(v *RubberTree) plantprovider.ContainerPtrOutput { return v.Container }).(plantprovider.ContainerPtrOutput)
+}
+
+func (o RubberTreeOutput) Diameter() DiameterOutput {
+	return o.ApplyT(func(v *RubberTree) DiameterOutput { return v.Diameter }).(DiameterOutput)
+}
+
+func (o RubberTreeOutput) Farm() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RubberTree) pulumi.StringPtrOutput { return v.Farm }).(pulumi.StringPtrOutput)
+}
+
+func (o RubberTreeOutput) Size() TreeSizePtrOutput {
+	return o.ApplyT(func(v *RubberTree) TreeSizePtrOutput { return v.Size }).(TreeSizePtrOutput)
+}
+
+func (o RubberTreeOutput) Type() RubberTreeVarietyOutput {
+	return o.ApplyT(func(v *RubberTree) RubberTreeVarietyOutput { return v.Type }).(RubberTreeVarietyOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*RubberTreeInput)(nil)).Elem(), &RubberTree{})
 	pulumi.RegisterOutputType(RubberTreeOutput{})

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
@@ -131,6 +131,26 @@ func (o RubberTreeOutput) ToRubberTreeOutputWithContext(ctx context.Context) Rub
 	return o
 }
 
+func (o RubberTreeOutput) Container() plant.ContainerPtrOutput {
+	return o.ApplyT(func(v *RubberTree) plant.ContainerPtrOutput { return v.Container }).(plant.ContainerPtrOutput)
+}
+
+func (o RubberTreeOutput) Diameter() DiameterOutput {
+	return o.ApplyT(func(v *RubberTree) DiameterOutput { return v.Diameter }).(DiameterOutput)
+}
+
+func (o RubberTreeOutput) Farm() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RubberTree) pulumi.StringPtrOutput { return v.Farm }).(pulumi.StringPtrOutput)
+}
+
+func (o RubberTreeOutput) Size() TreeSizePtrOutput {
+	return o.ApplyT(func(v *RubberTree) TreeSizePtrOutput { return v.Size }).(TreeSizePtrOutput)
+}
+
+func (o RubberTreeOutput) Type() RubberTreeVarietyOutput {
+	return o.ApplyT(func(v *RubberTree) RubberTreeVarietyOutput { return v.Type }).(RubberTreeVarietyOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*RubberTreeInput)(nil)).Elem(), &RubberTree{})
 	pulumi.RegisterOutputType(RubberTreeOutput{})

--- a/pkg/codegen/testing/test/testdata/eks.json
+++ b/pkg/codegen/testing/test/testdata/eks.json
@@ -1,0 +1,1361 @@
+{
+  "name": "eks",
+  "description": "Pulumi Amazon Web Services (AWS) EKS Components.",
+  "keywords": [
+    "pulumi",
+    "aws",
+    "eks"
+  ],
+  "homepage": "https://pulumi.com",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/pulumi/pulumi-eks",
+  "config": {},
+  "types": {
+    "eks:index:ClusterNodeGroupOptions": {
+      "description": "Describes the configuration options accepted by a cluster to create its own node groups.",
+      "properties": {
+        "amiId": {
+          "type": "string",
+          "description": "The AMI ID to use for the worker nodes.\n\nDefaults to the latest recommended EKS Optimized Linux AMI from the AWS Systems Manager Parameter Store.\n\nNote: `amiId` and `gpu` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html."
+        },
+        "autoScalingGroupTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags to apply to the NodeGroup's AutoScalingGroup in the CloudFormation Stack.\n\nPer AWS, all stack-level tags, including automatically created tags, and the `cloudFormationTags` option are propagated to resources that AWS CloudFormation supports, including the AutoScalingGroup. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html\n\nNote: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both."
+        },
+        "bootstrapExtraArgs": {
+          "type": "string",
+          "description": "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters."
+        },
+        "cloudFormationTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags to apply to the CloudFormation Stack of the Worker NodeGroup.\n\nNote: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both."
+        },
+        "clusterIngressRule": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "description": "The ingress rule that gives node group access."
+        },
+        "desiredCapacity": {
+          "type": "integer",
+          "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
+        },
+        "encryptRootBlockDevice": {
+          "type": "boolean",
+          "description": "Encrypt the root block device of the nodes in the node group."
+        },
+        "extraNodeSecurityGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+          },
+          "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
+        },
+        "gpu": {
+          "type": "boolean",
+          "description": "Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.\n\nDefaults to false.\n\nNote: `gpu` and `amiId` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\n- https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html"
+        },
+        "instanceProfile": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+          "description": "The ingress rule that gives node group access."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\"."
+        },
+        "keyName": {
+          "type": "string",
+          "description": "Name of the key pair to use for SSH access to worker nodes."
+        },
+        "kubeletExtraArgs": {
+          "type": "string",
+          "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument."
+        },
+        "maxSize": {
+          "type": "integer",
+          "description": "The maximum number of worker nodes running in the cluster. Defaults to 2."
+        },
+        "minSize": {
+          "type": "integer",
+          "description": "The minimum number of worker nodes running in the cluster. Defaults to 1."
+        },
+        "nodeAssociatePublicIpAddress": {
+          "type": "boolean",
+          "description": "Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs."
+        },
+        "nodePublicKey": {
+          "type": "string",
+          "description": "Public key material for SSH access to worker nodes. See allowed formats at:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\nIf not provided, no SSH access is enabled on VMs."
+        },
+        "nodeRootVolumeSize": {
+          "type": "integer",
+          "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
+        },
+        "nodeSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
+        },
+        "nodeSubnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The set of subnets to override and use for the worker node group.\n\nSetting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set."
+        },
+        "nodeUserData": {
+          "type": "string",
+          "description": "Extra code to run on node startup. This code will run after the AWS EKS bootstrapping code and before the node signals its readiness to the managing CloudFormation stack. This code must be a typical user data script: critically it must begin with an interpreter directive (i.e. a `#!`)."
+        },
+        "nodeUserDataOverride": {
+          "type": "string",
+          "description": "User specified code to run on node startup. This code is expected to handle the full AWS EKS bootstrapping code and signal node readiness to the managing CloudFormation stack. This code must be a complete and executable user data script in bash (Linux) or powershell (Windows).\n\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/worker.html"
+        },
+        "spotPrice": {
+          "type": "string",
+          "description": "Bidding price for spot instance. If set, only spot instances will be added as worker node."
+        },
+        "taints": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/eks:index:Taint"
+          },
+          "description": "Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument"
+        },
+        "version": {
+          "type": "string",
+          "description": "Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used."
+        }
+      },
+      "type": "object"
+    },
+    "eks:index:CoreData": {
+      "description": "Defines the core set of data associated with an EKS cluster, including the network in which it runs.",
+      "properties": {
+        "awsProvider": {
+          "$ref": "/aws/v4.15.0/schema.json#/provider"
+        },
+        "cluster": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2Fcluster:Cluster"
+        },
+        "clusterSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+        },
+        "eksNodeAccess": {
+          "$ref": "/kubernetes/v3.0.0/schema.json#/resources/kubernetes:core%2Fv1:ConfigMap"
+        },
+        "encryptionConfig": {
+          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FClusterEncryptionConfig:ClusterEncryptionConfig"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "fargateProfile": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2FfargateProfile:FargateProfile"
+        },
+        "instanceRoles": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+          }
+        },
+        "kubeconfig": {
+          "$ref": "pulumi.json#/Any"
+        },
+        "nodeGroupOptions": {
+          "$ref": "#/types/eks:index:ClusterNodeGroupOptions"
+        },
+        "nodeSecurityGroupTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "oidcProvider": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2FopenIdConnectProvider:OpenIdConnectProvider"
+        },
+        "privateSubnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provider": {
+          "$ref": "/kubernetes/v3.0.0/schema.json#/provider"
+        },
+        "publicSubnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "storageClasses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "/kubernetes/v3.0.0/schema.json#/resources/kubernetes:storage.k8s.io%2Fv1:StorageClass"
+          }
+        },
+        "subnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "vpcCni": {
+          "$ref": "#/resources/eks:index:VpcCni"
+        },
+        "vpcId": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "cluster",
+        "vpcId",
+        "subnetIds",
+        "endpoint",
+        "clusterSecurityGroup",
+        "provider",
+        "instanceRoles",
+        "nodeGroupOptions"
+      ]
+    },
+    "eks:index:CreationRoleProvider": {
+      "description": "Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
+      "properties": {
+        "provider": {
+          "$ref": "/aws/v4.15.0/schema.json#/provider"
+        },
+        "role": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+        }
+      },
+      "type": "object",
+      "required": [
+        "role",
+        "provider"
+      ]
+    },
+    "eks:index:FargateProfile": {
+      "description": "Defines how Kubernetes pods are executed in Fargate. See aws.eks.FargateProfileArgs for reference.",
+      "properties": {
+        "podExecutionRoleArn": {
+          "type": "string",
+          "description": "Specify a custom role to use for executing pods in Fargate. Defaults to creating a new role with the `arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy` policy attached."
+        },
+        "selectors": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FFargateProfileSelector:FargateProfileSelector"
+          },
+          "description": "Specify the namespace and label selectors to use for launching pods into Fargate."
+        },
+        "subnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Specify the subnets in which to execute Fargate tasks for pods. Defaults to the private subnets associated with the cluster."
+        }
+      },
+      "type": "object"
+    },
+    "eks:index:KubeconfigOptions": {
+      "description": "Represents the AWS credentials to scope a given kubeconfig when using a non-default credential chain.\n\nThe options can be used independently, or additively.\n\nA scoped kubeconfig is necessary for certain auth scenarios. For example:\n  1. Assume a role on the default account caller,\n  2. Use an AWS creds profile instead of the default account caller,\n  3. Use an AWS creds creds profile instead of the default account caller,\n     and then assume a given role on the profile. This scenario is also\n     possible by only using a profile, iff the profile includes a role to\n     assume in its settings.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html\n- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html\n- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html",
+      "properties": {
+        "profileName": {
+          "type": "string",
+          "description": "AWS credential profile name to always use instead of the default AWS credential provider chain.\n\nThe profile is passed to kubeconfig as an authentication environment setting."
+        },
+        "roleArn": {
+          "type": "string",
+          "description": "Role ARN to assume instead of the default AWS credential provider chain.\n\nThe role is passed to kubeconfig as an authentication exec argument."
+        }
+      },
+      "type": "object"
+    },
+    "eks:index:NodeGroupData": {
+      "description": "NodeGroupData describes the resources created for the given NodeGroup.",
+      "properties": {
+        "autoScalingGroupName": {
+          "type": "string",
+          "description": "The AutoScalingGroup name for the node group."
+        },
+        "cfnStack": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
+          "description": "The CloudFormation Stack which defines the Node AutoScalingGroup."
+        },
+        "extraNodeSecurityGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+          },
+          "description": "The additional security groups for the node group that captures user-specific rules."
+        },
+        "nodeSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group for the node group to communicate with the cluster."
+        }
+      },
+      "type": "object",
+      "required": [
+        "nodeSecurityGroup",
+        "extraNodeSecurityGroups",
+        "cfnStack",
+        "autoScalingGroupName"
+      ]
+    },
+    "eks:index:RoleMapping": {
+      "description": "Describes a mapping from an AWS IAM role to a Kubernetes user and groups.",
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of groups within Kubernetes to which the role is mapped."
+        },
+        "roleArn": {
+          "type": "string",
+          "description": "The ARN of the IAM role to add."
+        },
+        "username": {
+          "type": "string",
+          "description": "The user name within Kubernetes to map to the IAM role. By default, the user name is the ARN of the IAM role."
+        }
+      },
+      "type": "object",
+      "required": [
+        "roleArn",
+        "username",
+        "groups"
+      ]
+    },
+    "eks:index:StorageClass": {
+      "description": "StorageClass describes the inputs to a single Kubernetes StorageClass provisioned by AWS. Any number of storage classes can be added to a cluster at creation time. One of these storage classes may be configured the default storage class for the cluster.",
+      "properties": {
+        "allowVolumeExpansion": {
+          "type": "boolean",
+          "description": "AllowVolumeExpansion shows whether the storage class allow volume expand."
+        },
+        "default": {
+          "type": "boolean",
+          "description": "True if this storage class should be a default storage class for the cluster.\n\nNote: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html\n\nPlease note that at most one storage class can be marked as default. If two or more of them are marked as default, a PersistentVolumeClaim without `storageClassName` explicitly specified cannot be created. See: https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/#changing-the-default-storageclass"
+        },
+        "encrypted": {
+          "type": "boolean",
+          "description": "Denotes whether the EBS volume should be encrypted."
+        },
+        "iopsPerGb": {
+          "type": "integer",
+          "description": "I/O operations per second per GiB for \"io1\" volumes. The AWS volume plugin multiplies this with the size of a requested volume to compute IOPS of the volume and caps the result at 20,000 IOPS."
+        },
+        "kmsKeyId": {
+          "type": "string",
+          "description": "The full Amazon Resource Name of the key to use when encrypting the volume. If none is supplied but encrypted is true, a key is generated by AWS."
+        },
+        "metadata": {
+          "$ref": "/kubernetes/v3.0.0/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
+        },
+        "mountOptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. [\"ro\", \"soft\"]. Not validated - mount of the PVs will simply fail if one is invalid."
+        },
+        "reclaimPolicy": {
+          "type": "string",
+          "description": "Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete."
+        },
+        "type": {
+          "type": "string",
+          "description": "The EBS volume type."
+        },
+        "volumeBindingMode": {
+          "type": "string",
+          "description": "VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset, VolumeBindingImmediate is used. This field is alpha-level and is only honored by servers that enable the VolumeScheduling feature."
+        },
+        "zones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The AWS zone or zones for the EBS volume. If zones is not specified, volumes are generally round-robin-ed across all active zones where Kubernetes cluster has a node. zone and zones parameters must not be used at the same time."
+        }
+      },
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "eks:index:Taint": {
+      "description": "Represents a Kubernetes `taint` to apply to all Nodes in a NodeGroup. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.",
+      "properties": {
+        "effect": {
+          "type": "string",
+          "description": "The effect of the taint."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the taint."
+        }
+      },
+      "type": "object",
+      "required": [
+        "value",
+        "effect"
+      ]
+    },
+    "eks:index:UserMapping": {
+      "description": "Describes a mapping from an AWS IAM user to a Kubernetes user and groups.",
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of groups within Kubernetes to which the user is mapped to."
+        },
+        "userArn": {
+          "type": "string",
+          "description": "The ARN of the IAM user to add."
+        },
+        "username": {
+          "type": "string",
+          "description": "The user name within Kubernetes to map to the IAM user. By default, the user name is the ARN of the IAM user."
+        }
+      },
+      "type": "object",
+      "required": [
+        "userArn",
+        "username",
+        "groups"
+      ]
+    },
+    "eks:index:VpcCniOptions": {
+      "description": "Describes the configuration options available for the Amazon VPC CNI plugin for Kubernetes.",
+      "properties": {
+        "cniConfigureRpfilter": {
+          "type": "boolean",
+          "description": "Specifies whether ipamd should configure rp filter for primary interface. Default is `false`."
+        },
+        "cniCustomNetworkCfg": {
+          "type": "boolean",
+          "description": "Specifies that your pods may use subnets and security groups that are independent of your worker node's VPC configuration. By default, pods share the same subnet and security groups as the worker node's primary interface. Setting this variable to true causes ipamd to use the security groups and VPC subnet in a worker node's ENIConfig for elastic network interface allocation. You must create an ENIConfig custom resource for each subnet that your pods will reside in, and then annotate or label each worker node to use a specific ENIConfig (multiple worker nodes can be annotated or labelled with the same ENIConfig). Worker nodes can only be annotated with a single ENIConfig at a time, and the subnet in the ENIConfig must belong to the same Availability Zone that the worker node resides in. For more information, see CNI Custom Networking in the Amazon EKS User Guide. Default is `false`"
+        },
+        "cniExternalSnat": {
+          "type": "boolean",
+          "description": "Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have already been applied. Disable SNAT if you need to allow inbound communication to your pods from external VPNs, direct connections, and external VPCs, and your pods do not need to access the Internet directly via an Internet Gateway. However, your nodes must be running in a private subnet and connected to the internet through an AWS NAT Gateway or another external NAT device. Default is `false`"
+        },
+        "customNetworkConfig": {
+          "type": "boolean",
+          "description": "Specifies that your pods may use subnets and security groups (within the same VPC as your control plane resources) that are independent of your cluster's `resourcesVpcConfig`.\n\nDefaults to false."
+        },
+        "disableTcpEarlyDemux": {
+          "type": "boolean",
+          "description": "Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency."
+        },
+        "enablePodEni": {
+          "type": "boolean",
+          "description": "Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux."
+        },
+        "enablePrefixDelegation": {
+          "type": "boolean",
+          "description": "IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true."
+        },
+        "eniConfigLabelDef": {
+          "type": "string",
+          "description": "Specifies the ENI_CONFIG_LABEL_DEF environment variable value for worker nodes. This is used to tell Kubernetes to automatically apply the ENIConfig for each Availability Zone\nRef: https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html (step 5(c))\n\nDefaults to the official AWS CNI image in ECR."
+        },
+        "eniMtu": {
+          "type": "integer",
+          "description": "Used to configure the MTU size for attached ENIs. The valid range is from 576 to 9001.\n\nDefaults to 9001."
+        },
+        "externalSnat": {
+          "type": "boolean",
+          "description": "Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have already been applied.\n\nDefaults to false."
+        },
+        "image": {
+          "type": "string",
+          "description": "Specifies the container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI image in ECR."
+        },
+        "initImage": {
+          "type": "string",
+          "description": "Specifies the init container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI init container image in ECR."
+        },
+        "logFile": {
+          "type": "string",
+          "description": "Specifies the file path used for logs.\n\nDefaults to \"stdout\" to emit Pod logs for `kubectl logs`."
+        },
+        "logLevel": {
+          "type": "string",
+          "description": "Specifies the log level used for logs.\n\nDefaults to \"DEBUG\"\nValid values: \"DEBUG\", \"INFO\", \"WARN\", \"ERROR\", or \"FATAL\"."
+        },
+        "nodePortSupport": {
+          "type": "boolean",
+          "description": "Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.\n\nDefaults to true."
+        },
+        "securityContextPrivileged": {
+          "type": "boolean",
+          "description": "Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default"
+        },
+        "vethPrefix": {
+          "type": "string",
+          "description": "Specifies the veth prefix used to generate the host-side veth device name for the CNI.\n\nThe prefix can be at most 4 characters long.\n\nDefaults to \"eni\"."
+        },
+        "warmEniTarget": {
+          "type": "integer",
+          "description": "Specifies the number of free elastic network interfaces (and all of their available IP addresses) that the ipamD daemon should attempt to keep available for pod assignment on the node.\n\nDefaults to 1."
+        },
+        "warmIpTarget": {
+          "type": "integer",
+          "description": "Specifies the number of free IP addresses that the ipamD daemon should attempt to keep available for pod assignment on the node."
+        },
+        "warmPrefixTarget": {
+          "type": "integer",
+          "description": "WARM_PREFIX_TARGET will allocate one full (/28) prefix even if a single IP  is consumed with the existing prefix. Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "provider": {},
+  "resources": {
+    "eks:index:Cluster": {
+      "description": "Cluster is a component that wraps the AWS and Kubernetes resources necessary to run an EKS cluster, its worker nodes, its optional StorageClasses, and an optional deployment of the Kubernetes Dashboard.",
+      "properties": {
+        "awsProvider": {
+          "$ref": "/aws/v4.15.0/schema.json#/provider",
+          "description": "The AWS resource provider."
+        },
+        "clusterSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group for the EKS cluster."
+        },
+        "core": {
+          "$ref": "#/types/eks:index:CoreData",
+          "description": "The EKS cluster and its dependencies."
+        },
+        "defaultNodeGroup": {
+          "$ref": "#/types/eks:index:NodeGroupData",
+          "description": "The default Node Group configuration, or undefined if `skipDefaultNodeGroup` was specified."
+        },
+        "eksCluster": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
+          "description": "The EKS cluster."
+        },
+        "eksClusterIngressRule": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "description": "The ingress rule that gives node group access to cluster API server."
+        },
+        "instanceRoles": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+          },
+          "description": "The service roles used by the EKS cluster."
+        },
+        "kubeconfig": {
+          "$ref": "pulumi.json#/Any",
+          "description": "A kubeconfig that can be used to connect to the EKS cluster."
+        },
+        "nodeSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group for the cluster's nodes."
+        },
+        "provider": {
+          "$ref": "/kubernetes/v3.0.0/schema.json#/provider",
+          "description": "A Kubernetes resource provider that can be used to deploy into this cluster."
+        }
+      },
+      "required": [
+        "kubeconfig",
+        "awsProvider",
+        "provider",
+        "clusterSecurityGroup",
+        "instanceRoles",
+        "nodeSecurityGroup",
+        "eksClusterIngressRule",
+        "eksCluster",
+        "core"
+      ],
+      "inputProperties": {
+        "clusterSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups."
+        },
+        "clusterSecurityGroupTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags to apply to the cluster security group."
+        },
+        "clusterTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags to apply to the EKS cluster."
+        },
+        "createOidcProvider": {
+          "type": "boolean",
+          "description": "Indicates whether an IAM OIDC Provider is created for the EKS cluster.\n\nThe OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.\n\nSee for more details:\n - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html\n - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html\n - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/\n - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts"
+        },
+        "creationRoleProvider": {
+          "$ref": "#/types/eks:index:CreationRoleProvider",
+          "description": "The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html"
+        },
+        "desiredCapacity": {
+          "type": "integer",
+          "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
+        },
+        "enabledClusterLogTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: [\"api\", \"audit\", \"authenticator\", \"controllerManager\", \"scheduler\"]. By default it is off."
+        },
+        "encryptRootBlockDevice": {
+          "type": "boolean",
+          "description": "Encrypt the root block device of the nodes in the node group."
+        },
+        "encryptionConfigKeyArn": {
+          "type": "string",
+          "description": "KMS Key ARN to use with the encryption configuration for the cluster.\n\nOnly available on Kubernetes 1.13+ clusters created after March 6, 2020.\nSee for more details:\n- https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-eks-adds-envelope-encryption-for-secrets-with-aws-kms/"
+        },
+        "endpointPrivateAccess": {
+          "type": "boolean",
+          "description": "Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default is `false`."
+        },
+        "endpointPublicAccess": {
+          "type": "boolean",
+          "description": "Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default is `true`."
+        },
+        "fargate": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/types/eks:index:FargateProfile"
+            }
+          ],
+          "description": "Add support for launching pods in Fargate. Defaults to launching pods in the `default` namespace.  If specified, the default node group is skipped as though `skipDefaultNodeGroup: true` had been passed."
+        },
+        "gpu": {
+          "type": "boolean",
+          "description": "Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.\n\nDefaults to false.\n\nNote: `gpu` and `nodeAmiId` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\n- https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html"
+        },
+        "instanceProfileName": {
+          "type": "string",
+          "description": "The default IAM InstanceProfile to use on the Worker NodeGroups, if one is not already set in the NodeGroup."
+        },
+        "instanceRole": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role",
+          "description": "This enables the simple case of only registering a *single* IAM instance role with the cluster, that is required to be shared by *all* node groups in their instance profiles.\n\nNote: options `instanceRole` and `instanceRoles` are mutually exclusive."
+        },
+        "instanceRoles": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+          },
+          "description": "This enables the advanced case of registering *many* IAM instance roles with the cluster for per node group IAM, instead of the simpler, shared case of `instanceRole`.\n\nNote: options `instanceRole` and `instanceRoles` are mutually exclusive."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\"."
+        },
+        "kubernetesServiceIpAddressRange": {
+          "type": "string",
+          "description": "The CIDR block to assign Kubernetes service IP addresses from. If you don't\nspecify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or\n172.20.0.0/16 CIDR blocks. We recommend that you specify a block that does not overlap\nwith resources in other networks that are peered or connected to your VPC. You can only specify\na custom CIDR block when you create a cluster, changing this value will force a new cluster to be created.\n\nThe block must meet the following requirements:\n- Within one of the following private IP address blocks: 10.0.0.0/8, 172.16.0.0.0/12, or 192.168.0.0/16.\n- Doesn't overlap with any CIDR block assigned to the VPC that you selected for VPC.\n- Between /24 and /12."
+        },
+        "maxSize": {
+          "type": "integer",
+          "description": "The maximum number of worker nodes running in the cluster. Defaults to 2."
+        },
+        "minSize": {
+          "type": "integer",
+          "description": "The minimum number of worker nodes running in the cluster. Defaults to 1."
+        },
+        "name": {
+          "type": "string",
+          "description": "The cluster's physical resource name.\n\nIf not specified, the default is to use auto-naming for the cluster's name, resulting in a physical name with the format `${name}-eksCluster-0123abcd`.\n\nSee for more details: https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming"
+        },
+        "nodeAmiId": {
+          "type": "string",
+          "description": "The AMI ID to use for the worker nodes.\n\nDefaults to the latest recommended EKS Optimized Linux AMI from the AWS Systems Manager Parameter Store.\n\nNote: `nodeAmiId` and `gpu` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html."
+        },
+        "nodeAssociatePublicIpAddress": {
+          "type": "boolean",
+          "description": "Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs."
+        },
+        "nodeGroupOptions": {
+          "$ref": "#/types/eks:index:ClusterNodeGroupOptions",
+          "description": "The common configuration settings for NodeGroups."
+        },
+        "nodePublicKey": {
+          "type": "string",
+          "description": "Public key material for SSH access to worker nodes. See allowed formats at:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\nIf not provided, no SSH access is enabled on VMs."
+        },
+        "nodeRootVolumeDeleteOnTermination": {
+          "type": "boolean",
+          "description": "Whether to delete a cluster node's root volume on termination. Defaults to true.",
+          "default": true
+        },
+        "nodeRootVolumeEncrypted": {
+          "type": "boolean",
+          "description": "Whether to encrypt a cluster node's root volume. Defaults to false.",
+          "default": false
+        },
+        "nodeRootVolumeIops": {
+          "type": "integer",
+          "description": "Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes."
+        },
+        "nodeRootVolumeSize": {
+          "type": "integer",
+          "description": "The size in GiB of a cluster node's root volume. Defaults to 20.",
+          "default": 20
+        },
+        "nodeRootVolumeThroughput": {
+          "type": "integer",
+          "description": "Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes."
+        },
+        "nodeRootVolumeType": {
+          "type": "string",
+          "description": "Configured EBS type for a cluster node's root volume. Default is gp2.",
+          "default": "gp2"
+        },
+        "nodeSecurityGroupTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags to apply to the default `nodeSecurityGroup` created by the cluster.\n\nNote: The `nodeSecurityGroupTags` option and the node group option `nodeSecurityGroup` are mutually exclusive."
+        },
+        "nodeSubnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The subnets to use for worker nodes. Defaults to the value of subnetIds."
+        },
+        "nodeUserData": {
+          "type": "string",
+          "description": "Extra code to run on node startup. This code will run after the AWS EKS bootstrapping code and before the node signals its readiness to the managing CloudFormation stack. This code must be a typical user data script: critically it must begin with an interpreter directive (i.e. a `#!`)."
+        },
+        "privateSubnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The set of private subnets to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.\n\nIf `vpcId` is not set, the cluster will use the AWS account's default VPC subnets.\n\nWorker network architecture options:\n - Private-only: Only set `privateSubnetIds`.\n   - Default workers to run in a private subnet. In this setting, Kubernetes cannot create public, internet-facing load balancers for your pods.\n - Public-only: Only set `publicSubnetIds`.\n   - Default workers to run in a public subnet.\n - Mixed (recommended): Set both `privateSubnetIds` and `publicSubnetIds`.\n   - Default all worker nodes to run in private subnets, and use the public subnets for internet-facing load balancers.\n\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.Note: The use of `subnetIds`, along with `publicSubnetIds` and/or `privateSubnetIds` is mutually exclusive. The use of `publicSubnetIds` and `privateSubnetIds` is encouraged.\n\nAlso consider setting `nodeAssociatePublicIpAddress: true` for fully private workers."
+        },
+        "providerCredentialOpts": {
+          "$ref": "#/types/eks:index:KubeconfigOptions",
+          "description": "The AWS provider credential options to scope the cluster's kubeconfig authentication when using a non-default credential chain.\n\nThis is required for certain auth scenarios. For example:\n- Creating and using a new AWS provider instance, or\n- Setting the AWS_PROFILE environment variable, or\n- Using a named profile configured on the AWS provider via:\n`pulumi config set aws:profile <profileName>`\n\nSee for more details:\n- https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/#Provider\n- https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/\n- https://www.pulumi.com/docs/intro/cloud-providers/aws/#configuration\n- https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html"
+        },
+        "proxy": {
+          "type": "string",
+          "description": "The HTTP(S) proxy to use within a proxied environment.\n\n The proxy is used during cluster creation, and OIDC configuration.\n\nThis is an alternative option to setting the proxy environment variables: HTTP(S)_PROXY and/or http(s)_proxy.\n\nThis option is required iff the proxy environment variables are not set.\n\nFormat:      <protocol>://<host>:<port>\nAuth Format: <protocol>://<username>:<password>@<host>:<port>\n\nEx:\n  - \"http://proxy.example.com:3128\"\n  - \"https://proxy.example.com\"\n  - \"http://username:password@proxy.example.com:3128\""
+        },
+        "publicAccessCidrs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Indicates which CIDR blocks can access the Amazon EKS public API server endpoint."
+        },
+        "publicSubnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The set of public subnets to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.\n\nIf `vpcId` is not set, the cluster will use the AWS account's default VPC subnets.\n\nWorker network architecture options:\n - Private-only: Only set `privateSubnetIds`.\n   - Default workers to run in a private subnet. In this setting, Kubernetes cannot create public, internet-facing load balancers for your pods.\n - Public-only: Only set `publicSubnetIds`.\n   - Default workers to run in a public subnet.\n - Mixed (recommended): Set both `privateSubnetIds` and `publicSubnetIds`.\n   - Default all worker nodes to run in private subnets, and use the public subnets for internet-facing load balancers.\n\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.Note: The use of `subnetIds`, along with `publicSubnetIds` and/or `privateSubnetIds` is mutually exclusive. The use of `publicSubnetIds` and `privateSubnetIds` is encouraged."
+        },
+        "roleMappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/eks:index:RoleMapping"
+          },
+          "description": "Optional mappings from AWS IAM roles to Kubernetes users and groups."
+        },
+        "serviceRole": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role",
+          "description": "IAM Service Role for EKS to use to manage the cluster."
+        },
+        "skipDefaultNodeGroup": {
+          "type": "boolean",
+          "description": "If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided."
+        },
+        "storageClasses": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/types/eks:index:StorageClass"
+              }
+            }
+          ],
+          "description": "An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.\n\nNote: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html"
+        },
+        "subnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The set of all subnets, public and private, to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.\n\nIf `vpcId` is not set, the cluster will use the AWS account's default VPC subnets.\n\nIf the list of subnets includes both public and private subnets, the worker nodes will only be attached to the private subnets, and the public subnets will be used for internet-facing load balancers.\n\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.\n\nNote: The use of `subnetIds`, along with `publicSubnetIds` and/or `privateSubnetIds` is mutually exclusive. The use of `publicSubnetIds` and `privateSubnetIds` is encouraged."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value mapping of tags that are automatically applied to all AWS resources directly under management with this cluster, which support tagging."
+        },
+        "useDefaultVpcCni": {
+          "type": "boolean",
+          "description": "Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`."
+        },
+        "userMappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/eks:index:UserMapping"
+          },
+          "description": "Optional mappings from AWS IAM users to Kubernetes users and groups."
+        },
+        "version": {
+          "type": "string",
+          "description": "Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used."
+        },
+        "vpcCniOptions": {
+          "$ref": "#/types/eks:index:VpcCniOptions",
+          "description": "The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type."
+        },
+        "vpcId": {
+          "type": "string",
+          "description": "The VPC in which to create the cluster and its worker nodes. If unset, the cluster will be created in the default VPC."
+        }
+      },
+      "isComponent": true,
+      "methods": {
+        "getKubeconfig": "eks:index:Cluster/getKubeconfig"
+      }
+    },
+    "eks:index:ClusterCreationRoleProvider": {
+      "description": "ClusterCreationRoleProvider is a component that wraps creating a role provider that can be passed to the `Cluster`'s `creationRoleProvider`. This can be used to provide a specific role to use for the creation of the EKS cluster different from the role being used to run the Pulumi deployment.",
+      "properties": {
+        "provider": {
+          "$ref": "/aws/v4.15.0/schema.json#/provider"
+        },
+        "role": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+        }
+      },
+      "required": [
+        "role",
+        "provider"
+      ],
+      "inputProperties": {
+        "profile": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        }
+      },
+      "isComponent": true
+    },
+    "eks:index:ManagedNodeGroup": {
+      "description": "ManagedNodeGroup is a component that wraps creating an AWS managed node group.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html",
+      "properties": {
+        "nodeGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2FnodeGroup:NodeGroup",
+          "description": "The AWS managed node group."
+        }
+      },
+      "required": [
+        "nodeGroup"
+      ],
+      "inputProperties": {
+        "amiType": {
+          "type": "string",
+          "description": "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`. This provider will only perform drift detection if a configuration value is provided."
+        },
+        "capacityType": {
+          "type": "string",
+          "description": "Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided."
+        },
+        "cluster": {
+          "$ref": "#/types/eks:index:CoreData",
+          "description": "The target EKS cluster."
+        },
+        "clusterName": {
+          "type": "string",
+          "description": "Name of the EKS Cluster."
+        },
+        "diskSize": {
+          "type": "integer",
+          "description": "Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided."
+        },
+        "forceUpdateVersion": {
+          "type": "boolean",
+          "description": "Force version update if existing pods are unable to be drained due to a pod disruption budget issue."
+        },
+        "instanceTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Set of instance types associated with the EKS Node Group. Defaults to `[\"t3.medium\"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed."
+        },
+        "launchTemplate": {
+          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate",
+          "description": "Launch Template settings."
+        },
+        "nodeGroupName": {
+          "type": "string",
+          "description": "Name of the EKS Node Group. If omitted, this provider will assign a random, unique name. Conflicts with `nodeGroupNamePrefix`."
+        },
+        "nodeGroupNamePrefix": {
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `nodeGroupName`."
+        },
+        "nodeRole": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role",
+          "description": "The IAM Role that provides permissions for the EKS Node Group.\n\nNote, `nodeRole` and `nodeRoleArn` are mutually exclusive, and a single option must be used."
+        },
+        "nodeRoleArn": {
+          "type": "string",
+          "description": "Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.\n\nNote, `nodeRoleArn` and `nodeRole` are mutually exclusive, and a single option must be used."
+        },
+        "releaseVersion": {
+          "type": "string",
+          "description": "AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version."
+        },
+        "remoteAccess": {
+          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupRemoteAccess:NodeGroupRemoteAccess",
+          "description": "Remote access settings."
+        },
+        "scalingConfig": {
+          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupScalingConfig:NodeGroupScalingConfig",
+          "description": "Scaling settings.\n\nDefault scaling amounts of the node group autoscaling group are:\n  - desiredSize: 2\n  - minSize: 1\n  - maxSize: 2"
+        },
+        "subnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Identifiers of EC2 Subnets to associate with the EKS Node Group. These subnets must have the following resource tag: `kubernetes.io/cluster/CLUSTER_NAME` (where `CLUSTER_NAME` is replaced with the name of the EKS Cluster).\n\nDefault subnetIds is chosen from the following list, in order, if subnetIds arg is not set:\n  - core.subnetIds\n  - core.privateIds\n  - core.publicSubnetIds\n\nThis default logic is based on the existing subnet IDs logic of this package: https://git.io/JeM11"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value mapping of resource tags."
+        },
+        "taints": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupTaint:NodeGroupTaint"
+          },
+          "description": "The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group."
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": [
+        "cluster"
+      ],
+      "isComponent": true
+    },
+    "eks:index:NodeGroup": {
+      "description": "NodeGroup is a component that wraps the AWS EC2 instances that provide compute capacity for an EKS cluster.",
+      "properties": {
+        "autoScalingGroupName": {
+          "type": "string",
+          "description": "The AutoScalingGroup name for the Node group."
+        },
+        "cfnStack": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
+          "description": "The CloudFormation Stack which defines the Node AutoScalingGroup."
+        },
+        "extraNodeSecurityGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+          },
+          "description": "The additional security groups for the node group that captures user-specific rules."
+        },
+        "nodeSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group for the node group to communicate with the cluster."
+        }
+      },
+      "required": [
+        "nodeSecurityGroup",
+        "extraNodeSecurityGroups",
+        "cfnStack",
+        "autoScalingGroupName"
+      ],
+      "inputProperties": {
+        "amiId": {
+          "type": "string",
+          "description": "The AMI ID to use for the worker nodes.\n\nDefaults to the latest recommended EKS Optimized Linux AMI from the AWS Systems Manager Parameter Store.\n\nNote: `amiId` and `gpu` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html."
+        },
+        "autoScalingGroupTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags to apply to the NodeGroup's AutoScalingGroup in the CloudFormation Stack.\n\nPer AWS, all stack-level tags, including automatically created tags, and the `cloudFormationTags` option are propagated to resources that AWS CloudFormation supports, including the AutoScalingGroup. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html\n\nNote: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both."
+        },
+        "bootstrapExtraArgs": {
+          "type": "string",
+          "description": "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters."
+        },
+        "cloudFormationTags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The tags to apply to the CloudFormation Stack of the Worker NodeGroup.\n\nNote: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both."
+        },
+        "cluster": {
+          "$ref": "#/types/eks:index:CoreData",
+          "description": "The target EKS cluster."
+        },
+        "clusterIngressRule": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "description": "The ingress rule that gives node group access."
+        },
+        "desiredCapacity": {
+          "type": "integer",
+          "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
+        },
+        "encryptRootBlockDevice": {
+          "type": "boolean",
+          "description": "Encrypt the root block device of the nodes in the node group."
+        },
+        "extraNodeSecurityGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+          },
+          "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
+        },
+        "gpu": {
+          "type": "boolean",
+          "description": "Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.\n\nDefaults to false.\n\nNote: `gpu` and `amiId` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\n- https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html"
+        },
+        "instanceProfile": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+          "description": "The ingress rule that gives node group access."
+        },
+        "instanceType": {
+          "type": "string",
+          "description": "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\"."
+        },
+        "keyName": {
+          "type": "string",
+          "description": "Name of the key pair to use for SSH access to worker nodes."
+        },
+        "kubeletExtraArgs": {
+          "type": "string",
+          "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument."
+        },
+        "maxSize": {
+          "type": "integer",
+          "description": "The maximum number of worker nodes running in the cluster. Defaults to 2."
+        },
+        "minSize": {
+          "type": "integer",
+          "description": "The minimum number of worker nodes running in the cluster. Defaults to 1."
+        },
+        "nodeAssociatePublicIpAddress": {
+          "type": "boolean",
+          "description": "Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs."
+        },
+        "nodePublicKey": {
+          "type": "string",
+          "description": "Public key material for SSH access to worker nodes. See allowed formats at:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\nIf not provided, no SSH access is enabled on VMs."
+        },
+        "nodeRootVolumeSize": {
+          "type": "integer",
+          "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
+        },
+        "nodeSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
+        },
+        "nodeSubnetIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The set of subnets to override and use for the worker node group.\n\nSetting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set."
+        },
+        "nodeUserData": {
+          "type": "string",
+          "description": "Extra code to run on node startup. This code will run after the AWS EKS bootstrapping code and before the node signals its readiness to the managing CloudFormation stack. This code must be a typical user data script: critically it must begin with an interpreter directive (i.e. a `#!`)."
+        },
+        "nodeUserDataOverride": {
+          "type": "string",
+          "description": "User specified code to run on node startup. This code is expected to handle the full AWS EKS bootstrapping code and signal node readiness to the managing CloudFormation stack. This code must be a complete and executable user data script in bash (Linux) or powershell (Windows).\n\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/worker.html"
+        },
+        "spotPrice": {
+          "type": "string",
+          "description": "Bidding price for spot instance. If set, only spot instances will be added as worker node."
+        },
+        "taints": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/eks:index:Taint"
+          },
+          "description": "Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument"
+        },
+        "version": {
+          "type": "string",
+          "description": "Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used."
+        }
+      },
+      "requiredInputs": [
+        "cluster"
+      ],
+      "isComponent": true
+    },
+    "eks:index:NodeGroupSecurityGroup": {
+      "description": "NodeGroupSecurityGroup is a component that wraps creating a security group for node groups with the default ingress & egress rules required to connect and work with the EKS cluster security group.",
+      "properties": {
+        "securityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group for node groups with the default ingress & egress rules required to connect and work with the EKS cluster security group."
+        },
+        "securityGroupRule": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "description": "The EKS cluster ingress rule."
+        }
+      },
+      "required": [
+        "securityGroup",
+        "securityGroupRule"
+      ],
+      "inputProperties": {
+        "clusterSecurityGroup": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "description": "The security group associated with the EKS cluster."
+        },
+        "eksCluster": {
+          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
+          "description": "The EKS cluster associated with the worker node group"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Key-value mapping of tags to apply to this security group."
+        },
+        "vpcId": {
+          "type": "string",
+          "description": "The VPC in which to create the worker node group."
+        }
+      },
+      "requiredInputs": [
+        "vpcId",
+        "clusterSecurityGroup",
+        "eksCluster"
+      ],
+      "isComponent": true
+    },
+    "eks:index:VpcCni": {
+      "description": "VpcCni manages the configuration of the Amazon VPC CNI plugin for Kubernetes by applying its YAML chart.",
+      "inputProperties": {
+        "cniConfigureRpfilter": {
+          "type": "boolean",
+          "description": "Specifies whether ipamd should configure rp filter for primary interface. Default is `false`."
+        },
+        "cniCustomNetworkCfg": {
+          "type": "boolean",
+          "description": "Specifies that your pods may use subnets and security groups that are independent of your worker node's VPC configuration. By default, pods share the same subnet and security groups as the worker node's primary interface. Setting this variable to true causes ipamd to use the security groups and VPC subnet in a worker node's ENIConfig for elastic network interface allocation. You must create an ENIConfig custom resource for each subnet that your pods will reside in, and then annotate or label each worker node to use a specific ENIConfig (multiple worker nodes can be annotated or labelled with the same ENIConfig). Worker nodes can only be annotated with a single ENIConfig at a time, and the subnet in the ENIConfig must belong to the same Availability Zone that the worker node resides in. For more information, see CNI Custom Networking in the Amazon EKS User Guide. Default is `false`"
+        },
+        "cniExternalSnat": {
+          "type": "boolean",
+          "description": "Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have already been applied. Disable SNAT if you need to allow inbound communication to your pods from external VPNs, direct connections, and external VPCs, and your pods do not need to access the Internet directly via an Internet Gateway. However, your nodes must be running in a private subnet and connected to the internet through an AWS NAT Gateway or another external NAT device. Default is `false`"
+        },
+        "customNetworkConfig": {
+          "type": "boolean",
+          "description": "Specifies that your pods may use subnets and security groups (within the same VPC as your control plane resources) that are independent of your cluster's `resourcesVpcConfig`.\n\nDefaults to false."
+        },
+        "disableTcpEarlyDemux": {
+          "type": "boolean",
+          "description": "Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency."
+        },
+        "enablePodEni": {
+          "type": "boolean",
+          "description": "Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux."
+        },
+        "enablePrefixDelegation": {
+          "type": "boolean",
+          "description": "IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true."
+        },
+        "eniConfigLabelDef": {
+          "type": "string",
+          "description": "Specifies the ENI_CONFIG_LABEL_DEF environment variable value for worker nodes. This is used to tell Kubernetes to automatically apply the ENIConfig for each Availability Zone\nRef: https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html (step 5(c))\n\nDefaults to the official AWS CNI image in ECR."
+        },
+        "eniMtu": {
+          "type": "integer",
+          "description": "Used to configure the MTU size for attached ENIs. The valid range is from 576 to 9001.\n\nDefaults to 9001."
+        },
+        "externalSnat": {
+          "type": "boolean",
+          "description": "Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have already been applied.\n\nDefaults to false."
+        },
+        "image": {
+          "type": "string",
+          "description": "Specifies the container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI image in ECR."
+        },
+        "initImage": {
+          "type": "string",
+          "description": "Specifies the init container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI init container image in ECR."
+        },
+        "kubeconfig": {
+          "$ref": "pulumi.json#/Any",
+          "description": "The kubeconfig to use when setting the VPC CNI options."
+        },
+        "logFile": {
+          "type": "string",
+          "description": "Specifies the file path used for logs.\n\nDefaults to \"stdout\" to emit Pod logs for `kubectl logs`."
+        },
+        "logLevel": {
+          "type": "string",
+          "description": "Specifies the log level used for logs.\n\nDefaults to \"DEBUG\"\nValid values: \"DEBUG\", \"INFO\", \"WARN\", \"ERROR\", or \"FATAL\"."
+        },
+        "nodePortSupport": {
+          "type": "boolean",
+          "description": "Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.\n\nDefaults to true."
+        },
+        "securityContextPrivileged": {
+          "type": "boolean",
+          "description": "Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default"
+        },
+        "vethPrefix": {
+          "type": "string",
+          "description": "Specifies the veth prefix used to generate the host-side veth device name for the CNI.\n\nThe prefix can be at most 4 characters long.\n\nDefaults to \"eni\"."
+        },
+        "warmEniTarget": {
+          "type": "integer",
+          "description": "Specifies the number of free elastic network interfaces (and all of their available IP addresses) that the ipamD daemon should attempt to keep available for pod assignment on the node.\n\nDefaults to 1."
+        },
+        "warmIpTarget": {
+          "type": "integer",
+          "description": "Specifies the number of free IP addresses that the ipamD daemon should attempt to keep available for pod assignment on the node."
+        },
+        "warmPrefixTarget": {
+          "type": "integer",
+          "description": "WARM_PREFIX_TARGET will allocate one full (/28) prefix even if a single IP  is consumed with the existing prefix. Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md"
+        }
+      },
+      "requiredInputs": [
+        "kubeconfig"
+      ]
+    }
+  },
+  "functions": {
+    "eks:index:Cluster/getKubeconfig": {
+      "description": "Generate a kubeconfig for cluster authentication that does not use the default AWS credential provider chain, and instead is scoped to the supported options in `KubeconfigOptions`.\n\nThe kubeconfig generated is automatically stringified for ease of use with the pulumi/kubernetes provider.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html\n- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html\n- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html",
+      "inputs": {
+        "properties": {
+          "__self__": {
+            "$ref": "#/resources/eks:index:Cluster"
+          },
+          "profileName": {
+            "type": "string",
+            "description": "AWS credential profile name to always use instead of the default AWS credential provider chain.\n\nThe profile is passed to kubeconfig as an authentication environment setting."
+          },
+          "roleArn": {
+            "type": "string",
+            "description": "Role ARN to assume instead of the default AWS credential provider chain.\n\nThe role is passed to kubeconfig as an authentication exec argument."
+          }
+        },
+        "required": [
+          "__self__"
+        ]
+      },
+      "outputs": {
+        "properties": {
+          "result": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "result"
+        ]
+      }
+    }
+  },
+  "language": {
+    "csharp": {
+      "liftSingleValueMethodReturns": true,
+      "packageReferences": {
+        "Pulumi": "3.*",
+        "Pulumi.Aws": "4.15.*",
+        "Pulumi.Kubernetes": "3.*"
+      }
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-eks/sdk/go/eks",
+      "liftSingleValueMethodReturns": true
+    },
+    "python": {
+      "liftSingleValueMethodReturns": true,
+      "readme": "Pulumi Amazon Web Services (AWS) EKS Components.",
+      "requires": {
+        "pulumi": ">=3.0.0,<4.0.0",
+        "pulumi-aws": ">=4.15.0,<5.0.0",
+        "pulumi-kubernetes": ">=3.0.0,<4.0.0"
+      },
+      "usesIOClasses": true
+    }
+  },
+  "version": "0.37.1"
+}

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
@@ -200,6 +200,38 @@ func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) Compo
 	return o
 }
 
+func (o ComponentOutput) ResourceLocalAlias() awsec2.InstanceOutput {
+	return o.ApplyT(func(v *Component) awsec2.InstanceOutput { return v.ResourceLocalAlias }).(awsec2.InstanceOutput)
+}
+
+func (o ComponentOutput) ResourceLocalInsteadOfRemoteAlias() gcpiamv1.KeyOutput {
+	return o.ApplyT(func(v *Component) gcpiamv1.KeyOutput { return v.ResourceLocalInsteadOfRemoteAlias }).(gcpiamv1.KeyOutput)
+}
+
+func (o ComponentOutput) ResourceNoAlias() s3.BucketOutput {
+	return o.ApplyT(func(v *Component) s3.BucketOutput { return v.ResourceNoAlias }).(s3.BucketOutput)
+}
+
+func (o ComponentOutput) ResourceRemoteAlias() dns.PolicyOutput {
+	return o.ApplyT(func(v *Component) dns.PolicyOutput { return v.ResourceRemoteAlias }).(dns.PolicyOutput)
+}
+
+func (o ComponentOutput) TypeLocalAlias() awsec2.InstanceLaunchTemplateOutput {
+	return o.ApplyT(func(v *Component) awsec2.InstanceLaunchTemplateOutput { return v.TypeLocalAlias }).(awsec2.InstanceLaunchTemplateOutput)
+}
+
+func (o ComponentOutput) TypeLocalInsteadOfRemoteAlias() gcpiamv1.AuditConfigResponseOutput {
+	return o.ApplyT(func(v *Component) gcpiamv1.AuditConfigResponseOutput { return v.TypeLocalInsteadOfRemoteAlias }).(gcpiamv1.AuditConfigResponseOutput)
+}
+
+func (o ComponentOutput) TypeNoAlias() s3.BucketWebsiteOutput {
+	return o.ApplyT(func(v *Component) s3.BucketWebsiteOutput { return v.TypeNoAlias }).(s3.BucketWebsiteOutput)
+}
+
+func (o ComponentOutput) TypeRemoteAlias() dns.DnsKeySpecResponseOutput {
+	return o.ApplyT(func(v *Component) dns.DnsKeySpecResponseOutput { return v.TypeRemoteAlias }).(dns.DnsKeySpecResponseOutput)
+}
+
 type ComponentArrayOutput struct{ *pulumi.OutputState }
 
 func (ComponentArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/cat.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/cat.go
@@ -152,6 +152,10 @@ func (o CatOutput) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return o
 }
 
+func (o CatOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Cat) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
+}
+
 type CatArrayOutput struct{ *pulumi.OutputState }
 
 func (CatArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
@@ -176,6 +176,18 @@ func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) Compo
 	return o
 }
 
+func (o ComponentOutput) Provider() kubernetes.ProviderOutput {
+	return o.ApplyT(func(v *Component) kubernetes.ProviderOutput { return v.Provider }).(kubernetes.ProviderOutput)
+}
+
+func (o ComponentOutput) SecurityGroup() ec2.SecurityGroupOutput {
+	return o.ApplyT(func(v *Component) ec2.SecurityGroupOutput { return v.SecurityGroup }).(ec2.SecurityGroupOutput)
+}
+
+func (o ComponentOutput) StorageClasses() storagev1.StorageClassMapOutput {
+	return o.ApplyT(func(v *Component) storagev1.StorageClassMapOutput { return v.StorageClasses }).(storagev1.StorageClassMapOutput)
+}
+
 type ComponentArrayOutput struct{ *pulumi.OutputState }
 
 func (ComponentArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/workload.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/workload.go
@@ -149,6 +149,10 @@ func (o WorkloadOutput) ToWorkloadOutputWithContext(ctx context.Context) Workloa
 	return o
 }
 
+func (o WorkloadOutput) Pod() corev1.PodPtrOutput {
+	return o.ApplyT(func(v *Workload) corev1.PodPtrOutput { return v.Pod }).(corev1.PodPtrOutput)
+}
+
 type WorkloadArrayOutput struct{ *pulumi.OutputState }
 
 func (WorkloadArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/fargateTaskDefinition.go
+++ b/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/fargateTaskDefinition.go
@@ -129,6 +129,10 @@ func (o FargateTaskDefinitionOutput) ToFargateTaskDefinitionOutputWithContext(ct
 	return o
 }
 
+func (o FargateTaskDefinitionOutput) LoadBalancers() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *FargateTaskDefinition) pulumi.StringArrayOutput { return v.LoadBalancers }).(pulumi.StringArrayOutput)
+}
+
 type FargateTaskDefinitionArrayOutput struct{ *pulumi.OutputState }
 
 func (FargateTaskDefinitionArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/hyphen-url/go/registrygeoreplication/registryGeoReplication.go
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/go/registrygeoreplication/registryGeoReplication.go
@@ -140,6 +140,21 @@ func (o RegistryGeoReplicationOutput) ToRegistryGeoReplicationOutputWithContext(
 	return o
 }
 
+// The login server url
+func (o RegistryGeoReplicationOutput) AcrLoginServerOut() pulumi.StringOutput {
+	return o.ApplyT(func(v *RegistryGeoReplication) pulumi.StringOutput { return v.AcrLoginServerOut }).(pulumi.StringOutput)
+}
+
+// The Registry
+func (o RegistryGeoReplicationOutput) Registry() containerregistry.RegistryOutput {
+	return o.ApplyT(func(v *RegistryGeoReplication) containerregistry.RegistryOutput { return v.Registry }).(containerregistry.RegistryOutput)
+}
+
+// The replication policy
+func (o RegistryGeoReplicationOutput) Replication() containerregistry.ReplicationOutput {
+	return o.ApplyT(func(v *RegistryGeoReplication) containerregistry.ReplicationOutput { return v.Replication }).(containerregistry.ReplicationOutput)
+}
+
 type RegistryGeoReplicationArrayOutput struct{ *pulumi.OutputState }
 
 func (RegistryGeoReplicationArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resource.go
@@ -98,6 +98,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Bar() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Bar }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ResourceInput)(nil)).Elem(), &Resource{})
 	pulumi.RegisterOutputType(ResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resourceInput.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/resourceInput.go
@@ -98,6 +98,10 @@ func (o ResourceInputResourceOutput) ToResourceInputResourceOutputWithContext(ct
 	return o
 }
 
+func (o ResourceInputResourceOutput) Bar() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ResourceInputResource) pulumi.StringPtrOutput { return v.Bar }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ResourceInputResourceInput)(nil)).Elem(), &ResourceInputResource{})
 	pulumi.RegisterOutputType(ResourceInputResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
@@ -107,6 +107,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Baz() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Baz }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ResourceInput)(nil)).Elem(), &Resource{})
 	pulumi.RegisterOutputType(ResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
@@ -107,6 +107,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Bar() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Bar }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ResourceInput)(nil)).Elem(), &Resource{})
 	pulumi.RegisterOutputType(ResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
@@ -125,6 +125,11 @@ func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
 }
 
+// A test for plain types
+func (o FooOutput) DefaultKubeClientSettings() KubeClientSettingsPtrOutput {
+	return o.ApplyT(func(v *Foo) KubeClientSettingsPtrOutput { return v.DefaultKubeClientSettings }).(KubeClientSettingsPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*FooInput)(nil)).Elem(), &Foo{})
 	pulumi.RegisterOutputType(FooOutput{})

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
@@ -118,6 +118,11 @@ func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return o
 }
 
+// A test for plain types
+func (o FooOutput) DefaultKubeClientSettings() KubeClientSettingsPtrOutput {
+	return o.ApplyT(func(v *Foo) KubeClientSettingsPtrOutput { return v.DefaultKubeClientSettings }).(KubeClientSettingsPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*FooInput)(nil)).Elem(), &Foo{})
 	pulumi.RegisterOutputType(FooOutput{})

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
@@ -139,6 +139,16 @@ func (o StaticPageOutput) ToStaticPageOutputWithContext(ctx context.Context) Sta
 	return o
 }
 
+// The bucket resource.
+func (o StaticPageOutput) Bucket() s3.BucketOutput {
+	return o.ApplyT(func(v *StaticPage) s3.BucketOutput { return v.Bucket }).(s3.BucketOutput)
+}
+
+// The website URL.
+func (o StaticPageOutput) WebsiteUrl() pulumi.StringOutput {
+	return o.ApplyT(func(v *StaticPage) pulumi.StringOutput { return v.WebsiteUrl }).(pulumi.StringOutput)
+}
+
 type StaticPageArrayOutput struct{ *pulumi.OutputState }
 
 func (StaticPageArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/conditionalAccessPolicy.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/conditionalAccessPolicy.go
@@ -106,6 +106,10 @@ func (o ConditionalAccessPolicyOutput) ToConditionalAccessPolicyOutputWithContex
 	return o
 }
 
+func (o ConditionalAccessPolicyOutput) Conditions() ConditionalAccessPolicyConditionsOutput {
+	return o.ApplyT(func(v *ConditionalAccessPolicy) ConditionalAccessPolicyConditionsOutput { return v.Conditions }).(ConditionalAccessPolicyConditionsOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ConditionalAccessPolicyInput)(nil)).Elem(), &ConditionalAccessPolicy{})
 	pulumi.RegisterOutputType(ConditionalAccessPolicyOutput{})

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/cat.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/cat.go
@@ -165,6 +165,26 @@ func (o CatOutput) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return o
 }
 
+func (o CatOutput) Foes() ToyMapOutput {
+	return o.ApplyT(func(v *Cat) ToyMapOutput { return v.Foes }).(ToyMapOutput)
+}
+
+func (o CatOutput) Friends() ToyArrayOutput {
+	return o.ApplyT(func(v *Cat) ToyArrayOutput { return v.Friends }).(ToyArrayOutput)
+}
+
+func (o CatOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Cat) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+func (o CatOutput) Other() GodOutput {
+	return o.ApplyT(func(v *Cat) GodOutput { return v.Other }).(GodOutput)
+}
+
+func (o CatOutput) Toy() ToyPtrOutput {
+	return o.ApplyT(func(v *Cat) ToyPtrOutput { return v.Toy }).(ToyPtrOutput)
+}
+
 type CatArrayOutput struct{ *pulumi.OutputState }
 
 func (CatArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/dog.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/dog.go
@@ -152,6 +152,10 @@ func (o DogOutput) ToDogOutputWithContext(ctx context.Context) DogOutput {
 	return o
 }
 
+func (o DogOutput) Bone() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Dog) pulumi.StringPtrOutput { return v.Bone }).(pulumi.StringPtrOutput)
+}
+
 type DogArrayOutput struct{ *pulumi.OutputState }
 
 func (DogArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/god.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/god.go
@@ -148,6 +148,10 @@ func (o GodOutput) ToGodOutputWithContext(ctx context.Context) GodOutput {
 	return o
 }
 
+func (o GodOutput) Backwards() DogOutput {
+	return o.ApplyT(func(v *God) DogOutput { return v.Backwards }).(DogOutput)
+}
+
 type GodArrayOutput struct{ *pulumi.OutputState }
 
 func (GodArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/noRecursive.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/noRecursive.go
@@ -153,6 +153,14 @@ func (o NoRecursiveOutput) ToNoRecursiveOutputWithContext(ctx context.Context) N
 	return o
 }
 
+func (o NoRecursiveOutput) Rec() RecPtrOutput {
+	return o.ApplyT(func(v *NoRecursive) RecPtrOutput { return v.Rec }).(RecPtrOutput)
+}
+
+func (o NoRecursiveOutput) Replace() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *NoRecursive) pulumi.StringPtrOutput { return v.Replace }).(pulumi.StringPtrOutput)
+}
+
 type NoRecursiveArrayOutput struct{ *pulumi.OutputState }
 
 func (NoRecursiveArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/toyStore.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/toyStore.go
@@ -159,6 +159,22 @@ func (o ToyStoreOutput) ToToyStoreOutputWithContext(ctx context.Context) ToyStor
 	return o
 }
 
+func (o ToyStoreOutput) Chew() ChewPtrOutput {
+	return o.ApplyT(func(v *ToyStore) ChewPtrOutput { return v.Chew }).(ChewPtrOutput)
+}
+
+func (o ToyStoreOutput) Laser() LaserPtrOutput {
+	return o.ApplyT(func(v *ToyStore) LaserPtrOutput { return v.Laser }).(LaserPtrOutput)
+}
+
+func (o ToyStoreOutput) Stuff() ToyArrayOutput {
+	return o.ApplyT(func(v *ToyStore) ToyArrayOutput { return v.Stuff }).(ToyArrayOutput)
+}
+
+func (o ToyStoreOutput) Wanted() ToyArrayOutput {
+	return o.ApplyT(func(v *ToyStore) ToyArrayOutput { return v.Wanted }).(ToyArrayOutput)
+}
+
 type ToyStoreArrayOutput struct{ *pulumi.OutputState }
 
 func (ToyStoreArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/person.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/person.go
@@ -153,6 +153,14 @@ func (o PersonOutput) ToPersonOutputWithContext(ctx context.Context) PersonOutpu
 	return o
 }
 
+func (o PersonOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Person) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+func (o PersonOutput) Pets() PetTypeArrayOutput {
+	return o.ApplyT(func(v *Person) PetTypeArrayOutput { return v.Pets }).(PetTypeArrayOutput)
+}
+
 type PersonArrayOutput struct{ *pulumi.OutputState }
 
 func (PersonArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
@@ -150,6 +150,10 @@ func (o PetOutput) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return o
 }
 
+func (o PetOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Pet) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
+}
+
 type PetArrayOutput struct{ *pulumi.OutputState }
 
 func (PetArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/person.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/person.go
@@ -153,6 +153,14 @@ func (o PersonOutput) ToPersonOutputWithContext(ctx context.Context) PersonOutpu
 	return o
 }
 
+func (o PersonOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Person) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+func (o PersonOutput) Pets() PetTypeArrayOutput {
+	return o.ApplyT(func(v *Person) PetTypeArrayOutput { return v.Pets }).(PetTypeArrayOutput)
+}
+
 type PersonArrayOutput struct{ *pulumi.OutputState }
 
 func (PersonArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pet.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pet.go
@@ -150,6 +150,10 @@ func (o PetOutput) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return o
 }
 
+func (o PetOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Pet) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
+}
+
 type PetArrayOutput struct{ *pulumi.OutputState }
 
 func (PetArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/rec.go
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/rec.go
@@ -148,6 +148,10 @@ func (o RecOutput) ToRecOutputWithContext(ctx context.Context) RecOutput {
 	return o
 }
 
+func (o RecOutput) Rec() RecOutput {
+	return o.ApplyT(func(v *Rec) RecOutput { return v.Rec }).(RecOutput)
+}
+
 type RecArrayOutput struct{ *pulumi.OutputState }
 
 func (RecArrayOutput) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -131,6 +131,26 @@ func (o RubberTreeOutput) ToRubberTreeOutputWithContext(ctx context.Context) Rub
 	return o
 }
 
+func (o RubberTreeOutput) Container() plant.ContainerPtrOutput {
+	return o.ApplyT(func(v *RubberTree) plant.ContainerPtrOutput { return v.Container }).(plant.ContainerPtrOutput)
+}
+
+func (o RubberTreeOutput) Diameter() DiameterOutput {
+	return o.ApplyT(func(v *RubberTree) DiameterOutput { return v.Diameter }).(DiameterOutput)
+}
+
+func (o RubberTreeOutput) Farm() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RubberTree) pulumi.StringPtrOutput { return v.Farm }).(pulumi.StringPtrOutput)
+}
+
+func (o RubberTreeOutput) Size() TreeSizePtrOutput {
+	return o.ApplyT(func(v *RubberTree) TreeSizePtrOutput { return v.Size }).(TreeSizePtrOutput)
+}
+
+func (o RubberTreeOutput) Type() RubberTreeVarietyOutput {
+	return o.ApplyT(func(v *RubberTree) RubberTreeVarietyOutput { return v.Type }).(RubberTreeVarietyOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*RubberTreeInput)(nil)).Elem(), &RubberTree{})
 	pulumi.RegisterOutputType(RubberTreeOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
@@ -102,6 +102,42 @@ func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) Compo
 	return o
 }
 
+func (o ComponentOutput) A() pulumi.BoolOutput {
+	return o.ApplyT(func(v *Component) pulumi.BoolOutput { return v.A }).(pulumi.BoolOutput)
+}
+
+func (o ComponentOutput) B() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Component) pulumi.BoolPtrOutput { return v.B }).(pulumi.BoolPtrOutput)
+}
+
+func (o ComponentOutput) Bar() FooPtrOutput {
+	return o.ApplyT(func(v *Component) FooPtrOutput { return v.Bar }).(FooPtrOutput)
+}
+
+func (o ComponentOutput) Baz() FooArrayOutput {
+	return o.ApplyT(func(v *Component) FooArrayOutput { return v.Baz }).(FooArrayOutput)
+}
+
+func (o ComponentOutput) C() pulumi.IntOutput {
+	return o.ApplyT(func(v *Component) pulumi.IntOutput { return v.C }).(pulumi.IntOutput)
+}
+
+func (o ComponentOutput) D() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Component) pulumi.IntPtrOutput { return v.D }).(pulumi.IntPtrOutput)
+}
+
+func (o ComponentOutput) E() pulumi.StringOutput {
+	return o.ApplyT(func(v *Component) pulumi.StringOutput { return v.E }).(pulumi.StringOutput)
+}
+
+func (o ComponentOutput) F() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Component) pulumi.StringPtrOutput { return v.F }).(pulumi.StringPtrOutput)
+}
+
+func (o ComponentOutput) Foo() FooPtrOutput {
+	return o.ApplyT(func(v *Component) FooPtrOutput { return v.Foo }).(FooPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ComponentInput)(nil)).Elem(), &Component{})
 	pulumi.RegisterOutputType(ComponentOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
@@ -104,6 +104,42 @@ func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) Compo
 	return o
 }
 
+func (o ComponentOutput) A() pulumi.BoolOutput {
+	return o.ApplyT(func(v *Component) pulumi.BoolOutput { return v.A }).(pulumi.BoolOutput)
+}
+
+func (o ComponentOutput) B() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Component) pulumi.BoolPtrOutput { return v.B }).(pulumi.BoolPtrOutput)
+}
+
+func (o ComponentOutput) Bar() FooPtrOutput {
+	return o.ApplyT(func(v *Component) FooPtrOutput { return v.Bar }).(FooPtrOutput)
+}
+
+func (o ComponentOutput) Baz() FooArrayOutput {
+	return o.ApplyT(func(v *Component) FooArrayOutput { return v.Baz }).(FooArrayOutput)
+}
+
+func (o ComponentOutput) C() pulumi.IntOutput {
+	return o.ApplyT(func(v *Component) pulumi.IntOutput { return v.C }).(pulumi.IntOutput)
+}
+
+func (o ComponentOutput) D() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Component) pulumi.IntPtrOutput { return v.D }).(pulumi.IntPtrOutput)
+}
+
+func (o ComponentOutput) E() pulumi.StringOutput {
+	return o.ApplyT(func(v *Component) pulumi.StringOutput { return v.E }).(pulumi.StringOutput)
+}
+
+func (o ComponentOutput) F() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Component) pulumi.StringPtrOutput { return v.F }).(pulumi.StringPtrOutput)
+}
+
+func (o ComponentOutput) Foo() FooPtrOutput {
+	return o.ApplyT(func(v *Component) FooPtrOutput { return v.Foo }).(FooPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ComponentInput)(nil)).Elem(), &Component{})
 	pulumi.RegisterOutputType(ComponentOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
@@ -77,6 +77,10 @@ func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o OtherResourceOutput) Foo() ResourceOutput {
+	return o.ApplyT(func(v *OtherResource) ResourceOutput { return v.Foo }).(ResourceOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*OtherResourceInput)(nil)).Elem(), &OtherResource{})
 	pulumi.RegisterOutputType(OtherResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
@@ -100,6 +100,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Bar() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Bar }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ResourceInput)(nil)).Elem(), &Resource{})
 	pulumi.RegisterOutputType(ResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/barResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/barResource.go
@@ -78,6 +78,10 @@ func (o BarResourceOutput) ToBarResourceOutputWithContext(ctx context.Context) B
 	return o
 }
 
+func (o BarResourceOutput) Foo() ResourceOutput {
+	return o.ApplyT(func(v *BarResource) ResourceOutput { return v.Foo }).(ResourceOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*BarResourceInput)(nil)).Elem(), &BarResource{})
 	pulumi.RegisterOutputType(BarResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/fooResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/fooResource.go
@@ -78,6 +78,10 @@ func (o FooResourceOutput) ToFooResourceOutputWithContext(ctx context.Context) F
 	return o
 }
 
+func (o FooResourceOutput) Foo() ResourceOutput {
+	return o.ApplyT(func(v *FooResource) ResourceOutput { return v.Foo }).(ResourceOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*FooResourceInput)(nil)).Elem(), &FooResource{})
 	pulumi.RegisterOutputType(FooResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/otherResource.go
@@ -78,6 +78,10 @@ func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o OtherResourceOutput) Foo() ResourceOutput {
+	return o.ApplyT(func(v *OtherResource) ResourceOutput { return v.Foo }).(ResourceOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*OtherResourceInput)(nil)).Elem(), &OtherResource{})
 	pulumi.RegisterOutputType(OtherResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
@@ -110,6 +110,14 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Bar() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Bar }).(pulumi.StringPtrOutput)
+}
+
+func (o ResourceOutput) Baz() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Baz }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ResourceInput)(nil)).Elem(), &Resource{})
 	pulumi.RegisterOutputType(ResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/typeUses.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/typeUses.go
@@ -107,6 +107,18 @@ func (o TypeUsesOutput) ToTypeUsesOutputWithContext(ctx context.Context) TypeUse
 	return o
 }
 
+func (o TypeUsesOutput) Bar() SomeOtherObjectPtrOutput {
+	return o.ApplyT(func(v *TypeUses) SomeOtherObjectPtrOutput { return v.Bar }).(SomeOtherObjectPtrOutput)
+}
+
+func (o TypeUsesOutput) Baz() ObjectWithNodeOptionalInputsPtrOutput {
+	return o.ApplyT(func(v *TypeUses) ObjectWithNodeOptionalInputsPtrOutput { return v.Baz }).(ObjectWithNodeOptionalInputsPtrOutput)
+}
+
+func (o TypeUsesOutput) Foo() ObjectPtrOutput {
+	return o.ApplyT(func(v *TypeUses) ObjectPtrOutput { return v.Foo }).(ObjectPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*TypeUsesInput)(nil)).Elem(), &TypeUses{})
 	pulumi.RegisterOutputType(TypeUsesOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/otherResource.go
@@ -79,6 +79,10 @@ func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Contex
 	return o
 }
 
+func (o OtherResourceOutput) Foo() ResourceOutput {
+	return o.ApplyT(func(v *OtherResource) ResourceOutput { return v.Foo }).(ResourceOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*OtherResourceInput)(nil)).Elem(), &OtherResource{})
 	pulumi.RegisterOutputType(OtherResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
@@ -107,6 +107,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Bar() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Bar }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ResourceInput)(nil)).Elem(), &Resource{})
 	pulumi.RegisterOutputType(ResourceOutput{})

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/typeUses.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/typeUses.go
@@ -113,6 +113,38 @@ func (o TypeUsesOutput) ToTypeUsesOutputWithContext(ctx context.Context) TypeUse
 	return o
 }
 
+func (o TypeUsesOutput) Alpha() OutputOnlyEnumTypePtrOutput {
+	return o.ApplyT(func(v *TypeUses) OutputOnlyEnumTypePtrOutput { return v.Alpha }).(OutputOnlyEnumTypePtrOutput)
+}
+
+func (o TypeUsesOutput) Bar() SomeOtherObjectPtrOutput {
+	return o.ApplyT(func(v *TypeUses) SomeOtherObjectPtrOutput { return v.Bar }).(SomeOtherObjectPtrOutput)
+}
+
+func (o TypeUsesOutput) Baz() ObjectWithNodeOptionalInputsPtrOutput {
+	return o.ApplyT(func(v *TypeUses) ObjectWithNodeOptionalInputsPtrOutput { return v.Baz }).(ObjectWithNodeOptionalInputsPtrOutput)
+}
+
+func (o TypeUsesOutput) Beta() OutputOnlyObjectTypeArrayOutput {
+	return o.ApplyT(func(v *TypeUses) OutputOnlyObjectTypeArrayOutput { return v.Beta }).(OutputOnlyObjectTypeArrayOutput)
+}
+
+func (o TypeUsesOutput) Foo() ObjectPtrOutput {
+	return o.ApplyT(func(v *TypeUses) ObjectPtrOutput { return v.Foo }).(ObjectPtrOutput)
+}
+
+func (o TypeUsesOutput) Gamma() OutputOnlyEnumTypeMapOutput {
+	return o.ApplyT(func(v *TypeUses) OutputOnlyEnumTypeMapOutput { return v.Gamma }).(OutputOnlyEnumTypeMapOutput)
+}
+
+func (o TypeUsesOutput) Qux() RubberTreeVarietyPtrOutput {
+	return o.ApplyT(func(v *TypeUses) RubberTreeVarietyPtrOutput { return v.Qux }).(RubberTreeVarietyPtrOutput)
+}
+
+func (o TypeUsesOutput) Zed() OutputOnlyObjectTypePtrOutput {
+	return o.ApplyT(func(v *TypeUses) OutputOnlyObjectTypePtrOutput { return v.Zed }).(OutputOnlyObjectTypePtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*TypeUsesInput)(nil)).Elem(), &TypeUses{})
 	pulumi.RegisterOutputType(TypeUsesOutput{})


### PR DESCRIPTION
This enables generating output chaining methods such as this if we regenerated the AWS SDK:

```go
// The DNS name of the load balancer.
func (o LoadBalancerOutput) DnsName() pulumi.StringOutput {
	return o.ApplyT(func(v *LoadBalancer) pulumi.StringOutput { return v.DnsName }).(pulumi.StringOutput)
}
```

Enabling ergonomic access to outputs of resource-outputs:

```go
		lb, err := lb.NewApplicationLoadBalancer(ctx, "lb", nil)
		ctx.Export("dnsName", lb.LoadBalancer.DnsName())
```

Fixes #9506
Fixes #6073
