### PR TITLE
Fix goreleaser configs

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -29,7 +29,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi
+    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-windows
   binary: pulumi
@@ -38,7 +38,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi.exe
+    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-go-unix
   binary: pulumi-language-go
@@ -47,7 +47,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go
+    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-go-windows
   binary: pulumi-language-go
@@ -56,7 +56,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-nodejs-unix
   binary: pulumi-language-nodejs
@@ -65,7 +65,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs
+    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
@@ -74,7 +74,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-python-unix
   binary: pulumi-language-python
@@ -83,7 +83,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python
+    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-python-windows
   binary: pulumi-language-python
@@ -92,7 +92,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-dotnet-unix
   binary: pulumi-language-dotnet
@@ -101,7 +101,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet
+    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-dotnet-windows
   binary: pulumi-language-dotnet
@@ -110,7 +110,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-java-unix
   binary: pulumi-language-java

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi
+    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-windows
   binary: pulumi
@@ -32,7 +32,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi.exe
+    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-go-unix
   binary: pulumi-language-go
@@ -41,7 +41,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go
+    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-go-windows
   binary: pulumi-language-go
@@ -50,7 +50,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-nodejs-unix
   binary: pulumi-language-nodejs
@@ -59,7 +59,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs
+    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
@@ -68,7 +68,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-python-unix
   binary: pulumi-language-python
@@ -77,7 +77,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python
+    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-python-windows
   binary: pulumi-language-python
@@ -86,7 +86,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-dotnet-unix
   binary: pulumi-language-dotnet
@@ -95,7 +95,7 @@ builds:
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet-unix_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet
+    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-dotnet-windows
   binary: pulumi-language-dotnet
@@ -104,7 +104,7 @@ builds:
   goarch: ['amd64']
   goamd64: ['v1']
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet-windows_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet.exe
+    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet.exe
   mod_timestamp: '{{ .CommitTimestamp }}'
 - id: pulumi-language-java-unix
   binary: pulumi-language-java


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Prebuilt builder needs the right (changed) paths to find the binaries downloaded from the artifacts. Tested this one locally. Fixes failing build on master.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
