### PR TITLE
Automate release chores

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,34 +2,95 @@
 
 set -euo pipefail
 
-VERSION="@1"
-
-die()
-{
-    echo "$1"
-    exit 1
-}
-
 usage()
 {
-    echo "Usage: ./scripts/release.sh update-sdk-ref VERSION"
+    echo "Usage: ./scripts/release.sh start VERSION"
+    echo "   or: ./scripts/release.sh push  VERSION"
+    echo "   or: ./scripts/release.sh tag   VERSION"
+    echo ""
     echo "Automates release-related chores"
+    echo ""
+    echo "Example releasing v3.35.1:"
+    echo ""
+    echo "./scripts/release.sh start v3.35.1"
+    echo "# follow instructions to edit CHANGELOG.md"
+    echo "./scripts/release.sh push v3.35.1"
+    echo "# follow instructions to merge release/v3.35.1 branch to master"
+    echo "./scripts/release.sh tag v3.35.1"
 }
 
-if [ "$#" -eq 0 ]; then
+if [ "$#" -ne 2 ]; then
     usage
     exit 1
 fi
 
+VERSION="$2"
+
 case "$1" in
-    update-sdk-ref)
+    start)
+        git fetch origin master
+        git checkout master -b release/${VERSION}
+        echo "Please edit CHANGELOG.md to add a ${VERSION} section with CHANGELOG_PENDING.md changes."
+        echo "When done, run the following to commit and push the changes:"
+        echo ""
+        echo "    ./scripts/release.sh push"
+        ;;
+    push)
+        git add CHANGELOG.md
+        git commit -m "Prepare for ${VERSION} release"
+
         VERSION="$2"
         (cd pkg   && go mod edit -require github.com/pulumi/pulumi/sdk/v3@${VERSION})
         (cd tests && go mod edit -require github.com/pulumi/pulumi/sdk/v3@${VERSION})
         make tidy
+
+        git add pkg
+        git add tests
+        git commit -m "Release ${VERSION}"
+
+        echo "### Improvements" >  CHANGELOG_PENDING.md
+        echo ""                 >> CHANGELOG_PENDING.md
+        echo "### Bug Fixes"    >> CHANGELOG_PENDING.md
+        echo ""                 >> CHANGELOG_PENDING.md
+
+        git add CHANGELOG_PENDING.md
+        git commit -m "Cleanup after ${VERSION} release"
+
+        git push --set-upstream origin release/${VERSION}
+
+        echo "Open a PR and merge release/${VERSION} branch to master."
+        echo "Make sure to use 'Rebase and merge' option to preserve the commit sequence."
+        echo "When done, run the following to finish the release:"
+        echo ""
+        echo "    ./scripts/release.sh tag ${VERSION}"
+
+        ;;
+    tag)
+        git fetch origin master
+
+        SDK_COMMENT=$(git log --format=%B -n 1 origin/master~2)
+        REL_COMMENT=$(git log --format=%B -n 1 origin/master~1)
+
+        if [ "$REL_COMMENT" != "Release ${VERSION}" ]; then
+            echo "Aborting, expected origin/master~2 comment to be 'Release ${VERSION}' but got '${REL_COMMENT}'"
+            exit 1
+        fi
+
+        if [ "$SDK_COMMENT" != "Prepare for ${VERSION} release" ]; then
+            echo "Aborting, expected origin/master~1 comment to be 'Prepare for ${VERSION} release' but got '${SDK_COMMENT}'"
+            exit 1
+        fi
+
+        git tag sdk/${VERSION} origin/master~2
+        git tag pkg/${VERSION} origin/master~1
+        git tag ${VERSION}     origin/master~1
+        git push origin sdk/${VERSION}
+        git push origin pkg/${VERSION}
+        git push origin ${VERSION}
         ;;
     *)
+        echo "Invalid command: $1. Expecting one of: start, push, tag"
         usage
-        die "Unknown command: $1"
+        exit 1
         ;;
 esac


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This extends `scripts/release.sh` to partially automate our entire release sequence. I am always a little nervous messing things up doing it manually. And perhaps most importantly, taking 3 PRs to do the release is a lot.

The manual sequence is documented in https://github.com/pulumi/home/wiki/Producing-the-Pulumi-CLI-and-SDKs

With this helper script, the idea is to reorder merging and tagging so that only 1 PR is needed. I believe this should work. Three commits are created, and should me merged without squashing on top of master. Only after that all the tags are added. Once the tags are added, release.yml automation kicks off from the tags.

I have test-driven it on a t0yv0/pulumi fork.

As an alternative we could also tag the commits before they land on master. This is a bit dangerous if there is any history rewriting during PR merge.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
