### PR TITLE
[schema] Faster schema loading via caching alongside plugins

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,9 @@
 - [cli] The engine will now default resource parent to the root stack if it exists.
   [#9481](https://github.com/pulumi/pulumi/pull/9481)
 
+- [engine] Reduce memory usage in convert and yaml programs by caching of package schemas.
+  [#9684](https://github.com/pulumi/pulumi/issues/9684)
+
 ### Bug Fixes
 
 - [sdk/go] Correctly parse nested git projects in GitLab.

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -259,7 +259,6 @@ func generateImportedDefinitions(out io.Writer, stackName tokens.Name, projectNa
 		return false, err
 	}
 	loader := schema.NewPluginLoader(ctx.Host)
-	defer loader.Close()
 	return true, importer.GenerateLanguageDefinitions(out, loader, func(w io.Writer, p *pcl.Program) error {
 		files, _, err := programGenerator(p)
 		if err != nil {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -259,6 +259,7 @@ func generateImportedDefinitions(out io.Writer, stackName tokens.Name, projectNa
 		return false, err
 	}
 	loader := schema.NewPluginLoader(ctx.Host)
+	defer loader.Close()
 	return true, importer.GenerateLanguageDefinitions(out, loader, func(w io.Writer, p *pcl.Program) error {
 		files, _, err := programGenerator(p)
 		if err != nil {

--- a/pkg/codegen/importer/hcl2_test.go
+++ b/pkg/codegen/importer/hcl2_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -233,11 +232,6 @@ func TestGenerateHCL2Definition(t *testing.T) {
 	t.Parallel()
 
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
-	t.Cleanup(func() {
-		err := loader.Close()
-		require.NoError(t, err)
-	})
-
 	cases, err := readTestCases("testdata/cases.json")
 	if !assert.NoError(t, err) {
 		t.Fatal()

--- a/pkg/codegen/importer/hcl2_test.go
+++ b/pkg/codegen/importer/hcl2_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -232,6 +233,10 @@ func TestGenerateHCL2Definition(t *testing.T) {
 	t.Parallel()
 
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	t.Cleanup(func() {
+		err := loader.Close()
+		require.NoError(t, err)
+	})
 
 	cases, err := readTestCases("testdata/cases.json")
 	if !assert.NoError(t, err) {

--- a/pkg/codegen/importer/language_test.go
+++ b/pkg/codegen/importer/language_test.go
@@ -28,16 +28,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateLanguageDefinition(t *testing.T) {
 	t.Parallel()
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
-	t.Cleanup(func() {
-		err := loader.Close()
-		require.NoError(t, err)
-	})
 
 	cases, err := readTestCases("testdata/cases.json")
 	if !assert.NoError(t, err) {

--- a/pkg/codegen/importer/language_test.go
+++ b/pkg/codegen/importer/language_test.go
@@ -28,11 +28,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateLanguageDefinition(t *testing.T) {
 	t.Parallel()
 	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	t.Cleanup(func() {
+		err := loader.Close()
+		require.NoError(t, err)
+	})
 
 	cases, err := readTestCases("testdata/cases.json")
 	if !assert.NoError(t, err) {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -46,9 +46,9 @@ type pluginLoader struct {
 type pluginLoaderCacheOptions struct {
 	// useEntriesCache enables in-memory re-use of packages
 	disableEntryCache bool
-	// useFileCache enables skipping plugin loading when possible and caching JSON schemas to files.
+	// useFileCache enables skipping plugin loading when possible and caching JSON schemas to files
 	disableFileCache bool
-	// useMmap enables the use of memory mapped IO to avoid copying the JSON schema when using
+	// useMmap enables the use of memory mapped IO to avoid copying the JSON schema
 	disableMmap bool
 }
 

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -9,6 +10,10 @@ import (
 	"regexp"
 	"sync"
 	"time"
+
+	"github.com/edsrzf/mmap-go"
+	"github.com/hashicorp/go-multierror"
+	"github.com/natefinch/atomic"
 
 	"github.com/blang/semver"
 	"github.com/segmentio/encoding/json"
@@ -25,6 +30,7 @@ type Loader interface {
 
 type ReferenceLoader interface {
 	Loader
+	io.Closer
 
 	LoadPackageReference(pkg string, version *semver.Version) (PackageReference, error)
 }
@@ -34,6 +40,20 @@ type pluginLoader struct {
 
 	host    plugin.Host
 	entries map[string]PackageReference
+	files   []*os.File
+	mmaps   []mmap.MMap
+
+	cacheOptions pluginLoaderCacheOptions
+}
+
+// Caching options intended for benchmarking or debugging:
+type pluginLoaderCacheOptions struct {
+	// useEntriesCache enables in-memory re-use of packages
+	disableEntryCache bool
+	// useFileCache enables skipping plugin loading when possible and caching JSON schemas to files.
+	disableFileCache bool
+	// useMmap enables the use of memory mapped IO to avoid copying the JSON schema when using
+	disableMmap bool
 }
 
 func NewPluginLoader(host plugin.Host) ReferenceLoader {
@@ -43,12 +63,35 @@ func NewPluginLoader(host plugin.Host) ReferenceLoader {
 	}
 }
 
+func newPluginLoaderWithOptions(host plugin.Host, cacheOptions pluginLoaderCacheOptions) ReferenceLoader {
+	return &pluginLoader{
+		host:    host,
+		entries: map[string]PackageReference{},
+
+		cacheOptions: cacheOptions,
+	}
+}
+
 func (l *pluginLoader) getPackage(key string) (PackageReference, bool) {
-	l.m.RLock()
-	defer l.m.RUnlock()
+	if l.cacheOptions.disableEntryCache {
+		return nil, false
+	}
 
 	p, ok := l.entries[key]
 	return p, ok
+}
+
+func (l *pluginLoader) setPackage(key string, p PackageReference) PackageReference {
+	if l.cacheOptions.disableEntryCache {
+		return p
+	}
+
+	if p, ok := l.entries[key]; ok {
+		return p
+	}
+
+	l.entries[key] = p
+	return p
 }
 
 // ensurePlugin downloads and installs the specified plugin if it does not already exist.
@@ -134,6 +177,27 @@ func (l *pluginLoader) ensurePlugin(pkg string, version *semver.Version) error {
 	return nil
 }
 
+func (l *pluginLoader) Close() error {
+	var result error
+	for _, m := range l.mmaps {
+		if err := m.Unmap(); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	for _, f := range l.files {
+		if err := f.Close(); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	if err := l.host.Close(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result
+}
+
 func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Package, error) {
 	ref, err := l.LoadPackageReference(pkg, version)
 	if err != nil {
@@ -159,24 +223,15 @@ func schemaIsEmpty(schemaBytes []byte) bool {
 }
 
 func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version) (PackageReference, error) {
-	key := packageIdentity(pkg, version)
+	l.m.Lock()
+	defer l.m.Unlock()
 
+	key := packageIdentity(pkg, version)
 	if p, ok := l.getPackage(key); ok {
 		return p, nil
 	}
 
-	if err := l.ensurePlugin(pkg, version); err != nil {
-		return nil, err
-	}
-
-	provider, err := l.host.Provider(tokens.Package(pkg), version)
-	if err != nil {
-		return nil, err
-	}
-	contract.Assert(provider != nil)
-
-	schemaFormatVersion := 0
-	schemaBytes, err := provider.GetSchema(schemaFormatVersion)
+	schemaBytes, version, err := l.loadSchemaBytes(pkg, version)
 	if err != nil {
 		return nil, err
 	}
@@ -185,21 +240,13 @@ func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version)
 	}
 
 	var spec PartialPackageSpec
-	if _, err = json.Parse(schemaBytes, &spec, json.ZeroCopy); err != nil {
+	if _, err := json.Parse(schemaBytes, &spec, json.ZeroCopy); err != nil {
 		return nil, err
 	}
 
 	// Insert a version into the spec if the package does not provide one
-	if spec.PackageInfoSpec.Version == "" {
-		if version == nil {
-			providerInfo, err := provider.GetPluginInfo()
-			if err == nil {
-				version = providerInfo.Version
-			}
-		}
-		if version != nil {
-			spec.PackageInfoSpec.Version = version.String()
-		}
+	if version != nil && spec.PackageInfoSpec.Version == "" {
+		spec.PackageInfoSpec.Version = version.String()
 	}
 
 	p, err := importPartialSpec(spec, nil, l)
@@ -207,15 +254,7 @@ func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version)
 		return nil, err
 	}
 
-	l.m.Lock()
-	defer l.m.Unlock()
-
-	if p, ok := l.entries[pkg]; ok {
-		return p, nil
-	}
-	l.entries[key] = p
-
-	return p, nil
+	return l.setPackage(key, p), nil
 }
 
 func LoadPackageReference(loader Loader, pkg string, version *semver.Version) (PackageReference, error) {
@@ -227,4 +266,111 @@ func LoadPackageReference(loader Loader, pkg string, version *semver.Version) (P
 		return nil, err
 	}
 	return p.Reference(), nil
+}
+
+func (l *pluginLoader) loadSchemaBytes(pkg string, version *semver.Version) ([]byte, *semver.Version, error) {
+	if err := l.ensurePlugin(pkg, version); err != nil {
+		return nil, nil, err
+	}
+
+	pluginInfo, err := l.host.ResolvePlugin(workspace.ResourcePlugin, pkg, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if version == nil {
+		version = pluginInfo.Version
+	}
+
+	if pluginInfo.SchemaPath != "" {
+		schemaBytes, ok := l.loadCachedSchemaBytes(pkg, pluginInfo.SchemaPath, pluginInfo.SchemaTime)
+		if ok {
+			return schemaBytes, nil, nil
+		}
+	}
+
+	schemaBytes, provider, err := l.loadPluginSchemaBytes(pkg, version)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error loading schema from plugin: %w", err)
+	}
+
+	if pluginInfo.SchemaPath != "" {
+		err = atomic.WriteFile(pluginInfo.SchemaPath, bytes.NewReader(schemaBytes))
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error writing schema from plugin to cache: %w", err)
+		}
+	}
+
+	if version == nil {
+		info, err := provider.GetPluginInfo()
+		if err != nil {
+			// Nonfatal
+		}
+		version = info.Version
+	}
+
+	return schemaBytes, version, nil
+}
+
+func (l *pluginLoader) loadPluginSchemaBytes(pkg string, version *semver.Version) ([]byte, plugin.Provider, error) {
+	provider, err := l.host.Provider(tokens.Package(pkg), version)
+	if err != nil {
+		return nil, nil, err
+	}
+	contract.Assert(provider != nil)
+
+	schemaFormatVersion := 0
+	schemaBytes, err := provider.GetSchema(schemaFormatVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return schemaBytes, provider, nil
+}
+
+func (l *pluginLoader) loadCachedSchemaBytes(pkg string, path string, schemaTime time.Time) ([]byte, bool) {
+	if l.cacheOptions.disableFileCache {
+		return nil, false
+	}
+
+	success := false
+	schemaFile, err := os.OpenFile(path, os.O_RDONLY, 0644)
+	defer func() {
+		if success {
+			l.files = append(l.files, schemaFile)
+		} else {
+			schemaFile.Close()
+		}
+	}()
+	if err != nil {
+		return nil, success
+	}
+
+	stat, err := schemaFile.Stat()
+	if err != nil {
+		return nil, success
+	}
+	cachedAt := stat.ModTime()
+
+	if schemaTime.After(cachedAt) {
+		return nil, success
+	}
+
+	if l.cacheOptions.disableMmap {
+		data, err := io.ReadAll(schemaFile)
+		if err != nil {
+			return nil, success
+		}
+		success = true
+		return data, success
+	}
+
+	schemaMmap, err := mmap.Map(schemaFile, mmap.RDONLY, 0)
+	if err != nil {
+		return nil, success
+	}
+	success = true
+	l.mmaps = append(l.mmaps, schemaMmap)
+
+	return schemaMmap, success
 }

--- a/pkg/codegen/schema/loader_schema_test.go
+++ b/pkg/codegen/schema/loader_schema_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestEmptySchemaResponse(t *testing.T) {
 	t.Parallel()
+
 	assert.True(t, schemaIsEmpty([]byte("{}")))
 	assert.True(t, schemaIsEmpty([]byte("{  }")))
 	assert.True(t, schemaIsEmpty([]byte("{	}")))           // tab character

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -1,0 +1,110 @@
+package schema
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/stretchr/testify/require"
+)
+
+func initLoader(b *testing.B, options pluginLoaderCacheOptions) ReferenceLoader {
+	cwd, err := os.Getwd()
+	contract.AssertNoError(err)
+	sink := cmdutil.Diag()
+	ctx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
+	contract.AssertNoError(err)
+	loader := newPluginLoaderWithOptions(ctx.Host, options)
+	b.Cleanup(func() {
+		err := loader.Close()
+		require.NoError(b, err)
+	})
+
+	return loader
+}
+
+func BenchmarkLoadPackageReference(b *testing.B) {
+	cacheWarmingLoader := initLoader(b, pluginLoaderCacheOptions{})
+	// ensure the file cache exists for later tests:
+	_, err := cacheWarmingLoader.LoadPackageReference("azure-native", nil)
+	contract.AssertNoError(err)
+
+	b.Run("full-load", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			loader := initLoader(b, pluginLoaderCacheOptions{})
+
+			_, err := loader.LoadPackageReference("azure-native", nil)
+			contract.AssertNoError(err)
+		}
+	})
+
+	b.Run("full-cache", func(b *testing.B) {
+		loader := initLoader(b, pluginLoaderCacheOptions{})
+
+		b.StopTimer()
+		_, err := loader.LoadPackageReference("azure-native", nil)
+		contract.AssertNoError(err)
+		b.StartTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := loader.LoadPackageReference("azure-native", nil)
+			contract.AssertNoError(err)
+		}
+	})
+
+	b.Run("mmap-cache", func(b *testing.B) {
+		// Disables in-memory cache (single instancing), retains mmap of files:
+		loader := initLoader(b, pluginLoaderCacheOptions{
+			disableEntryCache: true,
+		})
+
+		b.StopTimer()
+		_, err := loader.LoadPackageReference("azure-native", nil)
+		contract.AssertNoError(err)
+		b.StartTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := loader.LoadPackageReference("azure-native", nil)
+			contract.AssertNoError(err)
+		}
+	})
+
+	b.Run("file-cache", func(b *testing.B) {
+		// Disables in-memory cache and mmaping of files:
+		loader := initLoader(b, pluginLoaderCacheOptions{
+			disableEntryCache: true,
+			disableMmap:       true,
+		})
+
+		b.StopTimer()
+		_, err := loader.LoadPackageReference("azure-native", nil)
+		contract.AssertNoError(err)
+		b.StartTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := loader.LoadPackageReference("azure-native", nil)
+			contract.AssertNoError(err)
+		}
+	})
+
+	b.Run("no-cache", func(b *testing.B) {
+		// Disables in-memory cache, mmaping, and using schema files:
+		loader := initLoader(b, pluginLoaderCacheOptions{
+			disableEntryCache: true,
+			disableMmap:       true,
+			disableFileCache:  true,
+		})
+
+		b.StopTimer()
+		_, err := loader.LoadPackageReference("azure-native", nil)
+		contract.AssertNoError(err)
+		b.StartTimer()
+
+		for n := 0; n < b.N; n++ {
+			_, err := loader.LoadPackageReference("azure-native", nil)
+			contract.AssertNoError(err)
+		}
+	})
+}

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/stretchr/testify/require"
 )
 
 func initLoader(b *testing.B, options pluginLoaderCacheOptions) ReferenceLoader {
@@ -17,10 +16,6 @@ func initLoader(b *testing.B, options pluginLoaderCacheOptions) ReferenceLoader 
 	ctx, err := plugin.NewContext(sink, sink, nil, nil, cwd, nil, true, nil)
 	contract.AssertNoError(err)
 	loader := newPluginLoaderWithOptions(ctx.Host, options)
-	b.Cleanup(func() {
-		err := loader.Close()
-		require.NoError(b, err)
-	})
 
 	return loader
 }

--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -378,6 +378,7 @@ func TestSDKCodegen(t *testing.T, opts *SDKCodegenOptions) { // revive:disable-l
 	require.NotNil(t, opts.TestCases, "No test cases were provided. This was probably a mistake")
 	for _, tt := range opts.TestCases {
 		tt := tt // avoid capturing loop variable `sdkTest` in the closure
+
 		t.Run(tt.Directory, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/codegen/testing/test/testdata/eks.json
+++ b/pkg/codegen/testing/test/testdata/eks.json
@@ -37,7 +37,7 @@
           "description": "The tags to apply to the CloudFormation Stack of the Worker NodeGroup.\n\nNote: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both."
         },
         "clusterIngressRule": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
           "description": "The ingress rule that gives node group access."
         },
         "desiredCapacity": {
@@ -51,7 +51,7 @@
         "extraNodeSecurityGroups": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+            "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
           },
           "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
         },
@@ -60,7 +60,7 @@
           "description": "Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.\n\nDefaults to false.\n\nNote: `gpu` and `amiId` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\n- https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html"
         },
         "instanceProfile": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
           "description": "The ingress rule that gives node group access."
         },
         "instanceType": {
@@ -103,7 +103,7 @@
           "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
         },
         "nodeSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
         },
         "nodeSubnetIds": {
@@ -143,30 +143,30 @@
       "description": "Defines the core set of data associated with an EKS cluster, including the network in which it runs.",
       "properties": {
         "awsProvider": {
-          "$ref": "/aws/v4.15.0/schema.json#/provider"
+          "$ref": "/aws/v4.36.0/schema.json#/provider"
         },
         "cluster": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2Fcluster:Cluster"
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:eks%2Fcluster:Cluster"
         },
         "clusterSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
         },
         "eksNodeAccess": {
           "$ref": "/kubernetes/v3.0.0/schema.json#/resources/kubernetes:core%2Fv1:ConfigMap"
         },
         "encryptionConfig": {
-          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FClusterEncryptionConfig:ClusterEncryptionConfig"
+          "$ref": "/aws/v4.36.0/schema.json#/types/aws:eks%2FClusterEncryptionConfig:ClusterEncryptionConfig"
         },
         "endpoint": {
           "type": "string"
         },
         "fargateProfile": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2FfargateProfile:FargateProfile"
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:eks%2FfargateProfile:FargateProfile"
         },
         "instanceRoles": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+            "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role"
           }
         },
         "kubeconfig": {
@@ -182,7 +182,7 @@
           }
         },
         "oidcProvider": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2FopenIdConnectProvider:OpenIdConnectProvider"
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2FopenIdConnectProvider:OpenIdConnectProvider"
         },
         "privateSubnetIds": {
           "type": "array",
@@ -240,10 +240,10 @@
       "description": "Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
       "properties": {
         "provider": {
-          "$ref": "/aws/v4.15.0/schema.json#/provider"
+          "$ref": "/aws/v4.36.0/schema.json#/provider"
         },
         "role": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role"
         }
       },
       "type": "object",
@@ -262,7 +262,7 @@
         "selectors": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FFargateProfileSelector:FargateProfileSelector"
+            "$ref": "/aws/v4.36.0/schema.json#/types/aws:eks%2FFargateProfileSelector:FargateProfileSelector"
           },
           "description": "Specify the namespace and label selectors to use for launching pods into Fargate."
         },
@@ -298,18 +298,18 @@
           "description": "The AutoScalingGroup name for the node group."
         },
         "cfnStack": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
           "description": "The CloudFormation Stack which defines the Node AutoScalingGroup."
         },
         "extraNodeSecurityGroups": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+            "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
           },
           "description": "The additional security groups for the node group that captures user-specific rules."
         },
         "nodeSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group for the node group to communicate with the cluster."
         }
       },
