### PR TITLE
Fix dotnet alias spec

### DIFF
--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
@@ -160,10 +160,14 @@ namespace Pulumi
                         }
 
                         var aliasSpec = new Pulumirpc.Alias.Types.Spec();
-                        aliasSpec.Name = await MaybeAwait(aliasVal.Name);
-                        aliasSpec.Type = await MaybeAwait(aliasVal.Type);
-                        aliasSpec.Stack= await MaybeAwait(aliasVal.Stack);
-                        aliasSpec.Project = await MaybeAwait(aliasVal.Project);
+                        var aliasName = await MaybeAwait(aliasVal.Name);
+                        if (aliasName != null) { aliasSpec.Name = aliasName; }
+                        var aliasType = await MaybeAwait(aliasVal.Type);
+                        if (aliasType != null) { aliasSpec.Type = aliasType; }
+                        var aliasStack= await MaybeAwait(aliasVal.Stack);
+                        if (aliasStack != null) { aliasSpec.Stack = aliasStack; }
+                        var aliasProject = await MaybeAwait(aliasVal.Project);
+                        if (aliasProject != null) { aliasSpec.Project = aliasProject; }
 
                         var parentCount =
                             (aliasVal.Parent != null ? 1 : 0) +
@@ -180,7 +184,7 @@ namespace Pulumi
                         if (aliasVal.NoParent) {
                             aliasSpec.NoParent = true;
                         }
-                        else if (parentUrn != null) {
+                        else if (alaisParentUrn != null) {
                             aliasSpec.ParentUrn = alaisParentUrn;
                         }
 

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
@@ -175,8 +175,14 @@ namespace Pulumi
                             $"Only specify one of '{nameof(Alias.Parent)}', '{nameof(Alias.ParentUrn)}' or '{nameof(Alias.NoParent)}' in an {nameof(Alias)}");
                         }
 
-                        aliasSpec.ParentUrn =  aliasVal.Parent == null ? await MaybeAwait(aliasVal.ParentUrn) : await MaybeAwait(aliasVal.Parent.Urn);
-                        aliasSpec.NoParent = aliasVal.NoParent;
+                        var alaisParentUrn = aliasVal.Parent == null ? await MaybeAwait(aliasVal.ParentUrn) : await MaybeAwait(aliasVal.Parent.Urn);
+                        // Setting either of NoParent or ParentUrn will reset the other so only set the one (if any) that has a value.
+                        if (aliasVal.NoParent) {
+                            aliasSpec.NoParent = true;
+                        }
+                        else if (parentUrn != null) {
+                            aliasSpec.ParentUrn = alaisParentUrn;
+                        }
 
                         rpcAlias.Spec = aliasSpec;
                     }


### PR DESCRIPTION
Protobuf string fields can't be set to null. As we're building the Spec object all the fields are optional and we were indicating that with nullness which then tripped the null check in the property setter. This changes the code to just check nullness first and only set the spec property if it's non-null.