### PR TITLE
Don't add children of remote componet resources

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,3 +13,6 @@
 
 - [sdk/python] Fix spurious diffs causing an "update" on resources created by dynamic providers.
   [#9656](https://github.com/pulumi/pulumi/pull/9656)
+
+- [sdk/python] Do not depend on the children of remote component resources.
+  [#9665](https://github.com/pulumi/pulumi/pull/9665)

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -799,11 +799,10 @@ async def _add_dependency(
 
     from .. import ComponentResource  # pylint: disable=import-outside-toplevel
 
-    if isinstance(res, ComponentResource):
+    if isinstance(res, ComponentResource) and not res._remote:
         for child in res._childResources:
             await _add_dependency(deps, child, from_resource)
-        if not res._remote:
-            return
+        return
 
     no_cycles = declare_dependency(from_resource, res) if from_resource else True
     if no_cycles:

--- a/sdk/python/lib/test/langhost/remote_component_dependencies/__init__.py
+++ b/sdk/python/lib/test/langhost/remote_component_dependencies/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/remote_component_dependencies/__main__.py
+++ b/sdk/python/lib/test/langhost/remote_component_dependencies/__main__.py
@@ -1,0 +1,45 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+from pulumi import ComponentResource, CustomResource, Output, ResourceOptions
+
+
+class MyResource(CustomResource):
+    def __init__(self, name, args, opts=None):
+        CustomResource.__init__(
+            self,
+            "test:index:MyResource",
+            name,
+            props={
+                **args,
+                "outprop": None,
+            },
+            opts=opts,
+        )
+
+
+class MyComponent(ComponentResource):
+    def __init__(self, name, opts=None):
+        ComponentResource.__init__(
+            self,
+            "test:index:MyComponent",
+            name,
+            opts=opts,
+            remote=True,
+        )
+
+
+resA = MyComponent("resA")
+resB = MyResource("resB", {"propA": resA})
+resC = MyResource("resC", {"propB": resB}, ResourceOptions(parent=resA))

--- a/sdk/python/lib/test/langhost/remote_component_dependencies/test_remote_component_dependencies.py
+++ b/sdk/python/lib/test/langhost/remote_component_dependencies/test_remote_component_dependencies.py
@@ -1,0 +1,62 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+import unittest
+from ..util import LanghostTest
+
+
+class RemoteComponentDependenciesTest(LanghostTest):
+    def test_remote_component_dependencies(self):
+        self.run_test(
+            program=path.join(self.base_path(), "remote_component_dependencies"),
+            expected_resource_count=3,
+        )
+
+    def register_resource(
+        self,
+        _ctx,
+        _dry_run,
+        ty,
+        name,
+        _resource,
+        _dependencies,
+        _parent,
+        _custom,
+        protect,
+        _provider,
+        _property_deps,
+        _delete_before_replace,
+        _ignore_changes,
+        _version,
+        _import,
+        _replace_on_changes,
+    ):
+
+        if name == "resA":
+            self.assertEqual(len(_dependencies), 0, "resA dependencies")
+        elif name == "resB":
+            self.assertEqual(len(_dependencies), 1, "resB dependencies")
+        elif name == "resC":
+            self.assertEqual(len(_dependencies), 1, "resC dependencies")
+            self.assertEqual(_parent, "resA", "resC parent")
+        else:
+            assert False
+
+        return {
+            "urn": name,
+            "id": name,
+            "object": {
+                "outprop": "qux",
+            },
+        }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9071

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
