### PR TITLE
Stop using Get/SetRootResource in dotnet

### DIFF
--- a/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
@@ -2,9 +2,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Grpc.Net.Client;
 using Pulumirpc;
@@ -58,11 +55,5 @@ namespace Pulumi
         
         public async Task LogAsync(LogRequest request)
             => await this._engine.LogAsync(request);
-
-        public async Task<SetRootResourceResponse> SetRootResourceAsync(SetRootResourceRequest request)
-            => await this._engine.SetRootResourceAsync(request);
-
-        public async Task<GetRootResourceResponse> GetRootResourceAsync(GetRootResourceRequest request)
-            => await this._engine.GetRootResourceAsync(request);
     }
 }

--- a/sdk/dotnet/Pulumi/Deployment/IEngine.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IEngine.cs
@@ -8,9 +8,5 @@ namespace Pulumi
     internal interface IEngine
     {
         Task LogAsync(LogRequest request);
-        
-        Task<SetRootResourceResponse> SetRootResourceAsync(SetRootResourceRequest request);
-
-        Task<GetRootResourceResponse> GetRootResourceAsync(GetRootResourceRequest request);
     }
 }

--- a/sdk/dotnet/Pulumi/Testing/MockEngine.cs
+++ b/sdk/dotnet/Pulumi/Testing/MockEngine.cs
@@ -9,9 +9,6 @@ namespace Pulumi.Testing
 {
     internal class MockEngine : IEngine
     {
-        private string? _rootResourceUrn;
-        private readonly object _rootResourceUrnLock = new object();
-        
         public readonly List<string> Errors = new List<string>();
 
         public Task LogAsync(LogRequest request)
@@ -23,33 +20,8 @@ namespace Pulumi.Testing
                     this.Errors.Add(request.Message);
                 }
             }
-            
+
             return Task.CompletedTask;
-        }
-
-        public Task<SetRootResourceResponse> SetRootResourceAsync(SetRootResourceRequest request)
-        {
-            lock (_rootResourceUrnLock)
-            {
-                if (_rootResourceUrn != null && _rootResourceUrn != request.Urn)
-                    throw new InvalidOperationException(
-                        $"An invalid attempt to set the root resource to {request.Urn} while it's already set to {_rootResourceUrn}");
-                
-                _rootResourceUrn = request.Urn;
-            }
-
-            return Task.FromResult(new SetRootResourceResponse());
-        }
-
-        public Task<GetRootResourceResponse> GetRootResourceAsync(GetRootResourceRequest request)
-        {
-            lock (_rootResourceUrnLock)
-            {
-                if (_rootResourceUrn == null)
-                    throw new InvalidOperationException("Root resource is not set");
-                
-                return Task.FromResult(new GetRootResourceResponse {Urn = _rootResourceUrn});
-            }
         }
     }
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

There's no reason to use this engine call in dotnet, the engine address and the root stack resource are both global variables. No point roundtripping through the engine.

Plan is to also remove this from nodejs (node does have true global variables, so we'll just use that) and then eventually kill this from the engine (probably a 4.0 change).

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
