### PR TITLE
[codegen/python] Implement deep merge on resource and invoke options, matching other SDKs

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -395,13 +395,15 @@ func (mod *modContext) genUtilitiesFile() []byte {
 	buffer := &bytes.Buffer{}
 	genStandardHeader(buffer, mod.tool)
 	fmt.Fprintf(buffer, utilitiesFile)
+	optionalUrl := "None"
 	if url := mod.pkg.PluginDownloadURL; url != "" {
-		_, err := fmt.Fprintf(buffer, `
-def get_plugin_download_url():
-	return %q
-`, url)
-		contract.AssertNoError(err)
+		optionalUrl = fmt.Sprintf("%q", url)
 	}
+	_, err := fmt.Fprintf(buffer, `
+def get_plugin_download_url():
+	return %s
+`, optionalUrl)
+	contract.AssertNoError(err)
 	return buffer.Bytes()
 }
 
@@ -1224,20 +1226,9 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	if res.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 		fmt.Fprintf(w, "        pulumi.log.warn(\"\"\"%s is deprecated: %s\"\"\")\n", name, res.DeprecationMessage)
 	}
-	fmt.Fprintf(w, "        if opts is None:\n")
-	fmt.Fprintf(w, "            opts = pulumi.ResourceOptions()\n")
-	fmt.Fprintf(w, "        else:\n")
-	// We mutate opts so ensure we take a copy of it (see https://github.com/pulumi/pulumi/issues/9801)
-	fmt.Fprintf(w, "            opts = copy.copy(opts)\n")
+	fmt.Fprintf(w, "        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)\n")
 	fmt.Fprintf(w, "        if not isinstance(opts, pulumi.ResourceOptions):\n")
 	fmt.Fprintf(w, "            raise TypeError('Expected resource options to be a ResourceOptions instance')\n")
-	fmt.Fprintf(w, "        if opts.version is None:\n")
-	fmt.Fprintf(w, "            opts.version = _utilities.get_version()\n")
-	if mod.pkg.PluginDownloadURL != "" {
-		fmt.Fprintf(w, "        if opts.plugin_download_url is None:\n")
-		fmt.Fprintf(w, "            opts.plugin_download_url = _utilities.get_plugin_download_url()\n")
-	}
-
 	if res.IsComponent {
 		fmt.Fprintf(w, "        if opts.id is not None:\n")
 		fmt.Fprintf(w, "            raise ValueError('ComponentResource classes do not support opts.id')\n")
@@ -1712,14 +1703,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	}
 
 	// If the caller explicitly specified a version, use it, otherwise inject this package's version.
-	fmt.Fprintf(w, "    if opts is None:\n")
-	fmt.Fprintf(w, "        opts = pulumi.InvokeOptions()\n")
-	fmt.Fprintf(w, "    if opts.version is None:\n")
-	fmt.Fprintf(w, "        opts.version = _utilities.get_version()\n")
-	if mod.pkg.PluginDownloadURL != "" {
-		fmt.Fprintf(w, "        if opts.plugin_download_url is None:\n")
-		fmt.Fprintf(w, "            opts.plugin_download_url = _utilities.get_plugin_download_url()\n")
-	}
+	fmt.Fprintf(w, "    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)\n")
 
 	// Now simply invoke the runtime function with the arguments.
 	var typ string
@@ -2968,6 +2952,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -170,7 +170,6 @@ func pyTestCheck(t *testing.T, codeDir string) {
 		t.Error(err)
 		return
 	}
-	fmt.Printf("🤯🤯🤯🤯 found venv: %v", venvDir)
 
 	cmd := func(name string, args ...string) error {
 		t.Logf("cd %s && %s %s", codeDir, name, strings.Join(args, " "))

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/python"
 )
 
@@ -143,6 +144,14 @@ func buildVirtualEnv(ctx context.Context) error {
 		return err
 	}
 
+	// install Pulumi Python SDK from the current source tree, -e means no-copy, ref directly
+	pyCmd := python.VirtualEnvCommand(venvDir, "python", "-m", "pip", "install", "-e", sdkDir)
+	pyCmd.Dir = hereDir
+	err = pyCmd.Run()
+	if err != nil {
+		contract.Failf("failed to link venv against in-source pulumi: %v", err)
+	}
+
 	if !gotSdk {
 		return fmt.Errorf("This test requires Python SDK to be built; please `cd sdk/python && make ensure build install`")
 	}
