### PR TITLE
[codegen/go] Support provider resources

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,7 @@
 
 - [cli] Only log github request headers at log level 11.
   [#10140](https://github.com/pulumi/pulumi/pull/10140)
+
+- [codegen/go] Support program generation, `pulumi convert` for programs that create explicit
+  provider resources.
+  [#10132](https://github.com/pulumi/pulumi/issues/10132)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -132,8 +132,6 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "aws-resource-options",
 		Description: "Resource Options",
-		SkipCompile: codegen.NewStringSet("go"),
-		// Blocked on go: TODO[pulumi/pulumi#8076]
 	},
 	{
 		Directory:   "aws-secret",

--- a/pkg/codegen/testing/test/testdata/aws-resource-options-pp/go/aws-resource-options.go
+++ b/pkg/codegen/testing/test/testdata/aws-resource-options-pp/go/aws-resource-options.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/providers"
+	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		provider, err := providers.Newaws(ctx, "provider", &providers.awsArgs{
-			Region: "us-west-2",
+		provider, err := aws.NewProvider(ctx, "provider", &aws.ProviderArgs{
+			Region: pulumi.String("us-west-2"),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes up import and constructor calling, input argument type naming and field typing for provider resources.

The issues were:

* Providers were imported from a `/providers` module path because we read it from the middle part of the type token, we weren't handling the `pulumi:providers:$packageName` special case token. Updates Go program generation to handle that, and to also handle the type name (e.g.: `NewProvider` not `Newaws`).
* Providers inputs and shape are populated from `schema.Config()`, but providers are resources in the schema, they just live in a special location. Updates the binder to special case providers and treat it as a resource.

Fixes https://github.com/pulumi/pulumi-yaml/issues/283
Fixes #8076
Fixes #6510
