### PR TITLE
Improve wording for the stack removal error when stack still has resources

### DIFF
--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -75,10 +75,10 @@ func newStackRmCmd() *cobra.Command {
 			if err != nil {
 				if hasResources {
 					return result.Errorf(
-						"'%s' still has resources; removal rejected. Possible actions:\n" +
-						"- Make sure the correct stack is selected\n" +
-						"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm` again\n" +
-						"- Run `pulumi stack rm --force` to override this error and remove the stack anyway", s.Ref())
+						"'%s' still has resources; removal rejected. Possible actions:\n"+
+							"- Make sure the correct stack is selected\n"+
+							"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm` again\n"+
+							"- Run `pulumi stack rm --force` to override this error and remove the stack anyway", s.Ref())
 				}
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -75,7 +75,10 @@ func newStackRmCmd() *cobra.Command {
 			if err != nil {
 				if hasResources {
 					return result.Errorf(
-						"'%s' still has resources; removal rejected; pass --force to override", s.Ref())
+						"'%s' still has resources; removal rejected. Possible actions:\n" +
+						"- Make sure the correct stack is selected\n" +
+						"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm` again\n" +
+						"- Run `pulumi stack rm --force` to override this error and remove the stack anyway", s.Ref())
 				}
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -76,9 +76,9 @@ func newStackRmCmd() *cobra.Command {
 				if hasResources {
 					return result.Errorf(
 						"'%s' still has resources; removal rejected. Possible actions:\n"+
-							"- Make sure the correct stack is selected\n"+
-							"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm` again\n"+
-							"- Run `pulumi stack rm --force` to override this error and remove the stack anyway", s.Ref())
+							"- Make sure that '%[1]s' is the stack that you want to destroy\n"+
+							"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`\n"+
+							"- Run `pulumi stack rm --force` to override this error", s.Ref())
 				}
 				return result.FromError(err)
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9166, please make sure the wording makes sense to you

Example of an output:

```
This will permanently remove the 'dev' stack!
Please confirm that this is what you'd like to do by typing ("dev"): dev
error: 'dev' still has resources; removal rejected. Possible actions:
- Make sure that 'dev' is the stack that you want to destroy
- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`
- Run `pulumi stack rm --force` to override this error
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
