### PR TITLE
Fix `join` equivalent operation when nesting ApplyT

### DIFF
--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -201,13 +201,15 @@ func (o *OutputState) fulfillValue(value reflect.Value, known, secret bool, deps
 }
 
 func mergeDependencies(ours []Resource, theirs []Resource) []Resource {
-	mergedDeps := make([]Resource, 0, len(ours)+len(theirs))
-	if theirs == nil {
-		return append(mergedDeps, ours...)
-	} else if ours == nil {
-		return append(mergedDeps, theirs...)
+	if len(ours) == 0 && len(theirs) == 0 {
+		return nil
+	} else if len(theirs) == 0 {
+		return append(make([]Resource, 0, len(ours)), ours...)
+	} else if len(ours) == 0 {
+		return append(make([]Resource, 0, len(ours)), theirs...)
 	}
 	depSet := make(map[Resource]struct{})
+	mergedDeps := make([]Resource, 0, len(ours)+len(theirs))
 	for _, d := range ours {
 		depSet[d] = struct{}{}
 	}

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -255,11 +255,11 @@ func (o *OutputState) await(ctx context.Context) (interface{}, bool, bool, []Res
 		o.mutex.Unlock()
 
 		deps = mergeDependencies(deps, o.deps)
-		if !o.known || o.err != nil {
-			return nil, false, false, deps, o.err
-		}
 		known = known && o.known
 		secret = secret || o.secret
+		if !o.known || o.err != nil {
+			return nil, known, secret, deps, o.err
+		}
 
 		// If the result is an Output, await it in turn.
 		//

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -201,10 +201,11 @@ func (o *OutputState) fulfillValue(value reflect.Value, known, secret bool, deps
 }
 
 func mergeDependencies(ours []Resource, theirs []Resource) []Resource {
+	mergedDeps := make([]Resource, 0, len(ours)+len(theirs))
 	if theirs == nil {
-		return ours
+		return append(mergedDeps, ours...)
 	} else if ours == nil {
-		return theirs
+		return append(mergedDeps, theirs...)
 	}
 	depSet := make(map[Resource]struct{})
 	for _, d := range ours {
@@ -213,7 +214,6 @@ func mergeDependencies(ours []Resource, theirs []Resource) []Resource {
 	for _, d := range theirs {
 		depSet[d] = struct{}{}
 	}
-	mergedDeps := make([]Resource, 0, len(depSet))
 	for d := range depSet {
 		mergedDeps = append(mergedDeps, d)
 	}
@@ -233,6 +233,10 @@ func (o *OutputState) reject(err error) {
 }
 
 func (o *OutputState) await(ctx context.Context) (interface{}, bool, bool, []Resource, error) {
+	known := true
+	secret := false
+	var deps []Resource
+
 	for {
 		if o == nil {
 			// If the state is nil, treat its value as resolved and unknown.
@@ -248,20 +252,21 @@ func (o *OutputState) await(ctx context.Context) (interface{}, bool, bool, []Res
 		}
 		o.mutex.Unlock()
 
+		deps = mergeDependencies(deps, o.deps)
 		if !o.known || o.err != nil {
-			return nil, o.known, o.secret, o.deps, o.err
+			return nil, false, false, deps, o.err
 		}
+		known = known && o.known
+		secret = secret || o.secret
 
 		// If the result is an Output, await it in turn.
 		//
 		// NOTE: this isn't exactly type safe! The element type of the inner output really needs to be assignable to
 		// the element type of the outer output. We should reconsider this.
 		if ov, ok := o.value.(Output); ok {
-			deps := o.deps
 			o = ov.getState()
-			o.deps = mergeDependencies(o.deps, deps)
 		} else {
-			return o.value, true, o.secret, o.deps, nil
+			return o.value, true, secret, deps, nil
 		}
 	}
 }

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -911,5 +911,5 @@ func TestApplyTOutputJoin(t *testing.T) {
 
 	assertResult(t, out3, 5, true, true, r3)
 	assertResult(t, out31, 2, true, true, r3, r1)
-	assertResult(t, out312, nil, false, false, r3, r1, r2) /* out2 is unknown, hiding the output */
+	assertResult(t, out312, nil, false, true, r3, r1, r2) /* out2 is unknown, hiding the output */
 }

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -817,3 +817,99 @@ func TestApplyTOutput(t *testing.T) {
 		assert.Len(t, deps, 4)
 	}
 }
+
+func assertResult(t *testing.T, o Output, expectedValue interface{}, expectedKnown, expectedSecret bool, expectedDeps ...CustomResource) {
+	t.Helper()
+	v, known, secret, deps, err := o.getState().await(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedValue, v, "values do not match")
+	assert.Equal(t, expectedKnown, known, "known-ness does not match")
+	assert.Equal(t, expectedSecret, secret, "secret-ness does not match")
+	var depUrns []URN
+	for _, v := range deps {
+		depUrns = append(depUrns, v.URN().value.(URN))
+	}
+	var expectedUrns []URN
+	for _, v := range expectedDeps {
+		expectedUrns = append(expectedUrns, v.URN().value.(URN))
+	}
+	assert.ElementsMatch(t, depUrns, expectedUrns)
+}
+
+// Test that nested Apply operations accumulate state correctly.
+func TestApplyTOutputJoinDeps(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := NewContext(context.Background(), RunInfo{})
+	assert.Nil(t, err)
+	rA := newSimpleCustomResource(ctx, URN("urnA"), ID("idA"))
+	rB := newSimpleCustomResource(ctx, URN("urnB"), ID("idB"))
+
+	outA := IntOutput{newOutputState(nil, reflect.TypeOf(0), rA)}
+	outB := IntOutput{newOutputState(nil, reflect.TypeOf(0), rB)}
+
+	applyF := func(outA, outB IntOutput) IntOutput {
+		return outA.ApplyT(func(v int) (IntOutput, error) {
+			return outB, nil
+		}).(IntOutput)
+	}
+
+	outAB := applyF(outA, outB)
+
+	outA.resolve(3, true, false, []Resource{rA})
+	outB.resolve(5, true, false, []Resource{rB})
+
+	assertResult(t, outA, 3, true, false, rA)
+	assertResult(t, outAB, 5, true, false, rA, rB)
+	assertResult(t, outB, 5, true, false, rB)
+
+}
+
+// Test that nested Apply operations accumulate state correctly.
+func TestApplyTOutputJoin(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := NewContext(context.Background(), RunInfo{})
+	assert.Nil(t, err)
+	r1 := newSimpleCustomResource(ctx, URN("urn1"), ID("id1"))
+	r2 := newSimpleCustomResource(ctx, URN("urn2"), ID("id2"))
+	r3 := newSimpleCustomResource(ctx, URN("urn3"), ID("id3"))
+
+	out1 := IntOutput{newOutputState(nil, reflect.TypeOf(0), r1)}
+	out2 := IntOutput{newOutputState(nil, reflect.TypeOf(0), r2)}
+	out3 := IntOutput{newOutputState(nil, reflect.TypeOf(0), r3)}
+
+	go func() {
+		out1.resolve(2, true, false, []Resource{r1})
+		out2.resolve(3, false, false, []Resource{r2}) // value set but known => output.value == nil
+		out3.resolve(5, true, true, []Resource{r3})
+	}()
+
+	applyF := func(outA, outB IntOutput) IntOutput {
+		return outA.ApplyT(func(v int) (IntOutput, error) {
+			return outB, nil
+		}).(IntOutput)
+	}
+
+	out12 := applyF(out1, out2)
+	out123 := applyF(out12, out3)
+
+	out23 := applyF(out2, out3)
+	out231 := applyF(out23, out1)
+
+	out31 := applyF(out3, out1)
+	out312 := applyF(out31, out2)
+
+	assertResult(t, out1, 2, true, false, r1)
+	assertResult(t, out12, nil, false, false, r1, r2)
+	assertResult(t, out123, nil, false, false, r1, r2) /* out2 is unknown, hiding out3 */
+
+	/* out2 is unknown, early exit hides all nested outputs */
+	assertResult(t, out2, nil, false, false, r2)
+	assertResult(t, out23, nil, false, false, r2)
+	assertResult(t, out231, nil, false, false, r2)
+
+	assertResult(t, out3, 5, true, true, r3)
+	assertResult(t, out31, 2, true, true, r3, r1)
+	assertResult(t, out312, nil, false, false, r3, r1, r2) /* out2 is unknown, hiding the output */
+}


### PR DESCRIPTION
An Output and its ApplyT method has behavior akin to NodeJS' Promise and then method, in that nested outputs are unwrapped. A previous PR, to fix #9506, lacked rigorous tests of the desired behavior of the unwrapping.

This adds those tests and solves some bugs caused by mutation in the `await` function. Instead, a fresh Output is created and we properly implement a Monadic "join" like behavior where we accumulate known-ness/errors, secret-ness, and dependencies. If not for known-ness, these would be a commutative monoid and order-independent. Two states however are non-commutative: when not known or the error field is set. This behaves similar to throwing an exception in NodeJS, we early exit and additional Then methods don't have their arguments called.

Without this PR, the added tests will fail as follows:

This line of `TestApplyTOutputJoinDeps`, due to mutation of `outB` adding `rA` to the dependencies:

https://github.com/pulumi/pulumi/blob/ef8af8843061be632b574744210aa2c253cede59/sdk/go/pulumi/types_test.go#L864

These lines of `TestApplyTOutputJoin`, due to mutation of `out2` adding `r1` to the dependencies:

https://github.com/pulumi/pulumi/blob/ef8af8843061be632b574744210aa2c253cede59/sdk/go/pulumi/types_test.go#L908-L910

This line of `TestApplyTOutputJoin`, due to `await` not accumulating secret-ness. 

https://github.com/pulumi/pulumi/blob/ef8af8843061be632b574744210aa2c253cede59/sdk/go/pulumi/types_test.go#L913
 