### PR TITLE
Fix default handling for schema.UnionType.String

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,16 +195,14 @@ type UnionType struct {
 }
 
 func (t *UnionType) String() string {
-	elements := make([]string, len(t.ElementTypes)+1)
+	elements := make([]string, len(t.ElementTypes))
 	for i, e := range t.ElementTypes {
 		elements[i] = e.String()
 	}
 
-	def := "default="
 	if t.DefaultType != nil {
-		def += t.DefaultType.String()
+		elements = append(elements, "default="+t.DefaultType.String())
 	}
-	elements[len(elements)-1] = def
 
 	return fmt.Sprintf("Union<%v>", strings.Join(elements, ", "))
 }

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -619,3 +619,37 @@ func TestValidateTypeToken(t *testing.T) {
 		})
 	}
 }
+
+func TestTypeString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input  Type
+		output string
+	}{
+		{
+			input: &UnionType{
+				ElementTypes: []Type{
+					StringType,
+					NumberType,
+				},
+			},
+			output: "Union<string, number>",
+		},
+		{
+			input: &UnionType{
+				ElementTypes: []Type{
+					StringType,
+				},
+				DefaultType: NumberType,
+			},
+			output: "Union<string, default=number>",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.output, func(t *testing.T) {
+			assert.Equal(t, c.output, c.input.String())
+		})
+	}
+}

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -648,7 +648,9 @@ func TestTypeString(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c := c
 		t.Run(c.output, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, c.output, c.input.String())
 		})
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Makes the stringified form of `schema.UnionType` slightly nicer. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