@@ -161,11 +170,14 @@ func pyTestCheck(t *testing.T, codeDir string) {
 		t.Error(err)
 		return
 	}
+	fmt.Printf("🤯🤯🤯🤯 found venv: %v", venvDir)
 
 	cmd := func(name string, args ...string) error {
 		t.Logf("cd %s && %s %s", codeDir, name, strings.Join(args, " "))
 		cmd := python.VirtualEnvCommand(venvDir, name, args...)
 		cmd.Dir = codeDir
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
 		return cmd.Run()
 	}
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/documentdb/sql_resource_sql_container.py
@@ -186,14 +186,9 @@ class SqlResourceSqlContainer(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/provider.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/pulumi_azure_native/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/provider.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
@@ -70,14 +70,9 @@ class ModuleResource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  thing: Optional[pulumi.Input[pulumi.InputType['_root_inputs.TopLevelArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/provider.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -92,14 +92,9 @@ class Nursery(pulumi.CustomResource):
                  sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -156,14 +156,9 @@ class RubberTree(pulumi.CustomResource):
                  size: Optional[pulumi.Input['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/provider.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
@@ -92,14 +92,9 @@ class Nursery(pulumi.CustomResource):
                  sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -156,14 +156,9 @@ class RubberTree(pulumi.CustomResource):
                  size: Optional[pulumi.Input['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/mymodule/iam_resource.py
@@ -69,14 +69,9 @@ class IamResource(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  config: Optional[pulumi.Input[pulumi.InputType['pulumi_google_native.iam.v1.AuditConfigArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference-python/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
@@ -83,14 +83,9 @@ class Trail(pulumi.ComponentResource):
                  advanced_event_selectors: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]] = None,
                  trail: Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
@@ -46,10 +46,7 @@ def arg_function(name: Optional['pulumi_random.RandomPet'] = None,
     """
     __args__ = dict()
     __args__['name'] = name
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/cat.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/cat.py
@@ -84,14 +84,9 @@ class Cat(pulumi.CustomResource):
                  age: Optional[pulumi.Input[int]] = None,
                  pet: Optional[pulumi.Input[pulumi.InputType['PetArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -137,14 +137,9 @@ class Component(pulumi.CustomResource):
                  required_metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  required_metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/workload.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/workload.py
@@ -56,14 +56,9 @@ class Workload(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/provider.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/registry_geo_replication.py
@@ -73,14 +73,9 @@ class RegistryGeoReplication(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  resource_group: Optional[pulumi.Input['pulumi_azure_native.resources.ResourceGroup']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource.py
@@ -55,14 +55,9 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource_input.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/resource_input.py
@@ -55,14 +55,9 @@ class ResourceInput(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
@@ -68,14 +68,9 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  baz: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/provider.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/nested/module/resource.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/nested/module/resource.py
@@ -68,14 +68,9 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/provider.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
@@ -76,10 +76,7 @@ def list_configurations(configuration_filters: Optional[Sequence[pulumi.InputTyp
     __args__['configurationFilters'] = configuration_filters
     __args__['customerSubscriptionDetails'] = customer_subscription_details
     __args__['skipToken'] = skip_token
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('myedgeorder::listConfigurations', __args__, opts=opts, typ=ListConfigurationsResult).value
 
     return AwaitableListConfigurationsResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
@@ -79,10 +79,7 @@ def list_product_families(customer_subscription_details: Optional[pulumi.InputTy
     __args__['expand'] = expand
     __args__['filterableProperties'] = filterable_properties
     __args__['skipToken'] = skip_token
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('myedgeorder::listProductFamilies', __args__, opts=opts, typ=ListProductFamiliesResult).value
 
     return AwaitableListProductFamiliesResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
@@ -132,10 +132,7 @@ def get_ami_ids(executable_users: Optional[Sequence[str]] = None,
     __args__['nameRegex'] = name_regex
     __args__['owners'] = owners
     __args__['sortAscending'] = sort_ascending
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::getAmiIds', __args__, opts=opts, typ=GetAmiIdsResult).value
 
     return AwaitableGetAmiIdsResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
@@ -62,10 +62,7 @@ def list_storage_account_keys(account_name: Optional[str] = None,
     __args__['accountName'] = account_name
     __args__['expand'] = expand
     __args__['resourceGroupName'] = resource_group_name
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::listStorageAccountKeys', __args__, opts=opts, typ=ListStorageAccountKeysResult).value
 
     return AwaitableListStorageAccountKeysResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
@@ -51,10 +51,7 @@ def func_with_all_optional_inputs(a: Optional[str] = None,
     __args__ = dict()
     __args__['a'] = a
     __args__['b'] = b
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithAllOptionalInputs', __args__, opts=opts, typ=FuncWithAllOptionalInputsResult).value
 
     return AwaitableFuncWithAllOptionalInputsResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_const_input.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_const_input.py
@@ -20,9 +20,6 @@ def func_with_const_input(plain_input: Optional[str] = None,
     """
     __args__ = dict()
     __args__['plainInput'] = plain_input
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithConstInput', __args__, opts=opts).value
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_default_value.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_default_value.py
@@ -47,10 +47,7 @@ def func_with_default_value(a: Optional[str] = None,
     __args__ = dict()
     __args__['a'] = a
     __args__['b'] = b
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithDefaultValue', __args__, opts=opts, typ=FuncWithDefaultValueResult).value
 
     return AwaitableFuncWithDefaultValueResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
@@ -47,10 +47,7 @@ def func_with_dict_param(a: Optional[Mapping[str, str]] = None,
     __args__ = dict()
     __args__['a'] = a
     __args__['b'] = b
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithDictParam', __args__, opts=opts, typ=FuncWithDictParamResult).value
 
     return AwaitableFuncWithDictParamResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
@@ -39,10 +39,7 @@ def func_with_empty_outputs(name: Optional[str] = None,
     """
     __args__ = dict()
     __args__['name'] = name
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithEmptyOutputs', __args__, opts=opts, typ=FuncWithEmptyOutputsResult).value
 
     return AwaitableFuncWithEmptyOutputsResult()

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_list_param.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_list_param.py
@@ -47,10 +47,7 @@ def func_with_list_param(a: Optional[Sequence[str]] = None,
     __args__ = dict()
     __args__['a'] = a
     __args__['b'] = b
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithListParam', __args__, opts=opts, typ=FuncWithListParamResult).value
 
     return AwaitableFuncWithListParamResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
@@ -62,10 +62,7 @@ def get_bastion_shareable_link(bastion_host_name: Optional[str] = None,
     __args__['bastionHostName'] = bastion_host_name
     __args__['resourceGroupName'] = resource_group_name
     __args__['vms'] = vms
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::getBastionShareableLink', __args__, opts=opts, typ=GetBastionShareableLinkResult).value
 
     return AwaitableGetBastionShareableLinkResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_client_config.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_client_config.py
@@ -84,10 +84,7 @@ def get_client_config(opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableG
     Failing example taken from azure-native. Original doc: Use this function to access the current configuration of the native Azure provider.
     """
     __args__ = dict()
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::getClientConfig', __args__, opts=opts, typ=GetClientConfigResult).value
 
     return AwaitableGetClientConfigResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
@@ -77,10 +77,7 @@ def get_integration_runtime_object_metadatum(factory_name: Optional[str] = None,
     __args__['integrationRuntimeName'] = integration_runtime_name
     __args__['metadataPath'] = metadata_path
     __args__['resourceGroupName'] = resource_group_name
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::getIntegrationRuntimeObjectMetadatum', __args__, opts=opts, typ=GetIntegrationRuntimeObjectMetadatumResult).value
 
     return AwaitableGetIntegrationRuntimeObjectMetadatumResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
@@ -62,10 +62,7 @@ def list_storage_account_keys(account_name: Optional[str] = None,
     __args__['accountName'] = account_name
     __args__['expand'] = expand
     __args__['resourceGroupName'] = resource_group_name
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::listStorageAccountKeys', __args__, opts=opts, typ=ListStorageAccountKeysResult).value
 
     return AwaitableListStorageAccountKeysResult(

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/provider.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
@@ -319,14 +319,9 @@ class ModuleResource(pulumi.CustomResource):
                  required_number: Optional[pulumi.Input[float]] = None,
                  required_string: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
@@ -128,14 +128,9 @@ class Foo(pulumi.CustomResource):
                  kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
                  settings: Optional[pulumi.Input[pulumi.InputType['LayeredTypeArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -52,10 +52,7 @@ def func_with_all_optional_inputs(a: Optional[pulumi.InputType['HelmReleaseSetti
     __args__ = dict()
     __args__['a'] = a
     __args__['b'] = b
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('example::funcWithAllOptionalInputs', __args__, opts=opts, typ=FuncWithAllOptionalInputsResult).value
 
     return AwaitableFuncWithAllOptionalInputsResult(

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/module_test.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/module_test.py
@@ -85,14 +85,9 @@ class ModuleTest(pulumi.CustomResource):
                  mod1: Optional[pulumi.Input[pulumi.InputType['_mod1.TypArgs']]] = None,
                  val: Optional[pulumi.Input[pulumi.InputType['TypArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
@@ -76,14 +76,9 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -128,14 +128,9 @@ class Foo(pulumi.CustomResource):
                  kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
                  settings: Optional[pulumi.Input[pulumi.InputType['LayeredTypeArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -52,10 +52,7 @@ def func_with_all_optional_inputs(a: Optional[pulumi.InputType['HelmReleaseSetti
     __args__ = dict()
     __args__['a'] = a
     __args__['b'] = b
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mypkg::funcWithAllOptionalInputs', __args__, opts=opts, typ=FuncWithAllOptionalInputsResult).value
 
     return AwaitableFuncWithAllOptionalInputsResult(

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/module_test.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/module_test.py
@@ -85,14 +85,9 @@ class ModuleTest(pulumi.CustomResource):
                  mod1: Optional[pulumi.Input[pulumi.InputType['_mod1.TypArgs']]] = None,
                  val: Optional[pulumi.Input[pulumi.InputType['TypArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -76,14 +76,9 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/static_page.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/static_page.py
@@ -88,14 +88,9 @@ class StaticPage(pulumi.ComponentResource):
                  foo: Optional[pulumi.InputType['FooArgs']] = None,
                  index_content: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
@@ -76,14 +76,9 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  favorite_color: Optional[pulumi.Input[Union[str, 'Color']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/get_custom_db_roles.py
@@ -43,10 +43,7 @@ def get_custom_db_roles(opts: Optional[pulumi.InvokeOptions] = None) -> Awaitabl
     Use this data source to access information about an existing resource.
     """
     __args__ = dict()
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('mongodbatlas::getCustomDbRoles', __args__, opts=opts, typ=GetCustomDbRolesResult).value
 
     return AwaitableGetCustomDbRolesResult(

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/pulumi_mongodbatlas/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/example_func.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/example_func.py
@@ -21,9 +21,6 @@ def example_func(enums: Optional[Sequence[Union[str, 'MyEnum']]] = None,
     """
     __args__ = dict()
     __args__['enums'] = enums
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('my8110::exampleFunc', __args__, opts=opts).value
 

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/provider.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/cat.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/cat.py
@@ -57,14 +57,9 @@ class Cat(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/dog.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/dog.py
@@ -55,14 +55,9 @@ class Dog(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/god.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/god.py
@@ -56,14 +56,9 @@ class God(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/no_recursive.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/no_recursive.py
@@ -56,14 +56,9 @@ class NoRecursive(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/toy_store.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/pulumi_example/toy_store.py
@@ -58,14 +58,9 @@ class ToyStore(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/person.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/person.py
@@ -84,14 +84,9 @@ class Person(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  pets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/pet.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/pet.py
@@ -68,14 +68,9 @@ class Pet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/person.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/person.py
@@ -84,14 +84,9 @@ class Person(pulumi.CustomResource):
                  name: Optional[pulumi.Input[str]] = None,
                  pets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/pet.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/pet.py
@@ -68,14 +68,9 @@ class Pet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/rec.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/pulumi_example/rec.py
@@ -55,14 +55,9 @@ class Rec(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -92,14 +92,9 @@ class Nursery(pulumi.CustomResource):
                  sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -156,14 +156,9 @@ class RubberTree(pulumi.CustomResource):
                  size: Optional[pulumi.Input['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
@@ -55,14 +55,9 @@ class Foo(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
@@ -57,14 +57,9 @@ class Foo(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
@@ -179,14 +179,9 @@ class Component(pulumi.ComponentResource):
                  f: Optional[str] = None,
                  foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -193,14 +193,9 @@ class Component(pulumi.ComponentResource):
                  f: Optional[str] = None,
                  foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/do_foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/do_foo.py
@@ -21,9 +21,6 @@ def do_foo(foo: Optional[pulumi.InputType['Foo']] = None,
     """
     __args__ = dict()
     __args__['foo'] = foo
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('example::doFoo', __args__, opts=opts).value
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
@@ -46,10 +46,7 @@ def arg_function(arg1: Optional['Resource'] = None,
     """
     __args__ = dict()
     __args__['arg1'] = arg1
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
@@ -69,14 +69,9 @@ class OtherResource(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  foo: Optional[pulumi.Input['Resource']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
@@ -68,14 +68,9 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
@@ -46,12 +46,7 @@ def arg_function(arg1: Optional['Resource'] = None,
     """
     __args__ = dict()
     __args__['arg1'] = arg1
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
-        if opts.plugin_download_url is None:
-            opts.plugin_download_url = _utilities.get_plugin_download_url()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/bar_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/bar_resource.py
@@ -69,16 +69,9 @@ class BarResource(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  foo: Optional[pulumi.Input['Resource']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
-        if opts.plugin_download_url is None:
-            opts.plugin_download_url = _utilities.get_plugin_download_url()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/foo_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/foo_resource.py
@@ -69,16 +69,9 @@ class FooResource(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  foo: Optional[pulumi.Input['Resource']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
-        if opts.plugin_download_url is None:
-            opts.plugin_download_url = _utilities.get_plugin_download_url()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -69,16 +69,9 @@ class OtherResource(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  foo: Optional[pulumi.Input['Resource']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
-        if opts.plugin_download_url is None:
-            opts.plugin_download_url = _utilities.get_plugin_download_url()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/provider.py
@@ -55,16 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
-        if opts.plugin_download_url is None:
-            opts.plugin_download_url = _utilities.get_plugin_download_url()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -68,16 +68,9 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
-        if opts.plugin_download_url is None:
-            opts.plugin_download_url = _utilities.get_plugin_download_url()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/type_uses.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/type_uses.py
@@ -99,16 +99,9 @@ class TypeUses(pulumi.CustomResource):
                  baz: Optional[pulumi.Input[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
                  foo: Optional[pulumi.Input[pulumi.InputType['ObjectArgs']]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
-        if opts.plugin_download_url is None:
-            opts.plugin_download_url = _utilities.get_plugin_download_url()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -98,6 +98,17 @@ _version_str = str(_version)
 def get_version():
     return _version_str
 
+def get_resource_opts_defaults() -> pulumi.ResourceOptions:
+    return pulumi.ResourceOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
+
+def get_invoke_opts_defaults() -> pulumi.InvokeOptions:
+    return pulumi.InvokeOptions(
+        version=get_version(),
+        plugin_download_url=get_plugin_download_url(),
+    )
 
 def get_resource_args_opts(resource_args_type, resource_options_type, *args, **kwargs):
     """
@@ -234,3 +245,6 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
                                             **resolved_args['kwargs']))
 
     return (lambda _: lifted_func)
+
+def get_plugin_download_url():
+	return None

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/arg_function.py
@@ -46,10 +46,7 @@ def arg_function(arg1: Optional['Resource'] = None,
     """
     __args__ = dict()
     __args__['arg1'] = arg1
-    if opts is None:
-        opts = pulumi.InvokeOptions()
-    if opts.version is None:
-        opts.version = _utilities.get_version()
+    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke('example::argFunction', __args__, opts=opts, typ=ArgFunctionResult).value
 
     return AwaitableArgFunctionResult(

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/other_resource.py
@@ -83,14 +83,9 @@ class OtherResource(pulumi.ComponentResource):
                  bar: Optional[Sequence[pulumi.Input[str]]] = None,
                  foo: Optional[pulumi.Input['Resource']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is not None:
             raise ValueError('ComponentResource classes do not support opts.id')
         else:

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/provider.py
@@ -55,14 +55,9 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/resource.py
@@ -68,14 +68,9 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[pulumi.Input[str]] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/type_uses.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/type_uses.py
@@ -114,14 +114,9 @@ class TypeUses(pulumi.CustomResource):
                  foo: Optional[pulumi.Input[pulumi.InputType['ObjectArgs']]] = None,
                  qux: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
-        if opts is None:
-            opts = pulumi.ResourceOptions()
-        else:
-            opts = copy.copy(opts)
+        opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.version is None:
-            opts.version = _utilities.get_version()
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -115,7 +115,7 @@ class InvokeOptions:
             raise TypeError("Expected opts2 to be a InvokeOptions instance")
 
         dest = copy.copy(opts1)
-        source = copy.copy(opts2)
+        source = opts2
 
         dest.parent = dest.parent if source.parent is None else source.parent
         dest.provider = dest.provider if source.provider is None else source.provider

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -60,7 +61,69 @@ class InvokeOptions:
                URL will be used to service the invocation. This will override the URL sourced from the host package, and
                should be rarely used.
         """
+        # Expose 'merge' again this this object, but this time as an instance method.
+        # TODO[python/mypy#2427]: mypy disallows method assignment
+        self.merge = self._merge_instance  # type: ignore
+        self.merge.__func__.__doc__ = InvokeOptions.merge.__doc__  # type: ignore
+
         self.parent = parent
         self.provider = provider
         self.version = version
         self.plugin_download_url = plugin_download_url
+
+    def _merge_instance(self, opts: "InvokeOptions") -> "InvokeOptions":
+        return InvokeOptions.merge(self, opts)
+
+    # pylint: disable=method-hidden
+    @staticmethod
+    def merge(
+        opts1: Optional["InvokeOptions"],
+        opts2: Optional["InvokeOptions"],
+    ) -> "InvokeOptions":
+        """
+        merge produces a new InvokeOptions object with the respective attributes of the `opts1`
+        instance in it with the attributes of `opts2` merged over them.
+
+        Both the `opts1` instance and the `opts2` instance will be unchanged.  Both of `opts1` and
+        `opts2` can be `None`, in which case its attributes are ignored.
+
+        Conceptually attributes merging follows these basic rules:
+
+        1. If the attributes is a collection, the final value will be a collection containing the
+           values from each options object. Both original collections in each options object will
+           be unchanged.
+
+        2. Simple scalar values from `opts2` (i.e. strings, numbers, bools) will replace the values
+           from `opts1`.
+
+        3. For the purposes of merging `depends_on` is always treated
+           as collections, even if only a single value was provided.
+
+        4. Attributes with value 'None' will not be copied over.
+
+        This method can be called either as static-method like `InvokeOptions.merge(opts1, opts2)`
+        or as an instance-method like `opts1.merge(opts2)`.  The former is useful for cases where
+        `opts1` may be `None` so the caller does not need to check for this case.
+        """
+        opts1 = InvokeOptions() if opts1 is None else opts1
+        opts2 = InvokeOptions() if opts2 is None else opts2
+
+        if not isinstance(opts1, InvokeOptions):
+            raise TypeError("Expected opts1 to be a InvokeOptions instance")
+
+        if not isinstance(opts2, InvokeOptions):
+            raise TypeError("Expected opts2 to be a InvokeOptions instance")
+
+        dest = copy.copy(opts1)
+        source = copy.copy(opts2)
+
+        dest.parent = dest.parent if source.parent is None else source.parent
+        dest.provider = dest.provider if source.provider is None else source.provider
+        dest.plugin_download_url = (
+            dest.plugin_download_url
+            if source.plugin_download_url is None
+            else source.plugin_download_url
+        )
+        dest.version = dest.version if source.version is None else source.version
+
+        return dest


### PR DESCRIPTION
This is similar to #9802 but goes a bit further in making SDKs generated via Python invoke a merge method to merge options, rather than shallow copy. This matches the Node SDK, and centralizes the logic for default resource options.

Fixes #9847 