### PR TITLE
Avoid realpath Makefile func that seems flaky on Win

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := Pulumi SDK
-PROJECT_ROOT := $(realpath .)
+PROJECT_ROOT := .
 SDKS         := dotnet nodejs python go
 SUB_PROJECTS := $(SDKS:%=sdk/%)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := Pulumi SDK
-PROJECT_ROOT := .
+PROJECT_ROOT := ..
 SDKS         := dotnet nodejs python go
 SUB_PROJECTS := $(SDKS:%=sdk/%)
 

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME    := Pulumi .NET Core SDK
 LANGHOST_PKG    := github.com/pulumi/pulumi/sdk/v3/dotnet/cmd/pulumi-language-dotnet
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
-PROJECT_ROOT    := $(realpath ../..)
+PROJECT_ROOT    := ../..
 
 DOTNET_VERSION  := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version --language dotnet))
 

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -4,7 +4,7 @@ VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ &
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
 TESTPARALLELISM  ?= 10
-PROJECT_ROOT     := $(realpath ../..)
+PROJECT_ROOT     := ../..
 
 include ../../build/common.mk
 

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -3,7 +3,7 @@ NODE_MODULE_NAME := @pulumi/pulumi
 VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version --language javascript))
 
 LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-nodejs
-PROJECT_ROOT     := $(realpath ../..)
+PROJECT_ROOT     := ../..
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
 TESTPARALLELISM ?= 10

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME     := Pulumi Python SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/python/cmd/pulumi-language-python
 VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version))
 PYPI_VERSION 	 := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version --language python))
-PROJECT_ROOT     := $(realpath ../..)
+PROJECT_ROOT     := ../..
 
 PYENV := ./env
 PYENVSRC := $(PYENV)/src


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9942

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
