### PR TITLE
Fix "secret name GITHUB_TOKEN cannot be used"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,7 +110,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_UPLOAD_ROLE_ARN: ${{ secrets.UPLOAD_ROLE_ARN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   #  examples_smoke_test:
   #    name: Trigger Examples Smoke Test

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -109,7 +109,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_UPLOAD_ROLE_ARN: ${{ secrets.UPLOAD_ROLE_ARN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -25,9 +25,6 @@ on:
       AWS_UPLOAD_ROLE_ARN:
         description: "AWS role for publishing binaries to S3"
         required: true
-      GITHUB_TOKEN:
-        description: "Token to use for GitHub API"
-        required: true
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_UPLOAD_ROLE_ARN: ${{ secrets.UPLOAD_ROLE_ARN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

https://github.com/pulumi/pulumi/pull/9617 broke master.yml, fixing the issue.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
