### PR TITLE
Rename optionalUrl to fix linter

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -395,14 +395,14 @@ func (mod *modContext) genUtilitiesFile() []byte {
 	buffer := &bytes.Buffer{}
 	genStandardHeader(buffer, mod.tool)
 	fmt.Fprintf(buffer, utilitiesFile)
-	optionalUrl := "None"
+	optionalURL := "None"
 	if url := mod.pkg.PluginDownloadURL; url != "" {
-		optionalUrl = fmt.Sprintf("%q", url)
+		optionalURL = fmt.Sprintf("%q", url)
 	}
 	_, err := fmt.Fprintf(buffer, `
 def get_plugin_download_url():
 	return %s
-`, optionalUrl)
+`, optionalURL)
 	contract.AssertNoError(err)
 	return buffer.Bytes()
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes the [linter](https://github.com/pulumi/pulumi/runs/6890736442) after an unfortunate merge in https://github.com/pulumi/pulumi/pull/9856

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
