### PR TITLE
fix mutation of resources by moving alias fixup

### DIFF
--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -176,7 +176,7 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 
 				if m.Old != nil {
 					oldState := stateForJSONOutput(m.Old.State, opts)
-					res, err := stack.SerializeResource(oldState, config.NewPanicCrypter(), false /* showSecrets */)
+					res, err := stack.SerializeResource(oldState, config.NewPanicCrypter(), false /* showSecrets */, nil /* aliases */)
 					if err == nil {
 						step.OldState = &res
 					} else {
@@ -185,7 +185,7 @@ func ShowPreviewDigest(events <-chan engine.Event, done chan<- bool, opts Option
 				}
 				if m.New != nil {
 					newState := stateForJSONOutput(m.New.State, opts)
-					res, err := stack.SerializeResource(newState, config.NewPanicCrypter(), false /* showSecrets */)
+					res, err := stack.SerializeResource(newState, config.NewPanicCrypter(), false /* showSecrets */, nil /* aliases */)
 					if err == nil {
 						step.NewState = &res
 					} else {

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -624,9 +624,6 @@ func (sm *SnapshotManager) snap() *deploy.Snapshot {
 // saveSnapshot persists the current snapshot and optionally verifies it afterwards.
 func (sm *SnapshotManager) saveSnapshot() error {
 	snap := sm.snap()
-	if err := snap.NormalizeURNReferences(); err != nil {
-		return fmt.Errorf("failed to normalize URN references: %w", err)
-	}
 	if err := sm.persister.Save(snap); err != nil {
 		return fmt.Errorf("failed to save snapshot: %w", err)
 	}

--- a/pkg/codegen/importer/hcl2_test.go
+++ b/pkg/codegen/importer/hcl2_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -280,7 +280,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			assert.Equal(t, state.Provider, actualState.Provider)
 			assert.Equal(t, state.Protect, actualState.Protect)
 			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
-				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false)
+				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false, nil)
 				contract.IgnoreError(err)
 
 				sb, err := json.MarshalIndent(s, "", "    ")

--- a/pkg/codegen/importer/language_test.go
+++ b/pkg/codegen/importer/language_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ func TestGenerateLanguageDefinition(t *testing.T) {
 			assert.Equal(t, state.Provider, actualState.Provider)
 			assert.Equal(t, state.Protect, actualState.Protect)
 			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
-				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false)
+				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false, nil)
 				contract.IgnoreError(err)
 
 				sb, err := json.MarshalIndent(s, "", "    ")

--- a/pkg/engine/journal.go
+++ b/pkg/engine/journal.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package engine
 
 import (
@@ -132,11 +146,7 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 	manifest.Magic = manifest.NewMagic()
 
 	snap := deploy.NewSnapshot(manifest, secretsManager, resources, operations)
-	err := snap.NormalizeURNReferences()
-	if err != nil {
-		return snap, err
-	}
-	return snap, snap.VerifyIntegrity()
+	return snap, nil
 }
 
 type Journal struct {

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1811,7 +1811,7 @@ func TestAliases(t *testing.T) {
 		}
 	}
 
-	snap = updateProgramWithResource(snap, []Resource{{
+	updateProgramWithResource(snap, []Resource{{
 		t:       "pkgA:index:t1-v100",
 		name:    "n1-new",
 		aliases: n1Aliases,
@@ -1826,9 +1826,6 @@ func TestAliases(t *testing.T) {
 		parent:  resource.URN("urn:pulumi:test::test::pkgA:index:t1-v100$pkgA:index:t2-v10::n1-new-sub"),
 		aliases: n3Aliases,
 	}}, []display.StepOp{deploy.OpSame}, false)
-
-	err := snap.NormalizeURNReferences()
-	assert.Nil(t, err)
 }
 
 func TestPersistentDiff(t *testing.T) {

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // Snapshot is a view of a collection of resources in an stack at a point in time.  It describes resources; their
@@ -47,57 +46,6 @@ func NewSnapshot(manifest Manifest, secretsManager secrets.Manager,
 		Resources:         resources,
 		PendingOperations: ops,
 	}
-}
-
-// NormalizeURNReferences fixes up all URN references in a snapshot to use the new URNs instead of potentially-aliased
-// URNs.  This will affect resources that are "old", and which would be expected to be updated to refer to the new names
-// later in the deployment.  But until they are, we still want to ensure that any serialization of the snapshot uses URN
-// references which do not need to be indirected through any alias lookups, and which instead refer directly to the URN
-// of a resource in the resources map.
-//
-// Note: This method modifies the snapshot (and resource.States in the snapshot) in-place.
-func (snap *Snapshot) NormalizeURNReferences() error {
-	if snap != nil {
-		aliased := make(map[resource.URN]resource.URN)
-		fixUrn := func(urn resource.URN) resource.URN {
-			if newUrn, has := aliased[urn]; has {
-				return newUrn
-			}
-			return urn
-		}
-		for _, state := range snap.Resources {
-			// Fix up any references to URNs
-			state.Parent = fixUrn(state.Parent)
-			for i, dependency := range state.Dependencies {
-				state.Dependencies[i] = fixUrn(dependency)
-			}
-			for k, deps := range state.PropertyDependencies {
-				for i, dep := range deps {
-					state.PropertyDependencies[k][i] = fixUrn(dep)
-				}
-			}
-			if state.Provider != "" {
-				ref, err := providers.ParseReference(state.Provider)
-				contract.AssertNoError(err)
-				ref, err = providers.NewReference(fixUrn(ref.URN()), ref.ID())
-				contract.AssertNoError(err)
-				state.Provider = ref.String()
-			}
-
-			// Add to aliased maps
-			for _, alias := range state.Aliases {
-				// For ease of implementation, some SDKs may end up creating the same alias to the
-				// same resource multiple times.  That's fine, only error if we see the same alias,
-				// but it maps to *different* resources.
-				if otherUrn, has := aliased[alias]; has && otherUrn != state.URN {
-					return fmt.Errorf("Two resources ('%s' and '%s') aliased to the same: '%s'", otherUrn, state.URN, alias)
-				}
-				aliased[alias] = state.URN
-			}
-		}
-	}
-
-	return nil
 }
 
 // VerifyIntegrity checks a snapshot to ensure it is well-formed.  Because of the cost of this operation,

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ func TestDeploymentSerialization(t *testing.T) {
 		false,
 	)
 
-	dep, err := SerializeResource(res, config.NopEncrypter, false /* showSecrets */)
+	dep, err := SerializeResource(res, config.NopEncrypter, false /* showSecrets */, nil /* aliases */)
 	assert.NoError(t, err)
 
 	// assert some things about the deployment record:


### PR DESCRIPTION
An attempt to resolve data races identified by #10060, this moves the alias fixup logic to the persistence step. Like #10128, but moving the logic further away from the snapshot. Instead, snapshots do not perform any alias fixup at all, but the Resource "v3" structs that are created in `SerializeResource` and `SerializeOperation` are fixed up incrementally in serializing the deployment.

This is a draft PR to let the larger test suite run async while the team evaluates various solutions. Apologies to @RobbieMcKinstry as I keep returning to this after thinking I've left it alone.