### PR TITLE
Use ElementType to deduce resultType

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -36,3 +36,7 @@
 
 - [sdk/python] update protobuf library to v4 which speeds up pulumi CLI dramatically on M1 machines
   [#10063](https://github.com/pulumi/pulumi/pull/10063)
+
+- [go] Fix panic when returning pulumi.String.Bool, .String, .Int, and .Float64 in the argument to
+  ApplyT and casting the result to the corresponding output, e.g.: BoolOutput.
+  [#10103](https://github.com/pulumi/pulumi/pull/10103)

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -25,6 +25,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
+// wrapper enables retrieving the inner type of newtype wrappers such as pulumi.String
+type wrapper interface {
+	ElementType() reflect.Type
+}
+
 // Output helps encode the relationship between resources in a Pulumi application. Specifically an output property
 // holds onto a value and the resource it came from. An output value can then be provided when constructing new
 // resources, allowing that new resource to know both the value as well as the resource the value came from.  This
@@ -40,6 +45,7 @@ type Output interface {
 
 var outputType = reflect.TypeOf((*Output)(nil)).Elem()
 var inputType = reflect.TypeOf((*Input)(nil)).Elem()
+var wrapperType = reflect.TypeOf((*wrapper)(nil)).Elem()
 
 var concreteTypeToOutputType sync.Map // map[reflect.Type]reflect.Type
 
@@ -478,6 +484,12 @@ func (o *OutputState) ApplyTWithContext(ctx context.Context, applier interface{}
 		resultType = ot.(reflect.Type)
 	} else if applierReturnType.Implements(outputType) {
 		resultType = applierReturnType
+	} else if applierReturnType.Implements(wrapperType) {
+		// Handle type aliases for primitive types: pulumi.String, .Int, and so on.
+		unwrappedType := reflect.New(applierReturnType).Interface().(wrapper).ElementType()
+		if ot, ok := concreteTypeToOutputType.Load(unwrappedType); ok {
+			resultType = ot.(reflect.Type)
+		}
 	}
 
 	result := newOutput(o.join, resultType, o.dependencies()...)

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -154,6 +154,38 @@ func TestStringOutputs(t *testing.T) {
 	}
 }
 
+func TestAliasedOutputs(t *testing.T) {
+	t.Parallel()
+
+	// Irrelevant for the tests, we're testing return type handling.
+	initialOutput := String("").ToStringOutput()
+
+	t.Run("Bool", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (Bool, error) {
+			return Bool(false), nil
+		}).(BoolOutput))
+	})
+	t.Run("Float64", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (Float64, error) {
+			return Float64(0.0), nil
+		}).(Float64Output))
+	})
+	t.Run("Int", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (Int, error) {
+			return Int(0), nil
+		}).(IntOutput))
+	})
+	t.Run("String", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (String, error) {
+			return String(""), nil
+		}).(StringOutput))
+	})
+}
+
 func TestResolveOutputToOutput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Although `pulumi.String` and other type primitive type aliases are not output types (do not implement `Output`), they all implement `ElementType` which gives us enough information to resolve them, via the element type, to their corresponding output types.

This adds a new interface we can use to deduce that and a fallback path.

Fixes #6505 