### PR TITLE
Add Warnings when Resource Options are applied to Components with no effect

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- [cli] The engine will now warn when a resource option is applied to a Component resource when that option will have no effect. This extends [#9863](https://github.com/pulumi/pulumi/pull/9863) which only warns for the `ignoreChanges` resource options.
+  [#9921](https://github.com/pulumi/pulumi/pull/9921)
+
 ### Bug Fixes

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -5322,6 +5322,126 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 	assert.True(t, resA.Outputs["c"].IsSecret())
 }
 
+// This test checks that warnings are emitted when options which have no
+// effect on components are attached to a component resource.
+func TestComponentOptionWarnings(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		optionName string
+		option     deploytest.ResourceOptions
+	}
+
+	// These are the options which have no effect on components.
+	var cases = []testCase{
+		{
+			optionName: "retainOnDelete",
+			option: deploytest.ResourceOptions{
+				RetainOnDelete: true,
+			},
+		}, {
+			optionName: "ignoreChanges",
+			option: deploytest.ResourceOptions{
+				IgnoreChanges: []string{"root"},
+			},
+		}, {
+			optionName: "customTimeouts",
+			option: deploytest.ResourceOptions{
+				CustomTimeouts: &resource.CustomTimeouts{},
+			},
+		}, {
+			optionName: "replaceOnChange",
+			option: deploytest.ResourceOptions{
+				ReplaceOnChanges: []string{"*"},
+			},
+		}, {
+			optionName: "additionalSecretOutputs",
+			option: deploytest.ResourceOptions{
+				AdditionalSecretOutputs: []resource.PropertyKey{"foobar"},
+			},
+		}}
+
+	// For each of these scenarios, assert that a component resource
+	// with this option applied produces a warning.
+	for i, testCase := range cases {
+		t.Run(fmt.Sprintf("Option #%d: %s", i, testCase.optionName), func(t *testing.T) {
+			var runtime = createRuntimeWithOption(t, testCase.option)
+			var host = deploytest.NewPluginHost(nil, nil, runtime)
+			var warningText = fmt.Sprintf("The option '%s'has no effect on component resources.", testCase.optionName)
+			var p = &TestPlan{
+				Options: UpdateOptions{Host: host},
+				// Steps:   MakeBasicLifecycleSteps(t, 1),
+				Steps: []TestStep{{
+					Op:            Update,
+					ExpectFailure: false,
+					SkipPreview:   true,
+					Validate: func(
+						project workspace.Project,
+						target deploy.Target,
+						entries JournalEntries,
+						evts []Event,
+						res result.Result,
+					) result.Result {
+						var foundWarning bool
+						for _, evt := range evts {
+							if evt.Type == DiagEvent {
+								e := evt.Payload().(DiagEventPayload)
+								msg := colors.Never.Colorize(e.Message)
+								foundWarning = strings.Contains(msg, warningText) && e.Severity == diag.Warning
+								if foundWarning {
+									break
+								}
+							}
+						}
+						assert.True(t, foundWarning)
+						return res
+					},
+				}},
+			}
+
+			/*
+				Steps: []TestStep{{
+					Op:            Update,
+					ExpectFailure: true,
+					SkipPreview:   true,
+					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
+						evts []Event, res result.Result) result.Result {
+
+						assertIsErrorOrBailResult(t, res)
+						sawExitCode := false
+						for _, evt := range evts {
+							if evt.Type == DiagEvent {
+								e := evt.Payload().(DiagEventPayload)
+								msg := colors.Never.Colorize(e.Message)
+								sawExitCode = strings.Contains(msg, errorText) && e.Severity == diag.Error
+								if sawExitCode {
+									break
+								}
+							}
+						}
+
+						assert.True(t, sawExitCode)
+						return res
+					},
+				}},
+
+			*/
+
+			p.Run(t, nil)
+		})
+	}
+}
+
+// This function creates a new language runtime registering a single resource:
+// a component registered with the provided option.
+func createRuntimeWithOption(t *testing.T, option deploytest.ResourceOptions) plugin.LanguageRuntime {
+	return deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("component", "resA", false, option)
+		assert.NoError(t, err)
+		return nil
+	})
+}
+
 func TestDefaultParents(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -5326,7 +5326,6 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 // effect on components are attached to a component resource.
 func TestComponentOptionWarnings(t *testing.T) {
 	t.Parallel()
-
 	type testCase struct {
 		optionName string
 		option     deploytest.ResourceOptions
@@ -5361,11 +5360,22 @@ func TestComponentOptionWarnings(t *testing.T) {
 			},
 		},
 	}
+	// This function creates a new language runtime registering a single resource:
+	// a component registered with the provided option.
+	var createRuntimeWithOption = func(t *testing.T, option deploytest.ResourceOptions) plugin.LanguageRuntime {
+		return deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, _, _, err := monitor.RegisterResource("component", "resA", false, option)
+			assert.NoError(t, err)
+			return nil
+		})
+	}
 
 	// For each of these scenarios, assert that a component resource
 	// with this option applied produces a warning.
