### PR TITLE
Change str(output) to return a warning message

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,9 @@
 ### Improvements
 
+- [sdk/python] Changed `Output[T].__str__()` to return an informative message rather than "<pulumi.output.Output object at 0x012345ABCDEF>".
+  [#XXXX](https://github.com/pulumi/pulumi/pull/XXXX)
+
 ### Bug Fixes
 
-- [sdk/go] [Correctly parse nested git projects in GitLab](https://github.com/pulumi/pulumi/issues/9354)
+- [sdk/go] Correctly parse nested git projects in GitLab.
+  [#9354](https://github.com/pulumi/pulumi/issues/9354)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,7 @@
 ### Improvements
 
 - [sdk/python] Changed `Output[T].__str__()` to return an informative message rather than "<pulumi.output.Output object at 0x012345ABCDEF>".
-  [#XXXX](https://github.com/pulumi/pulumi/pull/XXXX)
+  [#9848](https://github.com/pulumi/pulumi/pull/9848)
 
 ### Bug Fixes
 

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -499,6 +499,15 @@ class Output(Generic[T_co]):
         # invariant http://mypy.readthedocs.io/en/latest/common_issues.html#variance
         return Output.all(*transformed_items).apply("".join)  # type: ignore
 
+    def __str__(self) -> str:
+        return """Calling [str] on an [Output<T>] is not supported.
+
+To get the value of an Output[T] as an Output[str] consider:
+1. o.apply(lambda v => f"prefix{v}suffix")
+
+See https://pulumi.io/help/outputs for more details.
+This function may throw in a future version of Pulumi."""
+
 
 class Unknown:
     """

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -219,3 +219,15 @@ class OutputHoistingTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             for i in x:
                 print(i)
+
+class OutputStrTests(unittest.TestCase):
+    @pulumi_test
+    async def test_str(self):
+        o = Output.from_input(1)
+        self.assertEqual(str(o), """Calling [str] on an [Output<T>] is not supported.
+
+To get the value of an Output[T] as an Output[str] consider:
+1. o.apply(lambda v => f"prefix{v}suffix")
+
+See https://pulumi.io/help/outputs for more details.
+This function may throw in a future version of Pulumi.""")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Our other SDKs return a warning message when trying to stringify outputs. This updates the Python SDK to also return a warning message.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