@@ -543,11 +543,11 @@
       "description": "Cluster is a component that wraps the AWS and Kubernetes resources necessary to run an EKS cluster, its worker nodes, its optional StorageClasses, and an optional deployment of the Kubernetes Dashboard.",
       "properties": {
         "awsProvider": {
-          "$ref": "/aws/v4.15.0/schema.json#/provider",
+          "$ref": "/aws/v4.36.0/schema.json#/provider",
           "description": "The AWS resource provider."
         },
         "clusterSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group for the EKS cluster."
         },
         "core": {
@@ -559,17 +559,17 @@
           "description": "The default Node Group configuration, or undefined if `skipDefaultNodeGroup` was specified."
         },
         "eksCluster": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
           "description": "The EKS cluster."
         },
         "eksClusterIngressRule": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
           "description": "The ingress rule that gives node group access to cluster API server."
         },
         "instanceRoles": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+            "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role"
           },
           "description": "The service roles used by the EKS cluster."
         },
@@ -578,7 +578,7 @@
           "description": "A kubeconfig that can be used to connect to the EKS cluster."
         },
         "nodeSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group for the cluster's nodes."
         },
         "provider": {
@@ -599,7 +599,7 @@
       ],
       "inputProperties": {
         "clusterSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups."
         },
         "clusterSecurityGroupTags": {
@@ -671,13 +671,13 @@
           "description": "The default IAM InstanceProfile to use on the Worker NodeGroups, if one is not already set in the NodeGroup."
         },
         "instanceRole": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role",
           "description": "This enables the simple case of only registering a *single* IAM instance role with the cluster, that is required to be shared by *all* node groups in their instance profiles.\n\nNote: options `instanceRole` and `instanceRoles` are mutually exclusive."
         },
         "instanceRoles": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+            "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role"
           },
           "description": "This enables the advanced case of registering *many* IAM instance roles with the cluster for per node group IAM, instead of the simpler, shared case of `instanceRole`.\n\nNote: options `instanceRole` and `instanceRoles` are mutually exclusive."
         },
