### PR TITLE
Fix the panic on pulumi convert for package without a version

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,5 @@
 
 ### Bug Fixes
 
+- [cli] `pulumi convert` supports provider packages without a version.
+  [#9976](https://github.com/pulumi/pulumi/pull/9976)

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -181,7 +181,11 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 				packageName = fmt.Sprintf("%s.%s", csharpInfo.GetRootNamespace(), namespace)
 			}
 		}
-		csproj.WriteString(fmt.Sprintf(packageTemplate, packageName, p.Version.String()))
+		if p.Version != nil {
+			csproj.WriteString(fmt.Sprintf(packageTemplate, packageName, p.Version.String()))
+		} else {
+			csproj.WriteString(fmt.Sprintf(packageTemplate, packageName, "*"))
+		}
 	}
 
 	csproj.WriteString(`	</ItemGroup>

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -196,7 +196,10 @@ require (
 		}
 
 		// Relatively safe default, this works for Pulumi provider packages:
-		vPath := fmt.Sprintf("/v%d", p.Version.Major)
+		vPath := ""
+		if p.Version != nil && p.Version.Major > 1 {
+			vPath = fmt.Sprintf("/v%d", p.Version.Major)
+		}
 		packageName := fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s", p.Name, vPath, p.Name)
 		if langInfo, found := p.Language["go"]; found {
 			goInfo, ok := langInfo.(GoPackageInfo)

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -107,7 +107,11 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 				packageName = pyInfo.PackageName
 			}
 		}
-		requirementsTxt.WriteString(fmt.Sprintf("%s==%s\n", packageName, p.Version.String()))
+		if p.Version != nil {
+			requirementsTxt.WriteString(fmt.Sprintf("%s==%s\n", packageName, p.Version.String()))
+		} else {
+			requirementsTxt.WriteString(fmt.Sprintf("%s\n", packageName))
+		}
 	}
 
 	files["requirements.txt"] = requirementsTxt.Bytes()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes pulumi/pulumi-command#85

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
