### PR TITLE
Fix unsafe html emitted for Java properties

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -611,18 +611,20 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 		displayName = mod.cleanTypeString(t, langTypeString, lang, modName, characteristics.input)
 	}
 
-	// If word-breaks need to be inserted, then the type string should be html-encoded first in order to avoid confusing
-	// the Hugo rendering where the word-break tags are inserted. This is required for languages with template types.
-	if insertWordBreaks {
-		displayName = html.EscapeString(displayName)
-		displayName = wbr(displayName)
-	}
-
 	displayName = cleanOptionalIdentifier(displayName, lang)
 	langTypeString = cleanOptionalIdentifier(langTypeString, lang)
 
+	// Name and DisplayName should be html-escaped to avoid throwing off rendering for template types in languages like
+	// csharp, Java etc. If word-breaks need to be inserted, then the type string should be html-escaped first.
+	if insertWordBreaks {
+		displayName = html.EscapeString(displayName)
+		displayName = wbr(displayName)
+	} else {
+		displayName = html.EscapeString(displayName)
+	}
+
 	return propertyType{
-		Name:        langTypeString,
+		Name:        html.EscapeString(langTypeString),
 		DisplayName: displayName,
 		Link:        href,
 	}

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -616,11 +616,9 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 
 	// Name and DisplayName should be html-escaped to avoid throwing off rendering for template types in languages like
 	// csharp, Java etc. If word-breaks need to be inserted, then the type string should be html-escaped first.
+	displayName = html.EscapeString(displayName)
 	if insertWordBreaks {
-		displayName = html.EscapeString(displayName)
 		displayName = wbr(displayName)
-	} else {
-		displayName = html.EscapeString(displayName)
 	}
 
 	return propertyType{

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -611,14 +611,10 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 		displayName = mod.cleanTypeString(t, langTypeString, lang, modName, characteristics.input)
 	}
 
-	// If word-breaks need to be inserted, then the type string
-	// should be html-encoded first if the language is C# in order
-	// to avoid confusing the Hugo rendering where the word-break
-	// tags are inserted.
+	// If word-breaks need to be inserted, then the type string should be html-encoded first in order to avoid confusing
+	// the Hugo rendering where the word-break tags are inserted. This is required for languages with template types.
 	if insertWordBreaks {
-		if lang == "csharp" {
-			displayName = html.EscapeString(displayName)
-		}
+		displayName = html.EscapeString(displayName)
 		displayName = wbr(displayName)
 	}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This change fixes unsafe html emitted for Java properties for template types which results in mangling API docs for multiple resources, see https://www.pulumi.com/registry/packages/command/api-docs/local/command/ and https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/chart/ for instance.

The general expectation based on [this template]( https://github.com/pulumi/pulumi/blob/master/pkg/codegen/docs/templates/constructor_args.tmpl) is that the type name is already safe (`htmlSafe` marks literal strings to be safe) but this was not true before the change for template types (`e.g. List<T>`), resulting in unescaped html. 

I can certainly make the escaping parameterized on the language but I suspect this should be safe across all languages. Happy to make this more targeted if necessary.

Fixes # (issue)
https://github.com/pulumi/pulumi-kubernetes/issues/1982
https://github.com/pulumi/registry/issues/949

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
