### PR TITLE
Fix downstream codegen test failures

### DIFF
--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        provider: ["aws", "gcp", "azure", "azuread", "random", "kubernetes", "azure-native"]
+        provider: ["aws", "gcp", "azure", "azuread", "random", "kubernetes"]
       fail-fast: false
     steps:
       - name: Install Go

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -15,17 +15,34 @@ env:
 jobs:
   comment-notification:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: github.event_name == 'repository_dispatch'
     steps:
       - name: Create URL to the run output
         id: vars
-        run: echo ::set-output name=run-url::https://$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        run: echo ::set-output name=run-url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
       - name: Update with Result
         uses: peter-evans/create-or-update-comment@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          body: |
+            Please view the results of the Downstream Codegen Tests [Here][1]
+
+            [1]: ${{ steps.vars.outputs.run-url }}
+  comment-notification-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      - name: Update with Result
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
           body: |
             Please view the results of the Downstream Codegen Tests [Here][1]
 

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
           check-latest: true
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -14,8 +14,8 @@ env:
 
 jobs:
   comment-notification:
-    if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
       - name: Create URL to the run output
         id: vars

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - name: Create URL to the run output
         id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        run: echo ::set-output name=run-url::https://$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
       - name: Update with Result
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -65,14 +65,13 @@ jobs:
         with:
           ref: ${{ env.PR_COMMIT_SHA }}
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v7
+        uses: pulumi/action-test-provider-downstream@v1.0.0
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
           replacements: github.com/pulumi/pulumi/pkg/v3=pulumi/pkg,github.com/pulumi/pulumi/sdk/v3=pulumi/sdk
           downstream-name: pulumi-${{ matrix.provider }}
           downstream-url: https://github.com/pulumi/pulumi-${{ matrix.provider }}
-          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
           use-provider-dir: true
           issue-number: ${{ github.event.client_payload.github.payload.issue.number }}


### PR DESCRIPTION
Downstream tests will fail as they update their provider binaries to use go 1.18: https://github.com/pulumi/pulumi/runs/6872372597?check_suite_focus=true#step:8:49

This tactically only updates the Go version for these tests, as we don't want to inadvertently depend on any 1.18 behavior in the Go SDK yet.

Fixes: #9862 