### PR TITLE
Add github:// download url

### DIFF
--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -202,7 +202,9 @@ func (source *getPulumiSource) Download(
 
 // githubSource can download a plugin from github releases
 type githubSource struct {
+	host         string
 	organization string
+	repository   string
 	name         string
 	kind         PluginKind
 
@@ -210,7 +212,8 @@ type githubSource struct {
 }
 
 // Creates a new github source adding authentication data in the environment, if it exists
-func newGithubSource(organization, name string, kind PluginKind) *githubSource {
+func newGithubSource(url *url.URL, name string, kind PluginKind) (*githubSource, error) {
+	contract.Assert(url.Scheme == "github")
 
 	// 14-03-2022 we stopped looking at GITHUB_PERSONAL_ACCESS_TOKEN and sending basic auth for github and
 	// instead just look at GITHUB_TOKEN and send in a header. Given GITHUB_PERSONAL_ACCESS_TOKEN was an
@@ -220,13 +223,32 @@ func newGithubSource(organization, name string, kind PluginKind) *githubSource {
 		logging.Warningf("GITHUB_PERSONAL_ACCESS_TOKEN is no longer used for Github authentication, set GITHUB_TOKEN instead")
 	}
 
+	host := url.Host
+	parts := strings.Split(strings.Trim(url.Path, "/"), "/")
+
+	if host == "" {
+		return nil, fmt.Errorf("github:// url must have a host part, was: %s", url.String())
+	}
+
+	if len(parts) != 1 && len(parts) != 2 {
+		return nil, fmt.Errorf("github:// url must have the format <host>/<organization>[/<repository>], was: %s", url.String())
+	}
+
+	organization := parts[0]
+	repository := "pulumi-" + name
+	if len(parts) == 2 {
+		repository = parts[1]
+	}
+
 	return &githubSource{
+		host:         host,
 		organization: organization,
+		repository:   repository,
 		name:         name,
 		kind:         kind,
 
 		token: os.Getenv("GITHUB_TOKEN"),
-	}
+	}, nil
 }
 
 func (source *githubSource) HasAuthentication() bool {
@@ -236,8 +258,8 @@ func (source *githubSource) HasAuthentication() bool {
 func (source *githubSource) GetLatestVersion(
 	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error) {
 	releaseURL := fmt.Sprintf(
-		"https://api.github.com/repos/%s/pulumi-%s/releases/latest",
-		source.organization, source.name)
+		"https://%s/repos/%s/%s/releases/latest",
+		source.host, source.organization, source.repository)
 	logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
 	req, err := buildHTTPRequest(releaseURL, source.token)
 	if err != nil {
@@ -269,30 +291,12 @@ func (source *githubSource) GetLatestVersion(
 func (source *githubSource) Download(
 	version semver.Version, opSy string, arch string,
 	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (io.ReadCloser, int64, error) {
-	if !source.HasAuthentication() {
-		// If we're not using authentication we can just download from the release/download URL
 
-		logging.V(1).Infof(
-			"%s downloading from github.com/%s/pulumi-%s/releases",
-			source.name, source.organization, source.name)
-
-		pluginURL := fmt.Sprintf("https://github.com/%s/pulumi-%s/releases/download/v%s/%s",
-			source.organization, source.name, version.String(), url.QueryEscape(fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz",
-				source.kind, source.name, version.String(), opSy, arch)))
-
-		req, err := buildHTTPRequest(pluginURL, "")
-		if err != nil {
-			return nil, -1, err
-		}
-		return getHTTPResponse(req)
-	}
-
-	// If we are using authentication we need to lookup the asset via the github releases API
 	assetName := fmt.Sprintf("pulumi-%s-%s-v%s-%s-%s.tar.gz", source.kind, source.name, version.String(), opSy, arch)
 
 	releaseURL := fmt.Sprintf(
-		"https://api.github.com/repos/%s/pulumi-%s/releases/tags/v%s",
-		source.organization, source.name, version.String())
+		"https://%s/repos/%s/%s/releases/tags/v%s",
+		source.host, source.organization, source.repository, version.String())
 	logging.V(9).Infof("plugin GitHub releases url: %s", releaseURL)
 
 	req, err := buildHTTPRequest(releaseURL, source.token)
@@ -398,10 +402,20 @@ func newFallbackSource(name string, kind PluginKind) *fallbackSource {
 	}
 }
 
+func urlMustParse(rawURL string) *url.URL {
+	url, err := url.Parse(rawURL)
+	contract.AssertNoError(err)
+	return url
+}
+
 func (source *fallbackSource) GetLatestVersion(
 	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (*semver.Version, error) {
+
 	// Try and get this package from public pulumi github
-	public := newGithubSource("pulumi", source.name, source.kind)
+	public, err := newGithubSource(urlMustParse("github://api.github.com/pulumi"), source.name, source.kind)
+	if err != nil {
+		return nil, err
+	}
 	version, err := public.GetLatestVersion(getHTTPResponse)
 	if err == nil {
 		return version, nil
@@ -415,7 +429,11 @@ func (source *fallbackSource) GetLatestVersion(
 		if repoOwner == "" {
 			privateErr = errors.New("ENV[GITHUB_REPOSITORY_OWNER] not set")
 		} else {
-			private := newGithubSource(repoOwner, source.name, source.kind)
+			// This could panic on user input, but this is experimental and will be removed at some point
+			private, err := newGithubSource(urlMustParse("github://api.github.com/"+repoOwner), source.name, source.kind)
+			if err != nil {
+				return nil, err
+			}
 			if !private.HasAuthentication() {
 				privateErr = errors.New("no GitHub authentication information provided")
 			} else {
@@ -440,7 +458,10 @@ func (source *fallbackSource) Download(
 	version semver.Version, opSy string, arch string,
 	getHTTPResponse func(*http.Request) (io.ReadCloser, int64, error)) (io.ReadCloser, int64, error) {
 	// Try and get this package from public pulumi github
-	public := newGithubSource("pulumi", source.name, source.kind)
+	public, err := newGithubSource(urlMustParse("github://api.github.com/pulumi"), source.name, source.kind)
+	if err != nil {
+		return nil, -1, err
+	}
 	resp, length, err := public.Download(version, opSy, arch, getHTTPResponse)
 	if err == nil {
 		return resp, length, nil
@@ -453,7 +474,10 @@ func (source *fallbackSource) Download(
 		if repoOwner == "" {
 			err = errors.New("ENV[GITHUB_REPOSITORY_OWNER] not set")
 		} else {
-			private := newGithubSource(repoOwner, source.name, source.kind)
+			private, err := newGithubSource(urlMustParse("github://api.github.com/"+repoOwner), source.name, source.kind)
+			if err != nil {
+				return nil, -1, err
+			}
 			if !private.HasAuthentication() {
 				err = errors.New("no GitHub authentication information provided")
 			} else {
@@ -637,25 +661,38 @@ func interpolateURL(serverURL string, version semver.Version, os, arch string) s
 	return replacer.Replace(serverURL)
 }
 
-func (info PluginInfo) GetSource() PluginSource {
+func (info PluginInfo) GetSource() (PluginSource, error) {
 	// The plugin has a set URL use that.
 	if info.PluginDownloadURL != "" {
-		return newPluginURLSource(info.Name, info.Kind, info.PluginDownloadURL)
+		// Support schematised URLS if the URL has a "schema" part we recognize
+		url, err := url.Parse(info.PluginDownloadURL)
+		if err != nil {
+			return nil, err
+		}
+
+		if url.Scheme == "github" {
+			return newGithubSource(url, info.Name, info.Kind)
+		}
+
+		return newPluginURLSource(info.Name, info.Kind, info.PluginDownloadURL), nil
 	}
 
 	// If the plugin name matches an override, download the plugin from the override URL.
 	if url, ok := pluginDownloadURLOverridesParsed.get(info.Name); ok {
-		return newPluginURLSource(info.Name, info.Kind, url)
+		return newPluginURLSource(info.Name, info.Kind, url), nil
 	}
 
 	// Use our default fallback behaviour of github then get.pulumi.com
-	return newFallbackSource(info.Name, info.Kind)
+	return newFallbackSource(info.Name, info.Kind), nil
 }
 
 // GetLatestVersion tries to find the latest version for this plugin. This is currently only supported for
 // plugins we can get from github releases.
 func (info PluginInfo) GetLatestVersion() (*semver.Version, error) {
-	source := info.GetSource()
+	source, err := info.GetSource()
+	if err != nil {
+		return nil, err
+	}
 	return source.GetLatestVersion(getHTTPResponse)
 }
 
@@ -682,7 +719,10 @@ func (info PluginInfo) Download() (io.ReadCloser, int64, error) {
 		return nil, -1, errors.Errorf("unknown version for plugin %s", info.Name)
 	}
 
-	source := info.GetSource()
+	source, err := info.GetSource()
+	if err != nil {
+		return nil, -1, err
+	}
 	return source.Download(*info.Version, opSy, arch, getHTTPResponse)
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This will allow pulumiverse plugins (or others) to use the github releases api:
```
% pulumi plugin install resource astra --server github://api.github.com/pulumiverse
[resource plugin astra-1.0.25] installing
Downloading plugin: 15.12 MiB / 15.12 MiB [=========================] 100.00% 5s
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
