### PR TITLE
Fixes checksum validation issues and factors out publish-binaries.yml

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,7 +102,7 @@ jobs:
     name: Publish Binaries
     # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: [lint, language-sdk-lint, build, test-linux, test-windows, test-macos]
     with:
       goreleaser-config: '.goreleaser.prerelease.yml'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -106,6 +106,7 @@ jobs:
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-build-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
       goreleaser-flags: '-p 3 --skip-validate'
+    secrets: inherit
 
   #  examples_smoke_test:
   #    name: Trigger Examples Smoke Test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -106,7 +106,11 @@ jobs:
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-build-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
       goreleaser-flags: '-p 3 --skip-validate'
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_UPLOAD_ROLE_ARN: ${{ secrets.UPLOAD_ROLE_ARN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   #  examples_smoke_test:
   #    name: Trigger Examples Smoke Test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -97,99 +97,17 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           make -C sdk/${{ matrix.language}} publish
+
   publish-binaries:
     name: Publish Binaries
-    runs-on: macos-latest
+    # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
+    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
+    runs-on: ubuntu-latest
     needs: [lint, language-sdk-lint, build, test-linux, test-windows, test-macos]
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-    steps:
-      # This step rebuilds binaries to publish and validates that
-      # their checksums match the checksums of the tested binaries;
-      # since the tested binaries were build with coverage support we
-      # need to match it here for checksums to match.
-      - name: Enable code coverage
-        run: |
-          echo "PULUMI_TEST_COVERAGE_PATH=$(pwd)/coverage" >> $GITHUB_ENV
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-      - id: go-cache-paths
-        run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-      - name: Go Cache
-        uses: actions/cache@v2
-        id: go-cache
-        if: ${{ runner.os != 'Windows' }} # Note [Windows Go Cache] in build.yml
-        with:
-          path: |
-              ${{ steps.go-cache-paths.outputs.go-build }}
-              ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('*/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Fetch Tags
-        run: |
-          git fetch --quiet --prune --unshallow --tags
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-external-id: upload-pulumi-release
-          role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Set PreRelease Version
-        run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
-      - name: Run GoReleaser to verify tarball checksums
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --skip-publish --skip-announce
-      - name: Download pulumi-windows-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-windows-checksums
-          path: artifacts/checksums/windows
-      - name: Download pulumi-linux-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-linux-checksums
-          path: artifacts/checksums/linux
-      - name: Download pulumi-darwin-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-darwin-checksums
-          path: artifacts/checksums/darwin
-      - name: Verify checksums
-        run: |
-          C=artifacts/checksums/pulumi-tested-checksums.txt
-          echo "Tested tarballs with the following checksums:"
-          cat artifacts/checksums/*/* | sort | tee $C
-          echo "Released tarballs with the following checksums:"
-          sort goreleaser/*-checksums.txt
-          echo "Checking that tested and released checksums are identical:"
-          diff <(sort goreleaser/*-checksums.txt) $C
-      - name: Download pulumi-language-*
-        run: |
-          ./scripts/get-language-providers.sh
-      - name: Run GoReleaser to actually release
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate
+    with:
+      goreleaser-config: '.goreleaser.prerelease.yml'
+      goreleaser-build-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
+      goreleaser-flags: '-p 3 --skip-validate'
 
   #  examples_smoke_test:
   #    name: Trigger Examples Smoke Test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -100,8 +100,7 @@ jobs:
 
   publish-binaries:
     name: Publish Binaries
-    # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
-    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
+    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     needs: [lint, language-sdk-lint, build, test-linux, test-windows, test-macos]
     with:
       goreleaser-config: '.goreleaser.prerelease.yml'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,7 +102,6 @@ jobs:
     name: Publish Binaries
     # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
-    runs-on: macos-latest
     needs: [lint, language-sdk-lint, build, test-linux, test-windows, test-macos]
     with:
       goreleaser-config: '.goreleaser.prerelease.yml'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -100,8 +100,7 @@ jobs:
   publish-binaries:
     name: Publish Binaries
     needs: [lint, build, test-linux, test-macos, test-windows]
-    # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
-    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
+    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     with:
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-build-flags: '-p 3 --skip-publish --skip-announce --skip-validate'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -96,139 +96,18 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           make -C sdk/${{ matrix.language}} publish
+
   publish-binaries:
     name: Publish Binaries
     runs-on: macos-latest
     needs: [lint, build, test-linux, test-macos, test-windows]
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-    steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-      - id: go-cache-paths
-        run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-      - name: Go Cache
-        uses: actions/cache@v2
-        id: go-cache
-        if: ${{ runner.os != 'Windows' }} # Note [Windows Go Cache] in build.yml
-        with:
-          path: |
-              ${{ steps.go-cache-paths.outputs.go-build }}
-              ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('*/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Fetch Tags
-        run: |
-          git fetch --quiet --prune --unshallow --tags
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install goreleaser-filter
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: t0yv0/goreleaser-filter
-      - name: Download pulumi-linux-x64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-linux-x64
-          path: goreleaser-downloads
-      - name: Download pulumi-linux-arm64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-linux-arm64
-          path: goreleaser-downloads
-      - name: Download pulumi-darwin-x64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-darwin-x64
-          path: goreleaser-downloads
-      - name: Download pulumi-darwin-arm64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-darwin-arm64
-          path: goreleaser-downloads
-      - name: Download pulumi-windows-x64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-windows-x64
-          path: goreleaser-downloads
-      - name: Inspect goreleaser-downloads
-        run: |
-          find goreleaser-downloads
-      - name: Unpack goreleaser-downloads
-        run: |
-          ./scripts/unpack.sh
-      - name: Inspect goreleaser-prebuilt
-        run: |
-          find goreleaser-prebuilt
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-external-id: upload-pulumi-release
-          role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Set PreRelease Version
-        run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
-      - name: Download pulumi-windows-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-windows-checksums
-          path: artifacts/checksums/windows
-      - name: Download pulumi-linux-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-linux-checksums
-          path: artifacts/checksums/linux
-      - name: Download pulumi-darwin-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-darwin-checksums
-          path: artifacts/checksums/darwin
-      - name: Filter goreleaser config for pre-release check
-        run: |
-          cat .goreleaser.prerelease.yml | goreleaser-filter -no-blobs > /tmp/.goreleaser.current.yml
-      - name: Run GoReleaser to verify tarball checksums
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f /tmp/.goreleaser.current.yml --skip-publish --skip-announce --skip-validate --rm-dist --release-notes=CHANGELOG_PENDING.md
-      - name: Verify checksums
-        run: |
-          C=artifacts/checksums/pulumi-tested-checksums.txt
-          echo "Tested tarballs with the following checksums:"
-          cat artifacts/checksums/*/* | sort | tee $C
-          echo "Released tarballs with the following checksums:"
-          sort goreleaser/*-checksums.txt
-          echo "Checking that tested and released checksums are identical:"
-          diff <(sort goreleaser/*-checksums.txt) $C
-      - name: Download pulumi-language-*
-        run: |
-          ./scripts/get-language-providers.sh
-      - name: Run GoReleaser to actually release
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f .goreleaser.prerelease.yml --rm-dist
-      - uses: actions/upload-artifact@v3
-        with:
-          name: goreleaser-artifacts
-          path: |
-            goreleaser/pulumi-*.zip
-            goreleaser/pulumi-*.tar.gz
+    # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
+    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
+    with:
+      goreleaser-config: '.goreleaser.prerelease.yml'
+      goreleaser-build-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
+      goreleaser-flags: '-p 3'
+
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44
     container: golangci/golangci-lint:v1.44

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -99,7 +99,6 @@ jobs:
 
   publish-binaries:
     name: Publish Binaries
-    runs-on: macos-latest
     needs: [lint, build, test-linux, test-macos, test-windows]
     # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -105,6 +105,7 @@ jobs:
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-build-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
       goreleaser-flags: '-p 3'
+    secrets: inherit
 
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -105,7 +105,11 @@ jobs:
       goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-build-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
       goreleaser-flags: '-p 3'
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_UPLOAD_ROLE_ARN: ${{ secrets.UPLOAD_ROLE_ARN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Inspect goreleaser-prebuilt
         run: |
           find goreleaser-prebuilt
+
       # Section 3: dry-run goreleaser to verify checksums
       - name: Download pulumi-windows-checksums
         uses: actions/download-artifact@v2

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -133,7 +133,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: -p 3 -f ${{ inputs.goreleaser-config }} ${{ inputs.goreleaser-flags}}
+          args: -p 3 -f ${{ inputs.goreleaser-config }} ${{ inputs.goreleaser-flags }} --rm-dist
       - uses: actions/upload-artifact@v3
         with:
           name: goreleaser-artifacts

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -80,9 +80,15 @@ jobs:
         with:
           name: pulumi-windows-x64
           path: goreleaser-downloads
+      - name: Inspect goreleaser-downloads
+        run: |
+          find goreleaser-downloads
       - name: Unpack goreleaser-downloads
-        run: ./scripts/unpack.sh
-
+        run: |
+          ./scripts/unpack.sh
+      - name: Inspect goreleaser-prebuilt
+        run: |
+          find goreleaser-prebuilt
       # Section 3: dry-run goreleaser to verify checksums
       - name: Download pulumi-windows-checksums
         uses: actions/download-artifact@v2

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -15,7 +15,19 @@ on:
         description: 'The goreleaser-flags arg that build.yml was called with'
         required: true
         type: string
-    secrets: {}
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        description: "AWS key ID for publishing binaries to S3"
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        description: "AWS secret access key for publishing binaries to S3"
+        required: true
+      AWS_UPLOAD_ROLE_ARN:
+        description: "AWS role for publishing binaries to S3"
+        required: true
+      GITHUB_TOKEN:
+        description: "Token to use for GitHub API"
+        required: true
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,0 +1,142 @@
+name: Releases prebuilt CLI binaries
+
+on:
+  workflow_call:
+    inputs:
+      goreleaser-config:
+        description: 'Config file for goreleaser; must match the goreleaser-config build.yml was called with'
+        required: true
+        type: string
+      goreleaser-flags:
+        description: 'Command-line flags to pass to goreleaser'
+        required: true
+        type: string
+      goreleaser-build-flags:
+        description: 'The goreleaser-flags arg that build.yml was called with'
+        required: true
+        type: string
+    secrets: {}
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  publish-binaries:
+    name: Publish Binaries
+    runs-on: macos-latest
+    steps:
+
+      # Section 0: checkout repo and install dependencies
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Fetch Tags
+        run: git fetch --quiet --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install goreleaser-filter
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: t0yv0/goreleaser-filter
+
+      # Section 1: configure
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: us-east-2
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 3600
+          role-external-id: upload-pulumi-release
+          role-session-name: pulumi@githubActions
+          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+      - name: Configure Release Version
+        run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
+
+      # Section 2: download prebuilt binaries made by build.yml
+      - name: Download pulumi-linux-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-x64
+          path: goreleaser-downloads
+      - name: Download pulumi-linux-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-arm64
+          path: goreleaser-downloads
+      - name: Download pulumi-darwin-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-x64
+          path: goreleaser-downloads
+      - name: Download pulumi-darwin-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-arm64
+          path: goreleaser-downloads
+      - name: Download pulumi-windows-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-windows-x64
+          path: goreleaser-downloads
+      - name: Unpack goreleaser-downloads
+        run: ./scripts/unpack.sh
+
+      # Section 3: dry-run goreleaser to verify checksums
+      - name: Download pulumi-windows-checksums
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-windows-checksums
+          path: artifacts/checksums/windows
+      - name: Download pulumi-linux-checksums
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-checksums
+          path: artifacts/checksums/linux
+      - name: Download pulumi-darwin-checksums
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-checksums
+          path: artifacts/checksums/darwin
+      - name: Filter goreleaser config for the dry-run
+        run: |
+          cat ${{ inputs.goreleaser-config }} | goreleaser-filter -no-blobs > /tmp/.goreleaser.current.yml
+      - name: Dry-run GoReleaser to verify tarball checksums
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -p 3 -f /tmp/.goreleaser.current.yml ${{ inputs.goreleaser-build-flags }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: goreleaser-dryrun-artifacts
+          path: |
+            goreleaser/pulumi-*.zip
+            goreleaser/pulumi-*.tar.gz
+      - name: Verify checksums
+        run: |
+          C=artifacts/checksums/pulumi-tested-checksums.txt
+          echo "Tested tarballs with the following checksums:"
+          cat artifacts/checksums/*/* | sort | tee $C
+          echo "Released tarballs with the following checksums:"
+          sort goreleaser/*-checksums.txt
+          echo "Checking that tested and released checksums are identical:"
+          diff <(sort goreleaser/*-checksums.txt) $C
+
+      # Section 4: release with goreleaser
+      - name: Download pulumi-language-*
+        # NOTE: this must come after the dry-run currently as
+        # build.yml does not include these providers in the checksums.
+        run: |
+          ./scripts/get-language-providers.sh
+      - name: Run GoReleaser to actually release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -p 3 -f ${{ inputs.goreleaser-config }} ${{ inputs.goreleaser-flags}}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: goreleaser-artifacts
+          path: |
+            goreleaser/pulumi-*.zip
+            goreleaser/pulumi-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,6 @@ jobs:
 
   publish-binaries:
     name: Publish Binaries
-    runs-on: macos-latest
     needs: [lint, build, test-linux, test-macos, test-windows]
     # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,8 +209,7 @@ jobs:
   publish-binaries:
     name: Publish Binaries
     needs: [lint, build, test-linux, test-macos, test-windows]
-    # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
-    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
+    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     with:
       goreleaser-config: '.goreleaser.yml'
       goreleaser-build-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md --skip-publish --skip-announce --skip-validate'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,7 @@ jobs:
       goreleaser-config: '.goreleaser.yml'
       goreleaser-build-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md --skip-publish --skip-announce --skip-validate'
       goreleaser-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md'
+    secrets: inherit
 
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,11 @@ jobs:
       goreleaser-config: '.goreleaser.yml'
       goreleaser-build-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md --skip-publish --skip-announce --skip-validate'
       goreleaser-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md'
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_UPLOAD_ROLE_ARN: ${{ secrets.UPLOAD_ROLE_ARN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,140 +205,18 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           make -C sdk/${{ matrix.language}} publish
+
   publish-binaries:
     name: Publish Binaries
     runs-on: macos-latest
     needs: [lint, build, test-linux, test-macos, test-windows]
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-    steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-      - id: go-cache-paths
-        run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-      - name: Go Cache
-        uses: actions/cache@v2
-        id: go-cache
-        if: ${{ runner.os != 'Windows' }} # Note [Windows Go Cache] in build.yml
-        with:
-          path: |
-              ${{ steps.go-cache-paths.outputs.go-build }}
-              ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('*/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Fetch Tags
-        run: |
-          git fetch --quiet --prune --unshallow --tags
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install goreleaser-filter
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: t0yv0/goreleaser-filter
-      - name: Download pulumi-linux-x64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-linux-x64
-          path: goreleaser-downloads
-      - name: Download pulumi-linux-arm64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-linux-arm64
-          path: goreleaser-downloads
-      - name: Download pulumi-darwin-x64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-darwin-x64
-          path: goreleaser-downloads
-      - name: Download pulumi-darwin-arm64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-darwin-arm64
-          path: goreleaser-downloads
-      - name: Download pulumi-windows-x64
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-windows-x64
-          path: goreleaser-downloads
-      - name: Inspect goreleaser-downloads
-        run: |
-          find goreleaser-downloads
-      - name: Unpack goreleaser-downloads
-        run: |
-          ./scripts/unpack.sh
-      - name: Inspect goreleaser-prebuilt
-        run: |
-          find goreleaser-prebuilt
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-external-id: upload-pulumi-release
-          role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Set Release Version
-        run: |
-          echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
-      - name: Download pulumi-windows-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-windows-checksums
-          path: artifacts/checksums/windows
-      - name: Download pulumi-linux-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-linux-checksums
-          path: artifacts/checksums/linux
-      - name: Download pulumi-darwin-checksums
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-darwin-checksums
-          path: artifacts/checksums/darwin
-      - name: Filter goreleaser config for pre-release check
-        run: |
-          cat .goreleaser.yml | goreleaser-filter -no-blobs > /tmp/.goreleaser.current.yml
-      - name: Run GoReleaser to verify tarball checksums
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f /tmp/.goreleaser.current.yml --skip-publish --skip-announce --skip-validate --rm-dist --release-notes=CHANGELOG_PENDING.md
-      - name: Verify checksums
-        run: |
-          C=artifacts/checksums/pulumi-tested-checksums.txt
-          echo "Tested tarballs with the following checksums:"
-          cat artifacts/checksums/*/* | sort | tee $C
-          echo "Planning to release tarballs with the following checksums:"
-          sort goreleaser/*-checksums.txt
-          echo "Checking that tested and release checksums are identical:"
-          diff <(sort goreleaser/*-checksums.txt) $C
-      - name: Download pulumi-language-*
-        run: |
-          ./scripts/get-language-providers.sh
-      - name: Run GoReleaser to actually release
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: -p 3 -f .goreleaser.yml --rm-dist --release-notes=CHANGELOG_PENDING.md
-      - uses: actions/upload-artifact@v3
-        with:
-          name: goreleaser-artifacts
-          path: |
-            goreleaser/pulumi-*.zip
-            goreleaser/pulumi-*.tar.gz
+    # uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
+    uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@t0yv0/fix-publish-binaries
+    with:
+      goreleaser-config: '.goreleaser.yml'
+      goreleaser-build-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md --skip-publish --skip-announce --skip-validate'
+      goreleaser-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md'
+
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44
     container: golangci/golangci-lint:v1.44

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -170,6 +170,8 @@ jobs:
     uses: pulumi/pulumi/.github/workflows/build.yml@master
     with:
       enable-coverage: true
+      goreleaser-config: '.goreleaser.prerelease.yml'
+      goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
 
   test-linux:
     name: Test Linux

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -170,8 +170,6 @@ jobs:
     uses: pulumi/pulumi/.github/workflows/build.yml@master
     with:
       enable-coverage: true
-      goreleaser-config: '.goreleaser.prerelease.yml'
-      goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
 
   test-linux:
     name: Test Linux

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -28,7 +28,12 @@ case "$1" in
         ARGS=( "$@" )
         BUILDDIR=${ARGS[${#ARGS[@]}-1]}
         OUTPUT=${ARGS[${#ARGS[@]}-2]}
+
         PREBUILT="${OUTPUT/goreleaser/goreleaser-prebuilt}"
+
+        # Since at least goreleaser 1.8.3 binaries are named
+        # amd64_v1/... but prebuilt to `amd64/...`.
+        PREBUILT="${PREBUILT/amd64_v1/amd64}"
 
         MODE=coverage
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9602

It seems that we do not pin goreleaser and upgrades to 1.8.3 changed the binary naming, which defeated the `go-wrapper.sh` prebuilt logic. As a result we stopped reusing prebuilt binaries and sometimes would rebuild binaries in the publish step. This also slowed down the publish step significantly. Due to differences in go cache this would result in mismatch.

These kinds of changes are difficult to test but I've tested up to matching checksums by invoking the master.yml-like configuration from the `run-build-and-acceptance-tests.yml` script.

As a bonus I tried factoring out the publishing into a reusable workflow. This way there is a bit more hope that whatever we fix there goes out to all of master.yml, prerelease.yml, release.yml.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
