### PR TITLE
allow `pulumi destroy -s <stack>` if not in a pulumi project dir

### DIFF
--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -39,14 +39,14 @@ type Stack interface {
 	StackIdentifier() client.StackIdentifier
 }
 
-type cloudBackendReference struct {
+type CloudBackendReference struct {
 	name    tokens.Name
 	project string
 	owner   string
 	b       *cloudBackend
 }
 
-func (c cloudBackendReference) String() string {
+func (c CloudBackendReference) String() string {
 	// If the project names match, we can elide them.
 	if c.b.currentProject != nil && c.project == string(c.b.currentProject.Name) {
 
@@ -69,14 +69,22 @@ func (c cloudBackendReference) String() string {
 	return fmt.Sprintf("%s/%s/%s", c.owner, c.project, c.name)
 }
 
-func (c cloudBackendReference) Name() tokens.Name {
+func (c CloudBackendReference) Name() tokens.Name {
 	return c.name
+}
+
+func (c CloudBackendReference) Project() string {
+	return c.project
+}
+
+func (c CloudBackendReference) Owner() string {
+	return c.owner
 }
 
 // cloudStack is a cloud stack descriptor.
 type cloudStack struct {
 	// ref is the stack's unique name.
-	ref cloudBackendReference
+	ref CloudBackendReference
 	// orgName is the organization that owns this stack.
 	orgName string
 	// currentOperation contains information about any current operation being performed on the stack, as applicable.
@@ -92,7 +100,7 @@ type cloudStack struct {
 func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
 	// Now assemble all the pieces into a stack structure.
 	return &cloudStack{
-		ref: cloudBackendReference{
+		ref: CloudBackendReference{
 			owner:   apistack.OrgName,
 			project: apistack.ProjectName,
 			name:    tokens.Name(apistack.StackName.String()),
@@ -191,7 +199,7 @@ type cloudStackSummary struct {
 func (css cloudStackSummary) Name() backend.StackReference {
 	contract.Assert(css.summary.ProjectName != "")
 
-	return cloudBackendReference{
+	return CloudBackendReference{
 		owner:   css.summary.OrgName,
 		project: css.summary.ProjectName,
 		name:    tokens.Name(css.summary.StackName),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #2440 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
