### PR TITLE
bugfix/add-python-protobuf-dep-upperbound

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -31,3 +31,6 @@
 
 - [cli/backend] Fix a panic in the filestate backend when renaming history files.
   [#9673](https://github.com/pulumi/pulumi/pull/9673)
+  
+- [sdk/python] Added upperbound version pin to `protobuf` (<4.21.0).
+  [#9695](https://github.com/pulumi/pulumi/pull/9695)

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -37,7 +37,7 @@ setup(name='pulumi',
       },
       # Keep this list in sync with Pipfile
       install_requires=[
-          'protobuf>=3.6.0',
+          'protobuf>=3.6.0,<4.21.0',
           'dill>=0.3.0',
           'grpcio>=1.33.2',
           'six>=1.12.0',


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9694


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [x] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
