### PR TITLE
Use await not Task.Assign

### DIFF
--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -189,7 +189,7 @@ namespace Pulumi
 
             async Task<OutputData<T>> GetData()
             {
-                return new OutputData<T>(ImmutableHashSet<Resource>.Empty, await value, isKnown: true, isSecret);
+                return new OutputData<T>(ImmutableHashSet<Resource>.Empty, await value.ConfigureAwait(false), isKnown: true, isSecret);
             }
 
             return new Output<T>(GetData());

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -187,9 +187,12 @@ namespace Pulumi
                 throw new ArgumentNullException(nameof(value));
             }
 
-            var tcs = new TaskCompletionSource<OutputData<T>>();
-            value.Assign(tcs, t => OutputData.Create(ImmutableHashSet<Resource>.Empty, t, isKnown: true, isSecret: isSecret));
-            return new Output<T>(tcs.Task);
+            async Task<OutputData<T>> GetData()
+            {
+                return new OutputData<T>(ImmutableHashSet<Resource>.Empty, await value, isKnown: true, isSecret);
+            }
+
+            return new Output<T>(GetData());
         }
 
         internal static Output<T> CreateUnknown(T value)

--- a/sdk/dotnet/Pulumi/Extensions.cs
+++ b/sdk/dotnet/Pulumi/Extensions.cs
@@ -37,30 +37,5 @@ namespace Pulumi
 
         public static ImmutableArray<TResult> SelectAsArray<TItem, TResult>(this ImmutableArray<TItem> items, Func<TItem, TResult> map)
             => ImmutableArray.CreateRange(items, map);
-
-        public static void Assign<X, Y>(
-            this Task<X> response, TaskCompletionSource<Y> tcs, Func<X, Y> extract)
-        {
-            _ = response.ContinueWith(t =>
-            {
-                // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
-                switch (t.Status)
-                {
-                    default: throw new InvalidOperationException("Task was not complete: " + t.Status);
-                    case TaskStatus.Canceled: tcs.SetCanceled(); return;
-                    case TaskStatus.Faulted: tcs.SetException(t.Exception!.InnerExceptions); return;
-                    case TaskStatus.RanToCompletion:
-                        try
-                        {
-                            tcs.SetResult(extract(t.Result));
-                        }
-                        catch (Exception e)
-                        {
-                            tcs.TrySetException(e);
-                        }
-                        return;
-                }
-            }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
-        }
     }
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Noticed this while looking around the Output code checking for async bugs. I don't think this is a bug, the current logic looks like it handles cancellations and exceptions ok but there's no need for it. We can just use the compilers await logic to do the mapping from a task with a value to an OutputData structure. Also saves the extra TaskCompletionSource object.