### PR TITLE
[auto/go] - pass unquoted string to color flag

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,6 @@
   [#9921](https://github.com/pulumi/pulumi/pull/9921)
 
 ### Bug Fixes
+
+- [auto/go] Fix passing of the color option.
+  [#9940](https://github.com/pulumi/pulumi/pull/9940)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -361,7 +361,7 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--exec-agent=%s", upOpts.UserAgent))
 	}
 	if upOpts.Color != "" {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--color=%q", upOpts.Color))
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--color=%s", upOpts.Color))
 	}
 	if upOpts.Plan != "" {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--plan=%s", upOpts.Plan))
@@ -448,7 +448,7 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 		args = append(args, fmt.Sprintf("--exec-agent=%s", refreshOpts.UserAgent))
 	}
 	if refreshOpts.Color != "" {
-		args = append(args, fmt.Sprintf("--color=%q", refreshOpts.Color))
+		args = append(args, fmt.Sprintf("--color=%s", refreshOpts.Color))
 	}
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {
@@ -519,7 +519,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 		args = append(args, fmt.Sprintf("--exec-agent=%s", destroyOpts.UserAgent))
 	}
 	if destroyOpts.Color != "" {
-		args = append(args, fmt.Sprintf("--color=%q", destroyOpts.Color))
+		args = append(args, fmt.Sprintf("--color=%s", destroyOpts.Color))
 	}
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {


### PR DESCRIPTION
# Description

This PR fixes an issue which passes quoted string to color flag in golang auto sdk

```bash
error: unsupported color option: '\"auto\"'
```