### PR TITLE
Include pkg reference in bound schema types

### DIFF
--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -142,7 +142,7 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 		diags = diags.Extend(validationDiags)
 	}
 
-	types, pkgDiags, err := newBinder(spec.Info(), packageSpecSource{&spec}, loader)
+	types, pkgDiags, err := newBinder(spec.Info(), packageSpecSource{&spec}, loader, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -191,7 +191,7 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 	return pkg, diags, nil
 }
 
-func newBinder(info PackageInfoSpec, spec specSource, loader Loader) (*types, hcl.Diagnostics, error) {
+func newBinder(info PackageInfoSpec, spec specSource, loader Loader, bindTo PackageReference) (*types, hcl.Diagnostics, error) {
 	var diags hcl.Diagnostics
 
 	// Validate that there is a name
@@ -273,6 +273,8 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader) (*types, hc
 		tokens:       map[string]*TokenType{},
 		inputs:       map[Type]*InputType{},
 		optionals:    map[Type]*OptionalType{},
+
+		bindToReference: bindTo,
 	}
 
 	return types, diags, nil
@@ -301,19 +303,19 @@ func ImportSpec(spec PackageSpec, languages map[string]Language) (*Package, erro
 }
 
 func importPartialSpec(spec PartialPackageSpec, languages map[string]Language, loader Loader) (*PartialPackage, error) {
-	types, diags, err := newBinder(spec.PackageInfoSpec, partialPackageSpecSource{&spec}, loader)
+	pkg := &PartialPackage{
+		spec:      &spec,
+		languages: languages,
+	}
+	types, diags, err := newBinder(spec.PackageInfoSpec, partialPackageSpecSource{&spec}, loader, pkg)
 	if err != nil {
 		return nil, err
 	}
 	if diags.HasErrors() {
 		return nil, diags
 	}
-
-	return &PartialPackage{
-		spec:      &spec,
-		languages: languages,
-		types:     types,
-	}, nil
+	pkg.types = types
+	return pkg, nil
 }
 
 // ImportPartialSpec converts a serializable PartialPackageSpec into a PartialPackage. Unlike a typical Package, a
@@ -419,6 +421,9 @@ type types struct {
 	tokens    map[string]*TokenType
 	inputs    map[Type]*InputType
 	optionals map[Type]*OptionalType
+
+	// A pointer to the package reference that `types` is a part of if it exists.
+	bindToReference PackageReference
 }
 
 func (t *types) Close() error {
@@ -426,6 +431,14 @@ func (t *types) Close() error {
 		return t.loadCtx.Close()
 	}
 	return nil
+}
+
+// The package which bound types will link back to.
+func (t *types) externalPackage() PackageReference {
+	if t.bindToReference != nil {
+		return t.bindToReference
+	}
+	return t.pkg.Reference()
 }
 
 //nolint: goconst
@@ -1108,6 +1121,7 @@ func (t *types) bindObjectTypeDetails(path string, obj *ObjectType, token string
 	}
 
 	obj.Package = t.pkg
+	obj.PackageReference = t.externalPackage()
 	obj.Token = token
 	obj.Comment = spec.Description
 	obj.Language = language
@@ -1116,6 +1130,7 @@ func (t *types) bindObjectTypeDetails(path string, obj *ObjectType, token string
 	obj.IsOverlay = spec.IsOverlay
 
 	obj.InputShape.Package = t.pkg
+	obj.InputShape.PackageReference = t.externalPackage()
 	obj.InputShape.Token = token
 	obj.InputShape.Comment = spec.Description
 	obj.InputShape.Language = language
@@ -1172,12 +1187,13 @@ func (t *types) bindEnumType(token string, spec ComplexTypeSpec) (*EnumType, hcl
 	}
 
 	return &EnumType{
-		Package:     t.pkg,
-		Token:       token,
-		Elements:    values,
-		ElementType: typ,
-		Comment:     spec.Description,
-		IsOverlay:   spec.IsOverlay,
+		Package:          t.pkg,
+		PackageReference: t.externalPackage(),
+		Token:            token,
+		Elements:         values,
+		ElementType:      typ,
+		Comment:          spec.Description,
+		IsOverlay:        spec.IsOverlay,
 	}, diags
 }
 
@@ -1365,6 +1381,7 @@ func (t *types) bindResourceDetails(path, token string, spec ResourceSpec, decl 
 
 	*decl = Resource{
 		Package:            t.pkg,
+		PackageReference:   t.externalPackage(),
 		Token:              token,
 		Comment:            spec.Description,
 		InputProperties:    inputProperties,

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -191,7 +191,11 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 	return pkg, diags, nil
 }
 
-func newBinder(info PackageInfoSpec, spec specSource, loader Loader, bindTo PackageReference) (*types, hcl.Diagnostics, error) {
+// Create a new binder.
+//
+// bindTo overrides the PackageReference field contained in generated types.
+func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
+	bindTo PackageReference) (*types, hcl.Diagnostics, error) {
 	var diags hcl.Diagnostics
 
 	// Validate that there is a name

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -149,6 +149,9 @@ func (*ArrayType) isType() {}
 type EnumType struct {
 	// Package is the type's package.
 	Package *Package
+	// PackageReference is the PackageReference that defines the resource.
+	PackageReference PackageReference
+
 	// Token is the type's Pulumi type token.
 	Token string
 	// Comment is the description of the type, if any.
@@ -213,6 +216,8 @@ func (*UnionType) isType() {}
 type ObjectType struct {
 	// Package is the package that defines the resource.
 	Package *Package
+	// PackageReference is the PackageReference that defines the resource.
+	PackageReference PackageReference
 	// Token is the type's Pulumi type token.
 	Token string
 	// Comment is the description of the type, if any.
@@ -376,6 +381,8 @@ type Alias struct {
 type Resource struct {
 	// Package is the package that defines the resource.
 	Package *Package
+	// PackageReference is the PackageReference that defines the resource.
+	PackageReference PackageReference
 	// Token is the resource's Pulumi type token.
 	Token string
 	// Comment is the description of the resource, if any.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -147,11 +147,11 @@ func (*ArrayType) isType() {}
 
 // EnumType represents an enum.
 type EnumType struct {
-	// Package is the type's package.
+	// Package is the type's package. Package will not be accurate for types loaded by
+	// reference. In that case, use PackageReference instead.
 	Package *Package
 	// PackageReference is the PackageReference that defines the resource.
 	PackageReference PackageReference
-
 	// Token is the type's Pulumi type token.
 	Token string
 	// Comment is the description of the type, if any.
@@ -214,7 +214,8 @@ func (*UnionType) isType() {}
 
 // ObjectType represents schematized maps from strings to particular types.
 type ObjectType struct {
-	// Package is the package that defines the resource.
+	// Package is the package that defines the resource. Package will not be accurate for
+	// types loaded by reference. In that case, use PackageReference instead.
 	Package *Package
 	// PackageReference is the PackageReference that defines the resource.
 	PackageReference PackageReference
@@ -379,7 +380,8 @@ type Alias struct {
 
 // Resource describes a Pulumi resource.
 type Resource struct {
-	// Package is the package that defines the resource.
+	// Package is the package that defines the resource. Package will not be accurate for
+	// types loaded by reference. In that case, use PackageReference instead.
 	Package *Package
 	// PackageReference is the PackageReference that defines the resource.
 	PackageReference PackageReference

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -128,6 +128,7 @@ func TestEnums(t *testing.T) {
 				}
 				result := pkg.Types[0]
 				tt.expected.Package = pkg
+				tt.expected.PackageReference = pkg.Reference()
 				assert.Equal(t, tt.expected, result)
 			}
 		})


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

We include a `PackageReference` which is guaranteed to be correct with schema types.

Helps with #9932

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
