### PR TITLE
Update docstring for Cancel gRPC method

### DIFF
--- a/sdk/nodejs/proto/provider_grpc_pb.js
+++ b/sdk/nodejs/proto/provider_grpc_pb.js
@@ -465,7 +465,11 @@ construct: {
     responseSerialize: serialize_pulumirpc_ConstructResponse,
     responseDeserialize: deserialize_pulumirpc_ConstructResponse,
   },
-  // Cancel signals the provider to abort all outstanding resource operations.
+  // Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
+// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a
+// creation error or an initialization error). Since Cancel is advisory and non-blocking, it is up
+// to the host to decide how long to wait after Cancel is called before (e.g.)
+// hard-closing any gRPC connection.
 cancel: {
     path: '/pulumirpc.ResourceProvider/Cancel',
     requestStream: false,

--- a/sdk/proto/go/provider.pb.go
+++ b/sdk/proto/go/provider.pb.go
@@ -2136,7 +2136,11 @@ type ResourceProviderClient interface {
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	// Construct creates a new instance of the provided component resource and returns its state.
 	Construct(ctx context.Context, in *ConstructRequest, opts ...grpc.CallOption) (*ConstructResponse, error)
-	// Cancel signals the provider to abort all outstanding resource operations.
+	// Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
+	// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a
+	// creation error or an initialization error). Since Cancel is advisory and non-blocking, it is up
+	// to the host to decide how long to wait after Cancel is called before (e.g.)
+	// hard-closing any gRPC connection.
 	Cancel(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*empty.Empty, error)
 	// GetPluginInfo returns generic information about this plugin, like its version.
 	GetPluginInfo(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*PluginInfo, error)
@@ -2365,7 +2369,11 @@ type ResourceProviderServer interface {
 	Delete(context.Context, *DeleteRequest) (*empty.Empty, error)
 	// Construct creates a new instance of the provided component resource and returns its state.
 	Construct(context.Context, *ConstructRequest) (*ConstructResponse, error)
-	// Cancel signals the provider to abort all outstanding resource operations.
+	// Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
+	// Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a
+	// creation error or an initialization error). Since Cancel is advisory and non-blocking, it is up
+	// to the host to decide how long to wait after Cancel is called before (e.g.)
+	// hard-closing any gRPC connection.
 	Cancel(context.Context, *empty.Empty) (*empty.Empty, error)
 	// GetPluginInfo returns generic information about this plugin, like its version.
 	GetPluginInfo(context.Context, *empty.Empty) (*PluginInfo, error)

--- a/sdk/proto/provider.proto
+++ b/sdk/proto/provider.proto
@@ -65,7 +65,11 @@ service ResourceProvider {
     // Construct creates a new instance of the provided component resource and returns its state.
     rpc Construct(ConstructRequest) returns (ConstructResponse) {}
 
-    // Cancel signals the provider to abort all outstanding resource operations.
+    // Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
+    // Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a
+    // creation error or an initialization error). Since Cancel is advisory and non-blocking, it is up
+    // to the host to decide how long to wait after Cancel is called before (e.g.)
+    // hard-closing any gRPC connection.
     rpc Cancel(google.protobuf.Empty) returns (google.protobuf.Empty) {}
     // GetPluginInfo returns generic information about this plugin, like its version.
     rpc GetPluginInfo(google.protobuf.Empty) returns (PluginInfo) {}

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2_grpc.py
@@ -215,7 +215,11 @@ class ResourceProviderServicer(object):
     raise NotImplementedError('Method not implemented!')
 
   def Cancel(self, request, context):
-    """Cancel signals the provider to abort all outstanding resource operations.
+    """Cancel signals the provider to gracefully shut down and abort any ongoing resource operations.
+    Operations aborted in this way will return an error (e.g., `Update` and `Create` will either return a
+    creation error or an initialization error). Since Cancel is advisory and non-blocking, it is up
+    to the host to decide how long to wait after Cancel is called before (e.g.)
+    hard-closing any gRPC connection.
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
     context.set_details('Method not implemented!')


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Add a more comprehensive description about the semantics of the provider Cancel operation. This description was copied from the pulumi-kubernetes provider where this feature was originally implemented.
