### PR TITLE
[ci] use unprefixed (no-v) version for generic version, fix docker container builds

### DIFF
--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-GENERIC_VERSION=v$(pulumictl get version --language generic -o)
-echo GENERIC_VERSION=$GENERIC_VERSION
-echo PYPI_VERSION=$(pulumictl get version --language python)
-echo DOTNET_VERSION=$(pulumictl get version --language dotnet)
-echo GORELEASER_CURRENT_TAG=$GENERIC_VERSION
+GENERIC_VERSION="$(pulumictl get version --language generic -o)"
+echo GENERIC_VERSION="$GENERIC_VERSION"
+echo PYPI_VERSION="$(pulumictl get version --language python)"
+echo DOTNET_VERSION="$(pulumictl get version --language dotnet)"
+echo GORELEASER_CURRENT_TAG="v$GENERIC_VERSION"


### PR DESCRIPTION
The places where GENERIC_VERSION is used in the CI scripts previously expected a version like "a.b.c", not "***v***a.b.c".

Or to be precise, they expected the verbatim output of `$(pulumictl get version --language generic -o)`, and the GENERIC_VERSION env var added a `v` prefix.

Intended to fix build errors on pulumi-docker-containers like the following:

https://github.com/pulumi/pulumi-docker-containers/runs/6660404954?check_suite_focus=true