### PR TITLE
Add --diff to preview in acceptance test flow.

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1323,7 +1323,7 @@ func (pt *ProgramTester) exportImport(dir string) error {
 func (pt *ProgramTester) PreviewAndUpdate(dir string, name string, shouldFail, expectNopPreview,
 	expectNopUpdate bool) error {
 
-	preview := []string{"preview", "--non-interactive"}
+	preview := []string{"preview", "--non-interactive", "--diff"}
 	update := []string{"up", "--non-interactive", "--yes", "--skip-preview", "--event-log", pt.updateEventLog}
 	if pt.opts.GetDebugUpdates() {
 		preview = append(preview, "-d")


### PR DESCRIPTION
Add diffs in order to make debugging acceptance tests failures in CI easier. Sample output:

```
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:dev::test-bucket::pulumi:pulumi:Stack::test-bucket-dev]
    + aws:s3/bucket:Bucket: (create)
        [urn=urn:pulumi:dev::test-bucket::aws:s3/bucket:Bucket::my-bucket]
        [provider=urn:pulumi:dev::test-bucket::pulumi:providers:aws::default_5_4_0::978387a2-eabb-4b06-b63d-0cd0f7a5225d]
        acl          : "private"
        bucket       : "my-bucket-0e20e92"
        forceDestroy : false
        websiteDomain: "stack72.dev"
    --outputs:--
  ~ bucketName: "my-new-bucket-9d8e54f" => output<string>
    - aws:s3/bucket:Bucket: (delete)
        [id=my-new-bucket-9d8e54f]
        [urn=urn:pulumi:dev::test-bucket::aws:s3/bucket:Bucket::my-new-bucket]
        [provider=urn:pulumi:dev::test-bucket::pulumi:providers:aws::default_5_4_0::978387a2-eabb-4b06-b63d-0cd0f7a5225d]
        acl          : "private"
        bucket       : "my-new-bucket-9d8e54f"
        forceDestroy : false
        websiteDomain: "stack72.dev"
Resources:
    + 1 to create
    - 1 to delete
    2 changes. 1 unchanged
```