### PR TITLE
Fix non-determinism in Python dynamic provider serialization

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,6 @@
   [#9641](https://github.com/pulumi/pulumi/pull/9641)
 
 ### Bug Fixes
+
+- [sdk/python] Fix spurious diffs causing an "update" on resources created by dynamic providers.
+  [#9656](https://github.com/pulumi/pulumi/pull/9656)

--- a/tests/integration/enums/python/__main__.py
+++ b/tests/integration/enums/python/__main__.py
@@ -14,9 +14,15 @@ class Farm(str, Enum):
     PLANTS_R_US = "Plants'R'Us"
     PULUMI_PLANTERS_INC = "Pulumi Planters Inc."
 
+
+current_id = 0
+
+
 class PlantProvider(ResourceProvider):
     def create(self, inputs):
-        return CreateResult("plant", inputs)
+        global current_id
+        current_id += 1
+        return CreateResult(str(current_id), inputs)
 
 
 class Tree(Resource):


### PR DESCRIPTION
See:
- #9652
- #9653

Where this PR differs from #9653 is thanks to a suggestion on the upstream report to the `dill` package:

https://github.com/uqfoundation/dill/issues/481#issuecomment-1133789848

> I think a solution that will not require me rushing to get this to work but will not break compatibility with other versions of dill or your library, is to overwrite `pickle.Pickler. _batch_setitems` to sort the items.
> 
> ```python
>     unsorted_batch_setitems = pickle.Pickler._batch_setitems
> 
>     def _batch_setitems(self, items):
>         unsorted_batch_setitems(sorted(items))
> 
>     pickle.Pickler._batch_setitems = _batch_setitems
> ```
> 
> I hope this is able to fix the problem in pulumi's case while I work on the more general `deterministic` flag.

Thank you to @anivegesana, as this appears to resolve the issue for both failing tests.

Fixes #9652