-	for i, testCase := range cases {
-		t.Run(fmt.Sprintf("Option #%d: %s", i, testCase.optionName), func(t *testing.T) {
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.optionName, func(t *testing.T) {
+			t.Parallel()
 			var runtime = createRuntimeWithOption(t, testCase.option)
 			var host = deploytest.NewPluginHost(nil, nil, runtime)
 			var warningText = fmt.Sprintf("The option '%s' has no effect on component resources.", testCase.optionName)
@@ -5401,16 +5411,6 @@ func TestComponentOptionWarnings(t *testing.T) {
 			p.Run(t, nil)
 		})
 	}
-}
-
-// This function creates a new language runtime registering a single resource:
-// a component registered with the provided option.
-func createRuntimeWithOption(t *testing.T, option deploytest.ResourceOptions) plugin.LanguageRuntime {
-	return deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		_, _, _, err := monitor.RegisterResource("component", "resA", false, option)
-		assert.NoError(t, err)
-		return nil
-	})
 }
 
 func TestDefaultParents(t *testing.T) {

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -5350,7 +5350,7 @@ func TestComponentOptionWarnings(t *testing.T) {
 				CustomTimeouts: &resource.CustomTimeouts{},
 			},
 		}, {
-			optionName: "replaceOnChange",
+			optionName: "replaceOnChanges",
 			option: deploytest.ResourceOptions{
 				ReplaceOnChanges: []string{"*"},
 			},
@@ -5359,7 +5359,8 @@ func TestComponentOptionWarnings(t *testing.T) {
 			option: deploytest.ResourceOptions{
 				AdditionalSecretOutputs: []resource.PropertyKey{"foobar"},
 			},
-		}}
+		},
+	}
 
 	// For each of these scenarios, assert that a component resource
 	// with this option applied produces a warning.
@@ -5367,18 +5368,17 @@ func TestComponentOptionWarnings(t *testing.T) {
 		t.Run(fmt.Sprintf("Option #%d: %s", i, testCase.optionName), func(t *testing.T) {
 			var runtime = createRuntimeWithOption(t, testCase.option)
 			var host = deploytest.NewPluginHost(nil, nil, runtime)
-			var warningText = fmt.Sprintf("The option '%s'has no effect on component resources.", testCase.optionName)
+			var warningText = fmt.Sprintf("The option '%s' has no effect on component resources.", testCase.optionName)
 			var p = &TestPlan{
 				Options: UpdateOptions{Host: host},
-				// Steps:   MakeBasicLifecycleSteps(t, 1),
 				Steps: []TestStep{{
 					Op:            Update,
 					ExpectFailure: false,
 					SkipPreview:   true,
 					Validate: func(
-						project workspace.Project,
-						target deploy.Target,
-						entries JournalEntries,
+						_ workspace.Project,
+						_ deploy.Target,
+						_ JournalEntries,
 						evts []Event,
 						res result.Result,
 					) result.Result {
@@ -5398,35 +5398,6 @@ func TestComponentOptionWarnings(t *testing.T) {
 					},
 				}},
 			}
-
-			/*
-				Steps: []TestStep{{
-					Op:            Update,
-					ExpectFailure: true,
-					SkipPreview:   true,
-					Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
-						evts []Event, res result.Result) result.Result {
-
-						assertIsErrorOrBailResult(t, res)
-						sawExitCode := false
-						for _, evt := range evts {
-							if evt.Type == DiagEvent {
-								e := evt.Payload().(DiagEventPayload)
-								msg := colors.Never.Colorize(e.Message)
-								sawExitCode = strings.Contains(msg, errorText) && e.Severity == diag.Error
-								if sawExitCode {
-									break
-								}
-							}
-						}
-
-						assert.True(t, sawExitCode)
-						return res
-					},
-				}},
-
-			*/
-
 			p.Run(t, nil)
 		})
 	}

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -280,6 +280,7 @@ func (p *TestPlan) Run(t *testing.T, snapshot *deploy.Snapshot) *deploy.Snapshot
 	return snap
 }
 
