### PR TITLE
Bump pulumictl v0.0.31 -> v0.0.32 should fix downstream AzureAD tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Set up Go ${{ inputs.go-version }}
         uses: actions/setup-go@v2
@@ -142,7 +142,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v3
@@ -191,7 +191,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Set up Node ${{ inputs.node-version }}
         uses: actions/setup-node@v2
@@ -243,7 +243,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Set up DotNet ${{ inputs.dotnet-version }}
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -79,7 +79,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Fetch Tags
         run: |
@@ -125,7 +125,7 @@ jobs:
   #        uses: jaxxstorm/action-install-gh-release@v1.7.1
   #        with:
   #          repo: pulumi/pulumictl
-  #          tag: v0.0.31
+  #          tag: v0.0.32
   #          cache: enable
   #      - name: Repository Dispatch
   #        run: |
@@ -220,7 +220,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Ensure
         run: |
@@ -280,7 +280,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -79,7 +79,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Fetch Tags
         run: |
@@ -201,7 +201,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Ensure
         run: |
@@ -261,7 +261,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -47,7 +47,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       # Section 1: configure
       - name: Configure AWS Credentials

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Download versions.txt
         uses: actions/download-artifact@v2
@@ -58,7 +58,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Download versions.txt
         uses: actions/download-artifact@v2
@@ -82,7 +82,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Download versions.txt
         uses: actions/download-artifact@v2
@@ -109,7 +109,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Download versions.txt
         uses: actions/download-artifact@v2
@@ -136,7 +136,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Repository Dispatch
         run: |
@@ -154,7 +154,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Download versions.txt
         uses: actions/download-artifact@v2
@@ -181,7 +181,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Download versions.txt
         uses: actions/download-artifact@v2
@@ -256,7 +256,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Fetch Tags
         run: |
@@ -378,7 +378,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Ensure
         run: |
@@ -438,7 +438,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -152,7 +152,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Ensure
         run: |

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -75,7 +75,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Check out source code
         uses: actions/checkout@v2

--- a/.github/workflows/run-docs-generation.yml
+++ b/.github/workflows/run-docs-generation.yml
@@ -61,7 +61,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Check out source code
         uses: actions/checkout@v2

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -196,7 +196,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v1.7.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v1.7.1

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -23,7 +23,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.7.1
         with:
           repo: pulumi/pulumictl
-          tag: v0.0.31
+          tag: v0.0.32
           cache: enable
       - name: Compute versions
         run: ./scripts/versions.sh | tee versions.txt


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
