### PR TITLE
[codegen] Potpourri of codegen improvements for `pulumi convert`

### DIFF
--- a/pkg/codegen/dotnet/test.go
+++ b/pkg/codegen/dotnet/test.go
@@ -61,6 +61,14 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKP
 		err = os.RemoveAll(filepath.Join(dir, "obj"))
 		assert.NoError(t, err, "Failed to remove obj result")
 	}()
+	TypeCheck(t, path, dependencies, pulumiSDKPath)
+}
+
+func TypeCheck(t *testing.T, path string, dependencies codegen.StringSet, pulumiSDKPath string) {
+	var err error
+	dir := filepath.Dir(path)
+
+	ex, err := executable.FindExecutable("dotnet")
 	err = integration.RunCommand(t, "dotnet build",
 		[]string{ex, "build", "--nologo"}, dir, &integration.ProgramTestOptions{})
 	require.NoError(t, err, "Failed to build dotnet project")

--- a/pkg/codegen/dotnet/test.go
+++ b/pkg/codegen/dotnet/test.go
@@ -69,6 +69,8 @@ func TypeCheck(t *testing.T, path string, dependencies codegen.StringSet, pulumi
 	dir := filepath.Dir(path)
 
 	ex, err := executable.FindExecutable("dotnet")
+	require.NoError(t, err)
+
 	err = integration.RunCommand(t, "dotnet build",
 		[]string{ex, "build", "--nologo"}, dir, &integration.ProgramTestOptions{})
 	require.NoError(t, err, "Failed to build dotnet project")

--- a/pkg/codegen/go/test.go
+++ b/pkg/codegen/go/test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/executable"
 )
 
-func Check(t *testing.T, path string, _ codegen.StringSet, pulumiSDKPath string) {
+func Check(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath string) {
 	dir := filepath.Dir(path)
 	ex, err := executable.FindExecutable("go")
 	require.NoError(t, err)
@@ -41,6 +41,13 @@ func Check(t *testing.T, path string, _ codegen.StringSet, pulumiSDKPath string)
 			dir, &integration.ProgramTestOptions{})
 		require.NoError(t, err)
 	}
+	TypeCheck(t, path, deps, pulumiSDKPath)
+}
+
+func TypeCheck(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath string) {
+	dir := filepath.Dir(path)
+	ex, err := executable.FindExecutable("go")
+
 	err = integration.RunCommand(t, "go tidy after replace",
 		[]string{ex, "mod", "tidy"},
 		dir, &integration.ProgramTestOptions{})

--- a/pkg/codegen/go/test.go
+++ b/pkg/codegen/go/test.go
@@ -47,6 +47,7 @@ func Check(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath stri
 func TypeCheck(t *testing.T, path string, deps codegen.StringSet, pulumiSDKPath string) {
 	dir := filepath.Dir(path)
 	ex, err := executable.FindExecutable("go")
+	require.NoError(t, err)
 
 	err = integration.RunCommand(t, "go tidy after replace",
 		[]string{ex, "mod", "tidy"},

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -163,7 +163,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 	// For each package add a dependency line
 	packages := program.Packages()
 	for _, p := range packages {
-		if err := p.ImportLanguages(map[string]schema.Language{"go": Importer}); err != nil {
+		if err := p.ImportLanguages(map[string]schema.Language{"nodejs": Importer}); err != nil {
 			return err
 		}
 

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -158,6 +158,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 			"@types/node": "^14"
 		},
 		"dependencies": {
+			"typescript": "^4.0.0",
 			"@pulumi/pulumi": "^3.0.0"`, project.Name.String()))
 	// For each package add a dependency line
 	packages := program.Packages()

--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -54,6 +54,12 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, linkLocal 
 	err = os.WriteFile(filepath.Join(dir, "tsconfig.json"), tsConfigJSON, 0600)
 	require.NoError(t, err)
 
+	typeCheckGeneratedPackage(t, path, linkLocal)
+}
+
+func TypeCheck(t *testing.T, path string, dependencies codegen.StringSet, linkLocal bool) {
+	dir := filepath.Dir(path)
+
 	typeCheckGeneratedPackage(t, dir, linkLocal)
 }
 

--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -54,10 +54,10 @@ func Check(t *testing.T, path string, dependencies codegen.StringSet, linkLocal 
 	err = os.WriteFile(filepath.Join(dir, "tsconfig.json"), tsConfigJSON, 0600)
 	require.NoError(t, err)
 
-	typeCheckGeneratedPackage(t, path, linkLocal)
+	TypeCheck(t, path, dependencies, linkLocal)
 }
 
-func TypeCheck(t *testing.T, path string, dependencies codegen.StringSet, linkLocal bool) {
+func TypeCheck(t *testing.T, path string, _ codegen.StringSet, linkLocal bool) {
 	dir := filepath.Dir(path)
 
 	typeCheckGeneratedPackage(t, dir, linkLocal)

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -93,7 +93,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 	// For each package add a PackageReference line
 	packages := program.Packages()
 	for _, p := range packages {
-		if err := p.ImportLanguages(map[string]schema.Language{"go": Importer}); err != nil {
+		if err := p.ImportLanguages(map[string]schema.Language{"python": Importer}); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
* [codegen] Fix ImportLanguages map usage in python, nodejs
* [codegen] Add typescript dependency to packages during convert
* [testing] Add non-destructive TypeCheck operations for pulumi convert testing

These are used in:
- pulumi/pulumi-yaml#195