### PR TITLE
Set unspecified explicit provider version to default provider version

### DIFF
--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -237,7 +237,7 @@ func installPlugins(
 		return nil, nil, err
 	}
 
-	allPlugins := languagePlugins.Union(snapshotPlugins)
+	allPlugins := languagePlugins.Union(snapshotPlugins).Deduplicate()
 
 	// If there are any plugins that are not available, we can attempt to install them here.
 	//

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1010,6 +1010,8 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 				return nil, fmt.Errorf("%s: passed invalid version: %w", label, err)
 			}
 			providers.SetProviderVersion(props, &version)
+		} else if prov, ok := rm.defaultProviders.defaultProviderInfo[providers.GetProviderPackage(t)]; ok && prov.Version != nil {
+			providers.SetProviderVersion(props, prov.Version)
 		}
 		if req.GetPluginDownloadURL() != "" {
 			providers.SetProviderURL(props, req.GetPluginDownloadURL())


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9482 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
