### PR TITLE
Special case the error specifing app.pulumi.com

### DIFF
--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -121,9 +121,10 @@ func newLoginCmd() *cobra.Command {
 					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
 			} else if url := strings.TrimPrefix(strings.TrimPrefix(
-				cloudURL, "https://"), "http://"); strings.HasPrefix(url, "app.pulumi.com/") {
+				cloudURL, "https://"), "http://"); strings.HasPrefix(url, "app.pulumi.com/") ||
+				strings.HasPrefix(url, "pulumi.com") {
 				return fmt.Errorf("%s is not a valid self-hosted backend, "+
-					"use `pulumi login` without any arguments to log into the Pulumi service backend", cloudURL)
+					"use `pulumi login` without arguments to log into the Pulumi service backend", cloudURL)
 			} else {
 				// Ensure we have the correct cloudurl type before logging in
 				if err := validateCloudBackendType(cloudURL); err != nil {

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -120,8 +120,10 @@ func newLoginCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
-			} else if url := strings.TrimPrefix(strings.TrimPrefix(cloudURL, "https://"), "http://"); strings.HasPrefix(url, "app.pulumi.com/") {
-				return fmt.Errorf("%s is not a valid self-hosted backend, use `pulumi login` without any arguments to log into the Pulumi service backend", cloudURL)
+			} else if url := strings.TrimPrefix(strings.TrimPrefix(
+				cloudURL, "https://"), "http://"); strings.HasPrefix(url, "app.pulumi.com/") {
+				return fmt.Errorf("%s is not a valid self-hosted backend, "+
+					"use `pulumi login` without any arguments to log into the Pulumi service backend", cloudURL)
 			} else {
 				// Ensure we have the correct cloudurl type before logging in
 				if err := validateCloudBackendType(cloudURL); err != nil {

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -120,6 +120,8 @@ func newLoginCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
+			} else if url := strings.TrimPrefix(strings.TrimPrefix(cloudURL, "https://"), "http://"); strings.HasPrefix(url, "app.pulumi.com/") {
+				return fmt.Errorf("%s is not a valid self-hosted backend, use `pulumi login` without any arguments to log into the Pulumi service backend", cloudURL)
 			} else {
 				// Ensure we have the correct cloudurl type before logging in
 				if err := validateCloudBackendType(cloudURL); err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9410

I think we should just respond with an error message here. If you type `https://api.pulumi.com` then everything works as expected. We shouldn't perform the automatic conversion of `app` to `api`. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
