### PR TITLE
Pin python protobuf to <4

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,3 +28,6 @@
 
 - [cli/backend] Fix a panic in the filestate backend when renaming history files.
   [#9673](https://github.com/pulumi/pulumi/pull/9673)
+
+- [sdk/python] Pin protobuf library to <4.
+  [#9696](https://github.com/pulumi/pulumi/pull/9696)

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -37,7 +37,7 @@ setup(name='pulumi',
       },
       # Keep this list in sync with Pipfile
       install_requires=[
-          'protobuf>=3.6.0',
+          'protobuf>=3.6.0,<4',
           'dill>=0.3.0',
           'grpcio>=1.33.2',
           'six>=1.12.0',

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,6 +1,6 @@
 # Packages needed by the library.
 # Keep this list in sync with setup.py.
-protobuf>=3.6.0
+protobuf>=3.6.0,<4
 grpcio>=1.33.2
 dill>=0.3.0
 six>=1.12.0


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/9694

We should look at updating protoc such that we can generate new style python protobuf code. However that is _involved_ due to us being on an old version and both Go and Node generators have also changed substantially over time.

As quick fix for the p0 this just pins us to not use version 4 of the library.