### PR TITLE
Prefer static linking except on darwin where CGO is required

### DIFF
--- a/.goreleaser.build.yml
+++ b/.goreleaser.build.yml
@@ -50,6 +50,7 @@ builds:
   binary: pulumi-language-python
   dir: sdk
   main: ./python/cmd/pulumi-language-python
+  gobinary: ../scripts/go-wrapper.sh
   goarch:
     - amd64
     - arm64
@@ -67,6 +68,7 @@ builds:
   binary: pulumi-language-dotnet
   dir: sdk
   main: ./dotnet/cmd/pulumi-language-dotnet
+  gobinary: ../scripts/go-wrapper.sh
   goarch:
     - amd64
     - arm64
@@ -84,6 +86,7 @@ builds:
   binary: pulumi-language-go
   dir: sdk
   main: ./go/pulumi-language-go
+  gobinary: ../scripts/go-wrapper.sh
   goarch:
     - amd64
     - arm64

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,3 +8,7 @@
 
 - [sdk/python] Better explain the keyword arguments to create(etc)_stack.
   [#9794](https://github.com/pulumi/pulumi/pull/9794)
+
+- [cli] Revert to statically linked binaries on Windows and Linux,
+  fixing a regression introduced in 3.34.0
+  [#9816](https://github.com/pulumi/pulumi/issues/9816)

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -16,6 +16,15 @@ PKG=github.com/pulumi/pulumi/pkg/v3/...
 SDK=github.com/pulumi/pulumi/sdk/v3/...
 COVERPKG="$PKG,$SDK"
 
+case $(go env GOOS) in
+    darwin)
+        export CGO_ENABLED=1
+        ;;
+    *)
+        export CGO_ENABLED=0
+        ;;
+esac
+
 case "$1" in
     build)
         ARGS=( "$@" )


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9816

Example testing locally:

```
goreleaser -f .goreleaser.build.yml --skip-validate --rm-dist
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
