### PR TITLE
Update python requirments to pin to major version

### DIFF
--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -37,11 +37,11 @@ setup(name='pulumi',
       },
       # Keep this list in sync with Pipfile
       install_requires=[
-          'protobuf>=3.6.0,<4',
-          'dill>=0.3.0',
-          'grpcio>=1.33.2',
-          'six>=1.12.0',
-          'semver>=2.8.1',
-          'pyyaml>=5.3.1'
+          'protobuf~=3.6',
+          'grpcio~=1.33',
+          'dill~=0.3',
+          'six~=1.12',
+          'semver~=2.8',
+          'pyyaml~=5.3'
       ],
       zip_safe=False)

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,11 +1,11 @@
 # Packages needed by the library.
 # Keep this list in sync with setup.py.
-protobuf>=3.6.0,<4
-grpcio>=1.33.2
-dill>=0.3.0
-six>=1.12.0
-semver>=2.8.1
-pyyaml>=5.3.1
+protobuf~=3.6
+grpcio~=1.33
+dill~=0.3
+six~=1.12
+semver~=2.8
+pyyaml~=5.3
 
 # Dev packages only needed during development.
 pylint


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

After the _fun_ of protobuf releasing version 4 with breaking changes we want to try and reduce the chance of that happening across any of our dependencies again. 

`~=N.M` is the same as `==N.*,>=N.M`. That is no higher than the current major version, but higher or equal for the minor version.