### PR TITLE
Fix orphan bulk decrypt traces

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,10 @@
 
 - [cli] Only log github request headers at log level 11.
   [#10140](https://github.com/pulumi/pulumi/pull/10140)
+
+- [sdk/go] `config.Encrypter` and `config.Decrypter` interfaces now
+  require explicit `Context`. This is a minor breaking change to the
+  SDK. The change fixes parenting of opentracing spans that decorate
+  calls to the Pulumi Service crypter.
+
+  [#10037](https://github.com/pulumi/pulumi/pull/10037)

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -87,17 +87,22 @@ func (u *update) GetTarget() *deploy.Target {
 	return u.target
 }
 
-func (b *localBackend) newQuery(ctx context.Context,
+func (b *localBackend) newQuery(
+	ctx context.Context,
 	op backend.QueryOperation) (engine.QueryInfo, error) {
 
 	return &localQuery{root: op.Root, proj: op.Proj}, nil
 }
 
-func (b *localBackend) newUpdate(stackName tokens.Name, op backend.UpdateOperation) (*update, error) {
+func (b *localBackend) newUpdate(
+	ctx context.Context,
+	stackName tokens.Name,
+	op backend.UpdateOperation) (*update, error) {
 	contract.Require(stackName != "", "stackName")
 
 	// Construct the deployment target.
-	target, err := b.getTarget(stackName, op.StackConfiguration.Config, op.StackConfiguration.Decrypter)
+	target, err := b.getTarget(ctx, stackName,
+		op.StackConfiguration.Config, op.StackConfiguration.Decrypter)
 	if err != nil {
 		return nil, err
 	}
@@ -111,8 +116,12 @@ func (b *localBackend) newUpdate(stackName tokens.Name, op backend.UpdateOperati
 	}, nil
 }
 
-func (b *localBackend) getTarget(stackName tokens.Name, cfg config.Map, dec config.Decrypter) (*deploy.Target, error) {
-	snapshot, _, err := b.getStack(stackName)
+func (b *localBackend) getTarget(
+	ctx context.Context,
+	stackName tokens.Name,
+	cfg config.Map,
+	dec config.Decrypter) (*deploy.Target, error) {
+	snapshot, _, err := b.getStack(ctx, stackName)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +133,9 @@ func (b *localBackend) getTarget(stackName tokens.Name, cfg config.Map, dec conf
 	}, nil
 }
 
-func (b *localBackend) getStack(name tokens.Name) (*deploy.Snapshot, string, error) {
+func (b *localBackend) getStack(
+	ctx context.Context,
+	name tokens.Name) (*deploy.Snapshot, string, error) {
 	if name == "" {
 		return nil, "", errors.New("invalid empty stack name")
 	}
@@ -137,7 +148,7 @@ func (b *localBackend) getStack(name tokens.Name) (*deploy.Snapshot, string, err
 	}
 
 	// Materialize an actual snapshot object.
-	snapshot, err := stack.DeserializeCheckpoint(chk)
+	snapshot, err := stack.DeserializeCheckpoint(ctx, chk)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -272,7 +272,7 @@ func (b *cloudBackend) getSnapshot(ctx context.Context, stackRef backend.StackRe
 		return nil, err
 	}
 
-	snapshot, err := stack.DeserializeUntypedDeployment(untypedDeployment, stack.DefaultSecretsProvider)
+	snapshot, err := stack.DeserializeUntypedDeployment(ctx, untypedDeployment, stack.DefaultSecretsProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -469,6 +469,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			"    `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.RangeArgs(1, 2),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -515,7 +516,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 				if cerr != nil {
 					return cerr
 				}
-				enc, eerr := c.EncryptValue(value)
+				enc, eerr := c.EncryptValue(ctx, value)
 				if eerr != nil {
 					return eerr
 				}
@@ -579,6 +580,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			"    value of `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -616,7 +618,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 				if cerr != nil {
 					return cerr
 				}
-				enc, eerr := c.EncryptValue(value)
+				enc, eerr := c.EncryptValue(ctx, value)
 				if eerr != nil {
 					return eerr
 				}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -503,7 +503,7 @@ func newImportCmd() *cobra.Command {
 				UseLegacyDiff: useLegacyDiff(),
 			}
 
-			_, res := s.Import(commandContext(), backend.UpdateOperation{
+			_, res := s.Import(ctx, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
@@ -84,7 +84,7 @@ func TestFailInInteractiveWithoutYes(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.Error(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
@@ -130,7 +130,7 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
@@ -155,7 +155,7 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
@@ -183,7 +183,7 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	assert.Equal(t, stackName, loadStackName(t))
@@ -208,7 +208,7 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 		yes:               true,
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	removeStack(t, stackName)
@@ -252,7 +252,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 		yes:               true,
 	}
 
-	assert.NoError(t, runNew(args))
+	assert.NoError(t, runNew(context.Background(), args))
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, defaultProjectName, proj.Name.String())
 	// Expect the stack directory to have a checkpoint file for the stack.
@@ -283,7 +283,7 @@ func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	removeStack(t, stackName)
@@ -308,7 +308,7 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	removeStack(t, stackName)
@@ -340,7 +340,7 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "project with this name already exists")
 }
@@ -366,7 +366,7 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "project with this name already exists")
 }
@@ -396,7 +396,7 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	proj := loadProject(t, tempdir)
@@ -426,7 +426,7 @@ func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.NoError(t, err)
 
 	proj := loadProject(t, tempdir)
@@ -458,7 +458,7 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 		templateNameOrURL: "typescript",
 	}
 
-	err := runNew(args)
+	err := runNew(context.Background(), args)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "project name may only contain")
 }
@@ -478,7 +478,7 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 	}
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
-	err := runNew(newArgs{
+	err := runNew(context.Background(), newArgs{
 		generateOnly:      true,
 		interactive:       true,
 		prompt:            promptMock("not#valid", ""),
@@ -488,7 +488,7 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "project name may only contain")
 
-	err = runNew(newArgs{
+	err = runNew(context.Background(), newArgs{
 		generateOnly:      true,
 		interactive:       true,
 		prompt:            promptMock("", ""),
@@ -515,7 +515,7 @@ func TestInvalidTemplateName(t *testing.T) {
 			templateNameOrURL: "",
 		}
 
-		err := runNew(args)
+		err := runNew(context.Background(), args)
 		assert.Error(t, err)
 
 		assert.Contains(t, err.Error(), "no template selected")
@@ -536,7 +536,7 @@ func TestInvalidTemplateName(t *testing.T) {
 			templateNameOrURL: template,
 		}
 
-		err := runNew(args)
+		err := runNew(context.Background(), args)
 		assert.Error(t, err)
 
 		assert.Contains(t, err.Error(), "not found")
@@ -558,7 +558,7 @@ func TestInvalidTemplateName(t *testing.T) {
 			yes:               true,
 		}
 
-		err := runNew(args)
+		err := runNew(context.Background(), args)
 		assert.Error(t, err)
 
 		assert.Contains(t, err.Error(), "not found")

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(ctx context.Context, curr
 	if err != nil {
 		return err
 	}
-	snap, err := stack.DeserializeUntypedDeployment(checkpoint, stack.DefaultSecretsProvider)
+	snap, err := stack.DeserializeUntypedDeployment(ctx, checkpoint, stack.DefaultSecretsProvider)
 	if err != nil {
 		return checkDeploymentVersionError(err, currentStack.Ref().Name().String())
 	}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func newStackExportCmd() *cobra.Command {
 
 			if showSecrets {
 				// log show secrets event
-				snap, err := stack.DeserializeUntypedDeployment(deployment, stack.DefaultSecretsProvider)
+				snap, err := stack.DeserializeUntypedDeployment(ctx, deployment, stack.DefaultSecretsProvider)
 				if err != nil {
 					return checkDeploymentVersionError(err, stackName)
 				}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ func newStackImportCmd() *cobra.Command {
 			"to cloud resources, etc. can be reimported to the stack using this command.\n" +
 			"The updated deployment will be read from standard in.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -76,7 +77,7 @@ func newStackImportCmd() *cobra.Command {
 			// We do, however, now want to unmarshal the json.RawMessage into a real, typed deployment.  We do this so
 			// we can check that the deployment doesn't contain resources from a stack other than the selected one. This
 			// catches errors wherein someone imports the wrong stack's deployment (which can seriously hork things).
-			snapshot, err := stack.DeserializeUntypedDeployment(&deployment, stack.DefaultSecretsProvider)
+			snapshot, err := stack.DeserializeUntypedDeployment(ctx, &deployment, stack.DefaultSecretsProvider)
 			if err != nil {
 				return checkDeploymentVersionError(err, stackName.String())
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -138,7 +138,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Now perform the deployment.
-			if err = s.ImportDeployment(commandContext(), &dep); err != nil {
+			if err = s.ImportDeployment(ctx, &dep); err != nil {
 				return fmt.Errorf("could not import deployment: %w", err)
 			}
 			fmt.Printf("Import complete.\n")

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -335,11 +335,11 @@ type brokenDecrypter struct {
 	ErrorMessage string
 }
 
-func (b brokenDecrypter) DecryptValue(_ string) (string, error) {
+func (b brokenDecrypter) DecryptValue(_ context.Context, _ string) (string, error) {
 	return "", fmt.Errorf(b.ErrorMessage)
 }
 
-func (b brokenDecrypter) BulkDecrypt(_ []string) (map[string]string, error) {
+func (b brokenDecrypter) BulkDecrypt(_ context.Context, _ []string) (map[string]string, error) {
 	return nil, fmt.Errorf(b.ErrorMessage)
 }
 
@@ -2672,7 +2672,7 @@ func TestConfigSecrets(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	crypter := config.NewSymmetricCrypter(make([]byte, 32))
-	secret, err := crypter.EncryptValue("hunter2")
+	secret, err := crypter.EncryptValue(context.Background(), "hunter2")
 	assert.NoError(t, err)
 
 	p := &TestPlan{

--- a/pkg/operations/resources_test.go
+++ b/pkg/operations/resources_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package operations
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"testing"
@@ -26,12 +27,13 @@ import (
 )
 
 func getPulumiResources(t *testing.T, path string) *Resource {
+	ctx := context.Background()
 	var checkpoint apitype.CheckpointV3
 	byts, err := ioutil.ReadFile(path)
 	assert.NoError(t, err)
 	err = json.Unmarshal(byts, &checkpoint)
 	assert.NoError(t, err)
-	snapshot, err := stack.DeserializeCheckpoint(&checkpoint)
+	snapshot, err := stack.DeserializeCheckpoint(ctx, &checkpoint)
 	assert.NoError(t, err)
 	resources := NewResourceTree(snapshot.Resources)
 	return resources

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package stack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -107,10 +108,12 @@ func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
 
 // DeserializeCheckpoint takes a serialized deployment record and returns its associated snapshot. Returns nil
 // if there have been no deployments performed on this checkpoint.
-func DeserializeCheckpoint(chkpoint *apitype.CheckpointV3) (*deploy.Snapshot, error) {
+func DeserializeCheckpoint(
+	ctx context.Context,
+	chkpoint *apitype.CheckpointV3) (*deploy.Snapshot, error) {
 	contract.Require(chkpoint != nil, "chkpoint")
 	if chkpoint.Latest != nil {
-		return DeserializeDeploymentV3(*chkpoint.Latest, DefaultSecretsProvider)
+		return DeserializeDeploymentV3(ctx, *chkpoint.Latest, DefaultSecretsProvider)
 	}
 
 	return nil, nil

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -166,7 +166,9 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets 
 // from it. DeserializeDeployment will return an error if the untyped deployment's version is
 // not within the range `DeploymentSchemaVersionCurrent` and `DeploymentSchemaVersionOldestSupported`.
 func DeserializeUntypedDeployment(
-	deployment *apitype.UntypedDeployment, secretsProv SecretsProvider) (*deploy.Snapshot, error) {
+	ctx context.Context,
+	deployment *apitype.UntypedDeployment,
+	secretsProv SecretsProvider) (*deploy.Snapshot, error) {
 
 	contract.Require(deployment != nil, "deployment")
 	switch {
@@ -199,12 +201,14 @@ func DeserializeUntypedDeployment(
 		contract.Failf("unrecognized version: %d", deployment.Version)
 	}
 
-	return DeserializeDeploymentV3(v3deployment, secretsProv)
+	return DeserializeDeploymentV3(ctx, v3deployment, secretsProv)
 }
 
 // DeserializeDeploymentV3 deserializes a typed DeploymentV3 into a `deploy.Snapshot`.
-func DeserializeDeploymentV3(deployment apitype.DeploymentV3, secretsProv SecretsProvider) (*deploy.Snapshot, error) {
-	ctx := context.TODO()
+func DeserializeDeploymentV3(
+	ctx context.Context,
+	deployment apitype.DeploymentV3,
+	secretsProv SecretsProvider) (*deploy.Snapshot, error) {
 
 	// Unpack the versions.
 	manifest, err := deploy.DeserializeManifest(deployment.Manifest)

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package stack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -190,12 +191,13 @@ func TestDeploymentSerialization(t *testing.T) {
 
 func TestLoadTooNewDeployment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	untypedDeployment := &apitype.UntypedDeployment{
 		Version: apitype.DeploymentSchemaVersionCurrent + 1,
 	}
 
-	deployment, err := DeserializeUntypedDeployment(untypedDeployment, DefaultSecretsProvider)
+	deployment, err := DeserializeUntypedDeployment(ctx, untypedDeployment, DefaultSecretsProvider)
 	assert.Nil(t, deployment)
 	assert.Error(t, err)
 	assert.Equal(t, ErrDeploymentSchemaVersionTooNew, err)
@@ -203,12 +205,13 @@ func TestLoadTooNewDeployment(t *testing.T) {
 
 func TestLoadTooOldDeployment(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	untypedDeployment := &apitype.UntypedDeployment{
 		Version: DeploymentSchemaVersionOldestSupported - 1,
 	}
 
-	deployment, err := DeserializeUntypedDeployment(untypedDeployment, DefaultSecretsProvider)
+	deployment, err := DeserializeUntypedDeployment(ctx, untypedDeployment, DefaultSecretsProvider)
 	assert.Nil(t, deployment)
 	assert.Error(t, err)
 	assert.Equal(t, ErrDeploymentSchemaVersionTooOld, err)
@@ -428,7 +431,8 @@ func TestDeserializeDeploymentSecretCache(t *testing.T) {
 	t.Parallel()
 
 	urn := "urn:pulumi:prod::acme::acme:erp:Backend$aws:ebs/volume:Volume::PlatformBackendDb"
-	_, err := DeserializeDeploymentV3(apitype.DeploymentV3{
+	ctx := context.Background()
+	_, err := DeserializeDeploymentV3(ctx, apitype.DeploymentV3{
 		SecretsProviders: &apitype.SecretsProvidersV1{Type: b64.Type},
 		Resources: []apitype.ResourceV3{
 			{
@@ -445,7 +449,8 @@ func TestDeserializeDeploymentSecretCache(t *testing.T) {
 func TestDeserializeInvalidResourceErrors(t *testing.T) {
 	t.Parallel()
 
-	deployment, err := DeserializeDeploymentV3(apitype.DeploymentV3{
+	ctx := context.Background()
+	deployment, err := DeserializeDeploymentV3(ctx, apitype.DeploymentV3{
 		Resources: []apitype.ResourceV3{
 			{},
 		},
@@ -455,7 +460,8 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 	assert.Equal(t, "resource missing required 'urn' field", err.Error())
 
 	urn := "urn:pulumi:prod::acme::acme:erp:Backend$aws:ebs/volume:Volume::PlatformBackendDb"
-	deployment, err = DeserializeDeploymentV3(apitype.DeploymentV3{
+
+	deployment, err = DeserializeDeploymentV3(ctx, apitype.DeploymentV3{
 		Resources: []apitype.ResourceV3{
 			{
 				URN: resource.URN(urn),
@@ -466,7 +472,7 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Sprintf("resource '%s' missing required 'type' field", urn), err.Error())
 
-	deployment, err = DeserializeDeploymentV3(apitype.DeploymentV3{
+	deployment, err = DeserializeDeploymentV3(ctx, apitype.DeploymentV3{
 		Resources: []apitype.ResourceV3{
 			{
 				URN:    resource.URN(urn),

--- a/pkg/secrets/b64/manager.go
+++ b/pkg/secrets/b64/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package b64
 
 import (
+	"context"
 	"encoding/base64"
 
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -38,10 +39,11 @@ func (m *manager) Decrypter() (config.Decrypter, error) { return &base64Crypter{
 
 type base64Crypter struct{}
 
-func (c *base64Crypter) EncryptValue(s string) (string, error) {
+func (c *base64Crypter) EncryptValue(ctx context.Context, s string) (string, error) {
 	return base64.StdEncoding.EncodeToString([]byte(s)), nil
 }
-func (c *base64Crypter) DecryptValue(s string) (string, error) {
+
+func (c *base64Crypter) DecryptValue(ctx context.Context, s string) (string, error) {
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return "", err
@@ -49,6 +51,6 @@ func (c *base64Crypter) DecryptValue(s string) (string, error) {
 	return string(b), nil
 }
 
-func (c *base64Crypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return config.DefaultBulkDecrypt(c, ciphertexts)
+func (c *base64Crypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return config.DefaultBulkDecrypt(ctx, c, ciphertexts)
 }

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -16,6 +16,7 @@
 package passphrase
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -58,7 +59,9 @@ func symmetricCrypterFromPhraseAndState(phrase string, state string) (config.Cry
 	}
 
 	decrypter := config.NewSymmetricCrypterFromPassphrase(phrase, salt)
-	decrypted, err := decrypter.DecryptValue(state[indexN(state, ":", 2)+1:])
+	// symmetricCrypter does not use ctx, safe to pass context.Background()
+	ignoredCtx := context.Background()
+	decrypted, err := decrypter.DecryptValue(ignoredCtx, state[indexN(state, ":", 2)+1:])
 	if err != nil || decrypted != "pulumi" {
 		return nil, ErrIncorrectPassphrase
 	}
@@ -254,7 +257,10 @@ func PromptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 
 	// Encrypt a message and store it with the salt so we can test if the password is correct later.
 	crypter := config.NewSymmetricCrypterFromPassphrase(phrase, salt)
-	msg, err := crypter.EncryptValue("pulumi")
+
+	// symmetricCrypter does not use ctx, safe to use context.Background()
+	ignoredCtx := context.Background()
+	msg, err := crypter.EncryptValue(ignoredCtx, "pulumi")
 	contract.AssertNoError(err)
 
 	// Encode the salt as the passphrase secrets manager state.
@@ -314,17 +320,17 @@ func newLockedPasspharseSecretsManager(state localSecretsManagerState) secrets.M
 
 type errorCrypter struct{}
 
-func (ec *errorCrypter) EncryptValue(_ string) (string, error) {
+func (ec *errorCrypter) EncryptValue(ctx context.Context, _ string) (string, error) {
 	return "", errors.New("failed to encrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
 
-func (ec *errorCrypter) DecryptValue(_ string) (string, error) {
+func (ec *errorCrypter) DecryptValue(ctx context.Context, _ string) (string, error) {
 	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
 
-func (ec *errorCrypter) BulkDecrypt(_ []string) (map[string]string, error) {
+func (ec *errorCrypter) BulkDecrypt(ctx context.Context, _ []string) (map[string]string, error) {
 	return nil, errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,28 +43,28 @@ func newServiceCrypter(client *client.Client, stack client.StackIdentifier) conf
 	return &serviceCrypter{client: client, stack: stack}
 }
 
-func (c *serviceCrypter) EncryptValue(plaintext string) (string, error) {
-	ciphertext, err := c.client.EncryptValue(context.Background(), c.stack, []byte(plaintext))
+func (c *serviceCrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
+	ciphertext, err := c.client.EncryptValue(ctx, c.stack, []byte(plaintext))
 	if err != nil {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
-func (c *serviceCrypter) DecryptValue(cipherstring string) (string, error) {
+func (c *serviceCrypter) DecryptValue(ctx context.Context, cipherstring string) (string, error) {
 	ciphertext, err := base64.StdEncoding.DecodeString(cipherstring)
 	if err != nil {
 		return "", err
 	}
 
-	plaintext, err := c.client.DecryptValue(context.Background(), c.stack, ciphertext)
+	plaintext, err := c.client.DecryptValue(ctx, c.stack, ciphertext)
 	if err != nil {
 		return "", err
 	}
 	return string(plaintext), nil
 }
 
-func (c *serviceCrypter) BulkDecrypt(secrets []string) (map[string]string, error) {
+func (c *serviceCrypter) BulkDecrypt(ctx context.Context, secrets []string) (map[string]string, error) {
 	var secretsToDecrypt [][]byte
 	for _, val := range secrets {
 		ciphertext, err := base64.StdEncoding.DecodeString(val)
@@ -74,7 +74,7 @@ func (c *serviceCrypter) BulkDecrypt(secrets []string) (map[string]string, error
 		secretsToDecrypt = append(secretsToDecrypt, ciphertext)
 	}
 
-	decryptedList, err := c.client.BulkDecryptValue(context.Background(), c.stack, secretsToDecrypt)
+	decryptedList, err := c.client.BulkDecryptValue(ctx, c.stack, secretsToDecrypt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -573,7 +573,10 @@ func GetLogs(
 	stackInfo RuntimeValidationStackInfo,
 	query operations.LogQuery) *[]operations.LogEntry {
 
-	snap, err := stack.DeserializeDeploymentV3(*stackInfo.Deployment, stack.DefaultSecretsProvider)
+	snap, err := stack.DeserializeDeploymentV3(
+		context.Background(),
+		*stackInfo.Deployment,
+		stack.DefaultSecretsProvider)
 	assert.NoError(t, err)
 
 	tree := operations.NewResourceTree(snap.Resources)

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	cryptorand "crypto/rand"
@@ -30,15 +31,15 @@ import (
 
 // Encrypter encrypts plaintext into its encrypted ciphertext.
 type Encrypter interface {
-	EncryptValue(plaintext string) (string, error)
+	EncryptValue(ctx context.Context, plaintext string) (string, error)
 }
 
 // Decrypter decrypts encrypted ciphertext to its plaintext representation.
 type Decrypter interface {
-	DecryptValue(ciphertext string) (string, error)
+	DecryptValue(ctx context.Context, ciphertext string) (string, error)
 
 	// BulkDecrypt supports bulk decryption of secrets.
-	BulkDecrypt(ciphertexts []string) (map[string]string, error)
+	BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error)
 }
 
 // Crypter can both encrypt and decrypt values.
@@ -53,15 +54,15 @@ type nopCrypter struct{}
 var NopDecrypter Decrypter = nopCrypter{}
 var NopEncrypter Encrypter = nopCrypter{}
 
-func (nopCrypter) DecryptValue(ciphertext string) (string, error) {
+func (nopCrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
 	return ciphertext, nil
 }
 
-func (nopCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return DefaultBulkDecrypt(NopDecrypter, ciphertexts)
+func (nopCrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return DefaultBulkDecrypt(ctx, NopDecrypter, ciphertexts)
 }
 
-func (nopCrypter) EncryptValue(plaintext string) (string, error) {
+func (nopCrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
 	return plaintext, nil
 }
 
@@ -82,8 +83,8 @@ type trackingDecrypter struct {
 	secureValues []string
 }
 
-func (t *trackingDecrypter) DecryptValue(ciphertext string) (string, error) {
-	v, err := t.decrypter.DecryptValue(ciphertext)
+func (t *trackingDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
+	v, err := t.decrypter.DecryptValue(ctx, ciphertext)
 	if err != nil {
 		return "", err
 	}
@@ -91,8 +92,9 @@ func (t *trackingDecrypter) DecryptValue(ciphertext string) (string, error) {
 	return v, nil
 }
 
-func (t *trackingDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return DefaultBulkDecrypt(t, ciphertexts)
+func (t *trackingDecrypter) BulkDecrypt(
+	ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return DefaultBulkDecrypt(ctx, t, ciphertexts)
 }
 
 func (t *trackingDecrypter) SecureValues() []string {
@@ -111,16 +113,16 @@ func NewBlindingDecrypter() Decrypter {
 
 type blindingCrypter struct{}
 
-func (b blindingCrypter) DecryptValue(_ string) (string, error) {
+func (b blindingCrypter) DecryptValue(ctx context.Context, _ string) (string, error) {
 	return "[secret]", nil //nolint:goconst
 }
 
-func (b blindingCrypter) EncryptValue(plaintext string) (string, error) {
+func (b blindingCrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
 	return "[secret]", nil
 }
 
-func (b blindingCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return DefaultBulkDecrypt(b, ciphertexts)
+func (b blindingCrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return DefaultBulkDecrypt(ctx, b, ciphertexts)
 }
 
 // NewPanicCrypter returns a new config crypter that will panic if used.
@@ -130,15 +132,15 @@ func NewPanicCrypter() Crypter {
 
 type panicCrypter struct{}
 
-func (p panicCrypter) EncryptValue(_ string) (string, error) {
+func (p panicCrypter) EncryptValue(ctx context.Context, _ string) (string, error) {
 	panic("attempt to encrypt value")
 }
 
-func (p panicCrypter) DecryptValue(_ string) (string, error) {
+func (p panicCrypter) DecryptValue(ctx context.Context, _ string) (string, error) {
 	panic("attempt to decrypt value")
 }
 
-func (p panicCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+func (p panicCrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
 	panic("attempt to bulk decrypt values")
 }
 
@@ -164,13 +166,13 @@ type symmetricCrypter struct {
 	key []byte
 }
 
-func (s symmetricCrypter) EncryptValue(value string) (string, error) {
+func (s symmetricCrypter) EncryptValue(ctx context.Context, value string) (string, error) {
 	secret, nonce := encryptAES256GCGM(value, s.key)
 	return fmt.Sprintf("v1:%s:%s",
 		base64.StdEncoding.EncodeToString(nonce), base64.StdEncoding.EncodeToString(secret)), nil
 }
 
-func (s symmetricCrypter) DecryptValue(value string) (string, error) {
+func (s symmetricCrypter) DecryptValue(ctx context.Context, value string) (string, error) {
 	vals := strings.Split(value, ":")
 
 	if len(vals) != 3 {
@@ -194,8 +196,8 @@ func (s symmetricCrypter) DecryptValue(value string) (string, error) {
 	return decryptAES256GCM(enc, s.key, nonce)
 }
 
-func (s symmetricCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return DefaultBulkDecrypt(s, ciphertexts)
+func (s symmetricCrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return DefaultBulkDecrypt(ctx, s, ciphertexts)
 }
 
 // encryptAES256GCGM returns the ciphertext and the generated nonce
@@ -242,29 +244,30 @@ func newPrefixCrypter(prefix string) Crypter {
 	return prefixCrypter{prefix: prefix}
 }
 
-func (c prefixCrypter) DecryptValue(ciphertext string) (string, error) {
+func (c prefixCrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
 	return strings.TrimPrefix(ciphertext, c.prefix), nil
 }
 
-func (c prefixCrypter) EncryptValue(plaintext string) (string, error) {
+func (c prefixCrypter) EncryptValue(ctx context.Context, plaintext string) (string, error) {
 	return c.prefix + plaintext, nil
 }
 
-func (c prefixCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return DefaultBulkDecrypt(c, ciphertexts)
+func (c prefixCrypter) BulkDecrypt(ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return DefaultBulkDecrypt(ctx, c, ciphertexts)
 }
 
 // DefaultBulkDecrypt decrypts a list of ciphertexts. Each ciphertext is decrypted individually. The returned
 // map maps from ciphertext to plaintext. This should only be used by implementers of Decrypter to implement
 // their BulkDecrypt method in cases where they can't do more efficient than just individual decryptions.
-func DefaultBulkDecrypt(decrypter Decrypter, ciphertexts []string) (map[string]string, error) {
+func DefaultBulkDecrypt(ctx context.Context,
+	decrypter Decrypter, ciphertexts []string) (map[string]string, error) {
 	if len(ciphertexts) == 0 {
 		return nil, nil
 	}
 
 	secretMap := map[string]string{}
 	for _, ct := range ciphertexts {
-		pt, err := decrypter.DecryptValue(ct)
+		pt, err := decrypter.DecryptValue(ctx, ct)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/resource/config/value.go
+++ b/sdk/go/common/resource/config/value.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -71,7 +72,7 @@ func (c Value) Value(decrypter Decrypter) (string, error) {
 		return string(json), nil
 	}
 
-	return decrypter.DecryptValue(c.value)
+	return decrypter.DecryptValue(context.TODO(), c.value)
 }
 
 func (c Value) Copy(decrypter Decrypter, encrypter Encrypter) (Value, error) {
@@ -97,7 +98,7 @@ func (c Value) Copy(decrypter Decrypter, encrypter Encrypter) (Value, error) {
 
 			val = NewSecureObjectValue(string(json))
 		} else {
-			enc, eerr := encrypter.EncryptValue(raw)
+			enc, eerr := encrypter.EncryptValue(context.TODO(), raw)
 			if eerr != nil {
 				return Value{}, eerr
 			}
@@ -282,7 +283,7 @@ func reencryptObject(v interface{}, decrypter Decrypter, encrypter Encrypter) (i
 				return nil, err
 			}
 
-			encVal, err := encrypter.EncryptValue(raw)
+			encVal, err := encrypter.EncryptValue(context.TODO(), raw)
 			if err != nil {
 				return nil, err
 			}
@@ -324,7 +325,7 @@ func reencryptObject(v interface{}, decrypter Decrypter, encrypter Encrypter) (i
 func decryptObject(v interface{}, decrypter Decrypter) (interface{}, error) {
 	decryptIt := func(val interface{}) (interface{}, error) {
 		if isSecure, secureVal := isSecureValue(val); isSecure {
-			return decrypter.DecryptValue(secureVal)
+			return decrypter.DecryptValue(context.TODO(), secureVal)
 		}
 		return decryptObject(val, decrypter)
 	}

--- a/sdk/go/common/resource/config/value_test.go
+++ b/sdk/go/common/resource/config/value_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -215,12 +216,14 @@ func TestDecryptingValue(t *testing.T) {
 
 type passThroughDecrypter struct{}
 
-func (d passThroughDecrypter) DecryptValue(ciphertext string) (string, error) {
+func (d passThroughDecrypter) DecryptValue(
+	ctx context.Context, ciphertext string) (string, error) {
 	return ciphertext, nil
 }
 
-func (d passThroughDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
-	return DefaultBulkDecrypt(d, ciphertexts)
+func (d passThroughDecrypter) BulkDecrypt(
+	ctx context.Context, ciphertexts []string) (map[string]string, error) {
+	return DefaultBulkDecrypt(ctx, d, ciphertexts)
 }
 
 func TestSecureValues(t *testing.T) {

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -271,7 +272,9 @@ func TestStackCommands(t *testing.T) {
 			t.FailNow()
 		}
 		os.Setenv("PULUMI_CONFIG_PASSPHRASE", "correct horse battery staple")
-		snap, err := stack.DeserializeUntypedDeployment(&deployment, stack.DefaultSecretsProvider)
+		snap, err := stack.DeserializeUntypedDeployment(
+			context.Background(),
+			&deployment, stack.DefaultSecretsProvider)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Currently opentracing spans generated by the HTTP client when calling BulkDecrypt endpoint are not parented correctly. This seems to be an issue with not propagating `context.Context` through the code correctly. I took a stab at propagating it and I can see the spans snapping back into place.

Since we're changing interfaces under `sdk/` this is a breaking change. It can be fixed by injecting `context.Background()` at the call sites. 

Example project:

```
package main

import (
	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
)

func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {
		// Create an AWS resource (S3 Bucket)
		bucket, err := s3.NewBucket(ctx, "my-bucket", nil)
		if err != nil {
			return err
		}

		// Export the name of the bucket
		ctx.Export("bucketName", bucket.ID())
		return nil
	})
}
```


```
pulumi up --tracing file:./up.trace --yes
PULUMI_DEBUG_COMMANDS=1 pulumi view-trace ./up.trace
# observe orphan traces around bulkdecrypt calls
```

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
