### PR TITLE
Remove the deprecated PyNameLegacy function

### DIFF
--- a/pkg/codegen/python/python.go
+++ b/pkg/codegen/python/python.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 )
 
-// useLegacyName are names that should return the result of PyNameLegacy from PyName, for compatibility.
+// useLegacyName are names that should return a legacy result from PyName, for compatibility.
 var useLegacyName = codegen.NewStringSet(
 	// The following property name of a nested type is a case where the newer algorithm produces an incorrect name
 	// (`open_xjson_ser_de`). It should be the legacy name of `open_x_json_ser_de`.
@@ -44,14 +44,6 @@ var useLegacyName = codegen.NewStringSet(
 // PyName turns a variable or function name, normally using camelCase, to an underscore_case name.
 func PyName(name string) string {
 	return pyName(name, useLegacyName.Has(name))
-}
-
-// PyNameLegacy is an uncorrected and deprecated version of the PyName algorithm to maintain compatibility and avoid
-// a breaking change. See the linked issue for more context: https://github.com/pulumi/pulumi-kubernetes/issues/1179
-//
-// Deprecated: Use PyName instead.
-func PyNameLegacy(name string) string {
-	return pyName(name, true /*legacy*/)
 }
 
 func pyName(name string, legacy bool) string {

--- a/pkg/codegen/python/python_test.go
+++ b/pkg/codegen/python/python_test.go
@@ -58,7 +58,7 @@ func TestPyNameLegacy(t *testing.T) {
 		t.Run(tt.input, func(t *testing.T) {
 			t.Parallel()
 
-			result := PyNameLegacy(tt.input)
+			result := pyName(tt.input, true /*legacy*/)
 			assert.Equal(t, tt.legacy, result)
 		})
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Github search shows no usage of `PyNameLegacy` in our repos. Bumped into it while looking at #5175.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
