### PR TITLE
Allow PULUMI_CONFIG_PASSPHRASE to be empty

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [cli] The PULUMI_CONFIG_PASSPHRASE environment variables can be empty, this is treated different to being unset.
+  [#](https://github.com/pulumi/pulumi/pull/)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,4 +3,4 @@
 ### Bug Fixes
 
 - [cli] The PULUMI_CONFIG_PASSPHRASE environment variables can be empty, this is treated different to being unset.
-  [#](https://github.com/pulumi/pulumi/pull/)
+  [#9568](https://github.com/pulumi/pulumi/pull/9568)

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -272,7 +272,7 @@ func PromptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 
 func readPassphrase(prompt string, useEnv bool) (phrase string, interactive bool, err error) {
 	if useEnv {
-		if phrase, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok && phrase != "" {
+		if phrase, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok {
 			return phrase, false, nil
 		}
 		if phraseFile, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE"); ok && phraseFile != "" {

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -66,7 +66,8 @@ func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
-	sm, _ := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
+	sm, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
+	assert.NoError(t, err)
 	assert.NotNil(t, sm)
 }
 
@@ -84,16 +85,16 @@ func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
 }
 
 //nolint:paralleltest // mutates environment variables
-func TestPassphraseManagerEmptyPassphraseReturnsError(t *testing.T) {
+func TestPassphraseManagerEmptyPassphraseIsValid(t *testing.T) {
 	resetEnv := resetPassphraseTestEnvVars()
 	defer resetEnv()
 
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "")
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
 
-	_, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
-	assert.NotNil(t, err, strings.Contains(err.Error(), "unable to find either `PULUMI_CONFIG_PASSPHRASE` nor "+
-		"`PULUMI_CONFIG_PASSPHRASE_FILE`"))
+	sm, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
+	assert.NoError(t, err)
+	assert.NotNil(t, sm)
 }
 
 //nolint:paralleltest // mutates environment variables
@@ -110,7 +111,8 @@ func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
 	os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", tmpFile.Name())
 
-	sm, _ := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
+	sm, err := NewPromptingPassphaseSecretsManagerFromState([]byte(state))
+	assert.NoError(t, err)
 	assert.NotNil(t, sm)
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This partially reverts 273fa3343dbbef8a7551b3d8cf87af19bd356e89

I've left the behaviour that PULUMI_CONFIG_PASSPHRASE_FILE being empty is the same as unset because an empty file path isn't valid anyway.

Fixes https://github.com/pulumi/pulumi/issues/9541

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
