### PR TITLE
Add warning when using ignoreChange on Component.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 - [auto/*] Add `--policy-pack` and `--policy-pack-configs` options to automation API.
   [#9872](https://github.com/pulumi/pulumi/pull/9872)
 
+- [cli] The engine now produces a warning when the 'ignoreChanges' option is applied to a Component resource.
+
 - [sdk/python] Changed `Output[T].__str__()` to return an informative message rather than "<pulumi.output.Output object at 0x012345ABCDEF>".
   [#9848](https://github.com/pulumi/pulumi/pull/9848)
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,7 @@
   [#9872](https://github.com/pulumi/pulumi/pull/9872)
 
 - [cli] The engine now produces a warning when the 'ignoreChanges' option is applied to a Component resource.
+  [#9863](https://github.com/pulumi/pulumi/pull/9863)
 
 - [sdk/python] Changed `Output[T].__str__()` to return an informative message rather than "<pulumi.output.Output object at 0x012345ABCDEF>".
   [#9848](https://github.com/pulumi/pulumi/pull/9848)

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -470,7 +470,7 @@ func (d *defaultProviders) getDefaultProviderRef(req providers.ProviderRequest) 
 // resmon implements the pulumirpc.ResourceMonitor interface and acts as the gateway between a language runtime's
 // evaluation of a program and the internal resource planning and deployment logic.
 type resmon struct {
-	ctx                       *plugin.Context                    // the plugin context
+	diagostics                diag.Sink                          // logger for user-facing messages
 	providers                 ProviderSource                     // the provider source itself.
 	defaultProviders          *defaultProviders                  // the default provider manager.
 	constructInfo             plugin.ConstructInfo               // information for construct and call calls.
@@ -505,7 +505,7 @@ func newResourceMonitor(src *evalSource, provs ProviderSource, regChan chan *reg
 
 	// New up an engine RPC server.
 	resmon := &resmon{
-		ctx:                       src.plugctx,
+		diagostics:                src.plugctx.Diag,
 		providers:                 provs,
 		defaultProviders:          d,
 		regChan:                   regChan,
@@ -1178,7 +1178,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	// Revisit these semantics in Pulumi v4.0
 	// See this issue for more: https://github.com/pulumi/pulumi/issues/9704
 	if !custom && len(ignoreChanges) > 0 {
-		rm.ctx.Diag.Warningf(diag.Message(
+		rm.diagostics.Warningf(diag.Message(
 			result.State.URN,
 			"The option 'ignoreChanges' has no effect on component resources.",
 		))

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1178,7 +1178,10 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	// Revisit these semantics in Pulumi v4.0
 	// See this issue for more: https://github.com/pulumi/pulumi/issues/9704
 	if !custom && len(ignoreChanges) > 0 {
-		rm.ctx.Diag.Warningf(diag.Message(result.State.URN, "The option 'ignoreChanges' has no effect on components. This may be changed in a future version."))
+		rm.ctx.Diag.Warningf(diag.Message(
+			result.State.URN,
+			"The option 'ignoreChanges' has no effect on components. This may be changed in a future version.",
+		))
 	}
 
 	logging.V(5).Infof(

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1180,7 +1180,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	if !custom && len(ignoreChanges) > 0 {
 		rm.ctx.Diag.Warningf(diag.Message(
 			result.State.URN,
-			"The option 'ignoreChanges' has no effect on components. This may be changed in a future version.",
+			"The option 'ignoreChanges' has no effect on component resources.",
 		))
 	}
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -470,6 +470,7 @@ func (d *defaultProviders) getDefaultProviderRef(req providers.ProviderRequest) 
 // resmon implements the pulumirpc.ResourceMonitor interface and acts as the gateway between a language runtime's
 // evaluation of a program and the internal resource planning and deployment logic.
 type resmon struct {
+	ctx                       *plugin.Context                    // the plugin context
 	providers                 ProviderSource                     // the provider source itself.
 	defaultProviders          *defaultProviders                  // the default provider manager.
 	constructInfo             plugin.ConstructInfo               // information for construct and call calls.
@@ -504,6 +505,7 @@ func newResourceMonitor(src *evalSource, provs ProviderSource, regChan chan *reg
 
 	// New up an engine RPC server.
 	resmon := &resmon{
+		ctx:                       src.plugctx,
 		providers:                 provs,
 		defaultProviders:          d,
 		regChan:                   regChan,
@@ -1109,6 +1111,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
+
 		result = &RegisterResult{State: &resource.State{URN: constructResult.URN, Outputs: constructResult.Outputs}}
 
 		outputDeps = map[string]*pulumirpc.RegisterResourceResponse_PropertyDependencies{}
@@ -1169,6 +1172,13 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			}
 		}
 		outputs = filtered
+	}
+
+	// TODO(@platform): Currently component resources ignore the "ignoreChanges" option.
+	// Revisit these semantics in Pulumi v4.0
+	// See this issue for more: https://github.com/pulumi/pulumi/issues/9704
+	if !custom && len(ignoreChanges) > 0 {
+		rm.ctx.Diag.Warningf(diag.Message(result.State.URN, "The option 'ignoreChanges' has no effect on components. This may be changed in a future version."))
 	}
 
 	logging.V(5).Infof(


### PR DESCRIPTION
# Description

This PR adds a warning when component resources have the `ignoreChanges` option applied, since that option has no effect and is ignored by the engine.

**Reviewers:** Looking for guidance on how to test Diagnostic messages. If this change warrants a test, I'm happy to add one. Could you point me to an example of how I could inspect diagnostics and confirm my change works?

@Frassle [in the original issue](https://github.com/pulumi/pulumi/issues/9704#issuecomment-1139460514), you mentioned there could be other options that are ignored by components. If that's true, could you help me determine what those options are?

Fixes https://github.com/pulumi/pulumi/issues/9704

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change