### PR TITLE
[schema] Make PartialPackage concurrency-safe

### DIFF
--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -141,10 +141,7 @@ func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Packag
 }
 
 func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version) (PackageReference, error) {
-	key := pkg + "@"
-	if version != nil {
-		key += version.String()
-	}
+	key := packageIdentity(pkg, version)
 
 	if p, ok := l.getPackage(key); ok {
 		return p, nil

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -516,7 +516,7 @@ func (p *PartialPackage) Snapshot() (*Package, error) {
 
 	// NOTE: these writes are very much not concurrency-safe. There is a data race on each write to a slice-typed field
 	// because slices are multi-word values. Unfortunately, fixing this is rather involved. The simplest solution--
-	// returning a copy of p.types.pkg--breaks pacakge membership tests that use pointer equality (e.g. if the result
+	// returning a copy of p.types.pkg--breaks package membership tests that use pointer equality (e.g. if the result
 	// of Snapshot() is in a variable named `pkg`, `pkg.Resources[0].Package == pkg` will evaluate to `false`). It is
 	// likely that we will need to make a breaking change in order to fix this.
 	//

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -838,6 +838,24 @@ func (pkg *Package) ImportLanguages(languages map[string]Language) error {
 	return nil
 }
 
+func packageIdentity(name string, version *semver.Version) string {
+	// The package's identity is its name and version (if any) separated buy a ':'. The ':' character is not allowed
+	// in package names and so is safe to use as a separator.
+	id := name + ":"
+	if version != nil {
+		return id + version.String()
+	}
+	return id
+}
+
+func (pkg *Package) Identity() string {
+	return packageIdentity(pkg.Name, pkg.Version)
+}
+
+func (pkg *Package) Equals(other *Package) bool {
+	return pkg == other || pkg.Identity() == other.Identity()
+}
+
 var defaultModuleFormat = regexp.MustCompile("(.*)")
 
 func (pkg *Package) TokenToModule(tok string) string {

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -657,6 +657,8 @@ func TestTypeString(t *testing.T) {
 }
 
 func TestPackageIdentity(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		nameA    string
 		versionA string

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -655,3 +655,92 @@ func TestTypeString(t *testing.T) {
 		})
 	}
 }
+
+func TestPackageIdentity(t *testing.T) {
+	cases := []struct {
+		nameA    string
+		versionA string
+		nameB    string
+		versionB string
+		equal    bool
+	}{
+		{
+			nameA: "example",
+			nameB: "example",
+			equal: true,
+		},
+		{
+			nameA:    "example",
+			versionA: "1.0.0",
+			nameB:    "example",
+			versionB: "1.0.0",
+			equal:    true,
+		},
+		{
+			nameA:    "example",
+			versionA: "1.2.3-beta",
+			nameB:    "example",
+			versionB: "1.2.3-beta",
+			equal:    true,
+		},
+		{
+			nameA:    "example",
+			versionA: "1.2.3-beta+1234",
+			nameB:    "example",
+			versionB: "1.2.3-beta+1234",
+			equal:    true,
+		},
+		{
+			nameA:    "example",
+			versionA: "1.0.0",
+			nameB:    "example",
+		},
+		{
+			nameA:    "example",
+			nameB:    "example",
+			versionB: "1.0.0",
+		},
+		{
+			nameA:    "example",
+			versionA: "1.0.0",
+			nameB:    "example",
+			versionB: "1.2.3-beta",
+		},
+		{
+			nameA:    "example",
+			versionA: "1.2.3-beta+1234",
+			nameB:    "example",
+			versionB: "1.2.3-beta+5678",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.nameA, func(t *testing.T) {
+			t.Parallel()
+
+			var verA *semver.Version
+			if c.versionA != "" {
+				v := semver.MustParse(c.versionA)
+				verA = &v
+			}
+
+			var verB *semver.Version
+			if c.versionB != "" {
+				v := semver.MustParse(c.versionB)
+				verB = &v
+			}
+
+			pkgA := &Package{Name: c.nameA, Version: verA}
+			pkgB := &Package{Name: c.nameB, Version: verB}
+			if c.equal {
+				assert.Equal(t, packageIdentity(c.nameA, verA), packageIdentity(c.nameB, verB))
+				assert.Equal(t, pkgA.Identity(), pkgB.Identity())
+				assert.True(t, pkgA.Equals(pkgB))
+			} else {
+				assert.NotEqual(t, packageIdentity(c.nameA, verA), packageIdentity(c.nameB, verB))
+				assert.NotEqual(t, pkgA.Identity(), pkgB.Identity())
+				assert.False(t, pkgA.Equals(pkgB))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change is composed of two pieces: one to guard access to the binding
operations and their results using a mutex, and one to make the result of
PartialPackage.Snapshot safe to use concurrently.

The former set of changes is pretty straighforward, and just involves
adding a mutex and appropriate locking/unlocking around binding operations
and reads/writes from/to PartialPackage.def.

The latter change is a bit riskier. The result of PartialPackage.Snapshot
is a *Package. Prior to these changes, multiple calls to Snapshot would
return a pointer to the same Package value after updating its fields.
Becuase the *Package API is field-based instead of method-based, there is
no way to make the update itself concurrency-safe, as there's nowhere to
add locking, and it is not possible to atomically update some of the
fields that are being updated (e.g. slice-typed fields). After these
changes, each call to Snapshot will return a new copy of the package.
By far the riskiest part of this change is that pointer equality can no
longer be used with the result of Snapshot to determine whether or not
two *Package values are the same. To facilitate proper equality
comparison, these changes add Equals() and Identity() methods to the
*Package API. The former compares two *Packages; the latter returns a
stringified version of the *Package's name and version that can be used
as a map key.

Fixes #9667.