### PR TITLE
Fix --tracing flag propagation to resource plugins

### DIFF
--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -89,10 +89,6 @@ func buildArgsForNewPlugin(host Host, ctx *Context, options map[string]interface
 
 	args = append(args, fmt.Sprintf("-root=%s", filepath.Clean(root)))
 
-	if cmdutil.IsTracingEnabled() {
-		args = append(args, fmt.Sprintf("-tracing=%s", cmdutil.TracingEndpoint))
-	}
-
 	// NOTE: positional argument for the server addresss must come last
 	args = append(args, host.ServerAddr())
 

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -376,8 +376,7 @@ func buildPluginArguments(opts pluginArgumentOptions) []string {
 			args = append(args, "-v="+strconv.Itoa(opts.verbose))
 		}
 	}
-	// Flow tracing settings if we are using a remote collector.
-	if opts.tracingEndpoint != "" && !opts.tracingToFile {
+	if opts.tracingEndpoint != "" {
 		args = append(args, "--tracing", opts.tracingEndpoint)
 	}
 	args = append(args, opts.pluginArgs...)

--- a/sdk/go/common/util/cmdutil/trace.go
+++ b/sdk/go/common/util/cmdutil/trace.go
@@ -36,7 +36,14 @@ import (
 
 // TracingEndpoint is the Zipkin-compatible tracing endpoint where tracing data will be sent.
 var TracingEndpoint string
+
+// Deprecated. TracingToFile=true if pulumi was called with a file://
+// scheme URL (--tracing=file:///...). Even in this case
+// TracingEndpoint will now have the tcp:// scheme and will point to a
+// proxy server that will append traces to the user-specified file.
+// Plugins should respect TracingEndpoint and ignore TracingToFile.
 var TracingToFile bool
+
 var TracingRootSpan opentracing.Span
 
 var traceCloser io.Closer


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Not including the test case yet - but my informal test case is a program obtained from `pulumi new aws-go` invoked as: 

```
pulumi preview --tracing=file:./preview.tace
```

If one looks at how providers are invoked in that example it's like this:

```
EXEC /home/pulumit0yv0/bin/pulumi-language-go [-root=/home/pulumit0yv0/tmp/tracing-example -tracing=tcp://127.0.0.1:41793 127.0.0.1:39649]
EXEC /home/pulumit0yv0/.pulumi/plugins/resource-aws-v5.7.2/pulumi-resource-aws [127.0.0.1:39649]
```

`tcp://127.0.0.1:41793` is the proxy server that appends to `./preview.trace` started by `pulumi` process.

I think the right fix is to ignore TracingToFile var. Once I did that I started having `-tracing` arg populated twice for the pulumi-language-go command so I cleaned up the place where that happens also.

 With the fix both providers get `-tracing=tcp://127.0.0.1:41793` flag but I'm yet to verify that the traces land where they should.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