@@ -800,7 +800,7 @@
           "description": "Optional mappings from AWS IAM roles to Kubernetes users and groups."
         },
         "serviceRole": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role",
           "description": "IAM Service Role for EKS to use to manage the cluster."
         },
         "skipDefaultNodeGroup": {
@@ -868,10 +868,10 @@
       "description": "ClusterCreationRoleProvider is a component that wraps creating a role provider that can be passed to the `Cluster`'s `creationRoleProvider`. This can be used to provide a specific role to use for the creation of the EKS cluster different from the role being used to run the Pulumi deployment.",
       "properties": {
         "provider": {
-          "$ref": "/aws/v4.15.0/schema.json#/provider"
+          "$ref": "/aws/v4.36.0/schema.json#/provider"
         },
         "role": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role"
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role"
         }
       },
       "required": [
@@ -892,7 +892,7 @@
       "description": "ManagedNodeGroup is a component that wraps creating an AWS managed node group.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html",
       "properties": {
         "nodeGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2FnodeGroup:NodeGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:eks%2FnodeGroup:NodeGroup",
           "description": "The AWS managed node group."
         }
       },
@@ -939,7 +939,7 @@
           "description": "Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed."
         },
         "launchTemplate": {
-          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate",
+          "$ref": "/aws/v4.36.0/schema.json#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate",
           "description": "Launch Template settings."
         },
         "nodeGroupName": {
@@ -951,7 +951,7 @@
           "description": "Creates a unique name beginning with the specified prefix. Conflicts with `nodeGroupName`."
         },
         "nodeRole": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2Frole:Role",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2Frole:Role",
           "description": "The IAM Role that provides permissions for the EKS Node Group.\n\nNote, `nodeRole` and `nodeRoleArn` are mutually exclusive, and a single option must be used."
         },
         "nodeRoleArn": {
@@ -963,11 +963,11 @@
           "description": "AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version."
         },
         "remoteAccess": {
-          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupRemoteAccess:NodeGroupRemoteAccess",
+          "$ref": "/aws/v4.36.0/schema.json#/types/aws:eks%2FNodeGroupRemoteAccess:NodeGroupRemoteAccess",
           "description": "Remote access settings."
         },
         "scalingConfig": {
-          "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupScalingConfig:NodeGroupScalingConfig",
+          "$ref": "/aws/v4.36.0/schema.json#/types/aws:eks%2FNodeGroupScalingConfig:NodeGroupScalingConfig",
           "description": "Scaling settings.\n\nDefault scaling amounts of the node group autoscaling group are:\n  - desiredSize: 2\n  - minSize: 1\n  - maxSize: 2"
         },
         "subnetIds": {
@@ -987,7 +987,7 @@
         "taints": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/types/aws:eks%2FNodeGroupTaint:NodeGroupTaint"
+            "$ref": "/aws/v4.36.0/schema.json#/types/aws:eks%2FNodeGroupTaint:NodeGroupTaint"
           },
           "description": "The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group."
         },
