### PR TITLE
Handle input types in return position of ApplyT

### DIFF
--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -184,6 +184,30 @@ func TestAliasedOutputs(t *testing.T) {
 			return String(""), nil
 		}).(StringOutput))
 	})
+	t.Run("BoolInput", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (BoolInput, error) {
+			return Bool(false), nil
+		}).(BoolOutput))
+	})
+	t.Run("Float64Input", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (Float64Input, error) {
+			return Float64(0.0), nil
+		}).(Float64Output))
+	})
+	t.Run("IntInput", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (IntInput, error) {
+			return Int(0), nil
+		}).(IntOutput))
+	})
+	t.Run("StringInput", func(t *testing.T) {
+		t.Parallel()
+		assertApplied(t, initialOutput.ApplyT(func(v interface{}) (StringInput, error) {
+			return String(""), nil
+		}).(StringOutput))
+	})
 }
 
 func TestResolveOutputToOutput(t *testing.T) {


### PR DESCRIPTION
As identified by a build failure on master here: https://github.com/pulumi/pulumi/runs/7313397089?check_suite_focus=true#step:35:100

The previous PR, #10103 failed to handle `IntInput`, and in creating a new zero value (nil) value for the interface failed.

This adds a check to see if the return type is an input type, then it attempts to look up the associated concrete type to operate on that instead. This handles BoolInput, IntInput, et al. And otherwise attempting to look up the element type in the concrete type to output type map.

Manually re-running the failing test succeeds. The test is a bit idiosyncratic, using `GetResource` in an Apply to sequence it after creating a RandomPet, but it makes a good test case: we should expect unusual Go programs in the wild and handle them well.

https://github.com/pulumi/pulumi/blob/73a66f48ead301bacf1d7d2833c016cf803b57c1/tests/integration/get_resource/go/main.go#L43-L49