### PR TITLE
Revert "allow `pulumi destroy -s <stack>` if not in a pulumi project dir (#9613)"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,5 +9,5 @@
 - [sdk/python] Better explain the keyword arguments to create(etc)_stack.
   [#9794](https://github.com/pulumi/pulumi/pull/9794)
 
-- [cli] Revert changes to `pulumi destroy` that tried to operate without config files.
+- [cli] Revert changes causing a panic in `pulumi destroy` that tried to operate without config files.
   [#9821](https://github.com/pulumi/pulumi/pull/9821)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,4 +10,4 @@
   [#9794](https://github.com/pulumi/pulumi/pull/9794)
 
 - [cli] Revert changes to `pulumi destroy` that tried to operate without config files.
-  [#TODO](TODO)
+  [#9821](https://github.com/pulumi/pulumi/pull/9821)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,3 +8,6 @@
 
 - [sdk/python] Better explain the keyword arguments to create(etc)_stack.
   [#9794](https://github.com/pulumi/pulumi/pull/9794)
+
+- [cli] Revert changes to `pulumi destroy` that tried to operate without config files.
+  [#TODO](TODO)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -712,29 +712,6 @@ func (b *cloudBackend) GetStack(ctx context.Context, stackRef backend.StackRefer
 	return newStack(stack, b), nil
 }
 
-// Confirm the specified stack's project doesn't contradict the Pulumi.yaml of the current project.
-// if the CWD is not in a Pulumi project,
-//     does not contradict
-// if the project name in Pulumi.yaml is "foo".
-//     a stack with a name of foo/bar/foo should not work.
-func currentProjectContradictsWorkspace(stack client.StackIdentifier) bool {
-	projPath, err := workspace.DetectProjectPath()
-	if err != nil {
-		return false
-	}
-
-	if projPath == "" {
-		return false
-	}
-
-	proj, err := workspace.LoadProject(projPath)
-	if err != nil {
-		return false
-	}
-
-	return proj.Name.String() != stack.Project
-}
-
 func (b *cloudBackend) CreateStack(
 	ctx context.Context, stackRef backend.StackReference, _ interface{} /* No custom options for httpstate backend. */) (
 	backend.Stack, error) {
@@ -743,13 +720,16 @@ func (b *cloudBackend) CreateStack(
 		return nil, err
 	}
 
-	if currentProjectContradictsWorkspace(stackID) {
-		return nil, fmt.Errorf("provided project name %q doesn't match Pulumi.yaml", stackID.Project)
-	}
-
 	tags, err := backend.GetEnvironmentTagsForCurrentStack()
 	if err != nil {
 		return nil, fmt.Errorf("error determining initial tags: %w", err)
+	}
+
+	// Confirm the stack identity matches the environment. e.g. stack init foo/bar/baz shouldn't work
+	// if the project name in Pulumi.yaml is anything other than "bar".
+	projNameTag, ok := tags[apitype.ProjectNameTag]
+	if ok && stackID.Project != projNameTag {
+		return nil, fmt.Errorf("provided project name %q doesn't match Pulumi.yaml", stackID.Project)
 	}
 
 	apistack, err := b.client.CreateStack(ctx, stackID, tags)
@@ -923,10 +903,6 @@ func (b *cloudBackend) createAndStartUpdate(
 	stackID, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
 		return client.UpdateIdentifier{}, 0, "", err
-	}
-	if currentProjectContradictsWorkspace(stackID) {
-		return client.UpdateIdentifier{}, 0, "", fmt.Errorf(
-			"provided project name %q doesn't match Pulumi.yaml", stackID.Project)
 	}
 	metadata := apitype.UpdateMetadata{
 		Message:     op.M.Message,

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -112,6 +112,7 @@ func (s *cloudStack) CurrentOperation() *apitype.OperationStatus { return s.curr
 func (s *cloudStack) Tags() map[apitype.StackTagName]string      { return s.tags }
 
 func (s *cloudStack) StackIdentifier() client.StackIdentifier {
+
 	si, err := s.b.getCloudStackIdentifier(s.ref)
 	contract.AssertNoError(err) // the above only fails when ref is of the wrong type.
 	return si

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -171,8 +171,7 @@ func GetEnvironmentTagsForCurrentStack() (map[apitype.StackTagName]string, error
 	// Tags based on Pulumi.yaml.
 	projPath, err := workspace.DetectProjectPath()
 	if err != nil {
-		// No current stack return empty
-		return make(map[apitype.StackTagName]string), nil
+		return nil, err
 	}
 	if projPath != "" {
 		proj, err := workspace.LoadProject(projPath)

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -134,6 +134,16 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
+			sm, err := getStackSecretsManager(s)
+			if err != nil {
+				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
+			}
+
+			cfg, err := getStackConfiguration(s, sm)
+			if err != nil {
+				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
+			}
+
 			snap, err := s.Snapshot(commandContext())
 			if err != nil {
 				return result.FromError(err)
@@ -147,11 +157,6 @@ func newDestroyCmd() *cobra.Command {
 					fmt.Printf("There were no resources matching the wildcards provided.\n")
 				}
 				return nil
-			}
-
-			cfg, err := getStackConfiguration(s, snap.SecretsManager)
-			if err != nil {
-				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
 			refreshOption, err := getRefreshOption(proj, refresh)
@@ -199,7 +204,7 @@ func newDestroyCmd() *cobra.Command {
 				M:                  m,
 				Opts:               opts,
 				StackConfiguration: cfg,
-				SecretsManager:     snap.SecretsManager,
+				SecretsManager:     sm,
 				Scopes:             cancellationScopes,
 			})
 			if res == nil && protectedCount > 0 && !jsonDisplay {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -476,10 +476,13 @@ func readProject() (*workspace.Project, string, error) {
 	// Now that we got here, we have a path, so we will try to load it.
 	path, err := workspace.DetectProjectPathFrom(pwd)
 	if err != nil {
-		logging.Warningf("failed to find current Pulumi project because of "+
-			"an error when searching for the Pulumi.yaml file (searching upwards from %s) "+
-			"continuing with an empty project", pwd)
-		return &workspace.Project{}, "", nil
+		return nil, "", fmt.Errorf("failed to find current Pulumi project because of "+
+			"an error when searching for the Pulumi.yaml file (searching upwards from %s)"+": %w", pwd, err)
+
+	} else if path == "" {
+		return nil, "", fmt.Errorf(
+			"no Pulumi.yaml project file found (searching upwards from %s). If you have not "+
+				"created a project yet, use `pulumi new` to do so", pwd)
 	}
 	proj, err := workspace.LoadProject(path)
 	if err != nil {

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -125,18 +125,9 @@ func DetectProjectStackPath(stackName tokens.QName) (string, error) {
 // DetectProjectPathFrom locates the closest project from the given path, searching "upwards" in the directory
 // hierarchy.  If no project is found, an empty path is returned.
 func DetectProjectPathFrom(path string) (string, error) {
-	path, err := fsutil.WalkUp(path, isProject, func(s string) bool {
+	return fsutil.WalkUp(path, isProject, func(s string) bool {
 		return true
 	})
-	if err != nil {
-		return "", err
-	}
-	if path == "" {
-		return "", fmt.Errorf(
-			"no Pulumi.yaml project file found (searching upwards from %s). If you have not "+
-				"created a project yet, use `pulumi new` to do so", path)
-	}
-	return path, nil
 }
 
 // DetectPolicyPackPathFrom locates the closest Pulumi policy project from the given path,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -884,29 +884,6 @@ func testConstructMethodsErrors(t *testing.T, lang string, dependencies ...strin
 	}
 }
 
-//nolint:paralleltest // uses parallel programtest
-func TestDestroyStackRef(t *testing.T) {
-	e := ptesting.NewEnvironment(t)
-	defer func() {
-		if !t.Failed() {
-			e.DeleteEnvironment()
-		}
-	}()
-
-	e.ImportDirectory("large_resource/nodejs")
-	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
-
-	e.RunCommand("pulumi", "stack", "init", "dev")
-
-	e.RunCommand("yarn", "link", "@pulumi/pulumi")
-	e.RunCommand("yarn", "install")
-
-	e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
-
-	e.CWD = os.TempDir()
-	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes", "-s", "dev")
-}
-
 //nolint:paralleltest // mutates environment variables
 func TestRotatePassphrase(t *testing.T) {
 	e := ptesting.NewEnvironment(t)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This reverts commit 150aba462e248875d1ce3474e813868836f56d93.

Fixes https://github.com/pulumi/pulumi/issues/9815

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
