### PR TITLE
Fix typo in __str__ error message

### DIFF
--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -500,7 +500,7 @@ class Output(Generic[T_co]):
         return Output.all(*transformed_items).apply("".join)  # type: ignore
 
     def __str__(self) -> str:
-        return """Calling [str] on an [Output<T>] is not supported.
+        return """Calling __str__ on an Output[T] is not supported.
 
 To get the value of an Output[T] as an Output[str] consider:
 1. o.apply(lambda v => f"prefix{v}suffix")

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -224,7 +224,7 @@ class OutputStrTests(unittest.TestCase):
     @pulumi_test
     async def test_str(self):
         o = Output.from_input(1)
-        self.assertEqual(str(o), """Calling [str] on an [Output<T>] is not supported.
+        self.assertEqual(str(o), """Calling __str__ on an Output[T] is not supported.
 
 To get the value of an Output[T] as an Output[str] consider:
 1. o.apply(lambda v => f"prefix{v}suffix")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Not sure why I was using square braces here. This changes the error message to more match python syntax and names.