### PR TITLE
Enable polarity flip on GenerateExtraInputTypes

### DIFF
--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -69,6 +69,10 @@ type GoPackageInfo struct {
 	// all plain types, instead of for only types that are used as input/output types.
 	GenerateExtraInputTypes bool `json:"generateExtraInputTypes,omitempty"`
 
+	// omitExtraInputTypes determines whether the code generator generates input (and output) types
+	// for all plain types, instead of for only types that are used as input/output types.
+	OmitExtraInputTypes bool `json:"omitExtraInputTypes,omitempty"`
+
 	// Respect the Pkg.Version field for emitted code.
 	RespectSchemaVersion bool `json:"respectSchemaVersion,omitempty"`
 


### PR DESCRIPTION
First part of #10077

This is a no-op right now, we need to introduce this flag, wait for Azure Native to depend on this version and set it to "true", then we will change the behavior.