### PR TITLE
[codegen] Improve handling of resources with outputs that are resources.

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -936,7 +936,7 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 		typeAssertion = ".(pulumi.StringArrayOutput)"
 	} else {
 		typeAssertion = fmt.Sprintf(".(%sOutput)", retType)
-		if !strings.HasPrefix(retType, "pulumi.") {
+		if !strings.Contains(retType, ".") {
 			typeAssertion = fmt.Sprintf(".(pulumi.%sOutput)", Title(retType))
 		}
 	}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -38,6 +38,11 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "Assets and archives",
 	},
 	{
+		Directory:   "synthetic-resource-properties",
+		Description: "Synthetic resource properties",
+		SkipCompile: codegen.NewStringSet("nodejs", "dotnet", "go"), // not a real package
+	},
+	{
 		Directory:      "aws-s3-folder",
 		Description:    "AWS S3 Folder",
 		ExpectNYIDiags: allProgLanguages.Except("go"),

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/dotnet/synthetic-resource-properties.cs
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/dotnet/synthetic-resource-properties.cs
@@ -1,0 +1,25 @@
+using Pulumi;
+using Synthetic = Pulumi.Synthetic.Synthetic;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var rt = new Synthetic.ResourceProperties.Root("rt", new Synthetic.ResourceProperties.RootArgs
+        {
+        });
+        this.Trivial = rt;
+        this.Simple = rt.Res1;
+        this.Foo = rt.Res1.Apply(res1 => res1.Obj1?.Res2?.Obj2);
+        this.Complex = rt.Res1.Apply(res1 => res1.Obj1?.Res2?.Obj2?.Answer);
+    }
+
+    [Output("trivial")]
+    public Output<string> Trivial { get; set; }
+    [Output("simple")]
+    public Output<string> Simple { get; set; }
+    [Output("foo")]
+    public Output<string> Foo { get; set; }
+    [Output("complex")]
+    public Output<string> Complex { get; set; }
+}

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	resourceProperties "git.example.org/pulumi-synthetic/resourceProperties"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		rt, err := resourceProperties.NewRoot(ctx, "rt", nil)
+		if err != nil {
+			return err
+		}
+		ctx.Export("trivial", rt)
+		ctx.Export("simple", rt.Res1)
+		ctx.Export("foo", rt.Res1.ApplyT(func(res1 *resourceproperties.Res1) (resourceproperties.Obj2, error) {
+			return res1.Obj1.Res2.Obj2, nil
+		}).(resourceproperties.Obj2Output))
+		ctx.Export("complex", rt.Res1.ApplyT(func(res1 *resourceproperties.Res1) (float64, error) {
+			return res1.Obj1.Res2.Obj2.Answer, nil
+		}).(pulumi.Float64Output))
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/nodejs/synthetic-resource-properties.ts
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/nodejs/synthetic-resource-properties.ts
@@ -1,0 +1,8 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as synthetic from "@pulumi/synthetic";
+
+const rt = new synthetic.resourceproperties.Root("rt", {});
+export const trivial = rt;
+export const simple = rt.res1;
+export const foo = rt.res1.apply(res1 => res1.obj1?.res2?.obj2);
+export const complex = rt.res1.apply(res1 => res1.obj1?.res2?.obj2?.answer);

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/python/synthetic-resource-properties.py
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/python/synthetic-resource-properties.py
@@ -1,0 +1,8 @@
+import pulumi
+import pulumi_synthetic as synthetic
+
+rt = synthetic.resource_properties.Root("rt")
+pulumi.export("trivial", rt)
+pulumi.export("simple", rt.res1)
+pulumi.export("foo", rt.res1.obj1.res2.obj2)
+pulumi.export("complex", rt.res1.obj1.res2.obj2.answer)

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/synthetic-resource-properties.pp
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/synthetic-resource-properties.pp
@@ -1,0 +1,15 @@
+resource rt "synthetic:resourceProperties:Root" {
+}
+
+output trivial {
+    value = rt
+}
+output simple {
+    value = rt.res1
+}
+output foo {
+    value = rt.res1.obj1.res2.obj2
+}
+output complex {
+    value = rt.res1.obj1.res2.obj2.answer
+}

