### PR TITLE
Load runtime plugins in parallel to other plugins

### DIFF
--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -385,9 +385,6 @@ func (host *pluginHost) CloseProvider(provider plugin.Provider) error {
 	delete(host.plugins, provider)
 	return nil
 }
-func (host *pluginHost) ListPlugins() []workspace.PluginInfo {
-	return nil
-}
 func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
 	return nil
 }

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -71,9 +71,6 @@ func (host *testPluginHost) CloseProvider(provider plugin.Provider) error {
 func (host *testPluginHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
 	return nil, errors.New("unsupported")
 }
-func (host *testPluginHost) ListPlugins() []workspace.PluginInfo {
-	return nil
-}
 func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
 	return nil
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This isn't currently needed but it's a small enabler toward being able to use the runtime/language plugins to start up provider plugins (For example you'll be able to use the nodejs plugin to start up a pure nodejs project that runs as a resource provider, or to get the yaml plugin to behave as a resource provider based on a component.yaml file).

I think the only issue with loading these in parallel would of been the mutation of the plugins slice. But nothing actually used that, so I've just removed it.