### PR TITLE
[python,nodejs] Speed up codegen tests

### DIFF
--- a/pkg/codegen/nodejs/test.go
+++ b/pkg/codegen/nodejs/test.go
@@ -77,7 +77,8 @@ func typeCheckGeneratedPackage(t *testing.T, pwd string, linkLocal bool) {
 		// Avoid Out of Memory error on CI:
 		Env: []string{"NODE_OPTIONS=--max_old_space_size=4096"},
 	}
-	test.RunCommandWithOptions(t, tscOptions, "tsc", pwd, "yarn", "run", "tsc", "--noEmit")
+	test.RunCommandWithOptions(t, tscOptions, "tsc", pwd, "yarn", "run", "tsc",
+		"--noEmit", "--skipLibCheck", "true", "--skipDefaultLibCheck", "true")
 }
 
 // Returns the nodejs equivalent to the hcl2 package names provided.

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -150,6 +150,11 @@ func buildVirtualEnv() error {
 }
 
 func pyTestCheck(t *testing.T, codeDir string) {
+	extraDir := filepath.Join(filepath.Dir(codeDir), "python-extras")
+	if _, err := os.Stat(extraDir); os.IsNotExist(err) {
+		// We won't run any tests since no extra tests were included.
+		return
+	}
 	venvDir, err := virtualEnvPath()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Two codegen optimizations on the longest running languages:
- Python: Don't run pyTestCheck unless there were mixins that add tests. On my machine this changes the python test time from ~340s to ~55s.
- TypeScript: Add the `tsc` flags '--skipLibCheck true` and `--skipDefaultLibCheck true'. This cuts ~50s off of the
total time needed in github.com/pulumi/pulumi/pkg/v3/codegen/nodejs. This is valid if we assume that packages which we depend on are valid. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
