### PR TITLE
Fix Python Dynamic provider test failures: simplify test, remove capture of global variable

### DIFF
--- a/tests/integration/enums/python/__main__.py
+++ b/tests/integration/enums/python/__main__.py
@@ -14,15 +14,9 @@ class Farm(str, Enum):
     PLANTS_R_US = "Plants'R'Us"
     PULUMI_PLANTERS_INC = "Pulumi Planters Inc."
 
-
-current_id = 0
-
-
 class PlantProvider(ResourceProvider):
     def create(self, inputs):
-        global current_id
-        current_id += 1
-        return CreateResult(str(current_id), inputs)
+        return CreateResult("plant", inputs)
 
 
 class Tree(Resource):


### PR DESCRIPTION
Fixes #9652 

Having bisected our repo and then diffed CI logs, I found that the culprit of the test failures was a change in behavior in the `dill` library used to serialize dynamic providers in Python. I believe the issue is that a change in `dill` enabled capturing of closures, and this results in non-reproducible serialization of the provider.

I looked at three options for this:

1. Set an upper bound on `dill`. This did cause tests to pass locally, but it also meant opting out of ongoing security and bug fixes from the library until we could solve the non-determinism.

2. Fix the test so that it does not rely on capturing a global variable. This narrows the coverage of the test case, but it also more closely aligns with our docs on dynamic providers.

3. Update provider serialization (we have a wrapper called `serialize_provider`) and/or dill. This seemed to require deep knowledge of Python internals.

Of these, (2.) seemed like the best option. Serialization of objects in Python has a [history of challenges (link to MITRE CVE database search for pickle)](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=pickle) and with our current resources, it's better & safer for us to track upstream dependencies.

If and when `dill` changes again, we might want to re-examine the library we use for dynamic provider serialization. I've created an issue upstream to ask for help to figure out how we might get to a **reproducible** result here:
- https://github.com/uqfoundation/dill/issues/481