### PR TITLE
Include invoke.ts (and its type `InvokeOptions`) in generated documentation

### DIFF
--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -101,6 +101,6 @@
 
         "tests/automation/localWorkspace.spec.ts",
 
-        "tests_with_mocks/mocks.spec.ts",
+        "tests_with_mocks/mocks.spec.ts"
     ]
 }

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -18,6 +18,7 @@
         "index.ts",
         "config.ts",
         "errors.ts",
+        "invoke.ts",
         "metadata.ts",
         "output.ts",
         "resource.ts",


### PR DESCRIPTION
Addresses https://github.com/pulumi/docs/issues/2782.

All functions in Pulumi SDKs take an InvokeOptions-typed argument, and all the generated documentation for those functions has a broken link because it's not part of the NodeJS SDK documentation generated for pulumi/pulumi.

The version of TypeDoc used by pulumi/docs is quite old, and I suspect it consults `tsconfig.json` to find the source files (evidence: someone complaining that it does not do this well enough: https://github.com/TypeStrong/typedoc/issues/1515). I have conservatively just added the file in question to `files`, since:

 - I'm not sure if .files _should_ list all the files*
 - Upgrading TypeDoc would surely have many unintended consequences

(*If it should, it would not be that tricky to add a linting task which checks that it matches -- or just to use include/exclude in the tsconfig.js, though that would necessitate a tsdoc version bump.)