### PR TITLE
reenable commented tests from 3.33.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
 
   publish-binaries:
     name: Publish Binaries
-    needs: [lint, build]
+    needs: [lint, build, test-linux, test-macos, test-windows]
     uses: pulumi/pulumi/.github/workflows/publish-binaries.yml@master
     with:
       goreleaser-config: '.goreleaser.yml'
@@ -330,33 +330,33 @@ jobs:
       enable-coverage: false
       goreleaser-config: '.goreleaser.yml'
       goreleaser-flags: '-p 3 --release-notes=CHANGELOG_PENDING.md --skip-publish --skip-announce --skip-validate'
-  # test-linux:
-  #   name: Test Linux
-  #   needs: build
-  #   uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
-  #   with:
-  #     enable-coverage: false
-  #     platform: ubuntu-latest
-  #   secrets:
-  #     pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
-  # test-macos:
-  #   name: Test MacOS
-  #   needs: build
-  #   uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
-  #   with:
-  #     enable-coverage: false
-  #     platform: macos-latest
-  #   secrets:
-  #     pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
-  # test-windows:
-  #   name: Test Windows
-  #   needs: build
-  #   uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
-  #   with:
-  #     enable-coverage: false
-  #     platform: windows-latest
-  #   secrets:
-  #     pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-linux:
+    name: Test Linux
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: false
+      platform: ubuntu-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-macos:
+    name: Test MacOS
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: false
+      platform: macos-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  test-windows:
+    name: Test Windows
+    needs: build
+    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    with:
+      enable-coverage: false
+      platform: windows-latest
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   dispatch-docker-containers-release-build:
     name: Dispatch Docker containers release build
     needs: [publish-binaries, publish-sdks]


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9636 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
