### PR TITLE
Stop using Get/SetRootResource in nodejs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,9 @@
 - [sdk/nodejs] Lazy load inflight context to remove module import side-effect.
   [#9375](https://github.com/pulumi/pulumi/issues/9375)
 
+- [nodejs] No longer roundtrips requests for the stack URN via the engine.
+  [#9559](https://github.com/pulumi/pulumi/pull/9559)
+
 ### Bug Fixes
 
 - [sdk/python] Fix spurious diffs causing an "update" on resources created by dynamic providers.

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -49,8 +49,6 @@ import {
 import {
     excessiveDebugOutput,
     getMonitor,
-    getProject,
-    getRootResource,
     getStack,
     isDryRun,
     isLegacyApplyEnabled,
@@ -58,9 +56,9 @@ import {
     serialize,
     terminateRpcs,
 } from "./settings";
+import { getStackResource } from "./stack";
 
 const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
-const providerproto = require("../proto/provider_pb.js");
 const resproto = require("../proto/resource_pb.js");
 
 interface ResourceResolverOperation {
@@ -521,9 +519,8 @@ async function prepareResource(label: string, res: Resource, custom: boolean, re
 
         // Wait for the parent to complete.
         // If no parent was provided, parent to the root resource.
-        const parentURN = opts.parent
-            ? await opts.parent.urn.promise()
-            : await getRootResource();
+        const parent = opts.parent ?? getStackResource();
+        const parentURN = parent ? await parent.urn.promise() : undefined;
 
         let providerRef: string | undefined;
         let importID: ID | undefined;

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -20,10 +20,8 @@ import { debuggablePromise } from "./debuggable";
 
 const engrpc = require("../proto/engine_grpc_pb.js");
 const engproto = require("../proto/engine_pb.js");
-const provproto = require("../proto/provider_pb.js");
 const resrpc = require("../proto/resource_grpc_pb.js");
 const resproto = require("../proto/resource_pb.js");
-const structproto = require("google-protobuf/google/protobuf/struct_pb.js");
 
 // maxRPCMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
 export const maxRPCMessageSize: number = 1024 * 1024 * 400;
@@ -81,7 +79,7 @@ export function resetOptions(
 
     monitor = undefined;
     engine = undefined;
-    rootResource = undefined;
+    globalThis.stackResource = undefined;
     rpcDone = Promise.resolve();
     featureSupport = {};
 
@@ -431,46 +429,6 @@ export function rpcKeepAlive(): () => void {
     return done!;
 }
 
-let rootResource: Promise<URN> | undefined;
-
-/**
- * getRootResource returns a root resource URN that will automatically become the default parent of all resources.  This
- * can be used to ensure that all resources without explicit parents are parented to a common parent resource.
- */
-export function getRootResource(): Promise<URN | undefined> {
-    const engineRef: any = getEngine();
-    if (!engineRef) {
-        return Promise.resolve(undefined);
-    }
-
-    const req = new engproto.GetRootResourceRequest();
-    return new Promise<URN | undefined>((resolve, reject) => {
-        engineRef.getRootResource(req, (err: grpc.ServiceError, resp: any) => {
-            // Back-compat case - if the engine we're speaking to isn't aware that it can save and load root resources,
-            // fall back to the old behavior.
-            if (err && err.code === grpc.status.UNIMPLEMENTED) {
-                if (rootResource) {
-                    rootResource.then(resolve);
-                    return;
-                }
-
-                resolve(undefined);
-            }
-
-            if (err) {
-                return reject(err);
-            }
-
-            const urn = resp.getUrn();
-            if (urn) {
-                return resolve(urn);
-            }
-
-            return resolve(undefined);
-        });
-    });
-}
-
 /**
  * setRootResource registers a resource that will become the default parent for all resources without explicit parents.
  */
@@ -485,10 +443,9 @@ export async function setRootResource(res: ComponentResource): Promise<void> {
     req.setUrn(urn);
     return new Promise<void>((resolve, reject) => {
         engineRef.setRootResource(req, (err: grpc.ServiceError, resp: any) => {
-            // Back-compat case - if the engine we're speaking to isn't aware that it can save and load root resources,
-            // fall back to the old behavior.
+            // Back-compat case - if the engine we're speaking to isn't aware that it can save and load root
+            // resources, fall back to the old behavior.
             if (err && err.code === grpc.status.UNIMPLEMENTED) {
-                rootResource = res.urn.promise();
                 return resolve();
             }
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -14,7 +14,6 @@
 
 import * as assert from "assert";
 import * as childProcess from "child_process";
-import * as os from "os";
 import * as path from "path";
 import { ID, runtime, URN } from "../../../index";
 import { asyncTest } from "../../util";


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Just use globalThis to make the stack resource a global rather than a module variable. This ensures that even if we end up with multiple Pulumi modules they can all grab the stack object and read URN off it.

We'll keep calling SetRootResource so old modules SxS continue to pickup the stack URN, at some point (4.0 probably) we can clean all this up.

Note that we also need the stack resource to be global for stack transformations, the roundtripping of the URN via the engine didn't preserve those.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
