### PR TITLE
Fix handling of PULUMI_CONFIG_PASSPHRASE_FILE

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,7 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [cli] Fix an issue using PULUMI_CONFIG_PASSPHRASE_FILE.
+  [#9540](https://github.com/pulumi/pulumi/pull/9540)
+

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -275,7 +275,7 @@ func readPassphrase(prompt string, useEnv bool) (phrase string, interactive bool
 		if phrase, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok && phrase != "" {
 			return phrase, false, nil
 		}
-		if phraseFile, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE"); ok && phrase != "" {
+		if phraseFile, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE"); ok && phraseFile != "" {
 			phraseFilePath, err := filepath.Abs(phraseFile)
 			if err != nil {
 				return "", false, fmt.Errorf("unable to construct a path the PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -1,6 +1,7 @@
 package passphrase
 
 import (
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -89,6 +90,37 @@ func TestPassphraseManagerEmptyPassphraseReturnsError(t *testing.T) {
 
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
+
+	_, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
+	assert.NotNil(t, err, strings.Contains(err.Error(), "unable to find either `PULUMI_CONFIG_PASSPHRASE` nor "+
+		"`PULUMI_CONFIG_PASSPHRASE_FILE`"))
+}
+
+//nolint:paralleltest // mutates environment variables
+func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
+	resetEnv := resetPassphraseTestEnvVars()
+	defer resetEnv()
+
+	tmpFile, err := ioutil.TempFile("", "pulumi-secret-test")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.WriteString("password")
+	assert.NoError(t, err)
+
+	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
+	os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", tmpFile.Name())
+
+	sm, _ := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
+	assert.NotNil(t, sm)
+}
+
+//nolint:paralleltest // mutates environment variables
+func TestPassphraseManagerEmptyPassfileReturnsError(t *testing.T) {
+	resetEnv := resetPassphraseTestEnvVars()
+	defer resetEnv()
+
+	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
+	os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", "")
 
 	_, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
 	assert.NotNil(t, err, strings.Contains(err.Error(), "unable to find either `PULUMI_CONFIG_PASSPHRASE` nor "+

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -104,7 +104,7 @@ func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "pulumi-secret-test")
 	assert.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
-	tmpFile.WriteString("password")
+	_, err = tmpFile.WriteString("password")
 	assert.NoError(t, err)
 
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/9539

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