--- a/pkg/codegen/testing/test/testdata/synthetic.json
+++ b/pkg/codegen/testing/test/testdata/synthetic.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json",
+  "name": "synthetic",
+  "version": "0.1.0",
+  "//": [
+    "We construct a resource Root,",
+    "  which has a property res1, which is a resource output Res1",
+    "  which has a property obj1, which is an object output Obj1",
+    "  which has a property res2, which is a resource output Res2",
+    "  which has a property obj2, which is an empty object output Obj2"
+  ],
+  "resources": {
+    "synthetic:resourceProperties:Root": {
+      "properties": {
+        "res1": {
+          "$ref": "#/resources/synthetic:resourceProperties:Res1"
+        }
+      },
+      "required": ["res1"],
+      "type": "object"
+    },
+    "synthetic:resourceProperties:Res1": {
+      "properties": {
+        "obj1": {
+          "$ref": "#/types/synthetic:resourceProperties:Obj1"
+        }
+      },
+      "isComponent": true,
+      "type": "object"
+    },
+    "synthetic:resourceProperties:Res2": {
+      "properties": {
+        "obj2": {
+          "$ref": "#/types/synthetic:resourceProperties:Obj2"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "synthetic:resourceProperties:Obj1": {
+      "type": "object",
+      "properties": {
+        "res2": {
+          "$ref": "#/resources/synthetic:resourceProperties:Res2"
+        }
+      }
+    },
+    "synthetic:resourceProperties:Obj2": {
+      "type": "object",
+      "properties": {
+        "answer": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  "language": {
+    "nodejs": {
+      "packageName": "@pulumi/synthetic"
+    },
+    "csharp": {
+      "rootNamespace": "Pulumi.Synthetic"
+    },
+    "python": {
+      "packageName": "pulumi_synthetic"
+    },
+    "go": {
+      "importBasePath": "git.example.org/pulumi-synthetic",
+      "packageImportAliases": {
+        "git.example.org/pulumi-synthetic/resourceProperties": "resourceProperties"
+      }
+    }
+  }
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -28,5 +28,9 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		}),
 		deploytest.NewProviderLoader("other", semver.MustParse("0.1.0"), func() (plugin.Provider, error) {
 			return Other(schemaDirectoryPath)
-		}))
+		}),
+		deploytest.NewProviderLoader("synthetic", semver.MustParse("0.1.0"), func() (plugin.Provider, error) {
+			return Synthetic(schemaDirectoryPath)
+		}),
+	)
 }

--- a/pkg/codegen/testing/utils/providers.go
+++ b/pkg/codegen/testing/utils/providers.go
@@ -36,4 +36,5 @@ var (
 	Random      = NewProviderLoader("random")
 	Kubernetes  = NewProviderLoader("kubernetes")
 	Other       = NewProviderLoader("other")
+	Synthetic   = NewProviderLoader("synthetic")
 )


### PR DESCRIPTION
Code generation fails to bind types on scope traversals through outputs when the output is a resource type and not an object/map/etc.

Needed to fix: https://github.com/pulumi/pulumi-yaml/issues/185

The code generation is currently subpar as we aren't using lifted/proxied property access in each language, and I'm happy to take feedback if it's a small fix. As an example, the Go example should be:

```go
// This:
ctx.Export("simple", rt.Res1.Obj1())
// Not this:
ctx.Export("simple", rt.Res1.ApplyT(func(res1 *resourceproperties.Res1) (resourceproperties.Obj1, -error) {
	return res1.Obj1, nil
}).(resourceproperties.Obj1Output))
```

But I think that fixing this requires a new rewriting pass, akin to the one implemented in Node.