### PR TITLE
more confident CLI strings

### DIFF
--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -140,7 +140,7 @@ func newStackImportCmd() *cobra.Command {
 			if err = s.ImportDeployment(commandContext(), &dep); err != nil {
 				return fmt.Errorf("could not import deployment: %w", err)
 			}
-			fmt.Printf("Import successful.\n")
+			fmt.Printf("Import complete.\n")
 			return nil
 		}),
 	}

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -86,7 +86,7 @@ pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 					return res
 				}
 			}
-			fmt.Println("Resource deleted successfully")
+			fmt.Println("Resource deleted")
 			return nil
 		}),
 	}

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -111,7 +111,7 @@ pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 				return res
 			}
 
-			fmt.Println("Resource renamed successfully")
+			fmt.Println("Resource renamed")
 			return nil
 		}),
 	}

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -85,7 +85,7 @@ func unprotectAllResources(stackName string, showPrompt bool) result.Result {
 	if res != nil {
 		return res
 	}
-	fmt.Println("All resources successfully unprotected")
+	fmt.Println("All resources unprotected")
 	return nil
 }
 
@@ -94,6 +94,6 @@ func unprotectResource(stackName string, urn resource.URN, showPrompt bool) resu
 	if res != nil {
 		return res
 	}
-	fmt.Println("Resource successfully unprotected")
+	fmt.Println("Resource unprotected")
 	return nil
 }

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -203,7 +203,7 @@ func installPlugin(plugin workspace.PluginInfo) error {
 
 	}
 
-	logging.V(7).Infof("installPlugin(%s, %s): successfully installed", plugin.Name, plugin.Version)
+	logging.V(7).Infof("installPlugin(%s, %s): installed", plugin.Name, plugin.Version)
 	return nil
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Ideation on making the CLI more confident.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9643 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
