### PR TITLE
Update pulumi-java ref to v0.4.0

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 set -x
 
 # shellcheck disable=SC2043
-for i in "java v0.3.0" "yaml v0.5.1"; do
+for i in "java v0.4.0" "yaml v0.5.1"; do
   set -- $i # treat strings in loop as args
   PULUMI_LANG="$1"
   TAG="$2"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This would release pulumi-language-java v0.4.0 together with the new Pulumi CLI, see what's new in https://github.com/pulumi/pulumi-java/blob/main/CHANGELOG.md#040-2022-06-22

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