@@ -1008,18 +1008,18 @@
           "description": "The AutoScalingGroup name for the Node group."
         },
         "cfnStack": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
           "description": "The CloudFormation Stack which defines the Node AutoScalingGroup."
         },
         "extraNodeSecurityGroups": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+            "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
           },
           "description": "The additional security groups for the node group that captures user-specific rules."
         },
         "nodeSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group for the node group to communicate with the cluster."
         }
       },
@@ -1057,7 +1057,7 @@
           "description": "The target EKS cluster."
         },
         "clusterIngressRule": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
           "description": "The ingress rule that gives node group access."
         },
         "desiredCapacity": {
@@ -1071,7 +1071,7 @@
         "extraNodeSecurityGroups": {
           "type": "array",
           "items": {
-            "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+            "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
           },
           "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
         },
@@ -1080,7 +1080,7 @@
           "description": "Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.\n\nDefaults to false.\n\nNote: `gpu` and `amiId` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\n- https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html"
         },
         "instanceProfile": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
           "description": "The ingress rule that gives node group access."
         },
         "instanceType": {
@@ -1123,7 +1123,7 @@
           "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
         },
         "nodeSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
         },
         "nodeSubnetIds": {
@@ -1166,11 +1166,11 @@
       "description": "NodeGroupSecurityGroup is a component that wraps creating a security group for node groups with the default ingress & egress rules required to connect and work with the EKS cluster security group.",
       "properties": {
         "securityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group for node groups with the default ingress & egress rules required to connect and work with the EKS cluster security group."
         },
         "securityGroupRule": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
           "description": "The EKS cluster ingress rule."
         }
       },
