### PR TITLE
Clone and test pulumi/templates from the current working branch

### DIFF
--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -330,9 +330,7 @@ func retrievePulumiTemplates(templateName string, offline bool, templateKind Tem
 	currentGithubRepo := os.Getenv("GITHUB_REPOSITORY")
 
 	if !offline && currentGithubRepo == "pulumi/templates" {
-		// means we are running this function from pulumi/templates
-		// then make sure we are retrieving the templates from the branch
-		// that had triggered this code so that we are testing the right changes
+
 		currentGithubBranch := os.Getenv("GITHUB_BRANCH")
 		templatesBranch := plumbing.NewBranchReferenceName(currentGithubBranch)
 		err := gitutil.GitCloneOrPull(currentGithubRepo, templatesBranch, templateDir, false /*shallow*/)
@@ -349,6 +347,15 @@ func retrievePulumiTemplates(templateName string, offline bool, templateKind Tem
 			repo = pulumiPolicyTemplateGitRepository
 			branch = plumbing.NewBranchReferenceName(pulumiPolicyTemplateBranch)
 		}
+
+		if os.Getenv("GITHUB_REPOSITORY") == "pulumi/templates" {
+			// means we are running this function from pulumi/templates
+			// make sure we are retrieving the templates from the branch
+			// that had triggered this code so that we are testing the right changes
+			currentTemplatesBranch := os.Getenv("GITHUB_BRANCH")
+			branch = plumbing.NewBranchReferenceName(currentTemplatesBranch)
+		}
+
 		err := gitutil.GitCloneOrPull(repo, branch, templateDir, false /*shallow*/)
 		if err != nil {
 			return TemplateRepository{}, fmt.Errorf("cloning templates repo: %w", err)

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -326,7 +326,7 @@ func retrievePulumiTemplates(templateName string, offline bool, templateKind Tem
 	if err := os.MkdirAll(templateDir, 0700); err != nil {
 		return TemplateRepository{}, err
 	}
-	
+
 	if !offline {
 		// Clone or update the pulumi/templates repo.
 		repo := pulumiTemplateGitRepository

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -326,19 +326,7 @@ func retrievePulumiTemplates(templateName string, offline bool, templateKind Tem
 	if err := os.MkdirAll(templateDir, 0700); err != nil {
 		return TemplateRepository{}, err
 	}
-
-	currentGithubRepo := os.Getenv("GITHUB_REPOSITORY")
-
-	if !offline && currentGithubRepo == "pulumi/templates" {
-
-		currentGithubBranch := os.Getenv("GITHUB_BRANCH")
-		templatesBranch := plumbing.NewBranchReferenceName(currentGithubBranch)
-		err := gitutil.GitCloneOrPull(currentGithubRepo, templatesBranch, templateDir, false /*shallow*/)
-		if err != nil {
-			return TemplateRepository{}, fmt.Errorf("cloning templates repo: %w", err)
-		}
-	}
-
+	
 	if !offline {
 		// Clone or update the pulumi/templates repo.
 		repo := pulumiTemplateGitRepository


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Right now, when we are raising a PR in pulumi/templates, it uses [workspace.RetrieveTemplates](https://github.com/pulumi/templates/blob/master/tests/template_test.go#L70) which in turn calls [retrievePulumiTemplates](https://github.com/pulumi/pulumi/blob/master/sdk/go/common/workspace/templates.go#L311) in pulumi/pulumi that clones and tests the templates from `master` branch of pulumi/templates instead of cloning and testing the template changes from the raised PR 

> see [pulumi/templates#294](https://github.com/pulumi/templates/pull/294) where the problem comes to light: github actions building outdated templates from master branch and not the new ones

This PR makes sure that if we are running the tests of pulumi/templates that we are also cloning the right branch, not always defaulting to `master`

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
