### PR TITLE
Add typed error when an empty schema is returned

### DIFF
--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -143,7 +143,7 @@ func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Packag
 
 var ErrGetSchemaNotImplemented = getSchemaNotImplemented{}
 
-type getSchemaNotImplemented struct{ err error }
+type getSchemaNotImplemented struct{}
 
 func (f getSchemaNotImplemented) Error() string {
 	return fmt.Sprintf("it looks like GetSchema is not implemented")

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -140,6 +141,14 @@ func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Packag
 	return ref.Definition()
 }
 
+var ErrGetSchemaNotImplemented = getSchemaNotImplemented{}
+
+type getSchemaNotImplemented struct{ err error }
+
+func (f getSchemaNotImplemented) Error() string {
+	return fmt.Sprintf("it looks like GetSchema is not implemented")
+}
+
 func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version) (PackageReference, error) {
 	key := packageIdentity(pkg, version)
 
@@ -161,6 +170,11 @@ func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version)
 	schemaBytes, err := provider.GetSchema(schemaFormatVersion)
 	if err != nil {
 		return nil, err
+	}
+	// We assume that GetSchema isn't implemented it something of the form "{[\t\n ]*}" is
+	// returned. That is what we did in the past when we chose not to implement GetSchema.
+	if s := string(schemaBytes); strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(s, "{"), "}")) == "" {
+		return nil, getSchemaNotImplemented{}
 	}
 
 	var spec PartialPackageSpec


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This is part of fixing https://github.com/pulumi/pulumi-yaml/issues/135.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