@@ -1180,11 +1180,11 @@
       ],
       "inputProperties": {
         "clusterSecurityGroup": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
           "description": "The security group associated with the EKS cluster."
         },
         "eksCluster": {
-          "$ref": "/aws/v4.15.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
           "description": "The EKS cluster associated with the worker node group"
         },
         "tags": {

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/schema.json
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/schema.json
@@ -17,16 +17,16 @@
           "$ref": "/aws/v4.36.0/schema.json#/types/aws:ec2/InstanceLaunchTemplate:InstanceLaunchTemplate"
         },
         "resourceLocalInsteadOfRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/resources/google-native:iam/v1:Key"
+          "$ref": "/google-native/v0.18.2/schema.json#/resources/google-native:iam/v1:Key"
         },
         "typeLocalInsteadOfRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/types/google-native:iam/v1:AuditConfig"
+          "$ref": "/google-native/v0.18.2/schema.json#/types/google-native:iam/v1:AuditConfig"
         },
         "resourceRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/resources/google-native:dns/v1:Policy"
+          "$ref": "/google-native/v0.18.2/schema.json#/resources/google-native:dns/v1:Policy"
         },
         "typeRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/types/google-native:dns/v1:DnsKeySpec"
+          "$ref": "/google-native/v0.18.2/schema.json#/types/google-native:dns/v1:DnsKeySpec"
         }
       },
       "requiredInputs": [
@@ -53,16 +53,16 @@
           "$ref": "/aws/v4.36.0/schema.json#/types/aws:ec2/InstanceLaunchTemplate:InstanceLaunchTemplate"
         },
         "resourceLocalInsteadOfRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/resources/google-native:iam/v1:Key"
+          "$ref": "/google-native/v0.18.2/schema.json#/resources/google-native:iam/v1:Key"
         },
         "typeLocalInsteadOfRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/types/google-native:iam/v1:AuditConfigResponse"
+          "$ref": "/google-native/v0.18.2/schema.json#/types/google-native:iam/v1:AuditConfigResponse"
         },
         "resourceRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/resources/google-native:dns/v1:Policy"
