### PR TITLE
[sdk/go] Improve unknown stack references preview

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,6 @@
 
 - [sdk/go] Correctly parse nested git projects in GitLab.
   [#9354](https://github.com/pulumi/pulumi/issues/9354)
+
+- [sdk/go] Mark StackReference keys that don't exist as unknown. Error when converting unknown keys to strings.
+  [#9855](https://github.com/pulumi/pulumi/pull/9855)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

When a valid stack reference is asked to retrieve an absent key as a string, the default value is returned. This results in previews displaying `""` as the value of the stack reference key. See the [linked issue](https://github.com/pulumi/pulumi/issues/9365) for an example. 

This PR makes the following changes:
1. When the value is absent during a preview, return an unknown output. This fixes the linked issue.
2. When the value is absent during a `pulumi up`, error when a string is requested. This brings the behavior of `string` inline with `Int` and `Float64`.



Fixes #9365

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
