### PR TITLE
Expose SDK generation from `pulumi`

### DIFF
--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -461,7 +461,7 @@ func newImportCmd() *cobra.Command {
 				programGenerator = gogen.GenerateProgram
 			case "nodejs":
 				programGenerator = nodejs.GenerateProgram
-			case "python":
+			case "python": //nolint:goconst
 				programGenerator = python.GenerateProgram
 			case "java":
 				programGenerator = javagen.GenerateProgram

--- a/pkg/cmd/pulumi/schema.go
+++ b/pkg/cmd/pulumi/schema.go
@@ -31,5 +31,6 @@ package schemas for errors.`,
 	}
 
 	cmd.AddCommand(newSchemaCheckCommand())
+	cmd.AddCommand(newSchemaGenCommand())
 	return cmd
 }

--- a/pkg/cmd/pulumi/schema_check.go
+++ b/pkg/cmd/pulumi/schema_check.go
@@ -60,7 +60,7 @@ func newSchemaCheckCommand() *cobra.Command {
 			}
 
 			var pkgSpec schema.PackageSpec
-			if ext := filepath.Ext(file); ext == ".yaml" || ext == ".yml" {
+			if ext := filepath.Ext(file); ext == ".yaml" || ext == YMLExt {
 				err = yaml.Unmarshal(schemaBytes, &pkgSpec)
 			} else {
 				err = json.Unmarshal(schemaBytes, &pkgSpec)

--- a/pkg/cmd/pulumi/schema_generate.go
+++ b/pkg/cmd/pulumi/schema_generate.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -35,10 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -47,17 +43,22 @@ const YMLExt = ".yml"
 
 func newSchemaGenCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "generate",
-		Short:   "Generate SDKs from providers or schema",
-		Args:    cmdutil.ExactArgs(1),
-		Aliases: []string{"gen"},
+		Use:        "generate-sdk",
+		Short:      "Generate the SDK for a provider or schema",
+		Args:       cmdutil.ExactArgs(1),
+		SuggestFor: []string{"generate"},
 		Long: "Generate SDKs from providers or schema\n" +
 			"\n" +
-			"Leverage CrossCode to generate a local copy of the SDK provided by the given provider or schema.",
+			"Leverage CrossCode to generate a local copy of the SDK described by the given provider or schema.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 			version, err := cmd.Flags().GetString("version")
 			contract.AssertNoError(err)
+			runtime, err := cmd.Flags().GetString("language")
+			contract.AssertNoError(err)
+			out, err := cmd.Flags().GetString("out")
+			contract.AssertNoError(err)
+
 			var v *semver.Version
 			if version != "" {
 				ver, err := semver.Parse(version)
@@ -67,64 +68,109 @@ func newSchemaGenCommand() *cobra.Command {
 				v = &ver
 			}
 
-			pkg, err := getPackage(name, v)
+			pkg, err := fetchSchema(name, v)
 			if err != nil {
 				return err
 			}
 
-			proj, _, err := readProject()
-			if err != nil {
-				return err
-			}
-
-			runtime := proj.Runtime.Name()
-			var (
-				generatePackage func(string, *schema.Package, map[string][]byte) (map[string][]byte, error)
-				after           func(map[string][]byte)
-			)
-			switch runtime {
-			case "nodejs":
-				generatePackage = nodejs.GeneratePackage
-				after = func(m map[string][]byte) {
-					if pkg.Version != nil {
-						pkgJSON := "package.json"
-						b, ok := m[pkgJSON]
-						contract.Assert(ok)
-						m[pkgJSON] = []byte(strings.ReplaceAll(string(b), "${VERSION}", pkg.Version.String()))
-					}
+			// This means that you can run `pulumi schema generate` without being in a
+			// project if you specify the runtime.
+			if runtime == "" {
+				proj, _, err := readProject()
+				if err != nil {
+					return err
 				}
-			case "dotnet":
-				generatePackage = dotnet.GeneratePackage
-			case "python":
-				generatePackage = python.GeneratePackage
-			case "go":
-				generatePackage = func(tool string, pkg *schema.Package, _ map[string][]byte) (map[string][]byte, error) {
-					return golang.GeneratePackage(tool, pkg)
-				}
-			case "java":
-				generatePackage = java.GeneratePackage
-			default:
-				return fmt.Errorf("unable to generate an SDK for the '%s' runtime", runtime)
-			}
 
-			files, err := generatePackage("pulumi", pkg, nil)
-			if err != nil {
-				return fmt.Errorf("unable to generate SDK: %w", err)
-			}
-			if after != nil {
-				after(files)
+				runtime = proj.Runtime.Name()
 			}
 
 			if pkg.Name == "" {
 				return fmt.Errorf("package has no name")
 			}
 
-			return writeFiles(filepath.Join(".", "pulumi-sdks", pkg.Name), files)
+			callGen := func(gen generateSDKFunc, after sdkCleanupFunc) (map[string][]byte, error) {
+				files, err := gen("pulumi", pkg, nil)
+				if err != nil {
+					return nil, err
+				}
+				if after != nil {
+					after(files)
+				}
+				return files, nil
+			}
+
+			if runtime == "all" {
+				for _, t := range []string{"nodejs", "dotnet", "python", "go", "java"} {
+					wrapErr := func(err error) error {
+						return fmt.Errorf("unable to generate %s SDK: %w", t, err)
+					}
+					gen, after, err := generateSDK(t, pkg.Version)
+					if err != nil {
+						return wrapErr(err)
+					}
+					files, err := callGen(gen, after)
+					if err != nil {
+						return wrapErr(err)
+					}
+
+					err = writeFiles(filepath.Join(out, t, pkg.Name), files)
+					if err != nil {
+						return wrapErr(err)
+					}
+				}
+				return nil
+			} else {
+				generatePackage, after, err := generateSDK(runtime, pkg.Version)
+				if err != nil {
+					return fmt.Errorf("unable to generate SDK: %w", err)
+				}
+				files, err := callGen(generatePackage, after)
+				if err != nil {
+					return fmt.Errorf("unable to generate SDK: %w", err)
+				}
+
+				return writeFiles(filepath.Join(out, pkg.Name), files)
+			}
 		}),
 	}
 	cmd.PersistentFlags().String("version", "", "The plugin version to use")
+	cmd.PersistentFlags().String("runtime", "", "The pulumi runtime to generate the SDK in. "+
+		"One of 'nodejs', 'dotnet', 'python', 'go', 'java' or 'all'.")
+	defaultOut := filepath.Join(".", "pulumi-sdks")
+	cmd.PersistentFlags().String("out", defaultOut,
+		fmt.Sprintf("The output directory to write the SDK to. Default is %s.", defaultOut))
 
 	return cmd
+}
+
+type generateSDKFunc func(string, *schema.Package, map[string][]byte) (map[string][]byte, error)
+type sdkCleanupFunc func(map[string][]byte)
+
+func generateSDK(runtime string, version *semver.Version) (generateSDKFunc, sdkCleanupFunc, error) {
+	noAfter := func(map[string][]byte) {}
+	switch runtime {
+	case "nodejs":
+		return nodejs.GeneratePackage, func(m map[string][]byte) {
+			if version != nil {
+				pkgJSON := "package.json"
+				b, ok := m[pkgJSON]
+				contract.Assert(ok)
+				m[pkgJSON] = []byte(strings.ReplaceAll(string(b), "${VERSION}", version.String()))
+			}
+		}, nil
+	case "dotnet":
+		return dotnet.GeneratePackage, noAfter, nil
+	case "python":
+		return python.GeneratePackage, noAfter, nil
+	case "go":
+		return func(tool string, pkg *schema.Package, _ map[string][]byte) (map[string][]byte, error) {
+			return golang.GeneratePackage(tool, pkg)
+		}, noAfter, nil
+	case "java":
+		return java.GeneratePackage, noAfter, nil
+	default:
+		return nil, nil, fmt.Errorf("unable to generate an SDK for the '%s' runtime", runtime)
+	}
 }
 
 func writeFiles(root string, files map[string][]byte) error {
@@ -142,39 +188,14 @@ func writeFiles(root string, files map[string][]byte) error {
 	return nil
 }
 
-func getPackage(name string, version *semver.Version) (*schema.Package, error) {
+// fetchSchema gets the package.Schema described by nameOrPath and version. If nameOrPath
+// is a path, it loads the schema from a file and verifies it is valid. If nameOrPath does
+// not end in a valid schema suffix (json, yaml, yml) it attempts to get the schema from
+// the provider called nameOrPath.
+func fetchSchema(nameOrPath string, version *semver.Version) (*schema.Package, error) {
 	// This is a schema file
-	if ext := filepath.Ext(name); ext == ".json" || ext == encoding.YAMLExt || ext == YMLExt {
-		schemaBytes, err := ioutil.ReadFile(name)
-		if err != nil {
-			return nil, fmt.Errorf("could not get schema file: %w", err)
-		}
-
-		var pkgSpec schema.PackageSpec
-		if ext == encoding.YAMLExt || ext == YMLExt {
-			err = yaml.Unmarshal(schemaBytes, &pkgSpec)
-		} else {
-			err = json.Unmarshal(schemaBytes, &pkgSpec)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
-		}
-
-		pkg, diags, err := schema.BindSpec(pkgSpec, nil)
-		if err != nil {
-			return nil, fmt.Errorf("unable to bind schema: %w", err)
-		}
-		diagWriter := hcl.NewDiagnosticTextWriter(os.Stderr, nil, 0, true)
-		wrErr := diagWriter.WriteDiagnostics(diags)
-		contract.IgnoreError(wrErr)
-		if diags.HasErrors() {
-			return nil, fmt.Errorf("invalid schema")
-		}
-
-		if pkg.Version != nil && version != nil && !pkg.Version.EQ(*version) {
-			return nil, fmt.Errorf("schema version did not match version flag: %s != %s", pkg.Version, version)
-		}
-		return pkg, nil
+	if ext := filepath.Ext(nameOrPath); ext == ".json" || ext == encoding.YAMLExt || ext == YMLExt {
+		return fetchSchemaFromFile(nameOrPath, version)
 	}
 
 	// This is a plugin
@@ -183,48 +204,45 @@ func getPackage(name string, version *semver.Version) (*schema.Package, error) {
 		return nil, fmt.Errorf("failed to load plugin host: %w", err)
 	}
 	loader := schema.NewPluginLoader(host)
-	pkg, err := loader.LoadPackage(name, version)
+	pkg, err := loader.LoadPackage(nameOrPath, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load package: %w", err)
 	}
 	return pkg, nil
-
 }
 
-func defaultPluginHost() (plugin.Host, error) {
-	var cfg plugin.ConfigSource
-	pwd, err := os.Getwd()
+// fetchSchemaFromFile retrieves a schema from a file at `path`. Schemas can be in either
+// JSON or YAML.
+func fetchSchemaFromFile(path string, version *semver.Version) (*schema.Package, error) {
+	ext := filepath.Ext(path)
+	schemaBytes, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not get schema file: %w", err)
 	}
-	sink := diag.DefaultSink(&stdio{false}, &stdio{false}, diag.FormatOptions{
-		Color: colors.Never,
-	})
-	context, err := plugin.NewContext(sink, sink, nil, cfg, pwd, nil, false, nil)
+
+	var pkgSpec schema.PackageSpec
+	if ext == encoding.YAMLExt || ext == YMLExt {
+		err = yaml.Unmarshal(schemaBytes, &pkgSpec)
+	} else {
+		err = json.Unmarshal(schemaBytes, &pkgSpec)
+	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
 	}
-	return plugin.NewDefaultHost(context, nil, nil, false)
-}
 
-// An io.ReadWriteCloser, whose value indicates if the closer is closed.
-type stdio struct{ bool }
-
-func (s *stdio) Read(p []byte) (n int, err error) {
-	if s.bool {
-		return 0, io.EOF
+	pkg, diags, err := schema.BindSpec(pkgSpec, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to bind schema: %w", err)
 	}
-	return os.Stdin.Read(p)
-}
-
-func (s *stdio) Write(p []byte) (n int, err error) {
-	if s.bool {
-		return 0, io.EOF
+	diagWriter := hcl.NewDiagnosticTextWriter(os.Stderr, nil, 0, true)
+	wrErr := diagWriter.WriteDiagnostics(diags)
+	contract.IgnoreError(wrErr)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("invalid schema")
 	}
-	return os.Stdout.Write(p)
-}
 
-func (s *stdio) Close() error {
-	s.bool = true
-	return nil
+	if pkg.Version != nil && version != nil && !pkg.Version.EQ(*version) {
+		return nil, fmt.Errorf("schema version did not match version flag: %s != %s", pkg.Version, version)
+	}
+	return pkg, nil
 }

--- a/pkg/cmd/pulumi/schema_generate.go
+++ b/pkg/cmd/pulumi/schema_generate.go
@@ -119,18 +119,19 @@ func newSchemaGenCommand() *cobra.Command {
 					}
 				}
 				return nil
-			} else {
-				generatePackage, after, err := generateSDK(runtime, pkg.Version)
-				if err != nil {
-					return fmt.Errorf("unable to generate SDK: %w", err)
-				}
-				files, err := callGen(generatePackage, after)
-				if err != nil {
-					return fmt.Errorf("unable to generate SDK: %w", err)
-				}
-
-				return writeFiles(filepath.Join(out, pkg.Name), files)
 			}
+
+			// A specific runtime was specified
+			generatePackage, after, err := generateSDK(runtime, pkg.Version)
+			if err != nil {
+				return fmt.Errorf("unable to generate SDK: %w", err)
+			}
+			files, err := callGen(generatePackage, after)
+			if err != nil {
+				return fmt.Errorf("unable to generate SDK: %w", err)
+			}
+
+			return writeFiles(filepath.Join(out, pkg.Name), files)
 		}),
 	}
 	cmd.PersistentFlags().String("version", "", "The plugin version to use")

--- a/pkg/cmd/pulumi/schema_generate.go
+++ b/pkg/cmd/pulumi/schema_generate.go
@@ -1,0 +1,199 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/blang/semver"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+const YMLExt = ".yml"
+
+func newSchemaGenCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "generate",
+		Short:   "Generate SDKs from providers or schema",
+		Args:    cmdutil.ExactArgs(1),
+		Aliases: []string{"gen"},
+		Long: "Generate SDKs from providers or schema\n" +
+			"\n" +
+			"Leverage CrossCode to generate a local copy of the SDK provided by the given provider or schema.",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			version, err := cmd.Flags().GetString("version")
+			contract.AssertNoError(err)
+			var v *semver.Version
+			if version != "" {
+				ver, err := semver.Parse(version)
+				if err != nil {
+					return fmt.Errorf("failed to parse version: %w", err)
+				}
+				v = &ver
+			}
+
+			pkg, err := getPackage(name, v)
+			if err != nil {
+				return err
+			}
+
+			proj, _, err := readProject()
+			if err != nil {
+				return err
+			}
+
+			var files map[string][]byte
+			runtime := proj.Runtime.Name()
+			switch runtime {
+			case "nodejs":
+				files, err = nodejs.GeneratePackage("pulumi", pkg, nil)
+			default:
+				return fmt.Errorf("unable to generate an SDK for the '%s' runtime", runtime)
+			}
+			if err != nil {
+				return fmt.Errorf("unable to generate SDK: %w", err)
+			}
+
+			if pkg.Name == "" {
+				return fmt.Errorf("package has no name")
+			}
+
+			return writeFiles(filepath.Join(".", "pulumi_sdks", pkg.Name), files)
+		}),
+	}
+	cmd.PersistentFlags().String("version", "", "The plugin version to use")
+
+	return cmd
+}
+
+func writeFiles(root string, files map[string][]byte) error {
+	for file, bytes := range files {
+		relPath := filepath.FromSlash(file)
+		path := filepath.Join(root, relPath)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && !os.IsExist(err) {
+			return err
+		}
+
+		if err := ioutil.WriteFile(path, bytes, 0600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getPackage(name string, version *semver.Version) (*schema.Package, error) {
+	// This is a schema file
+	if ext := filepath.Ext(name); ext == ".json" || ext == encoding.YAMLExt || ext == YMLExt {
+		schemaBytes, err := ioutil.ReadFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("could not get schema file: %w", err)
+		}
+
+		var pkgSpec schema.PackageSpec
+		if ext == encoding.YAMLExt || ext == YMLExt {
+			err = yaml.Unmarshal(schemaBytes, &pkgSpec)
+		} else {
+			err = json.Unmarshal(schemaBytes, &pkgSpec)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
+		}
+
+		pkg, diags, err := schema.BindSpec(pkgSpec, nil)
+		if err != nil {
+			return nil, fmt.Errorf("unable to bind schema: %w", err)
+		}
+		diagWriter := hcl.NewDiagnosticTextWriter(os.Stderr, nil, 0, true)
+		wrErr := diagWriter.WriteDiagnostics(diags)
+		contract.IgnoreError(wrErr)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("invalid schema")
+		}
+
+		if pkg.Version != nil && version != nil && !pkg.Version.EQ(*version) {
+			return nil, fmt.Errorf("schema version did not match version flag: %s != %s", pkg.Version, version)
+		}
+		return pkg, nil
+	}
+
+	// This is a plugin
+	host, err := defaultPluginHost()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load plugin host: %w", err)
+	}
+	loader := schema.NewPluginLoader(host)
+	pkg, err := loader.LoadPackage(name, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load package: %w", err)
+	}
+	return pkg, nil
+
+}
+
+func defaultPluginHost() (plugin.Host, error) {
+	var cfg plugin.ConfigSource
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	sink := diag.DefaultSink(&stdio{false}, &stdio{false}, diag.FormatOptions{
+		Color: colors.Never,
+	})
+	context, err := plugin.NewContext(sink, sink, nil, cfg, pwd, nil, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plugin.NewDefaultHost(context, nil, nil, false)
+}
+
+// An io.ReadWriteCloser, whose value indicates if the closer is closed.
+type stdio struct{ bool }
+
+func (s *stdio) Read(p []byte) (n int, err error) {
+	if s.bool {
+		return 0, io.EOF
+	}
+	return os.Stdin.Read(p)
+}
+
+func (s *stdio) Write(p []byte) (n int, err error) {
+	if s.bool {
+		return 0, io.EOF
+	}
+	return os.Stdout.Write(p)
+}
+
+func (s *stdio) Close() error {
+	s.bool = true
+	return nil
+}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,8 +49,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -946,4 +948,21 @@ func log3rdPartySecretsProviderDecryptionEvent(ctx context.Context, backend back
 			}
 		}
 	}
+}
+
+// Creates a simple plugin host that writes to the terminal.
+func defaultPluginHost() (plugin.Host, error) {
+	var cfg plugin.ConfigSource
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	sink := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
+		Color: colors.Never,
+	})
+	context, err := plugin.NewContext(sink, sink, nil, cfg, pwd, nil, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return plugin.NewDefaultHost(context, nil, nil, false)
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This is an updated and expanded version of https://github.com/pulumi/pulumi/pull/7876. 

With regards to versioning:
We build codegen as part of pulumi/pulumi, so our codegen would be part of the same versioning scheme. This should be ok for the vast majority of users. If users are concerned about versioning SDKgen (codegen) separately from the CLI, they are able to write their own binary, pinning specific versions of pulumi/pulumi and pulumi/pulumi-java as they feel necessary. While I think that this system can be used by power users, adding `pulumi schema generate-sdk` does not restrict more invested users from building out SDKgen (codegen) as their own application.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
