### PR TITLE
[sdk/go] Support nested git project paths

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [sdk/go] [Correctly parse nested git projects in GitLab](https://github.com/pulumi/pulumi/issues/9354)

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -328,6 +328,9 @@ func parseGistURL(u *url.URL) (string, error) {
 // ParseGitRepoURL returns the URL to the Git repository and path from a raw URL.
 // For example, an input of "https://github.com/pulumi/templates/templates/javascript" returns
 // "https://github.com/pulumi/templates.git" and "templates/javascript".
+// Additionally, it supports nested git projects, as used by GitLab.
+// For example, "https://github.com/pulumi/platform-team/templates.git/templates/javascript"
+// returns "https://github.com/pulumi/platform-team/templates.git" and "templates/javascript"
 func ParseGitRepoURL(rawurl string) (string, string, error) {
 	u, err := url.Parse(rawurl)
 	if err != nil {
@@ -351,6 +354,17 @@ func ParseGitRepoURL(rawurl string) (string, string, error) {
 	paths := strings.Split(path, "/")
 	if len(paths) < 2 {
 		return "", "", errors.New("invalid Git URL")
+	}
+
+	// Special case: URI Path contains '.git'
+	// Cleave URI into what comes before and what comes after.
+	const gitExtension string = ".git"
+	if loc := strings.LastIndex(path, gitExtension); loc != -1 {
+		var extensionOffset = loc + len(gitExtension)
+		var resultURL = u.Scheme + "://" + u.Host + "/" + path[:extensionOffset]
+		var gitRepoPath = path[extensionOffset:]
+		var resultPath = strings.Trim(gitRepoPath, "/")
+		return resultURL, resultPath, nil
 	}
 
 	owner := paths[0]

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -358,9 +358,8 @@ func ParseGitRepoURL(rawurl string) (string, string, error) {
 
 	// Shortcut for general case: URI Path contains '.git'
 	// Cleave URI into what comes before and what comes after.
-	const gitExtension string = ".git"
-	if loc := strings.LastIndex(path, gitExtension); loc != -1 {
-		var extensionOffset = loc + len(gitExtension)
+	if loc := strings.LastIndex(path, defaultGitCloudRepositorySuffix); loc != -1 {
+		var extensionOffset = loc + len(defaultGitCloudRepositorySuffix)
 		var resultURL = u.Scheme + "://" + u.Host + "/" + path[:extensionOffset]
 		var gitRepoPath = path[extensionOffset:]
 		var resultPath = strings.Trim(gitRepoPath, "/")

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -356,7 +356,7 @@ func ParseGitRepoURL(rawurl string) (string, string, error) {
 		return "", "", errors.New("invalid Git URL")
 	}
 
-	// Special case: URI Path contains '.git'
+	// Shortcut for general case: URI Path contains '.git'
 	// Cleave URI into what comes before and what comes after.
 	const gitExtension string = ".git"
 	if loc := strings.LastIndex(path, gitExtension); loc != -1 {

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -75,6 +75,10 @@ func TestParseGitRepoURL(t *testing.T) {
 	exp = "https://gitlab.com/a/b/c/d/e/f/g/finally.git"
 	test(exp, "1/2/3/4/5", pre)
 	test(exp, "1/2/3/4/5", pre+"/")
+	pre = "https://gitlab.com/dotgit/.git.git"
+	exp = "https://gitlab.com/dotgit/.git.git"
+	test(exp, "", pre)
+	test(exp, "foobar", pre+"/foobar")
 
 	// No owner.
 	testError("https://github.com")

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -62,6 +62,20 @@ func TestParseGitRepoURL(t *testing.T) {
 		assert.Error(t, err)
 	}
 
+	// GitLab.
+	pre = "https://gitlab.com/my-org/proj/subproj/doot.git/poc/waka-waka"
+	exp = "https://gitlab.com/my-org/proj/subproj/doot.git"
+	test(exp, "poc/waka-waka", pre)
+	test(exp, "poc/waka-waka", pre+"/")
+	pre = "https://gitlab.com/pulumi/platform/templates.git/templates/javascript"
+	exp = "https://gitlab.com/pulumi/platform/templates.git"
+	test(exp, "templates/javascript", pre)
+	test(exp, "templates/javascript", pre+"///")
+	pre = "https://gitlab.com/a/b/c/d/e/f/g/finally.git/1/2/3/4/5"
+	exp = "https://gitlab.com/a/b/c/d/e/f/g/finally.git"
+	test(exp, "1/2/3/4/5", pre)
+	test(exp, "1/2/3/4/5", pre+"/")
+
 	// No owner.
 	testError("https://github.com")
 	testError("https://github.com/")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The `ParseGitRepoURLs()` function makes a few of assumptions about the number of paths in a given git URI. This PR sidesteps those assumptions in the general case where the URI contains `.git` using a more general approach.  As a result, we can parse nested git projects.

Fixes https://github.com/pulumi/pulumi/issues/9354

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
