### PR TITLE
Don't check QName is valid in alias logic

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,6 @@
 
 - [auto/go] Fix passing of the color option.
   [#9940](https://github.com/pulumi/pulumi/pull/9940)
+
+- [engine] Fix panic from unexpected resource name formats.
+  [#9950](https://github.com/pulumi/pulumi/pull/9950)

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -398,7 +398,7 @@ func (sg *stepGenerator) inheritedChildAlias(
 
 	aliasName := childName
 	if strings.HasPrefix(childName.String(), parentName.String()) {
-		aliasName = tokens.AsQName(
+		aliasName = tokens.QName(
 			parentAlias.Name().String() +
 				strings.TrimPrefix(childName.String(), parentName.String()))
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We really need to sort out what are actually valid names and validate them correctly, but that's part of https://github.com/pulumi/pulumi/issues/8949. For now assume it's fine to throw any string in here because it's been working so far.

Fixes https://github.com/pulumi/pulumi/issues/9947

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
