### PR TITLE
add support for local policy packs in auto api

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- [auto/*] Add `--policy-pack` and `--policy-pack-configs` options to automation API.
+  [#9872](https://github.com/pulumi/pulumi/pull/9872)
+
 - [sdk/python] Changed `Output[T].__str__()` to return an informative message rather than "<pulumi.output.Output object at 0x012345ABCDEF>".
   [#9848](https://github.com/pulumi/pulumi/pull/9848)
 

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt
@@ -315,7 +315,7 @@ Pulumi.Automation.UpdateOptions.Target.set -> void
 Pulumi.Automation.UpdateOptions.PolicyPacks.get -> System.Collections.Generic.List<string>
 Pulumi.Automation.UpdateOptions.PolicyPacks.set -> void
 Pulumi.Automation.UpdateOptions.PolicyPackConfigs.get -> System.Collections.Generic.List<string>
-Pulumi.Automation.UpdateOptions.PolicyConfigs.set -> void
+Pulumi.Automation.UpdateOptions.PolicyPackConfigs.set -> void
 Pulumi.Automation.UpdateOptions.UpdateOptions() -> void
 Pulumi.Automation.UpdateResult
 Pulumi.Automation.UpdateResult.StandardError.get -> string

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt
@@ -312,6 +312,10 @@ Pulumi.Automation.UpdateOptions.Parallel.get -> int?
 Pulumi.Automation.UpdateOptions.Parallel.set -> void
 Pulumi.Automation.UpdateOptions.Target.get -> System.Collections.Generic.List<string>
 Pulumi.Automation.UpdateOptions.Target.set -> void
+Pulumi.Automation.UpdateOptions.PolicyPacks.get -> System.Collections.Generic.List<string>
+Pulumi.Automation.UpdateOptions.PolicyPacks.set -> void
+Pulumi.Automation.UpdateOptions.PolicyPackConfigs.get -> System.Collections.Generic.List<string>
+Pulumi.Automation.UpdateOptions.PolicyConfigs.set -> void
 Pulumi.Automation.UpdateOptions.UpdateOptions() -> void
 Pulumi.Automation.UpdateResult
 Pulumi.Automation.UpdateResult.StandardError.get -> string

--- a/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
@@ -18,6 +18,10 @@ namespace Pulumi.Automation
 
         public List<string>? Target { get; set; }
 
+        public List<string>? PolicyPacks { get; set; }
+
+        public List<string>? PolicyPackConfigs { get; set; }
+
         /// <summary>
         /// Optional callback which is invoked whenever StandardOutput is written into
         /// </summary>

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -261,6 +261,24 @@ namespace Pulumi.Automation
                     }
                 }
 
+                if (options.PolicyPacks?.Any() == true)
+                {
+                    foreach (var item in options.PolicyPacks)
+                    {
+                        args.Add("--policy-pack");
+                        args.Add(item);
+                    }
+                }
+
+                if (options.PolicyPackConfigs?.Any() == true)
+                {
+                    foreach (var item in options.PolicyPackConfigs)
+                    {
+                        args.Add("--policy-pack-configs");
+                        args.Add(item);
+                    }
+                }
+
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
 
@@ -386,6 +404,24 @@ namespace Pulumi.Automation
                     foreach (var item in options.Target)
                     {
                         args.Add("--target");
+                        args.Add(item);
+                    }
+                }
+
+                if (options.PolicyPacks?.Any() == true)
+                {
+                    foreach (var item in options.PolicyPacks)
+                    {
+                        args.Add("--policy-pack");
+                        args.Add(item);
+                    }
+                }
+
+                if (options.PolicyPackConfigs?.Any() == true)
+                {
+                    foreach (var item in options.PolicyPackConfigs)
+                    {
+                        args.Add("--policy-pack-configs");
                         args.Add(item);
                     }
                 }

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -144,6 +144,10 @@ type Options struct {
 	Color string
 	// Save an update plan to the given path.
 	Plan string
+	// Run one or more policy packs as part of this update
+	PolicyPacks []string
+	// Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag
+	PolicyPackConfigs []string
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -144,6 +144,10 @@ type Options struct {
 	Color string
 	// Use the update plan at the given path.
 	Plan string
+	// Run one or more policy packs as part of this update
+	PolicyPacks []string
+	// Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag
+	PolicyPackConfigs []string
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -232,6 +232,12 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	for _, tURN := range preOpts.Target {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--target=%s", tURN))
 	}
+	for _, pack := range preOpts.PolicyPacks {
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack=%s", pack))
+	}
+	for _, packConfig := range preOpts.PolicyPackConfigs {
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack-config=%s", packConfig))
+	}
 	if preOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")
 	}
@@ -338,6 +344,12 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	}
 	for _, tURN := range upOpts.Target {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--target=%s", tURN))
+	}
+	for _, pack := range upOpts.PolicyPacks {
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack=%s", pack))
+	}
+	for _, packConfig := range upOpts.PolicyPackConfigs {
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--policy-pack-config=%s", packConfig))
 	}
 	if upOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -175,6 +175,16 @@ Event: ${line}\n${e.toString()}`);
                     args.push("--target", tURN);
                 }
             }
+            if (opts.policyPacks) {
+                for (const pack of opts.policyPacks) {
+                    args.push("--policy-pack", pack);
+                }
+            }
+            if (opts.policyPackConfigs) {
+                for (const packConfig of opts.policyPackConfigs) {
+                    args.push("--policy-pack-config", packConfig);
+                }
+            }
             if (opts.targetDependents) {
                 args.push("--target-dependents");
             }
@@ -288,6 +298,16 @@ Event: ${line}\n${e.toString()}`);
             if (opts.target) {
                 for (const tURN of opts.target) {
                     args.push("--target", tURN);
+                }
+            }
+            if (opts.policyPacks) {
+                for (const pack of opts.policyPacks) {
+                    args.push("--policy-pack", pack);
+                }
+            }
+            if (opts.policyPackConfigs) {
+                for (const packConfig of opts.policyPackConfigs) {
+                    args.push("--policy-pack-config", packConfig);
                 }
             }
             if (opts.targetDependents) {
@@ -746,6 +766,8 @@ export interface UpOptions {
     expectNoChanges?: boolean;
     diff?: boolean;
     replace?: string[];
+    policyPacks?: string[];
+    policyPackConfigs?: string[];
     target?: string[];
     targetDependents?: boolean;
     userAgent?: string;
@@ -768,6 +790,8 @@ export interface PreviewOptions {
     expectNoChanges?: boolean;
     diff?: boolean;
     replace?: string[];
+    policyPacks?: string[];
+    policyPackConfigs?: string[];
     target?: string[];
     targetDependents?: boolean;
     userAgent?: string;

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -704,7 +704,7 @@ def _parse_extra_args(**kwargs) -> List[str]:
             extra_args.extend(["--policy-pack", p])
     if policy_pack_configs:
         for p in policy_pack_configs:
-            extra_args.extend(["--policy-pack-config", p]) 
+            extra_args.extend(["--policy-pack-config", p])
     if target_dependents:
         extra_args.append("--target-dependents")
     if parallel:

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -201,6 +201,8 @@ class Stack:
         parallel: Optional[int] = None,
         message: Optional[str] = None,
         target: Optional[List[str]] = None,
+        policy_packs: Optional[List[str]] = None,
+        policy_pack_configs: Optional[List[str]] = None,
         expect_no_changes: Optional[bool] = None,
         diff: Optional[bool] = None,
         target_dependents: Optional[bool] = None,
@@ -220,6 +222,8 @@ class Stack:
         :param message: Message (optional) to associate with the update operation.
         :param target: Specify an exclusive list of resource URNs to destroy.
         :param expect_no_changes: Return an error if any changes occur during this update.
+        :param policy_packs: Run one or more policy packs as part of this update.
+        :param policy_pack_configs: Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag.
         :param diff: Display operation as a rich diff showing the overall change.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
         :param replace: Specify resources to replace.
@@ -300,6 +304,8 @@ class Stack:
         parallel: Optional[int] = None,
         message: Optional[str] = None,
         target: Optional[List[str]] = None,
+        policy_packs: Optional[List[str]] = None,
+        policy_pack_configs: Optional[List[str]] = None,
         expect_no_changes: Optional[bool] = None,
         diff: Optional[bool] = None,
         target_dependents: Optional[bool] = None,
@@ -318,6 +324,8 @@ class Stack:
                          (1 for no parallelism). Defaults to unbounded (2147483647).
         :param message: Message to associate with the preview operation.
         :param target: Specify an exclusive list of resource URNs to update.
+        :param policy_packs: Run one or more policy packs as part of this update.
+        :param policy_pack_configs: Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag.
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param diff: Display operation as a rich diff showing the overall change.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
@@ -673,6 +681,8 @@ def _parse_extra_args(**kwargs) -> List[str]:
     diff = kwargs.get("diff")
     replace = kwargs.get("replace")
     target = kwargs.get("target")
+    policy_packs = kwargs.get("policy_packs")
+    policy_pack_configs = kwargs.get("policy_pack_configs")
     target_dependents = kwargs.get("target_dependents")
     parallel = kwargs.get("parallel")
     color = kwargs.get("color")
@@ -689,6 +699,12 @@ def _parse_extra_args(**kwargs) -> List[str]:
     if target:
         for t in target:
             extra_args.extend(["--target", t])
+    if policy_packs:
+        for p in policy_packs:
+            extra_args.extend(["--policy-pack", p])
+    if policy_pack_configs:
+        for p in policy_pack_configs:
+            extra_args.extend(["--policy-pack-config", p]) 
     if target_dependents:
         extra_args.append("--target-dependents")
     if parallel:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds support for policy packs in automation API so we can address https://github.com/pulumi/actions/issues/212

Fixes #6757

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
