### PR TITLE
fix: Adds support for C#-specific InputProperty names

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,6 @@
 
 - [cli] `pulumi convert` help text is wrong
   [#9892](https://github.com/pulumi/pulumi/issues/9892)
+
+- [cli] `pulumi convert` generates incorrect input parameter names for C#
+  [#10042](https://github.com/pulumi/pulumi/issues/10042)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -75,6 +75,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		// Flaky in go: TODO[pulumi/pulumi#8123]
 	},
 	{
+		Directory:   "aws-iam-policy",
+		Description: "AWS IAM Policy",
+		SkipCompile: codegen.NewStringSet("go"),
+		// Blocked on go
+	},
+	{
 		Directory:   "aws-optionals",
 		Description: "AWS get invoke with nested object constructor that takes an optional string",
 		// Testing Go behavior exclusively:

--- a/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/aws-iam-policy.pp
+++ b/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/aws-iam-policy.pp
@@ -1,0 +1,23 @@
+// Create a policy with multiple Condition keys
+resource policy "aws:iam/policy:Policy" {
+	__logicalName = "policy"
+	path = "/"
+	description = "My test policy"
+    policy = toJSON({
+		Version = "2012-10-17"
+		Statement = [{
+			Effect = "Allow"
+			Principal = "*"
+			Action = [ "s3:GetObject" ]
+			Resource = [ "arn:aws:s3:::some-aws-bucket/*" ]
+            Condition = {
+				Foo = {
+					Bar: ["iamuser-admin", "iamuser2-admin"]
+				},
+				Baz: {
+					Qux: ["iamuser3-admin"]
+				}
+			}
+		}]
+	})
+}

--- a/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/dotnet/aws-iam-policy.cs
+++ b/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/dotnet/aws-iam-policy.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        // Create a policy with multiple Condition keys
+        var policy = new Aws.Iam.Policy("policy", new Aws.Iam.PolicyArgs
+        {
+            Path = "/",
+            Description = "My test policy",
+            PolicyDocument = JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                { "Version", "2012-10-17" },
+                { "Statement", new[]
+                    {
+                        new Dictionary<string, object?>
+                        {
+                            { "Effect", "Allow" },
+                            { "Principal", "*" },
+                            { "Action", new[]
+                                {
+                                    "s3:GetObject",
+                                }
+                             },
+                            { "Resource", new[]
+                                {
+                                    "arn:aws:s3:::some-aws-bucket/*",
+                                }
+                             },
+                            { "Condition", new Dictionary<string, object?>
+                            {
+                                { "Foo", new Dictionary<string, object?>
+                                {
+                                    { "Bar", new[]
+                                        {
+                                            "iamuser-admin",
+                                            "iamuser2-admin",
+                                        }
+                                     },
+                                } },
+                                { "Baz", new Dictionary<string, object?>
+                                {
+                                    { "Qux", new[]
+                                        {
+                                            "iamuser3-admin",
+                                        }
+                                     },
+                                } },
+                            } },
+                        },
+                    }
+                 },
+            }),
+        });
+    }
+
+}

--- a/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/go/aws-iam-policy.go
+++ b/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/go/aws-iam-policy.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		tmpJSON0, err := json.Marshal(map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
+				map[string]interface{}{
+					"Effect":    "Allow",
+					"Principal": "*",
+					"Action": []string{
+						"s3:GetObject",
+					},
+					"Resource": []string{
+						"arn:aws:s3:::some-aws-bucket/*",
+					},
+					"Condition": map[string]interface{}{
+						"Foo": map[string]interface{}{
+							"Bar": []string{
+								"iamuser-admin",
+								"iamuser2-admin",
+							},
+						},
+						"Baz": map[string]interface{}{
+							"Qux": []string{
+								"iamuser3-admin",
+							},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		json0 := string(tmpJSON0)
+		_, err = iam.NewPolicy(ctx, "policy", &iam.PolicyArgs{
+			Path:        pulumi.String("/"),
+			Description: pulumi.String("My test policy"),
+			Policy:      pulumi.String(json0),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/nodejs/aws-iam-policy.ts
+++ b/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/nodejs/aws-iam-policy.ts
@@ -1,0 +1,28 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+// Create a policy with multiple Condition keys
+const policy = new aws.iam.Policy("policy", {
+    path: "/",
+    description: "My test policy",
+    policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Effect: "Allow",
+            Principal: "*",
+            Action: ["s3:GetObject"],
+            Resource: ["arn:aws:s3:::some-aws-bucket/*"],
+            Condition: {
+                Foo: {
+                    Bar: [
+                        "iamuser-admin",
+                        "iamuser2-admin",
+                    ],
+                },
+                Baz: {
+                    Qux: ["iamuser3-admin"],
+                },
+            },
+        }],
+    }),
+});

--- a/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/python/aws-iam-policy.py
+++ b/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/python/aws-iam-policy.py
@@ -1,0 +1,28 @@
+import pulumi
+import json
+import pulumi_aws as aws
+
+# Create a policy with multiple Condition keys
+policy = aws.iam.Policy("policy",
+    path="/",
+    description="My test policy",
+    policy=json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": ["s3:GetObject"],
+            "Resource": ["arn:aws:s3:::some-aws-bucket/*"],
+            "Condition": {
+                "Foo": {
+                    "Bar": [
+                        "iamuser-admin",
+                        "iamuser2-admin",
+                    ],
+                },
+                "Baz": {
+                    "Qux": ["iamuser3-admin"],
+                },
+            },
+        }],
+    }))


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes [#10042  (issue)](https://github.com/pulumi/pulumi/issues/10042)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
