### PR TITLE
Set the package.json pulumi name even if PluginName isn't set

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,3 +19,6 @@
 
 - [cli] `pulumi state change-secrets-provider` now takes `--stack` into account
   [#10075](https://github.com/pulumi/pulumi/pull/10075)
+
+- [nodejs/sdkgen] Default set `pulumi.name` in package.json to the pulumi package name.
+  [#10088](https://github.com/pulumi/pulumi/pull/10088)

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -2135,6 +2135,13 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 		scriptVersion = pluginVersion
 	}
 
+	pluginName := info.PluginName
+	// Default to the pulumi package name if PluginName isn't set by the user. This is different to the npm
+	// package name, e.g. the npm package "@pulumiverse/sentry" has a pulumi package name of just "sentry".
+	if pluginName == "" {
+		pluginName = pkg.Name
+	}
+
 	// Create info that will get serialized into an NPM package.json.
 	npminfo := npmPackage{
 		Name:        packageName,
@@ -2152,7 +2159,7 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 		Pulumi: plugin.PulumiPluginJSON{
 			Resource: true,
 			Server:   pkg.PluginDownloadURL,
-			Name:     info.PluginName,
+			Name:     pluginName,
 			Version:  pluginVersion,
 		},
 	}

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/nodejs/package.json
@@ -22,6 +22,7 @@
         "typescript": "^4.3.5"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "azure-native"
     }
 }

--- a/pkg/codegen/testing/test/testdata/cyclic-types/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "foo-bar"
     }
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "plant"
     }
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/different-enum/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "plant"
     }
 }

--- a/pkg/codegen/testing/test/testdata/enum-reference/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/enum-reference/nodejs/package.json
@@ -15,6 +15,7 @@
     },
     "pulumi": {
         "resource": true,
+        "name": "example",
         "version": "3.2.1"
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-node-compatibility/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/external-node-compatibility/nodejs/package.json
@@ -15,6 +15,7 @@
         "@pulumi/pulumi": "latest"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/package.json
@@ -17,6 +17,7 @@
         "@pulumi/pulumi": "latest"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/hyphen-url/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/nodejs/package.json
@@ -13,6 +13,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "registrygeoreplication"
     }
 }

--- a/pkg/codegen/testing/test/testdata/naming-collisions/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "foo-bar"
     }
 }

--- a/pkg/codegen/testing/test/testdata/nested-module/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/nested-module/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "foo"
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/package.json
@@ -14,6 +14,7 @@
         "@pulumi/pulumi": "latest"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "myedgeorder"
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/package.json
@@ -16,6 +16,7 @@
         "@pulumi/pulumi": "latest"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "mypkg"
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/package.json
@@ -16,6 +16,7 @@
         "@pulumi/pulumi": "latest"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "mypkg"
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "foobar"
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/nodejs/package.json
@@ -13,6 +13,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "xyz"
     }
 }

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "configstation"
     }
 }

--- a/pkg/codegen/testing/test/testdata/regress-8403/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/regress-8403/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "mongodbatlas"
     }
 }

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/nodejs/package.json
@@ -14,6 +14,7 @@
         "@pulumi/pulumi": "latest"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "my8110"
     }
 }

--- a/pkg/codegen/testing/test/testdata/replace-on-change/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/package.json
@@ -13,6 +13,7 @@
     },
     "pulumi": {
         "resource": true,
+        "name": "plant",
         "version": "0.0.1"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/package.json
@@ -13,6 +13,7 @@
         "@pulumi/pulumi": "latest"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/package.json
@@ -13,6 +13,7 @@
     },
     "pulumi": {
         "resource": true,
+        "name": "example",
         "version": "3.2.1",
         "server": "example.com/download"
     }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/package.json
@@ -12,6 +12,7 @@
         "typescript": "^3.7.0"
     },
     "pulumi": {
-        "resource": true
+        "resource": true,
+        "name": "example"
     }
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Related to https://github.com/pulumi/pulumi/issues/10087

Currently the nodejs runtime will use "pulumi.name" from package.json as the plugin name, if it's not set it falls back to the npm package name (i.e. "name" in package.json). This is nearly always wrong as npm names look like "@pulumiverse/sentry" while the pulumi package name (and thus plugin name) would be something like "sentry".

This changes nodejs codegen to always set "pulumi.name" to either the user given "PluginName", or if that is not set to the pulumi package name. This should mean most users don't even need to set "PluginName".

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
