### PR TITLE
Reference a later version of source-map-support

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -20,7 +20,7 @@
         "read-package-tree": "^5.3.1",
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",
-        "source-map-support": "^0.4.16",
+        "source-map-support": "^0.5.6",
         "ts-node": "^7.0.1",
         "typescript": "~3.7.3",
         "upath": "^1.1.0"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Update the explicit reference to `source-map-support` from `^0.4.16` to `^0.5.6`. It's the same one that we reference transitively via `ts-node@7.0.1`, which, I believe, is the reason why `yank.lock` hasn't changed.

I validated manually that `0.5.x` has no `Buffer()` in its source code.

It's a partial fix to https://github.com/pulumi/pulumi/issues/8790 - after this change gets released, I'll have to go through all tests that reference Pulumi (like Automation API) and update them to the latest version, including bumping their `package.json.lock` files.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
