### PR TITLE
Add --secrets-provider passthrough option

### DIFF
--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/passthrough"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 )
 
@@ -54,6 +55,9 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 
 	sm, err := func() (secrets.Manager, error) {
 		if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
+			if ps.SecretsProvider == passthrough.Type {
+				return newPassthroughSecretsManager(s.Ref().Name(), stackConfigFile)
+			}
 			return newCloudSecretsManager(s.Ref().Name(), stackConfigFile, ps.SecretsProvider)
 		}
 
@@ -80,7 +84,7 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 
 func validateSecretsProvider(typ string) error {
 	kind := strings.SplitN(typ, ":", 2)[0]
-	supportedKinds := []string{"default", "passphrase", "awskms", "azurekeyvault", "gcpkms", "hashivault"}
+	supportedKinds := []string{"default", "passphrase", "awskms", "azurekeyvault", "gcpkms", "hashivault", "passthrough"}
 	for _, supportedKind := range supportedKinds {
 		if kind == supportedKind {
 			return nil

--- a/pkg/cmd/pulumi/crypto_passthrough.go
+++ b/pkg/cmd/pulumi/crypto_passthrough.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/passthrough"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newPassthroughSecretsManager(stackName tokens.Name, configFile string) (secrets.Manager, error) {
+	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
+
+	if configFile == "" {
+		f, err := workspace.DetectProjectStackPath(stackName.Q())
+		if err != nil {
+			return nil, err
+		}
+		configFile = f
+	}
+
+	info, err := workspace.LoadProjectStack(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// If there are any other secrets providers set in the config, remove them.
+	info.EncryptionSalt = ""
+	info.EncryptedKey = ""
+	info.SecretsProvider = "passthrough"
+	if err = info.Save(configFile); err != nil {
+		return nil, err
+	}
+
+	return passthrough.NewPassthroughSecretsManager(), nil
+}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -34,7 +34,7 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(1),
 		Short: "Change the secrets provider for the current stack",
 		Long: "Change the secrets provider for the current stack. " +
-			"Valid secret providers types are `default`, `passphrase`, `awskms`, `azurekeyvault`, `gcpkms`, `hashivault`.\n\n" +
+			"Valid secret providers types are `default`, `passphrase`, `awskms`, `azurekeyvault`, `gcpkms`, `hashivault`, 'passthrough'.\n\n" +
 			"To change to using the Pulumi Default Secrets Provider, use the following:\n" +
 			"\n" +
 			"pulumi stack change-secrets-provider default" +

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	possibleSecretsProviderChoices = "The type of the provider that should be used to encrypt and decrypt secrets\n" +
-		"(possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault)"
+		"(possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault, passthrough)"
 )
 
 func newStackInitCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/passthrough"
 	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -175,9 +176,13 @@ func createSecretsManager(b backend.Backend, stackRef backend.StackReference, se
 	}
 
 	if secretsProvider == passphrase.Type {
-		if _, pharseErr := newPassphraseSecretsManager(stackRef.Name(), stackConfigFile,
-			rotatePassphraseSecretsProvider); pharseErr != nil {
-			return pharseErr
+		if _, phraseErr := newPassphraseSecretsManager(stackRef.Name(), stackConfigFile,
+			rotatePassphraseSecretsProvider); phraseErr != nil {
+			return phraseErr
+		}
+	} else if secretsProvider == passthrough.Type {
+		if _, secretsErr := newPassthroughSecretsManager(stackRef.Name(), stackConfigFile); secretsErr != nil {
+			return secretsErr
 		}
 	} else if !isDefaultSecretsProvider {
 		// All other non-default secrets providers are handled by the cloud secrets provider which

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/passthrough"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -49,6 +50,8 @@ func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.
 	switch ty {
 	case b64.Type:
 		sm = b64.NewBase64SecretsManager()
+	case passthrough.Type:
+		sm = passthrough.NewPassthroughSecretsManager()
 	case passphrase.Type:
 		sm, err = passphrase.NewPromptingPassphaseSecretsManagerFromState(state)
 	case service.Type:

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -230,6 +230,13 @@ func PromptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 		if err != nil {
 			return "", nil, err
 		}
+		if first == "" {
+			// Warn that empty passwords should probably use 'passthrough' instead, but give a work around if
+			// they really want an empty password.
+			cmdutil.Diag().Warningf(diag.Message("", "empty passphrases are not recommended, "+
+				"you probably want to use --secret-provider=passthrough."))
+		}
+
 		secondMessage := "Re-enter your passphrase to confirm"
 		if rotate {
 			secondMessage = "Re-enter your new passphrase to confirm"

--- a/pkg/secrets/passthrough/manager.go
+++ b/pkg/secrets/passthrough/manager.go
@@ -1,0 +1,49 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package passthrough implements a passthrough secrets manager for cases where the user wants to disable pulumi encryption.
+package passthrough
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+)
+
+const Type = "passthrough"
+
+// NewPassthroughSecretsManager returns a secrets manager that doesn't do any encrypting.
+func NewPassthroughSecretsManager() secrets.Manager {
+	return &manager{}
+}
+
+type manager struct{}
+
+func (m *manager) Type() string                         { return Type }
+func (m *manager) State() interface{}                   { return map[string]string{} }
+func (m *manager) Encrypter() (config.Encrypter, error) { return &passthroughCrypter{}, nil }
+func (m *manager) Decrypter() (config.Decrypter, error) { return &passthroughCrypter{}, nil }
+
+type passthroughCrypter struct{}
+
+func (c *passthroughCrypter) EncryptValue(s string) (string, error) {
+	return s, nil
+}
+
+func (c *passthroughCrypter) DecryptValue(s string) (string, error) {
+	return s, nil
+}
+
+func (c *passthroughCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	return config.DefaultBulkDecrypt(c, ciphertexts)
+}

--- a/pkg/secrets/passthrough/manager.go
+++ b/pkg/secrets/passthrough/manager.go
@@ -31,19 +31,5 @@ type manager struct{}
 
 func (m *manager) Type() string                         { return Type }
 func (m *manager) State() interface{}                   { return map[string]string{} }
-func (m *manager) Encrypter() (config.Encrypter, error) { return &passthroughCrypter{}, nil }
-func (m *manager) Decrypter() (config.Decrypter, error) { return &passthroughCrypter{}, nil }
-
-type passthroughCrypter struct{}
-
-func (c *passthroughCrypter) EncryptValue(s string) (string, error) {
-	return s, nil
-}
-
-func (c *passthroughCrypter) DecryptValue(s string) (string, error) {
-	return s, nil
-}
-
-func (c *passthroughCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return config.DefaultBulkDecrypt(c, ciphertexts)
-}
+func (m *manager) Encrypter() (config.Encrypter, error) { return config.NopEncrypter, nil }
+func (m *manager) Decrypter() (config.Decrypter, error) { return config.NopDecrypter, nil }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This can be used for users who don't want _any_ encryption.

Currently user in this situtation use the passphrase option with an empty passphrase. That's been made more difficult because we've started treating PULUMI_CONFIG_PASSPHRASE="" the same as it not being set at all.

This users can now use passthrough which then doesn't require any environment variables set to work.

If users try to make a passphrase stack with an empty passphrase we'll warn that it's not recomnded:
```
pulumi stack init --secrets-provider=passphrase
Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name: (dev) secrets
Created stack 'secrets'
Enter your passphrase to protect config/secrets:
warning: empty passphrases are not recommended, you probably want to use --secret-provider=passthrough.
```

Two design questions came up while putting this together.
1) Is "passthrough" the right name for this?
2) Should we just leave it in plain text or should we do something to blind the values in the state file like base64 encoding them. I like the former for making it _very_ clear that there is *NO* security with this option, I like the later so you don't have to worry about accidently cat'ing a secret to your screen looking at state files.

Fixes https://github.com/pulumi/pulumi/issues/9541

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
