### PR TITLE
[cli] Disable plugin install progress bar in CI, non-interactive shells

### DIFF
--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1234,6 +1234,10 @@ func ReadCloserProgressBar(
 		return closer
 	}
 
+	if !cmdutil.Interactive() {
+		return closer
+	}
+
 	// If we know the length of the download, show a progress bar.
 	bar := pb.New(int(size))
 	bar.Output = os.Stderr


### PR DESCRIPTION
In CI environments that capture all terminal output, the `Downloading plugin` output can end up concatenated over and over, like so:

```
Downloading plugin: 90.43 MiB / 105 MiB  85.35% 00m13sDownloading plugin: 90.43 MiB / 105 MiB  85.35% 00m13sDownloading plugin: 90.43 MiB / 105 MiB  85.35% 00m13s...
```

If we're in a non-interactive environment, disable the progress bar.