### PR TITLE
add additional CI provider detection

### DIFF
--- a/sdk/go/common/util/ciutil/detect.go
+++ b/sdk/go/common/util/ciutil/detect.go
@@ -120,6 +120,13 @@ var detectors = map[SystemName]system{
 		Name:            Semaphore,
 		EnvVarsToDetect: []string{"SEMAPHORE"},
 	},
+	Spacelift: baseCI{
+		Name: Spacelift,
+		EnvVarsToDetect: []string{
+			"SPACELIFT_MAX_REQUESTS_BURST", "TF_VAR_spacelift_run_trigger", "SPACELIFT_STORE_HOOKS_ENV_VARS",
+			"TF_VAR_spacelift_commit_branch", "SPACELIFT_WORKER_TRACING_ENABLED",
+		},
+	},
 	TaskCluster: baseCI{
 		Name:            TaskCluster,
 		EnvVarsToDetect: []string{"TASK_ID", "RUN_ID"},

--- a/sdk/go/common/util/ciutil/systems.go
+++ b/sdk/go/common/util/ciutil/systems.go
@@ -44,6 +44,7 @@ const (
 	Jenkins       SystemName = "Jenkins"
 	MagnumCI      SystemName = "Magnum CI"
 	Semaphore     SystemName = "Semaphore"
+	Spacelift     SystemName = "Spacelift"
 	TaskCluster   SystemName = "TaskCluster"
 	TeamCity      SystemName = "TeamCity"
 	Travis        SystemName = "Travis CI"


### PR DESCRIPTION
Detect an additional CI provider, relying on the default implementation of [DetectVars](https://github.com/pulumi/pulumi/blob/29eb7bd3300f974e42791ad049a7c821ecf69c8b/sdk/go/common/util/ciutil/systems.go#L109) that just populates the provider name. 