### PR TITLE
Attempt to connect to the bucket while logging in to a local backend

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - [plugins] Plugin download urls now support GitHub as a first class url schema. For example "github://api.github.com/pulumiverse".
   [#9984](https://github.com/pulumi/pulumi/pull/9984)
 
+- [backends] When logging in to a file backend, validate that the bucket is accessible.
+  [#10012](https://github.com/pulumi/pulumi/pull/10012)
+
 ### Bug Fixes
 
 - [cli] `pulumi convert` supports provider packages without a version.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -153,6 +153,14 @@ func New(d diag.Sink, originalURL string) (Backend, error) {
 		}
 	}
 
+	isAcc, err := bucket.IsAccessible(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("unable to access bucket %s: %w", u, err)
+	}
+	if !isAcc {
+		return nil, fmt.Errorf("bucket %s is not accessible", u)
+	}
+
 	// Allocate a unique lock ID for this backend instance.
 	lockID, err := uuid.NewV4()
 	if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Attempt to connect to the bucket while logging in to a local backend to make sure that the bucket exists and can be used under current user settings.

Not logged in to AWS:

```
$pulumi login s3://$(uuidgen)               
error: problem logging in: unable to access bucket s3://85765016-FCBB-4F81-B8B5-E0F5C6269026: blob (code=Unknown): InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records.
	status code: 403, request id: <redacted>, host id: <redacted>
```

Non-existing S3 bucket:

```
$pulumi login s3://$(uuidgen)
error: problem logging in: bucket s3://90ABFB7B-3C5D-4BAC-A557-23688A0CF9C6 is not accessible
```

Existing bucket:

```
pulumi login s3://api-f3144
Logged in to Bla as mikhailshilkov (s3://api-f3144)
```

Do we have any automated tests for local backends?

Fixes #8144

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
