### PR TITLE
Set DeleteBeforeReplace for forced replaces

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,6 +24,9 @@
 - [sdk/dotnet] The dotnet SDK will now send alias objects rather than URNs to the engine.
   [#9731](https://github.com/pulumi/pulumi/pull/9731)
 
+- [engine] The engine will default to delete before create for replacements when it has no information from the provider that create before delete is safe.
+  [#9909](https://github.com/pulumi/pulumi/pull/9909)
+
 ### Bug Fixes
 
 - [sdk/go] Handle nils in mapper encoding.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1462,7 +1462,7 @@ func (sg *stepGenerator) diff(urn resource.URN, old, new *resource.State, oldInp
 	newInputs resource.PropertyMap, prov plugin.Provider, allowUnknowns bool,
 	ignoreChanges []string) (plugin.DiffResult, error) {
 
-	// TODO: Note that currently we have to always return DeleteBeforeReplace for targetted replaces and
+	// TODO: Note that currently we have to always return DeleteBeforeReplace for targeted replaces and
 	// provider diffs. This is because we don't currently have any interface into the provider to ask if it's
 	// safe to do a create first. For a normal replace we call the provider Diff method which gives the
 	// provider a chance to do checks such as "this resource needs a replace, but its new and old name are the


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This sets DeleteBeforeReplace to true when doing a targeted replace, or a replace due to a provider change.

This is so that if doing a replace where we aren't changing a unique field (such as the name) we can't safely create the new resource until we've delete the old. We don't currently have an interface to ask the provider "given this old state and new state, assuming we do a replace is it safe to do a CreateBeforeDelete?".

Part of fixing https://github.com/pulumi/pulumi-aws/issues/2009

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
