### PR TITLE
Fix panic in 'pulumi console' when no stack is selected.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,3 +16,6 @@
 
 - [codegen/python] Fix importing of enum types from other packages.
   [#9579](https://github.com/pulumi/pulumi/pull/9579)
+
+- [cli] Fix panic in `pulumi console` when no stack is selected.
+  [#9594](https://github.com/pulumi/pulumi/pull/9594)

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -66,7 +66,7 @@ func newConsoleCmd() *cobra.Command {
 					}
 					if stack == nil {
 						fmt.Println("No stack is currently selected. " +
-							"Please run `pulumi stack select` to select a stack.")
+							"Run `pulumi stack select` to select a stack.")
 						return nil
 					}
 				}

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -64,6 +64,11 @@ func newConsoleCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
+					if stack == nil {
+						fmt.Println("No stack is currently selected. " +
+							"Please run `pulumi stack select` to select a stack.")
+						return nil
+					}
 				}
 
 				// Open the stack specific URL (e.g. app.pulumi.com/{org}/{project}/{stack}) for this


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9594

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
