### PR TITLE
[pkg] Enable main_test to compile on go 1.17 and go 1.18

### DIFF
--- a/pkg/cmd/pulumi/main_1.17_test.go
+++ b/pkg/cmd/pulumi/main_1.17_test.go
@@ -1,0 +1,25 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.18
+// +build !go1.18
+
+package main
+
+import "testing"
+
+func MainStart() *testing.M {
+	// go1.18 added an additional arg
+	return testing.MainStart(noTestDeps(0), nil, nil, nil)
+}

--- a/pkg/cmd/pulumi/main_1.17_test.go
+++ b/pkg/cmd/pulumi/main_1.17_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !go1.18
-// +build !go1.18
 
 package main
 

--- a/pkg/cmd/pulumi/main_1.18_test.go
+++ b/pkg/cmd/pulumi/main_1.18_test.go
@@ -1,0 +1,24 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package main
+
+import "testing"
+
+func MainStart() *testing.M {
+	return testing.MainStart(noTestDeps(0), nil, nil, nil, nil)
+}

--- a/pkg/cmd/pulumi/main_1.18_test.go
+++ b/pkg/cmd/pulumi/main_1.18_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build go1.18
-// +build go1.18
 
 package main
 


### PR DESCRIPTION
This file previously compiled only on go 1.17 as the signature for `MainStart` changed. This adds the necessary methods and via conditional compilation, targets pre-1.18 and 1.18 methods.