### PR TITLE
Stop using Get/SetRootResource in nodejs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- [nodejs] No longer roundtrips requests for the stack URN via the engine.
+  [#9559](https://github.com/pulumi/pulumi/pull/9559)
+
 ### Bug Fixes

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -49,7 +49,6 @@ import {
 import {
     excessiveDebugOutput,
     getMonitor,
-    getProject,
     getRootResource,
     getStack,
     isDryRun,
@@ -60,7 +59,6 @@ import {
 } from "./settings";
 
 const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
-const providerproto = require("../proto/provider_pb.js");
 const resproto = require("../proto/resource_pb.js");
 
 interface ResourceResolverOperation {

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -460,7 +460,7 @@ export async function setRootResource(res: ComponentResource): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         engineRef.setRootResource(req, (err: grpc.ServiceError, resp: any) => {
             // Back-compat case - if the engine we're speaking to isn't aware that it can save and load root
-            // resources, we can just ignore this case there's nothing we can do.
+            // resources, fall back to the old behavior.
             if (err && err.code === grpc.status.UNIMPLEMENTED) {
                 return resolve();
             }

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -433,7 +433,7 @@ export function rpcKeepAlive(): () => void {
  * can be used to ensure that all resources without explicit parents are parented to a common parent resource.
  */
 export async function getRootResource(): Promise<URN | undefined> {
-    var stack = globalThis.stackResource;
+    const stack = globalThis.stackResource;
     if (stack === undefined) {
         return undefined;
     }

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -14,9 +14,9 @@
 
 import * as asset from "../asset";
 import { getProject, getStack } from "../metadata";
-import { Inputs, Output, output, secret } from "../output";
+import { Inputs, Output, output } from "../output";
 import { ComponentResource, Resource, ResourceTransformation } from "../resource";
-import { getRootResource, isDryRun, isQueryMode, setRootResource } from "./settings";
+import { getRootResource, isDryRun, isQueryMode } from "./settings";
 
 /**
  * rootPulumiStackTypeName is the type name that should be used to construct the root component in the tree of Pulumi
@@ -25,11 +25,14 @@ import { getRootResource, isDryRun, isQueryMode, setRootResource } from "./setti
  */
 export const rootPulumiStackTypeName = "pulumi:pulumi:Stack";
 
-let stackResource: Stack | undefined;
+// The stack resource needs to be a a true global, so that if we end up with multiple Pulumi modules loaded they all resolve to the same variable.
+declare global {
+    var stackResource: Stack | undefined;
+}
 
 // Get the root stack resource for the current stack deployment
 export function getStackResource(): Stack | undefined {
-    return stackResource;
+    return globalThis.stackResource;
 }
 
 /**
@@ -68,14 +71,12 @@ class Stack extends ComponentResource<Inputs> {
      * @param init The callback to run in the context of this Pulumi stack
      */
     async initialize(args: { init: () => Promise<Inputs> }): Promise<Inputs> {
-        const parent = await getRootResource();
-        if (parent) {
+        if (globalThis.stackResource !== undefined) {
             throw new Error("Only one root Pulumi Stack may be active at once");
         }
-        await setRootResource(this);
 
         // Set the global reference to the stack resource before invoking this init() function
-        stackResource = this;
+        globalThis.stackResource = this
 
         let outputs: Inputs | undefined;
         try {
@@ -88,7 +89,6 @@ class Stack extends ComponentResource<Inputs> {
             // Resources.
             super.registerOutputs(outputs);
         }
-
         return outputs!;
     }
 }

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -16,7 +16,7 @@ import * as asset from "../asset";
 import { getProject, getStack } from "../metadata";
 import { Inputs, Output, output } from "../output";
 import { ComponentResource, Resource, ResourceTransformation } from "../resource";
-import { getRootResource, isDryRun, isQueryMode } from "./settings";
+import { isDryRun, isQueryMode } from "./settings";
 
 /**
  * rootPulumiStackTypeName is the type name that should be used to construct the root component in the tree of Pulumi
@@ -27,6 +27,8 @@ export const rootPulumiStackTypeName = "pulumi:pulumi:Stack";
 
 // The stack resource needs to be a a true global, so that if we end up with multiple Pulumi modules loaded they all resolve to the same variable.
 declare global {
+    // globals have to be vars
+    // eslint-disable-next-line no-var
     var stackResource: Stack | undefined;
 }
 
@@ -76,7 +78,7 @@ class Stack extends ComponentResource<Inputs> {
         }
 
         // Set the global reference to the stack resource before invoking this init() function
-        globalThis.stackResource = this
+        globalThis.stackResource = this;
 
         let outputs: Inputs | undefined;
         try {

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -16,7 +16,7 @@ import * as asset from "../asset";
 import { getProject, getStack } from "../metadata";
 import { Inputs, Output, output } from "../output";
 import { ComponentResource, Resource, ResourceTransformation } from "../resource";
-import { isDryRun, isQueryMode } from "./settings";
+import { isDryRun, isQueryMode, setRootResource } from "./settings";
 
 /**
  * rootPulumiStackTypeName is the type name that should be used to construct the root component in the tree of Pulumi
@@ -61,6 +61,10 @@ class Stack extends ComponentResource<Inputs> {
     public readonly outputs: Output<Inputs>;
 
     constructor(init: () => Promise<Inputs>) {
+        const parent = globalThis.stackResource;
+        if (parent !== undefined) {
+            throw new Error("Only one root Pulumi Stack may be active at once");
+        }
         super(rootPulumiStackTypeName, `${getProject()}-${getStack()}`, { init });
         const data = this.getData();
         this.outputs = output(data);
@@ -73,12 +77,9 @@ class Stack extends ComponentResource<Inputs> {
      * @param init The callback to run in the context of this Pulumi stack
      */
     async initialize(args: { init: () => Promise<Inputs> }): Promise<Inputs> {
-        if (globalThis.stackResource !== undefined) {
-            throw new Error("Only one root Pulumi Stack may be active at once");
-        }
-
         // Set the global reference to the stack resource before invoking this init() function
         globalThis.stackResource = this;
+        await setRootResource(this);
 
         let outputs: Inputs | undefined;
         try {
@@ -91,6 +92,7 @@ class Stack extends ComponentResource<Inputs> {
             // Resources.
             super.registerOutputs(outputs);
         }
+
         return outputs!;
     }
 }
@@ -216,8 +218,8 @@ async function massageComplex(prop: any, objectStack: any[]): Promise<any> {
  * Add a transformation to all future resources constructed in this Pulumi stack.
  */
 export function registerStackTransformation(t: ResourceTransformation) {
-    if (!stackResource) {
+    if (!globalThis.stackResource) {
         throw new Error("The root stack resource was referenced before it was initialized.");
     }
-    stackResource.__transformations = [...(stackResource.__transformations || []), t];
+    globalThis.stackResource.__transformations = [...(globalThis.stackResource.__transformations || []), t];
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Follow on from https://github.com/pulumi/pulumi/pull/9515

Just use globalThis to make the stack resource a global rather than a module variable. This ensures that even if we end up with multiple Pulumi modules they can all grab the stack object and read URN off it.

This is also a temporary fix, we're going to move a lot of the parenting logic to the engine so SDKs won't need this global state.

We've kept the SetRootResource calls in this version of the SDK so that if a user ends up with an old SDK version (that was using the engine calls and module variables) loaded side by side with this version of the SDK both should work together fine.

At the point we change the engine to set parents to the stack if they're parent option is unset we can rip all these calls out completely. Old SDKs that were using Get/SetRootResource will start seeing "undefined" for the GetRootResource call (because it will return NotImplemented and their fallback logic is to then read the module variable that won't have been set) but that won't break anything as they'll just send a RegisterResource call with parent=undefined and the engine will fill it in to the root stack resource.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
