### PR TITLE
Make ts-node and typescript peer dependencies

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Improvements
 
+- [sdk/nodejs] - Updates SDK to allow using any newer version of ts-node and typescript
+
 - [cli] Display outputs during the very first preview.
   [#10031](https://github.com/pulumi/pulumi/pull/10031)
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -21,8 +21,6 @@
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",
         "source-map-support": "^0.5.6",
-        "ts-node": "^7.0.1",
-        "typescript": "~3.7.3",
         "upath": "^1.1.0"
     },
     "devDependencies": {
@@ -43,6 +41,10 @@
         "mocha": "^9.0.0",
         "mockpackage": "file:tests/mockpackage",
         "nyc": "^15.1.0"
+    },
+    "peerDependencies": {
+        "ts-node": ">7.0.1",
+        "typescript": ">3.7.3"
     },
     "pulumi": {
         "comment": "Do not remove. Marks this as as a deployment-time-only package"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/8177
Related to https://github.com/pulumi/pulumi/issues/4876

Newer ts-node and typescript versions can make configurations not work with Pulumi at all right now. In my case, I am developing in a monorepo that uses newer versions of ts-node and typescript, and these older versions cause my code to not be able to run. See the more detailed descriptions I left in those two Issues linked above for what exactly is breaking

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works

This is not an application code change

<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [x] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

I'm not sure where to update this version, but this deserves probably a minor bump in the node sdk
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