+// resCount is the expected number of resources registered during this test.
 func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 	return []TestStep{
 		// Initial update

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1206,11 +1206,33 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			"The option 'ignoreChanges' has no effect on component resources.",
 		))
 	}
+	// Timeouts are no recognized on component resources.
+	if !custom && customTimeouts != nil {
+		rm.ctx.Diag.Warningf(diag.Message(
+			result.State.URN,
+			"The option 'customTimeouts' has no effect on components.",
+		))
+	}
+
 	// additionalSecretOutputs are ignored on components.
 	if !custom && len(additionalSecretOutputs) > 0 {
 		rm.diagostics.Warningf(diag.Message(
 			result.State.URN,
 			"The option 'additionalSecretOutputs' has no effect on component resources.",
+		))
+	}
+
+	if !custom && len(replaceOnChanges) > 0 {
+		rm.ctx.Diag.Warningf(diag.Message(
+			result.State.URN,
+			"The option 'replaceOnChanges' has no effect on components.",
+		))
+	}
+
+	if !custom && retainOnDelete {
+		rm.ctx.Diag.Warningf(diag.Message(
+			result.State.URN,
+			"The option 'retainOnDelete' has no effect on components.",
 		))
 	}
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1254,14 +1254,14 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 }
 
 // checkComponentOption generates a warning message on the resource
-// 'srcURN' if 'check' returns true.
+// 'urn' if 'check' returns true.
 // This function is intended to validate options passed to component resources,
-// so srcURN is expected to refer to a component.
-func (rm *resmon) checkComponentOption(srcURN resource.URN, optName string, check func() bool) {
+// so urn is expected to refer to a component.
+func (rm *resmon) checkComponentOption(urn resource.URN, optName string, check func() bool) {
 	var msg = fmt.Sprintf("The option '%s' has no effect on component resources.", optName)
 	if check() {
 		rm.diagostics.Warningf(diag.Message(
-			srcURN,
+			urn,
 			msg,
 		))
 	}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1211,7 +1211,13 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			return len(ignoreChanges) > 0
 		})
 		rm.checkComponentOption(result.State.URN, "customTimeouts", func() bool {
-			return customTimeouts != nil
+			if customTimeouts == nil {
+				return false
+			}
+			var hasUpdateTimeout = customTimeouts.Update != ""
+			var hasCreateTimeout = customTimeouts.Create != ""
+			var hasDeleteTimeout = customTimeouts.Delete != ""
+			return hasCreateTimeout || hasUpdateTimeout || hasDeleteTimeout
 		})
 		rm.checkComponentOption(result.State.URN, "additionalSecretOutputs", func() bool {
 			return len(additionalSecretOutputs) > 0

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1206,6 +1206,13 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			"The option 'ignoreChanges' has no effect on component resources.",
 		))
 	}
+	// additionalSecretOutputs are ignored on components.
+	if !custom && len(additionalSecretOutputs) > 0 {
+		rm.diagostics.Warningf(diag.Message(
+			result.State.URN,
+			"The option 'additionalSecretOutputs' has no effect on component resources.",
+		))
+	}
 
 	logging.V(5).Infof(
 		"ResourceMonitor.RegisterResource operation finished: t=%v, urn=%v, #outs=%v",


### PR DESCRIPTION
# Description

This PR is a follow-on to https://github.com/pulumi/pulumi/pull/9863. There are some resource options that have no effect when applied to component resources. This PR will produce a warning each time those options are applied to components.
The initial PR was scoped to emit a warning for the `ignoreChanges` option, while this PR addresses resource options `customTimeouts`, `additinoalSecretOutputs`, `replaceOnChanges`, and `retainOnDelete` as well.

Fixes https://github.com/pulumi/pulumi/issues/9877

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version