### PR TITLE
Pin and enable caching installed tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,13 +77,13 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
           cache: enable
       - name: Install goreleaser-filter
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: t0yv0/goreleaser-filter
           tag: v0.3.0
@@ -150,7 +150,7 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -193,7 +193,7 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -245,7 +245,7 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,13 +77,17 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Install goreleaser-filter
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: t0yv0/goreleaser-filter
+          tag: v0.3.0
+          cache: enable
       - name: Set up Go ${{ inputs.go-version }}
         uses: actions/setup-go@v2
         with:
@@ -146,9 +150,11 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v3
         with:
@@ -187,9 +193,11 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Set up Node ${{ inputs.node-version }}
         uses: actions/setup-node@v2
         with:
@@ -237,9 +245,11 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Set up DotNet ${{ inputs.dotnet-version }}
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -76,9 +76,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -120,9 +122,11 @@ jobs:
   #      - name: Checkout Repo
   #        uses: actions/checkout@v2
   #      - name: Install pulumictl
-  #        uses: jaxxstorm/action-install-gh-release@v1.5.0
+  #        uses: jaxxstorm/action-install-gh-release@v1.7.0
   #        with:
   #          repo: pulumi/pulumictl
+  #          tag: v0.0.31
+  #          cache: enable
   #      - name: Repository Dispatch
   #        run: |
   #          pulumictl dispatch -r pulumi/examples -c smoke-test-cli $(pulumictl get version --language generic -o)
@@ -213,9 +217,11 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Ensure
         run: |
           make ensure
@@ -271,9 +277,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Fetch Tags

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -122,7 +122,7 @@ jobs:
   #      - name: Checkout Repo
   #        uses: actions/checkout@v2
   #      - name: Install pulumictl
-  #        uses: jaxxstorm/action-install-gh-release@v1.7.0
+  #        uses: jaxxstorm/action-install-gh-release@v1.7.1
   #        with:
   #          repo: pulumi/pulumictl
   #          tag: v0.0.31
@@ -217,7 +217,7 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -76,9 +76,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -196,9 +198,11 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Ensure
         run: |
           make ensure
@@ -254,9 +258,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Fetch Tags

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -198,7 +198,7 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -44,13 +44,13 @@ jobs:
       - name: Fetch Tags
         run: git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
           cache: enable
       - name: Install goreleaser-filter
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: t0yv0/goreleaser-filter
           tag: v0.3.0

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -44,14 +44,17 @@ jobs:
       - name: Fetch Tags
         run: git fetch --quiet --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Install goreleaser-filter
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: t0yv0/goreleaser-filter
-
+          tag: v0.3.0
+          cache: enable
       # Section 1: configure
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Repository Dispatch
         run: |
           pulumictl dispatch -r pulumi/templates -c trigger-cron $(pulumictl get version --language generic -o)
@@ -44,9 +46,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Repository Dispatch
         run: pulumictl dispatch -r pulumi/templates -c update-templates $(pulumictl get version --language generic -o)
   examples_smoke_test:
@@ -57,9 +61,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Repository Dispatch
         run: |
           pulumictl dispatch -r pulumi/examples -c smoke-test-cli $(pulumictl get version --language generic -o)
@@ -73,9 +79,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Repository Dispatch
         run: |
           pulumictl create choco-deploy $(pulumictl get version --language generic -o)
@@ -89,9 +97,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Repository Dispatch
         run: |
           pulumictl winget-deploy
@@ -105,9 +115,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Repository Dispatch
         run: |
           pulumictl create cli-docs-build $(pulumictl get version --language generic -o)
@@ -121,9 +133,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Repository Dispatch
         run: |
           pulumictl create homebrew-bump $(pulumictl get version --language generic -o) ${{ github.sha }}
@@ -185,9 +199,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -305,9 +321,11 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Ensure
         run: |
           make ensure
@@ -363,9 +381,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Fetch Tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -97,7 +97,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -115,7 +115,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -133,7 +133,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -199,7 +199,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -321,7 +321,7 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -381,7 +381,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -149,9 +149,11 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Ensure
         run: |
           make ensure

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -55,9 +55,11 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Check out source code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31

--- a/.github/workflows/run-docs-generation.yml
+++ b/.github/workflows/run-docs-generation.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31

--- a/.github/workflows/run-docs-generation.yml
+++ b/.github/workflows/run-docs-generation.yml
@@ -58,9 +58,11 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Check out source code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -193,19 +193,23 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Install gotestsum
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: gotestyourself/gotestsum
           tag: v1.7.0
+          cache: enable
       - name: Install goteststats
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7
+          cache: enable
       - name: Download Pulumi Go Binaries (linux-x64)
         if: ${{ inputs.platform == 'ubuntu-latest' }}
         uses: actions/download-artifact@v2

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -193,19 +193,19 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
           cache: enable
       - name: Install gotestsum
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: gotestyourself/gotestsum
-          tag: v1.7.0
+          tag: v1.8.1
           cache: enable
       - name: Install goteststats
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
           tag: v0.0.31
@@ -223,9 +223,9 @@ jobs:
         uses: aaronfriel/action-install-gh-release@v1.4.0-beta.4
         with:
           repo: gotestyourself/gotestsum
-          tag: v1.7.0
+          tag: v1.8.1
       - name: Install goteststats
-        uses: jaxxstorm/action-install-gh-release@v1.7.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,19 +214,22 @@ jobs:
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname $(pwd))" >> $GITHUB_ENV
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: pulumi/pulumictl
+          tag: v0.0.31
+          cache: enable
       - name: Install gotestsum
         uses: aaronfriel/action-install-gh-release@v1.4.0-beta.4
         with:
           repo: gotestyourself/gotestsum
           tag: v1.7.0
       - name: Install goteststats
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        uses: jaxxstorm/action-install-gh-release@v1.7.0
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7
+          cache: enable
       - name: Download Pulumi Go Binaries (linux-x64)
         if: ${{ inputs.platform == 'ubuntu-latest' }}
         uses: actions/download-artifact@v2


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Uses the new facility in jaxxstorm/action-install-gh-release to cache the tools (has to pin them to cache). Aimed at avoiding ratelimit issues.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
