### PR TITLE
Allow a path to a file when constructing an archive

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- [sdk] Allow constructing archives with just a file
+  [#9838](https://github.com/pulumi/pulumi/pull/9838)
+
 ### Bug Fixes


### PR DESCRIPTION
# Description

It's legitimate to construct an archive with a single file (rather than a directory) by mentioning the file's name:

    zip handler.zip handler/main

In fact, that's what the AWS Lambda docs suggest: https://docs.aws.amazon.com/lambda/latest/dg/golang-package.html

This PR lets you do the equivalent when making an `asset.FileArchive`. It needs a little rearrangement of `directoryArchiveReader` so that the individual paths are relative to a base rather than sharing a prefix; otherwise, a single-file archive (in which the name is the entire file path) cannot be constructed. I've sign-posted this generalisation by renaming the helper struct in question to `filesystemArchiveReader`.

In the context of making aws.lambda.Function objects, this is useful for uploading a binary (e.g., using the `go1.x` runtime) conveniently, rather than making your own ZIP file out of band, or including irrelevant files.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
