### PR TITLE
Fix the function template to show YAML under the YAML tab

### DIFF
--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -93,7 +93,7 @@ func </span>{{ .FunctionName.go }}Output<span class="p">(</span>{{ htmlSafe .Fun
 
 <!-- YAML -->
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> {{ .FunctionName.yaml }}
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
@@ -87,7 +87,7 @@ func </span>ArgFunctionOutput<span class="p">(</span><span class="nx">ctx</span>
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:argFunction
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
@@ -87,7 +87,7 @@ func </span>ArgFunctionOutput<span class="p">(</span><span class="nx">ctx</span>
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:argFunction
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
@@ -87,7 +87,7 @@ func </span>OverlayFunctionOutput<span class="p">(</span><span class="nx">ctx</s
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:overlayFunction
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
@@ -94,7 +94,7 @@ func </span>ListConfigurationsOutput<span class="p">(</span><span class="nx">ctx
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> myedgeorder:listConfigurations
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
@@ -96,7 +96,7 @@ func </span>ListProductFamiliesOutput<span class="p">(</span><span class="nx">ct
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> myedgeorder:listProductFamilies
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
@@ -99,7 +99,7 @@ func </span>GetAmiIdsOutput<span class="p">(</span><span class="nx">ctx</span><s
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:getAmiIds
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
@@ -94,7 +94,7 @@ func </span>ListStorageAccountKeysOutput<span class="p">(</span><span class="nx"
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:listStorageAccountKeys
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
@@ -91,7 +91,7 @@ func </span>FuncWithAllOptionalInputsOutput<span class="p">(</span><span class="
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:funcWithAllOptionalInputs
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithconstinput/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithconstinput/_index.md
@@ -76,7 +76,7 @@ Codegen demo with const inputs
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:funcWithConstInput
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
@@ -91,7 +91,7 @@ func </span>FuncWithDefaultValueOutput<span class="p">(</span><span class="nx">c
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:funcWithDefaultValue
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
@@ -91,7 +91,7 @@ func </span>FuncWithDictParamOutput<span class="p">(</span><span class="nx">ctx<
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:funcWithDictParam
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
@@ -91,7 +91,7 @@ func </span>FuncWithListParamOutput<span class="p">(</span><span class="nx">ctx<
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:funcWithListParam
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
@@ -94,7 +94,7 @@ func </span>GetBastionShareableLinkOutput<span class="p">(</span><span class="nx
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:getBastionShareableLink
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
@@ -75,7 +75,7 @@ Failing example taken from azure-native. Original doc: Use this function to acce
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:getClientConfig
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
@@ -96,7 +96,7 @@ func </span>GetIntegrationRuntimeObjectMetadatumOutput<span class="p">(</span><s
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:getIntegrationRuntimeObjectMetadatum
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
@@ -94,7 +94,7 @@ func </span>ListStorageAccountKeysOutput<span class="p">(</span><span class="nx"
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:listStorageAccountKeys
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -91,7 +91,7 @@ func </span>FuncWithAllOptionalInputsOutput<span class="p">(</span><span class="
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:funcWithAllOptionalInputs
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -91,7 +91,7 @@ func </span>FuncWithAllOptionalInputsOutput<span class="p">(</span><span class="
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mypkg:funcWithAllOptionalInputs
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
@@ -73,7 +73,7 @@ no_edit_this_page: true
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> mongodbatlas:getCustomDbRoles
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
@@ -74,7 +74,7 @@ no_edit_this_page: true
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> my8110:exampleFunc
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
@@ -74,7 +74,7 @@ no_edit_this_page: true
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:doFoo
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
@@ -87,7 +87,7 @@ func </span>ArgFunctionOutput<span class="p">(</span><span class="nx">ctx</span>
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:argFunction
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
@@ -87,7 +87,7 @@ func </span>ArgFunctionOutput<span class="p">(</span><span class="nx">ctx</span>
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:argFunction
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
@@ -87,7 +87,7 @@ func </span>OverlayFunctionOutput<span class="p">(</span><span class="nx">ctx</s
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:overlayFunction
 <span class="k">&nbsp;&nbsp;Arguments:</span>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
@@ -85,7 +85,7 @@ def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</spa
 
 
 <div>
-<pulumi-choosable type="language" values="java">
+<pulumi-choosable type="language" values="yaml">
 <div class="highlight"><pre class="chroma"><code class="language-yaml" data-lang="yaml"><span class="k">Fn::Invoke:</span>
 <span class="k">&nbsp;&nbsp;Function:</span> example:argFunction
 <span class="k">&nbsp;&nbsp;Arguments:</span>


### PR DESCRIPTION
Right now, YAML examples are being shown under the Java tab:

![image](https://user-images.githubusercontent.com/274700/167215978-f65c63b6-f140-42a8-947b-e32739aef3dd.png)

Th change fixes that.