### PR TITLE
Fix python automation api text coloring option

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,4 +22,4 @@
 
 
 - [auto/python] - Fix text color argument being ignored during stack     operations.
-  [#XXXX](https://github.com/pulumi/pulumi/pull/)
+  [#9615](https://github.com/pulumi/pulumi/pull/9615)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,3 +19,7 @@
 
 - [cli] Fix panic in `pulumi console` when no stack is selected.
   [#9594](https://github.com/pulumi/pulumi/pull/9594)
+
+
+- [auto/python] - Fix text color argument being ignored during stack     operations.
+  [#XXXX](https://github.com/pulumi/pulumi/pull/)

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -675,6 +675,7 @@ def _parse_extra_args(**kwargs) -> List[str]:
     target = kwargs.get("target")
     target_dependents = kwargs.get("target_dependents")
     parallel = kwargs.get("parallel")
+    color = kwargs.get("color")
 
     if message:
         extra_args.extend(["--message", message])
@@ -692,6 +693,8 @@ def _parse_extra_args(**kwargs) -> List[str]:
         extra_args.append("--target-dependents")
     if parallel:
         extra_args.extend(["--parallel", str(parallel)])
+    if color:
+        extra_args.extend(["--color", color])
     return extra_args
 
 


### PR DESCRIPTION
# Description

I want to have text coloring using automation API and Python in order to help understand what is changed in the CI. I saw that the color option was ignored in automation API stack operations. I added it.

Fixes # (issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
    * I could not find any test that tested automation API argument parsing

- [X] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
    * This is a minor change that does not affect the service.