### PR TITLE
Simplify and harden escaping in Python doc strings SDK gen

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -319,9 +319,7 @@ func printComment(w io.Writer, comment string, indent string) {
 	}
 
 	// Known special characters that need escaping.
-	// TODO: Consider replacing the docstring with a raw string which may make sense if this
-	// list grows much further.
-	replacer := strings.NewReplacer(`"""`, `\"\"\"`, `\x`, `\\x`, `\N`, `\\N`)
+	replacer := strings.NewReplacer(`\`, `\\`, `"""`, `\"\"\"`)
 	fmt.Fprintf(w, "%s\"\"\"\n", indent)
 	for _, l := range lines {
 		if l == "" {

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -15,6 +15,7 @@
 package python
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -238,4 +240,27 @@ func TestGenerateTypeNames(t *testing.T) {
 			return root.typeString(t, false, false)
 		}
 	})
+}
+
+func TestEscapeDocString(t *testing.T) {
+	t.Parallel()
+	lines := []string{
+		`Active directory email address. Example: xyz@contoso.com or Contoso\xyz`,
+		`Triple quotes """ are all escaped`,
+		`But just quotes " are not`,
+		`This \N should be escaped`,
+		`Here \\N slashes should be escaped but not N`,
+	}
+	source := strings.Join(lines, "\n")
+	expected := `"""
+Active directory email address. Example: xyz@contoso.com or Contoso\\xyz
+Triple quotes \"\"\" are all escaped
+But just quotes " are not
+This \\N should be escaped
+Here \\\\N slashes should be escaped but not N
+"""
+`
+	w := &bytes.Buffer{}
+	printComment(w, source, "")
+	assert.Equal(t, expected, w.String())
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

I feel like this is simpler, more universal, and more correct than what we have? Let me know if you see counter-cases. It's the last test case that trips our current escaping and the AzureDevOps provider.

Fixes #9441

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