+          "$ref": "/google-native/v0.18.2/schema.json#/resources/google-native:dns/v1:Policy"
         },
         "typeRemoteAlias": {
-          "$ref": "/google-native/v0.13.0/schema.json#/types/google-native:dns/v1:DnsKeySpecResponse"
+          "$ref": "/google-native/v0.18.2/schema.json#/types/google-native:dns/v1:DnsKeySpecResponse"
         }
       },
       "required": [

--- a/pkg/codegen/testing/test/testdata/external-node-compatibility/schema.json
+++ b/pkg/codegen/testing/test/testdata/external-node-compatibility/schema.json
@@ -5,7 +5,7 @@
     "example::Foo": {
       "inputProperties": {
         "auditConfig": {
-          "$ref": "/google-native/v0.11.0/schema.json#/types/google-native:iam/v1:AuditConfig"
+          "$ref": "/google-native/v0.18.2/schema.json#/types/google-native:iam/v1:AuditConfig"
         }
       },
       "requiredInputs": [

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/schema.json
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/schema.json
@@ -5,33 +5,33 @@
     "example::Pet": {
       "properties": {
         "name": {
-          "$ref": "/random/v4.2.0/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+          "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
         },
         "requiredName": {
-          "$ref": "/random/v4.2.0/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+          "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
         },
         "nameArray": {
           "type": "array",
           "items": {
-            "$ref": "/random/v4.2.0/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
           }
         },
         "requiredNameArray": {
           "type": "array",
           "items": {
-            "$ref": "/random/v4.2.0/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
           }
         },
         "nameMap": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "/random/v4.2.0/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
           }
         },
         "requiredNameMap": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "/random/v4.2.0/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
           }
         },
         "age": {
@@ -73,7 +73,7 @@
           "$ref": "/kubernetes/v3.7.0/schema.json#/provider"
         },
         "securityGroup": {
-          "$ref": "/aws/v4.19.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
         },
         "storageClasses": {
           "type": "object",
@@ -127,7 +127,7 @@
       "inputs": {
         "properties": {
           "name": {
-            "$ref": "/random/v4.2.0/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+            "$ref": "/random/v4.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
           }
         }
       },

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/schema.json
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/schema.json
@@ -27,7 +27,7 @@
       "requiredInputs": ["indexContent"],
       "properties": {
         "bucket": {
-          "$ref": "/aws/v4.0.0/schema.json#/resources/aws:s3%2Fbucket:Bucket",
+          "$ref": "/aws/v4.36.0/schema.json#/resources/aws:s3%2Fbucket:Bucket",
           "description": "The bucket resource."
         },
         "websiteUrl": {

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -4,33 +4,24 @@ import (
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 func NewHost(schemaDirectoryPath string) plugin.Host {
+	mockProvider := func(name tokens.Package, loader ProviderLoader) *deploytest.PluginLoader {
+		return deploytest.NewProviderLoader(name, semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return loader(schemaDirectoryPath)
+		}, deploytest.WithPath(schemaDirectoryPath))
+	}
+
 	return deploytest.NewPluginHost(nil, nil, nil,
-		deploytest.NewProviderLoader("aws", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return AWS(schemaDirectoryPath)
-		}),
-		deploytest.NewProviderLoader("azure", semver.MustParse("3.24.0"), func() (plugin.Provider, error) {
-			return Azure(schemaDirectoryPath)
-		}),
-		deploytest.NewProviderLoader("azure-native", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return AzureNative(schemaDirectoryPath)
-		}),
-		deploytest.NewProviderLoader("random", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return Random(schemaDirectoryPath)
-		}),
-		deploytest.NewProviderLoader("kubernetes", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return Kubernetes(schemaDirectoryPath)
-		}),
-		deploytest.NewProviderLoader("aws-native", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return AwsNative(schemaDirectoryPath)
-		}),
-		deploytest.NewProviderLoader("other", semver.MustParse("0.1.0"), func() (plugin.Provider, error) {
-			return Other(schemaDirectoryPath)
-		}),
-		deploytest.NewProviderLoader("synthetic", semver.MustParse("0.1.0"), func() (plugin.Provider, error) {
-			return Synthetic(schemaDirectoryPath)
-		}),
+		mockProvider("aws", AWS),
+		mockProvider("azure", Azure),
+		mockProvider("azure-native", AzureNative),
+		mockProvider("random", Random),
+		mockProvider("kubernetes", Kubernetes),
+		mockProvider("aws-native", AwsNative),
+		mockProvider("other", Other),
+		mockProvider("synthetic", Synthetic),
 	)
 }

