### PR TITLE
Tidy Nodejs SDK imports

### DIFF
--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -816,8 +816,6 @@ const execKind = {
 
 type StackInitMode = "create" | "select" | "createOrSelect";
 
-const delay = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
-
 const createLogFile = (command: string) => {
     const logDir = fs.mkdtempSync(upath.joinSafe(os.tmpdir(), `automation-logs-${command}-`));
     const logFile = upath.joinSafe(logDir, "eventlog.txt");

--- a/sdk/nodejs/automation/stackSettings.ts
+++ b/sdk/nodejs/automation/stackSettings.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as yaml from "js-yaml";
-
 /**
  * A description of the Stack's configuration and encryption metadata.
  */

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as minimist from "minimist";
-import * as path from "path";
-
 import * as grpc from "@grpc/grpc-js";
 
 import * as dynamic from "../../dynamic";
-import * as resource from "../../resource";
 import * as runtime from "../../runtime";
 import { version } from "../../version";
 

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -361,9 +361,7 @@ export async function main(args: string[]) {
     if (args.length === 0) {
         console.error("fatal: Missing <engine> address");
         process.exit(-1);
-        return;
     }
-    const engineAddr: string = args[0];
 
     // Finally connect up the gRPC client/server and listen for incoming requests.
     const server = new grpc.Server({

--- a/sdk/nodejs/config.ts
+++ b/sdk/nodejs/config.ts
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 import { RunError } from "./errors";
-import * as log from "./log";
 import { getProject } from "./metadata";
 import { Output } from "./output";
-import { getConfig, isConfigSecret } from "./runtime";
+import { getConfig } from "./runtime";
 
 function makeSecret<T>(value: T): Output<T> {
     return new Output(

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -17,7 +17,6 @@
         "js-yaml": "^3.14.0",
         "minimist": "^1.2.6",
         "normalize-package-data": "^2.4.0",
-        "protobufjs": "^6.8.6",
         "read-package-tree": "^5.3.1",
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",
@@ -52,7 +51,10 @@
         "node": ">=8.13.0 || >=10.10.0"
     },
     "mocha": {
-        "require": ["ts-node/register", "source-map-support/register"]
+        "require": [
+            "ts-node/register",
+            "source-map-support/register"
+        ]
     },
     "//": [
         "NOTE: @types/node is pinned due to grpc/grpc-node#2002"

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -14,7 +14,6 @@
 
 import { Input, Inputs } from "../output";
 import * as resource from "../resource";
-import * as runtime from "../runtime";
 
 /**
  * CheckResult represents the results of a call to `ResourceProvider.check`.

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -658,7 +658,7 @@ export async function main(provider: Provider, args: string[]) {
  * otherwise return an instance of DependencyProviderResource.
  */
 function createProviderResource(ref: string): resource.ProviderResource {
-    const [urn, _] = resource.parseResourceReference(ref);
+    const [urn] = resource.parseResourceReference(ref);
     const urnParts = urn.split("::");
     const qualifiedType = urnParts[2];
     const urnName = urnParts[3];

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as minimist from "minimist";
-import * as path from "path";
-
 import * as grpc from "@grpc/grpc-js";
 
 import { Provider } from "./provider";
@@ -23,10 +20,8 @@ import * as log from "../log";
 import { Inputs, Output, output } from "../output";
 import * as resource from "../resource";
 import * as runtime from "../runtime";
-import { version } from "../version";
 import { parseArgs } from "./internals";
 
-const requireFromString = require("require-from-string");
 const anyproto = require("google-protobuf/google/protobuf/any_pb.js");
 const emptyproto = require("google-protobuf/google/protobuf/empty_pb.js");
 const structproto = require("google-protobuf/google/protobuf/struct_pb.js");

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1292,10 +1292,6 @@ async function getOrCreateEntryAsync(
     }
 }
 
-async function isOutputAsync(obj: any): Promise<boolean> {
-    return Output.isInstance(obj);
-}
-
 // Is this a constructor derived from a noCapture constructor.  if so, we don't want to
 // emit it.  We would be unable to actually hook up the "super()" call as one of the base
 // constructors was set to not be captured.

--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -461,13 +461,11 @@ function serializeJavaScriptText(
             // Walk the names of the array properties directly. This ensures we work efficiently
             // with sparse arrays.  i.e. if the array has length 1k, but only has one value in it
             // set, we can just set htat value, instead of setting 999 undefineds.
-            let length = 0;
             for (const key of Object.getOwnPropertyNames(arr)) {
                 if (key !== "length") {
                     const entryString = envEntryToString(arr[<any>key], `${varName}_${key}`);
                     environmentText += `${envVar}${
                         isNumeric(key) ? `[${key}]` : `.${key}`} = ${entryString};\n`;
-                    length++;
                 }
             }
         }

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -305,7 +305,7 @@ export function call<T>(tok: string, props: Inputs, res?: Resource): Output<T> {
             const rpcDeps = resp.getReturndependenciesMap();
             if (rpcDeps) {
                 const urns = new Set<string>();
-                for (const [k, returnDeps] of rpcDeps.entries()) {
+                for (const [, returnDeps] of rpcDeps.entries()) {
                     for (const urn of returnDeps.getUrnsList()) {
                         urns.add(urn);
                     }

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -13,12 +13,9 @@
 // limitations under the License.
 
 import * as grpc from "@grpc/grpc-js";
-import * as fs from "fs";
 
 import { AsyncIterable } from "@pulumi/query/interfaces";
 
-import * as asset from "../asset";
-import { Config } from "../config";
 import { InvokeOptions } from "../invoke";
 import * as log from "../log";
 import { Inputs, Output } from "../output";

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -49,7 +49,6 @@ import {
 import {
     excessiveDebugOutput,
     getMonitor,
-    getProject,
     getRootResource,
     getStack,
     isDryRun,
@@ -60,7 +59,6 @@ import {
 } from "./settings";
 
 const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
-const providerproto = require("../proto/provider_pb.js");
 const resproto = require("../proto/resource_pb.js");
 
 interface ResourceResolverOperation {

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -16,15 +16,13 @@ import * as asset from "../asset";
 import { isGrpcError } from "../errors";
 import * as log from "../log";
 import { getAllResources, Input, Inputs, isUnknown, Output, unknown } from "../output";
-import { ComponentResource, CustomResource, DependencyResource, ProviderResource, Resource, URN } from "../resource";
-import { debuggablePromise, errorString, promiseDebugString } from "./debuggable";
+import { ComponentResource, CustomResource, DependencyResource, ProviderResource, Resource } from "../resource";
+import { debuggablePromise, errorString } from "./debuggable";
 import { excessiveDebugOutput, isDryRun, monitorSupportsOutputValues, monitorSupportsResourceReferences,
     monitorSupportsSecrets } from "./settings";
 import { getAllTransitivelyReferencedResourceURNs } from "./resource";
 
 import * as semver from "semver";
-
-const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
 
 export type OutputResolvers = Record<string, (value: any, isStable: boolean, isSecret: boolean, deps?: Resource[], err?: Error) => void>;
 

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -20,10 +20,8 @@ import { debuggablePromise } from "./debuggable";
 
 const engrpc = require("../proto/engine_grpc_pb.js");
 const engproto = require("../proto/engine_pb.js");
-const provproto = require("../proto/provider_pb.js");
 const resrpc = require("../proto/resource_grpc_pb.js");
 const resproto = require("../proto/resource_pb.js");
-const structproto = require("google-protobuf/google/protobuf/struct_pb.js");
 
 // maxRPCMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
 export const maxRPCMessageSize: number = 1024 * 1024 * 400;

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -14,7 +14,7 @@
 
 import * as asset from "../asset";
 import { getProject, getStack } from "../metadata";
-import { Inputs, Output, output, secret } from "../output";
+import { Inputs, Output, output } from "../output";
 import { ComponentResource, Resource, ResourceTransformation } from "../resource";
 import { getRootResource, isDryRun, isQueryMode, setRootResource } from "./settings";
 

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -131,13 +131,6 @@ export class StackReference extends CustomResource {
     }
 }
 
-// Shape of the result that the engine returns to us when we invoke 'pulumi:pulumi:readStackOutputs'
-interface ReadStackOutputsResult {
-    name: string;
-    outputs: Record<string, any>;
-    secretOutputNames: string[];
-}
-
 /**
  * The set of arguments for constructing a StackReference resource.
  */

--- a/sdk/nodejs/tests/resource.spec.ts
+++ b/sdk/nodejs/tests/resource.spec.ts
@@ -15,7 +15,7 @@
 /* eslint-disable */
 
 import * as assert from "assert";
-import { Output, all, concat, interpolate, output } from "../output";
+import { all } from "../output";
 import * as runtime from "../runtime";
 import { asyncTest } from "./util";
 import { allAliases, createUrn, ComponentResource, CustomResourceOptions, DependencyProviderResource } from "../resource";

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -14,7 +14,6 @@
 
 import * as assert from "assert";
 import * as childProcess from "child_process";
-import * as os from "os";
 import * as path from "path";
 import { ID, runtime, URN } from "../../../index";
 import { asyncTest } from "../../util";

--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { InvokeOptions } from "./invoke";
-
 /**
  * Common code for doing RTTI typechecks.  RTTI is done by having a boolean property on an object
  * with a special name (like "__resource" or "__asset").  This function checks that the object


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Quick bit of housekeeping to remove dead code from the nodejs SDK.

Mostly found issues by running `yarn tsc --noUnusedLocals` which can't be enabled as an option yet because some tests rely on unused code.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
