### PR TITLE
Fix 9763 test-windows-cron

### DIFF
--- a/.github/workflows/test-windows-cron.yml
+++ b/.github/workflows/test-windows-cron.yml
@@ -13,11 +13,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     needs: versions
     with:
-      # Cross-compiling from ubuntu-latest is faster but the artifact
-      # checksums will not match what publish-binaries expects.
-      default-build-platform: macos-latest
       enable-coverage: true
-      goreleaser-config: '.goreleaser.prerelease.yml'
       goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
   test-windows:
     name: Test Windows

--- a/.github/workflows/test-windows-cron.yml
+++ b/.github/workflows/test-windows-cron.yml
@@ -14,7 +14,7 @@ jobs:
     needs: versions
     with:
       enable-coverage: true
-      goreleaser-flags: '-p 3 --skip-publish --skip-announce --skip-validate'
+      goreleaser-flags: -p 3 --skip-validate
   test-windows:
     name: Test Windows
     needs: build


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9763 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
