### PR TITLE
[codegen] isolate and make concurrency-safe the opaque types in binder

### DIFF
--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -525,23 +525,25 @@ func TestObjectType(t *testing.T) {
 func TestOpaqueType(t *testing.T) {
 	t.Parallel()
 
-	foo, err := NewOpaqueType("foo")
+	m := NewOpaqueTypeMap()
+
+	foo, err := m.InsertOpaqueType("foo")
 	assert.NotNil(t, foo)
 	assert.NoError(t, err)
 
-	foo2, ok := GetOpaqueType("foo")
+	foo2, ok := m.GetOpaqueType("foo")
 	assert.EqualValues(t, foo, foo2)
 	assert.True(t, ok)
 
-	foo3, err := NewOpaqueType("foo")
+	foo3, err := m.InsertOpaqueType("foo")
 	assert.Nil(t, foo3)
 	assert.Error(t, err)
 
-	bar, ok := GetOpaqueType("bar")
+	bar, ok := m.GetOpaqueType("bar")
 	assert.Nil(t, bar)
 	assert.False(t, ok)
 
-	bar, err = NewOpaqueType("bar")
+	bar, err = m.InsertOpaqueType("bar")
 	assert.NotNil(t, bar)
 	assert.NoError(t, err)
 

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -55,6 +55,8 @@ type binder struct {
 	tokens syntax.TokenMap
 	nodes  []Node
 	root   *model.Scope
+
+	opaqueTypes model.OpaqueTypeMap
 }
 
 type BindOption func(*bindOptions)
@@ -122,6 +124,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		referencedPackages: map[string]schema.PackageReference{},
 		schemaTypes:        map[schema.Type]model.Type{},
 		root:               model.NewRootScope(syntax.None),
+		opaqueTypes:        model.NewOpaqueTypeMap(),
 	}
 
 	// Define null.

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -234,12 +234,7 @@ func (b *binder) schemaTypeToType(src schema.Type) model.Type {
 		}
 		return objType
 	case *schema.TokenType:
-		t, ok := model.GetOpaqueType(src.Token)
-		if !ok {
-			tt, err := model.NewOpaqueType(src.Token)
-			contract.IgnoreError(err)
-			t = tt
-		}
+		t := b.opaqueTypes.InsertOpaqueType(src.Token)
 
 		if src.UnderlyingType != nil {
 			underlyingType := b.schemaTypeToType(src.UnderlyingType)


### PR DESCRIPTION
A test failure on the PR #9686 exposed a data race that could cause a spurious error or a panic. The data race occurs if two threads both do a Get of the same name from the global map, both find that the entry is absent, and one succeeds in inserting before the other, resulting in NewOpaqueType erroneously returning an error. The panic occurs if both threads end up in the map write at the same time.

https://github.com/pulumi/pulumi/blob/36cbf572f45790f6859a8da3f8d67f6b32620fca/pkg/codegen/pcl/binder_schema.go#L237-L239