### PR TITLE
Insert deep copies prior to mutating objects held by EngineEvents.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- [engine] Fix rare data races where engine events were experiencing writes concurrent with reads during diagnostic emission.
+  [#10107](https://github.com/pulumi/pulumi/pull/10107)
+
 - [cli] Display outputs during the very first preview.
   [#10031](https://github.com/pulumi/pulumi/pull/10031)
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,8 +1,5 @@
 ### Improvements
 
-- [engine] Fix rare data races where engine events were experiencing writes concurrent with reads during diagnostic emission.
-  [#10107](https://github.com/pulumi/pulumi/pull/10107)
-
 - [cli] Display outputs during the very first preview.
   [#10031](https://github.com/pulumi/pulumi/pull/10031)
 
@@ -18,6 +15,9 @@
   [#9905](https://github.com/pulumi/pulumi/issues/9905)
 
 ### Bug Fixes
+
+- [engine] Fix rare data races where engine events were experiencing writes concurrent with reads during diagnostic emission.
+  [#10107](https://github.com/pulumi/pulumi/pull/10107)
 
 - [cli] `pulumi convert` help text is wrong
   [#9892](https://github.com/pulumi/pulumi/issues/9892)

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 )
 
 // Snapshot is a view of a collection of resources in an stack at a point in time.  It describes resources; their
@@ -57,6 +58,10 @@ func NewSnapshot(manifest Manifest, secretsManager secrets.Manager,
 //
 // Note: This method modifies the snapshot (and resource.States in the snapshot) in-place.
 func (snap *Snapshot) NormalizeURNReferences() error {
+	// Make a deep copy prior to mutating, since this object's pointer
+	// may be held across thread boundaries as a field on an EngineEvent.
+	var snapCopy = deepcopy.Copy(snap).(*Snapshot)
+	*snap = *snapCopy
 	if snap != nil {
 		aliased := make(map[resource.URN]resource.URN)
 		fixUrn := func(urn resource.URN) resource.URN {


### PR DESCRIPTION
# Description

Issue https://github.com/pulumi/pulumi/issues/10060 uncovered some insidious data races. This PR resolves two races specific to emitting Diagnostics.

`EngineEvents` are read from a channel and displayed to the user on a separate thread from ongoing engine work. When the events are read, a deepcopy is made of their `payload`. During the deepcopy, all nested fields are read from memory on the goroutine emitting diagnostics.

In Go, iterating over a map in one thread while writing to a map in another thread results in a panic, because writing to a map could cause a bucket rebalance, and the iterator on the reading thread could be reading from freed memory. Therefore, any `EngineEvent` passed to the `Diagnostics` channel cannot be mutated from another thread, because doing so could result in panic when the diagnostics thread deep-copies a map that's being concurrently written to.

As a complication, it's insufficient to deep-copy the `EngineEvent` prior to writing it to the channel, since _that_ deepcopy could be concurrent with a mutation in a separate (third) thread. Instead, we must locate any instance of mutation, and perform the deepcopy at the site of mutation. This pull request uncovered two such sites:

1. `deploymentExecutor.undangleParentResources`

2. `Snapshot.NormalizeURNReferences`

I attempted to insert deepcopies at more convenient locations farther up the stack, but I was unable to remove the data races with this approach. I opted to insert the copies as close to the mutation as possible.

It's possible this change could result in an (unacceptably large) increase in memory. I think that's unlikely since the objects being copied are not particularly numerous, and the locations where the copies are occurring seem to be called only once per object. Without actually profiling the memory usage of pulumi, those are just assumptions.

Fixes https://github.com/pulumi/pulumi/issues/10060

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works

**Note:** You can't exactly write a test for this change. But you can validate the race detector no longer finds a race! `cd` into `/tests` and run...

```bash
PULUMI_TEST_ORG=robbie GOWORK=off go test -timeout 1h -tags all -run '^TestPrintfGo$' github.com/pulumi/pulumi/tests/integration -v
```

<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
