### PR TITLE
Fix out-of-date docs for `runtime.isDryRun` et al

### DIFF
--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -113,9 +113,9 @@ export function _setIsDryRun(val: boolean) {
 }
 
 /**
- * Returns true if we're currently performing a dry-run, or false if this is a true update. Note that we
- * always consider executions in test mode to be "dry-runs", since we will never actually carry out an update,
- * and therefore certain output properties will never be resolved.
+ * Returns whether or not we are currently doing a preview.
+ *
+ * When writing unit tests, you can set this flag via either `setMocks` or `_setIsDryRun`.
  */
 export function isDryRun(): boolean {
     return options().dryRun === true;
@@ -138,6 +138,10 @@ export function _setFeatureSupport(key: string, val: boolean) {
 
 /**
  * Returns true if test mode is enabled (PULUMI_TEST_MODE).
+ *
+ * NB: this test mode has nothing to do with preview/dryRun modality, and it is not automatically
+ * enabled by calling `setMocks`. It is a vestigial mechanism related to testing the runtime itself,
+ * and is not relevant to writing or running unit tests for a Pulumi project.
  */
 export function isTestModeEnabled(): boolean {
     return options().testModeEnabled === true;

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -116,6 +116,9 @@ def configure(settings: Settings):
 def is_dry_run() -> bool:
     """
     Returns whether or not we are currently doing a preview.
+
+    When writing unit tests, you can set this flag via `set_mocks` by supplying a value
+    for the argument `preview`.
     """
     return bool(SETTINGS.dry_run)
 
@@ -123,6 +126,11 @@ def is_dry_run() -> bool:
 def is_test_mode_enabled() -> bool:
     """
     Returns true if test mode is enabled (PULUMI_TEST_MODE).
+
+    NB: this test mode has nothing to do with preview/dry_run modality, and it is not
+    automatically enabled by calling `set_mocks`. It is a vestigial mechanism related to
+    testing the runtime itself, and is not relevant to writing or running unit tests for
+    a Pulumi project.
     """
     return bool(SETTINGS.test_mode_enabled)
 


### PR DESCRIPTION
As described in #9957 the removed text is no longer correct, relevant, or useful. It is actively misleading because “test mode” in fact has nothing to do with the modality of preview/dryRun.

See also #3045

Fixes #9957

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes #9957

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] ~I have added tests that prove my fix is effective or that my feature works~ — seems unnecessary
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] ~I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change~ — seems unnecessary
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] ~Yes, there are changes in this PR that warrants bumping the Pulumi Service API version~ — nope
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
