### PR TITLE
Bump versions of semver and OneOf

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - [cli] Add `--stack` to `pulumi about`.
   [#9518](https://github.com/pulumi/pulumi/pull/9518)
 
+- [sdk/dotnet] Bumped several dependency versions to avoid pulling packages with known vulnerabilities.
+  [#9591](https://github.com/pulumi/pulumi/pull/9591)
+
 ### Bug Fixes
 
 - [cli] The PULUMI_CONFIG_PASSPHRASE environment variables can be empty, this is treated different to being unset.

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1549,7 +1549,7 @@ namespace Pulumi.Automation.Tests
         [InlineData("invalid", true, false)]
         public void ValidVersionTheory(string currentVersion, bool errorExpected, bool optOut)
         {
-            var testMinVersion = SemVersion.Parse("2.21.1");
+            var testMinVersion = new SemVersion(2, 21, 1);
 
             if (errorExpected)
             {

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -36,7 +36,7 @@ namespace Pulumi.Automation
         private readonly LocalSerializer _serializer = new LocalSerializer();
         private readonly bool _ownsWorkingDir;
         private readonly Task _readyTask;
-        private static readonly SemVersion _minimumVersion = SemVersion.Parse("3.1.0");
+        private static readonly SemVersion _minimumVersion = new SemVersion(3, 1, 0);
 
         /// <inheritdoc/>
         public override string WorkDir { get; }
@@ -384,7 +384,7 @@ namespace Pulumi.Automation
 
         internal static SemVersion? ParseAndValidatePulumiVersion(SemVersion minVersion, string currentVersion, bool optOut)
         {
-            if (!SemVersion.TryParse(currentVersion, out SemVersion? version))
+            if (!SemVersion.TryParse(currentVersion, SemVersionStyles.Any, out SemVersion? version))
             {
                 version = null;
             }

--- a/sdk/dotnet/Pulumi/Pulumi.csproj
+++ b/sdk/dotnet/Pulumi/Pulumi.csproj
@@ -42,9 +42,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.16" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="OneOf" Version="2.1.151" />
+    <PackageReference Include="OneOf" Version="3.0.216" />
     <PackageReference Include="Pulumi.Protobuf" Version="3.13.0" />
-    <PackageReference Include="semver" Version="2.0.6" />
+    <PackageReference Include="semver" Version="2.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>

--- a/sdk/dotnet/Pulumi/Serialization/ResourcePackages.cs
+++ b/sdk/dotnet/Pulumi/Serialization/ResourcePackages.cs
@@ -37,7 +37,7 @@ namespace Pulumi
 
         internal static bool TryGetResourceType(string name, string? version, [NotNullWhen(true)] out Type? type)
         {
-            var minimalVersion = !string.IsNullOrEmpty(version) ? SemVersion.Parse(version) : new SemVersion(0);
+            var minimalVersion = !string.IsNullOrEmpty(version) ? SemVersion.Parse(version, SemVersionStyles.Any) : new SemVersion(0);
             var yes = _resourceTypes.Value.TryGetValue(name, out var types);
             if (!yes)
             {
@@ -47,7 +47,7 @@ namespace Pulumi
 
             var matches =
                     from vt in types
-                    let resourceVersion = !string.IsNullOrEmpty(vt.Item1) ? SemVersion.Parse(vt.Item1) : minimalVersion
+                    let resourceVersion = !string.IsNullOrEmpty(vt.Item1) ? SemVersion.Parse(vt.Item1, SemVersionStyles.Any) : minimalVersion
                     where resourceVersion >= minimalVersion
                     where (string.IsNullOrEmpty(version) || vt.Item1 == null || minimalVersion.Major == resourceVersion.Major)
                     orderby resourceVersion descending


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Both OneOf (https://github.com/mcintyre321/OneOf/pull/102) and semver (https://github.com/maxhauser/semver/pull/66) has recently added a `netstandard2.0` target to their packages, which means they no longer drag along the NETStandard.Library dependency when targeting non-.NET Framework platforms:

![image](https://user-images.githubusercontent.com/582487/168275422-8957ea7f-5fd3-4791-944c-fb1d12f2acba.png)

![image](https://user-images.githubusercontent.com/582487/168275461-3ae38985-5135-418c-884b-f0705c58ee6b.png)

This PR bumps those packages to their latest versions to get rid of the NETStandard.Library dependency and subsequently some vulnerability warnings in Snyk (and other analyzers):

![image](https://user-images.githubusercontent.com/582487/168275022-ccf2fba9-36b0-4519-8ad0-b9f94fa8818d.png)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
