### PR TITLE
added confirmation string to `pulumi logout`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- [cli] `pulumi logout` now prints a confirmation message that it logged out.
+  [#9641](https://github.com/pulumi/pulumi/pull/9641)
+
 ### Bug Fixes

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -74,6 +74,7 @@ func newLogoutCmd() *cobra.Command {
 			var be backend.Backend
 			var err error
 			if filestate.IsFileStateBackendURL(cloudURL) {
+				fmt.Printf("Logged out of %s\n", cloudURL)
 				return workspace.DeleteAccount(cloudURL)
 			}
 
@@ -88,6 +89,7 @@ func newLogoutCmd() *cobra.Command {
 			} else {
 				logoutErr = be.Logout()
 			}
+			fmt.Printf("Logged out of %s\n", be.URL())
 			return logoutErr
 		}),
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Adds a confirmation string to `pulumi logout` to add more clarity/confidence in the state after the command exits.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9450 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
