### PR TITLE
[codegen/nodejs] fix invalid 'import * from' branch in codegen

### DIFF
--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -303,11 +303,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 			continue
 		}
 		as := makeValidIdentifier(path.Base(pkg))
-		if as != pkg || pkg == "crypto" {
-			imports = append(imports, fmt.Sprintf("import * as %v from \"%v\";", as, pkg))
-		} else {
-			imports = append(imports, fmt.Sprintf("import * from \"%v\";", pkg))
-		}
+		imports = append(imports, fmt.Sprintf("import * as %v from \"%v\";", as, pkg))
 	}
 	sort.Strings(imports)
 

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
@@ -1,6 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import * from "fs";
+import * as fs from "fs";
 
 // Create a bucket and expose a website index document
 const siteBucket = new aws.s3.Bucket("siteBucket", {website: {


### PR DESCRIPTION
The `import * from ...` path wasn't exercised except in one test where it was invalid. TC-39 has not specified a meaning for that syntax: [Import forms mappings](https://tc39.es/ecma262/#_ref_488)

Rather than add an additional special case for the `fs` module, I've removed the conditional and regenerated our local codegen. This fixes a bug encountered while implementing `pulumi convert` for YAML feature pulumi/pulumi-yaml#200.