--- a/pkg/codegen/testing/utils/providers.go
+++ b/pkg/codegen/testing/utils/providers.go
@@ -1,27 +1,49 @@
 package utils
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
+	"github.com/edsrzf/mmap-go"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
 func GetSchema(schemaDirectoryPath, providerName string) ([]byte, error) {
-	return ioutil.ReadFile(filepath.Join(schemaDirectoryPath, providerName+".json"))
+	path := filepath.Join(schemaDirectoryPath, providerName+".json")
+	schemaFile, err := os.OpenFile(path, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	// We'll leak this memory, but we are in a testing environment and
+	schemaMmap, err := mmap.Map(schemaFile, mmap.RDONLY, 0)
+	if err != nil {
+		schemaFile.Close()
+		return nil, err
+	}
+
+	return schemaMmap, nil
 }
 
 type ProviderLoader func(string) (plugin.Provider, error)
 
 func NewProviderLoader(pkg string) ProviderLoader {
 	return func(schemaDirectoryPath string) (plugin.Provider, error) {
-		schema, err := GetSchema(schemaDirectoryPath, pkg)
-		if err != nil {
-			return nil, err
-		}
+		// Single instance schema:
+		var schema []byte
+		var err error
 		return &deploytest.Provider{
 			GetSchemaF: func(version int) ([]byte, error) {
+				if schema != nil {
+					return schema, nil
+				}
+
+				schema, err = GetSchema(schemaDirectoryPath, pkg)
+				if err != nil {
+					return nil, err
+				}
+
 				return schema, nil
 			},
 		}, nil

--- a/pkg/codegen/testing/utils/providers.go
+++ b/pkg/codegen/testing/utils/providers.go
@@ -3,10 +3,12 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"sync"
 
-	"github.com/edsrzf/mmap-go"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+
+	"github.com/edsrzf/mmap-go"
 )
 
 func GetSchema(schemaDirectoryPath, providerName string) ([]byte, error) {
@@ -33,8 +35,11 @@ func NewProviderLoader(pkg string) ProviderLoader {
 		// Single instance schema:
 		var schema []byte
 		var err error
+		var m sync.Mutex
 		return &deploytest.Provider{
 			GetSchemaF: func(version int) ([]byte, error) {
+				m.Lock()
+				defer m.Unlock()
 				if schema != nil {
 					return schema, nil
 				}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -152,6 +152,8 @@ require (
 )
 
 require (
+	github.com/edsrzf/mmap-go v1.1.0
+	github.com/natefinch/atomic v1.0.1
 	github.com/pulumi/pulumi-java/pkg v0.2.0
 	github.com/pulumi/pulumi-yaml v0.5.1
 	github.com/segmentio/encoding v0.3.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -291,6 +291,8 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -672,6 +674,8 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxschmitt/golang-combinations v1.0.0 h1:NFoO7CSP8MUcFlHpe1YdewKwMa15dgDbaqkVLC5DUPI=
 github.com/mxschmitt/golang-combinations v1.0.0/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
+github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
+github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"sync"
 
 	"github.com/blang/semver"
@@ -57,12 +58,19 @@ func WithGrpc(p *PluginLoader) {
 	p.useGRPC = true
 }
 
+func WithPath(path string) func(p *PluginLoader) {
+	return func(p *PluginLoader) {
+		p.path = path
+	}
+}
+
 type PluginLoader struct {
 	kind         workspace.PluginKind
 	name         string
 	version      semver.Version
 	load         LoadPluginFunc
 	loadWithHost LoadPluginWithHostFunc
+	path         string
 	useGRPC      bool
 }
 
@@ -387,6 +395,25 @@ func (host *pluginHost) CloseProvider(provider plugin.Provider) error {
 }
 func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
 	return nil
+}
+func (host *pluginHost) ResolvePlugin(
+	kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error) {
+	for _, v := range host.pluginLoaders {
+		if v.kind == kind && v.name == name {
+			// TODO: for multi-version testing, support multiple versions of plugins concurrently. Not
+			// allowed at present time.
+			return &workspace.PluginInfo{
+				Kind:       kind,
+				Name:       name,
+				Path:       v.path,
+				Version:    &v.version,
+				SchemaPath: filepath.Join(v.path, name+".json"),
+				// SchemaTime not set as caching is indefinite.
+			}, nil
+		}
+	}
+
+	return nil, nil
 }
 func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
 	kinds plugin.Flags) ([]workspace.PluginInfo, error) {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -74,6 +74,10 @@ func (host *testPluginHost) LanguageRuntime(runtime string) (plugin.LanguageRunt
 func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
 	return nil
 }
+func (host *testPluginHost) ResolvePlugin(
+	kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error) {
+	return nil, nil
+}
 func (host *testPluginHost) GetRequiredPlugins(info plugin.ProgInfo,
 	kinds plugin.Flags) ([]workspace.PluginInfo, error) {
 	return nil, nil

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -72,6 +72,8 @@ type Host interface {
 	// EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
 	// and/or there are errors loading one or more plugins, a non-nil error is returned.
 	EnsurePlugins(plugins []workspace.PluginInfo, kinds Flags) error
+	// ResolvePlugin resolves a plugin kind, name, and optional semver to a candidate plugin to load.
+	ResolvePlugin(kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
 
 	// SignalCancellation asks all resource providers to gracefully shut down and abort any ongoing
 	// operations. Operation aborted in this way will return an error (e.g., `Update` and `Create`
@@ -375,6 +377,11 @@ func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds Fla
 	}
 
 	return result
+}
+
+func (host *defaultHost) ResolvePlugin(
+	kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error) {
+	return workspace.GetPluginInfo(kind, name, version)
 }
 
 func (host *defaultHost) SignalCancellation() error {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -485,6 +485,8 @@ type PluginInfo struct {
 	LastUsedTime      time.Time       // the last time the plugin was used.
 	PluginDownloadURL string          // an optional server to use when downloading this plugin.
 	PluginDir         string          // if set, will be used as the root plugin dir instead of ~/.pulumi/plugins.
+	SchemaPath        string          // if set, used as the path for loading and caching the schema
+	SchemaTime        time.Time       // if set and newer than the file at SchemaPath, used to invalidate a cached schema
 }
 
 // Dir gets the expected plugin directory for this plugin.
@@ -584,20 +586,47 @@ func (info *PluginInfo) SetFileMetadata(path string) error {
 
 	// Next, get the size from the directory (or, if there is none, just the file).
 	size, err := getPluginSize(path)
-	if err != nil {
-		return errors.Wrapf(err, "getting plugin dir %s size", path)
+	if err == nil {
+		info.Size = size
+	} else {
+		logging.V(6).Infof("unable to get plugin dir size for %s: %v", path, err)
 	}
-	info.Size = size
 
 	// Next get the access times from the plugin binary itself.
 	tinfo := times.Get(file)
 
-	if tinfo.HasBirthTime() {
-		info.InstallTime = tinfo.BirthTime()
+	if tinfo.HasChangeTime() {
+		info.InstallTime = tinfo.ChangeTime()
+	} else {
+		info.InstallTime = tinfo.ModTime()
 	}
 
 	info.LastUsedTime = tinfo.AccessTime()
+
+	if info.Kind == ResourcePlugin {
+		info.SetSchemaMetadata()
+	}
+
 	return nil
+}
+
+func (info *PluginInfo) SetSchemaMetadata() {
+	binpath, err := info.FilePath()
+	if err != nil {
+		return
+	}
+	bintime, err := times.Stat(binpath)
+	if err != nil {
+		return
+	}
+
+	dir, err := info.DirPath()
+	if err != nil {
+		return
+	}
+
+	info.SchemaPath = filepath.Join(dir, "schema-"+info.Name+".json")
+	info.SchemaTime = bintime.ModTime()
 }
 
 func interpolateURL(serverURL string, version semver.Version, os, arch string) string {
@@ -1015,12 +1044,13 @@ func getPlugins(dir string, skipMetadata bool) ([]PluginInfo, error) {
 	for _, file := range files {
 		// Skip anything that doesn't look like a plugin.
 		if kind, name, version, ok := tryPlugin(file); ok {
+			path := filepath.Join(dir, file.Name())
 			plugin := PluginInfo{
 				Name:    name,
 				Kind:    kind,
 				Version: &version,
+				Path:    path,
 			}
-			path := filepath.Join(dir, file.Name())
 			if _, err := os.Stat(fmt.Sprintf("%s.partial", path)); err == nil {
 				// Skip it if the partial file exists, meaning the plugin is not fully installed.
 				continue
@@ -1044,6 +1074,53 @@ func getPlugins(dir string, skipMetadata bool) ([]PluginInfo, error) {
 // using standard semver sorting rules.  A plugin may be overridden entirely by placing it on your $PATH, though it is
 // possible to opt out of this behavior by setting PULUMI_IGNORE_AMBIENT_PLUGINS to any non-empty value.
 func GetPluginPath(kind PluginKind, name string, version *semver.Version) (string, string, error) {
+	info, path, err := getPluginInfoOrPath(kind, name, version, true /* skipMetadata */)
+	if err != nil {
+		return "", "", err
+	}
+
+	if info != nil {
+		matchDir, err := info.DirPath()
+		if err != nil {
+			return "", "", err
+		}
+
+		matchPath, err := info.FilePath()
+		if err != nil {
+			return "", "", err
+		}
+
+		return matchDir, matchPath, nil
+	}
+
+	return "", path, err
+}
+
+func GetPluginInfo(kind PluginKind, name string, version *semver.Version) (*PluginInfo, error) {
+	info, path, err := getPluginInfoOrPath(kind, name, version, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if info != nil {
+		return info, nil
+	}
+
+	info = &PluginInfo{
+		Kind: kind,
+		Name: name,
+		Path: filepath.Dir(path),
+	}
+
+	return info, nil
+}
+
+// getPluginInfoOrPath searches for a compatible plugin kind, name, and version and returns either:
+//  * if found as an ambient plugin, nil and the path to the executable
+//  * if found in the pulumi dir's installed plugins, a PluginInfo and path to the executable
+//  * an error in all other cases.
+func getPluginInfoOrPath(
+	kind PluginKind, name string, version *semver.Version, skipMetadata bool) (*PluginInfo, string, error) {
 	var filename string
 
 	// We currently bundle some plugins with "pulumi" and thus expect them to be next to the pulumi binary. We
@@ -1061,7 +1138,7 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version) (strin
 		filename = (&PluginInfo{Kind: kind, Name: name, Version: version}).FilePrefix()
 		if path, err := exec.LookPath(filename); err == nil {
 			logging.V(6).Infof("GetPluginPath(%s, %s, %v): found on $PATH %s", kind, name, version, path)
-			return "", path, nil
+			return nil, path, nil
 		}
 	}
 
@@ -1086,7 +1163,7 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version) (strin
 						logging.V(6).Infof("GetPluginPath(%s, %s, %v): found next to current executable %s",
 							kind, name, version, candidate)
 
-						return "", candidate, nil
+						return nil, candidate, nil
 					}
 				}
 			}
@@ -1094,9 +1171,15 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version) (strin
 	}
 
 	// Otherwise, check the plugin cache.
-	plugins, err := GetPlugins()
+	var plugins []PluginInfo
+	var err error
+	if skipMetadata {
+		plugins, err = GetPlugins()
+	} else {
+		plugins, err = GetPluginsWithMetadata()
+	}
 	if err != nil {
-		return "", "", errors.Wrapf(err, "loading plugin list")
+		return nil, "", errors.Wrapf(err, "loading plugin list")
 	}
 
 	var match *PluginInfo
@@ -1104,7 +1187,7 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version) (strin
 		logging.V(6).Infof("GetPluginPath(%s, %s, %s): enabling new plugin behavior", kind, name, version)
 		candidate, err := SelectCompatiblePlugin(plugins, kind, name, semver.MustParseRange(version.String()))
 		if err != nil {
-			return "", "", NewMissingError(PluginInfo{
+			return nil, "", NewMissingError(PluginInfo{
 				Name:    name,
 				Kind:    kind,
 				Version: version,
@@ -1139,20 +1222,16 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version) (strin
 	}
 
 	if match != nil {
-		matchDir, err := match.DirPath()
-		if err != nil {
-			return "", "", err
-		}
 		matchPath, err := match.FilePath()
 		if err != nil {
-			return "", "", err
+			return nil, "", err
 		}
 
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v): found in cache at %s", kind, name, version, matchPath)
-		return matchDir, matchPath, nil
+		return match, matchPath, nil
 	}
 
-	return "", "", NewMissingError(PluginInfo{
+	return nil, "", NewMissingError(PluginInfo{
 		Name:    name,
 		Kind:    kind,
 		Version: version,

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
@@ -104,6 +105,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
+	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -282,6 +282,8 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -642,6 +644,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxschmitt/golang-combinations v1.0.0/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
+github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
+github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=


### PR DESCRIPTION
Implements caching of schemas in package loader. Package loader searches for plugins & before calling GetSchema, attempts to read a `schema-${pkg}.json` file. On cache miss or when the plugin is newer than the cache, the file is updated via GetSchema call.

Tested against locally installed packages as well as plugin cache located packages, e.g.: when `pulumi-resource-azure-native` is in $GOBIN, this caches the schema to `$GOBIN/schema-azure-native.json`.

A micro benchmark shows substantial improvements in wall time and bytes of memory allocated/copied, and a combined benchmark of this PR along with PRs to Azure Native & YAML reduced the time for a `pulumi preview` on an Azure Native stack down to 2.5 seconds from 12, and down to 340MiB peak memory usage from ~2GiB.

A microbenchmark shows the reduction in `loader_test.go`:

```
enchmarkLoadPackageReference/no-cache-8      1   2231342910 ns/op  351691352 B/op   7063 allocs/op
BenchmarkLoadPackageReference/file-cache-8   4    281257858 ns/op  631195948 B/op   2998 allocs/op
BenchmarkLoadPackageReference/mmap-cache-8   7    157173553 ns/op   15967628 B/op   2934 allocs/op
```
no cache: starting a plugin process and calling GetSchema() on it in every iteration. the memory usage is misleading as a result - it can't count the subprocess.

file cache: using a schema.json file colocated with the plugin. (this benchmark is pre-warmed, but it would be created if this cache misses)

mmap cache: instead of using io.ReadAll (copying) bytes, use mmap with O_RDONLY

Related PRs:
- https://github.com/pulumi/pulumi/pull/9620
- https://github.com/pulumi/pulumi-azure-native/pull/1689/
- https://github.com/pulumi/pulumi-yaml/pull/230
