### PR TITLE
Do not track go-releaser build directories: fixes release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ artifacts/
 goreleaser-downloads/
 goreleaser-prebuilt/
 goreleaser-lang/
+goreleaser-linux/
+goreleaser-darwin/
+goreleaser-windows/
 
 __pycache__
 .pytest_cache


### PR DESCRIPTION
The release.yml workflow [failed](https://github.com/pulumi/pulumi/runs/6794002150?check_suite_focus=true) to publish v3.34 because go releaser doesn't like to see the build artifacts tracked in git so here we ignore them