### PR TITLE
Fix eager loading of inflight context

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 - [cli] `pulumi logout` now prints a confirmation message that it logged out.
   [#9641](https://github.com/pulumi/pulumi/pull/9641)
 
+- [sdk/nodejs] Lazy load inflight context to remove module import side-effect [#9375](https://github.com/pulumi/pulumi/issues/9375)
+
 ### Bug Fixes
 
 - [sdk/python] Fix spurious diffs causing an "update" on resources created by dynamic providers.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Remove secondary source of eager caching on module load to fix provider warnings about accessing the inspector object. Load and cache on first use instead.

Fixes #9375 

Follow up to #9614 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
