### PR TITLE
Don't try to display empty rows

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [cli/display] Avoid an assert in the table display logic.
+  [#9543](https://github.com/pulumi/pulumi/pull/9543)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -433,10 +433,14 @@ func (display *ProgressDisplay) refreshColumns(
 
 	msg := display.getPaddedMessage(colorizedColumns, uncolorizedColumns, maxColumnLengths)
 
-	if display.isTerminal {
-		display.colorizeAndWriteProgress(makeActionProgress(id, msg))
-	} else {
-		display.writeSimpleMessage(msg)
+	// getPaddedmessage trims our message and potentially trims it to "" which will trigger
+	// asserts in later display functions if we try to show it
+	if msg != "" {
+		if display.isTerminal {
+			display.colorizeAndWriteProgress(makeActionProgress(id, msg))
+		} else {
+			display.writeSimpleMessage(msg)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

[Couple of community members](https://pulumi-community.slack.com/archives/C84L4E3N1/p1651678078066689) have seen an assert panic around here:
```
panic: fatal: An assertion has failed: action must be non empty

goroutine 2009 [running]:
github.com/pulumi/pulumi/sdk/v3/go/common/util/contract.failfast(...)
	/private/tmp/pulumi-20220504-79959-1budjvw/sdk/go/common/util/contract/failfast.go:23
github.com/pulumi/pulumi/sdk/v3/go/common/util/contract.Assertf(0x0?, {0x1053aa67e?, 0x140010182d0?}, {0x0?, 0x10537c4e7?, 0x3?})
	/private/tmp/pulumi-20220504-79959-1budjvw/sdk/go/common/util/contract/assert.go:33 +0xe4
github.com/pulumi/pulumi/pkg/v3/backend/display.makeActionProgress({0x106864480, 0x1}, {0x0, 0x0})
	/private/tmp/pulumi-20220504-79959-1budjvw/pkg/backend/display/progress.go:59 +0xa8
github.com/pulumi/pulumi/pkg/v3/backend/display.(*ProgressDisplay).refreshColumns(0x14001d94780, {0x106864480, 0x1}, {0x140021259f0, 0x5, 0x5}, {0x14000a46060, 0x5, 0x5})
	/private/tmp/pulumi-20220504-79959-1budjvw/pkg/backend/display/progress.go:437 +0x9c
github.com/pulumi/pulumi/pkg/v3/backend/display.(*ProgressDisplay).refreshAllRowsIfInTerminal(0x14001d94780)
	/private/tmp/pulumi-20220504-79959-1budjvw/pkg/backend/display/progress.go:655 +0x598
github.com/pulumi/pulumi/pkg/v3/backend/display.(*ProgressDisplay).processNormalEvent(0x14001d94780, {{0x105398980?, 0x7?}, {0x105a667e0?, 0x14000849400?}})
	/private/tmp/pulumi-20220504-79959-1budjvw/pkg/backend/display/progress.go:1134 +0xd48
github.com/pulumi/pulumi/pkg/v3/backend/display.(*ProgressDisplay).processEvents(0x14002d61e40?, 0x140035a49b0, 0x1400079f6e0)
	/private/tmp/pulumi-20220504-79959-1budjvw/pkg/backend/display/progress.go:1202 +0xc0
github.com/pulumi/pulumi/pkg/v3/backend/display.ShowProgressEvents.func1()
	/private/tmp/pulumi-20220504-79959-1budjvw/pkg/backend/display/progress.go:342 +0x34
created by github.com/pulumi/pulumi/pkg/v3/backend/display.ShowProgressEvents
	/private/tmp/pulumi-20220504-79959-1budjvw/pkg/backend/display/progress.go:341 +0x658
```

It looks like this can happen when the CLI thinks the terminal width is 0, but its potentially ending up empty due to other reasons as well. Just drop the message rather than asserting.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
