### PR TITLE
Remove PROJECT_ROOT Make var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PROJECT_NAME := Pulumi SDK
-PROJECT_ROOT := ..
 SDKS         := dotnet nodejs python go
 SUB_PROJECTS := $(SDKS:%=sdk/%)
 
@@ -22,6 +21,9 @@ TESTPARALLELISM ?= 10
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running
 # `test_all` without the dependencies.
 TEST_ALL_DEPS ?= build $(SUB_PROJECTS:%=%_install)
+
+GO_TEST      = $(PYTHON) ../scripts/go-test.py $(GO_TEST_FLAGS)
+GO_TEST_FAST = $(PYTHON) ../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
 ensure: .ensure.phony pulumictl.ensure go.ensure $(SUB_PROJECTS:%=%_ensure)
 .ensure.phony: sdk/go.mod pkg/go.mod tests/go.mod

--- a/build/common.mk
+++ b/build/common.mk
@@ -98,10 +98,14 @@ PIP ?= pip3
 PULUMI_BIN          := $(PULUMI_ROOT)/bin
 PULUMI_NODE_MODULES := $(PULUMI_ROOT)/node_modules
 PULUMI_NUGET        := $(PULUMI_ROOT)/nuget
-GO_TEST_OPTIONS     :=
 
-GO_TEST_FAST = $(PYTHON) ${PROJECT_ROOT}/scripts/go-test.py -short -count=1 -cover -tags=all -timeout 1h -parallel ${TESTPARALLELISM} ${GO_TEST_OPTIONS}
-GO_TEST = $(PYTHON) $(PROJECT_ROOT)/scripts/go-test.py -count=1 -cover -timeout 1h -tags=all -parallel ${TESTPARALLELISM} ${GO_TEST_OPTIONS}
+# Extra options to pass to `go test` command, for example:
+#
+#     make GO_TEST_OPTIONS="-short -test.v" test_fast
+GO_TEST_OPTIONS :=
+
+GO_TEST_FLAGS = -count=1 -cover -tags=all -timeout 1h -parallel ${TESTPARALLELISM} ${GO_TEST_OPTIONS}
+GO_TEST_FAST_FLAGS = -short ${GO_TEST_FLAGS}
 GOPROXY = 'https://proxy.golang.org'
 
 .PHONY: default all only_build only_test lint install test_all core build

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -2,7 +2,6 @@ PROJECT_NAME    := Pulumi .NET Core SDK
 LANGHOST_PKG    := github.com/pulumi/pulumi/sdk/v3/dotnet/cmd/pulumi-language-dotnet
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
-PROJECT_ROOT    := ../..
 
 DOTNET_VERSION  := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version --language dotnet))
 
@@ -25,6 +24,9 @@ TEST_COVERAGE_ARGS := -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura 
 else
 TEST_COVERAGE_ARGS := -p:CollectCoverage=false -p:CoverletOutput=$(PULUMI_TEST_COVERAGE_PATH)
 endif
+
+GO_TEST      = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FLAGS)
+GO_TEST_FAST = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
 build::
 	# From the nuget docs:

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -4,13 +4,15 @@ VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ &
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
 TESTPARALLELISM  ?= 10
-PROJECT_ROOT     := ../..
 
 include ../../build/common.mk
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running
 # `test_all` without the dependencies.
 TEST_ALL_DEPS ?= install
+
+GO_TEST      = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FLAGS)
+GO_TEST_FAST = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
 gen::
 	go generate ./pulumi/...

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -3,7 +3,6 @@ NODE_MODULE_NAME := @pulumi/pulumi
 VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version --language javascript))
 
 LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-nodejs
-PROJECT_ROOT     := ../..
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
 TESTPARALLELISM ?= 10
@@ -16,6 +15,9 @@ TEST_ALL_DEPS ?= build
 include ../../build/common.mk
 
 export PATH:=$(shell yarn bin 2>/dev/null):$(PATH)
+
+GO_TEST      = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FLAGS)
+GO_TEST_FAST = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
 ensure:: yarn.ensure node.ensure .ensure.phony
 .ensure.phony: package.json

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -2,7 +2,6 @@ PROJECT_NAME     := Pulumi Python SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/python/cmd/pulumi-language-python
 VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version))
 PYPI_VERSION 	 := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell cd ../../ && pulumictl get version --language python))
-PROJECT_ROOT     := ../..
 
 PYENV := ./env
 PYENVSRC := $(PYENV)/src
@@ -17,6 +16,9 @@ include ../../build/common.mk
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running
 # `test_all` without the dependencies.
 TEST_ALL_DEPS ?= build
+
+GO_TEST      = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FLAGS)
+GO_TEST_FAST = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
 ensure:: $(PYTHON).ensure .ensure.phony
 .ensure.phony:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Following up on the earlier comment by @iwahbe that PROJECT_ROOT is confusing, and not really root. This PR removes the PROJECT_ROOT variable. It was needed because common Go flags were defined in `common.mk` but the paths to the wrapper script were different depending on which target was run. In the updated code, `GO_TEST` and `GO_TEST_FAST` are simply redefined in every Makefile with the appropriate relative path to the wrapper.




<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
