### PR TITLE
[ci] Reduce PR cycle time, MacOS runner demand

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,8 +173,9 @@ jobs:
       - name: Upload pulumi.whl
         uses: actions/upload-artifact@v2
         with:
-            name: pulumi.whl
-            path: sdk/python/lib/dist/*.whl
+          name: pulumi.whl
+          path: sdk/python/lib/dist/*.whl
+          retention-days: 2
 
   build_node_sdk:
     name: Build Pulumi Node SDK tarball
@@ -225,8 +226,9 @@ jobs:
       - name: Upload pulumi-node-sdk.tgz
         uses: actions/upload-artifact@v2
         with:
-            name: pulumi-node-sdk.tgz
-            path: sdk/nodejs/bin/*.tgz
+          name: pulumi-node-sdk.tgz
+          path: sdk/nodejs/bin/*.tgz
+          retention-days: 2
 
   build_dotnet_sdk:
     name: Build Pulumi .NET SDK NuGet packages
@@ -269,5 +271,6 @@ jobs:
       - name: Upload the NuGet packages
         uses: actions/upload-artifact@v2
         with:
-            name: pulumi-nuget-packages
-            path: sdk/dotnet/nupkgs/*.nupkg
+          name: pulumi-nuget-packages
+          path: sdk/dotnet/nupkgs/*.nupkg
+          retention-days: 2

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -91,9 +91,6 @@ jobs:
         with:
           name: pulumi-Windows-X64
           path: goreleaser-windows
-      - name: Download pulumi-language-*
-        run: |
-          ./scripts/get-language-providers.sh
 
       # Section 3: release with goreleaser
       - name: Run GoReleaser to actually release

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -205,7 +205,7 @@ jobs:
   test-macos:
     name: Test MacOS
     needs: build
-    uses: ./.github/workflows/test-fast.yml
+    uses: ./.github/workflows/test-minimal.yml
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       enable-coverage: true
@@ -215,7 +215,7 @@ jobs:
   test-windows:
     name: Test Windows
     needs: build
-    uses: ./.github/workflows/test-fast.yml
+    uses: ./.github/workflows/test-minimal.yml
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       enable-coverage: true

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -220,21 +220,19 @@ jobs:
         with:
           name: pulumi-${{ runner.os }}-${{ runner.arch }}
           path: artifacts/go
-      - name: Install pulumi-language-python-exec
-        run: |
-          mkdir -p bin
-          cp sdk/python/cmd/pulumi-language-python-exec bin/
       - name: Install Pulumi Go Binaries
         run: |
+          echo "Running prep script to put artifacts in bin"
+          ./scripts/prep-for-goreleaser.sh $(go env GOOS)
+
           echo "Checking contents of artifacts/go"
           find artifacts/go
-          mkdir -p bin
           mv artifacts/go/pulumi*/* $PWD/bin/
           chmod a+x $PWD/bin/*
+
           echo "Checking contents of $PWD/bin"
           find $PWD/bin
-      - name: Add ./bin to PATH
-        run: |
+
           LOCAL_PATH=$(./scripts/normpath "${{ github.workspace }}/bin")
           echo "Adding LOCAL_PATH=$LOCAL_PATH to PATH"
           echo $LOCAL_PATH >> $GITHUB_PATH

--- a/.github/workflows/test-macos-cron.yml
+++ b/.github/workflows/test-macos-cron.yml
@@ -20,7 +20,6 @@ jobs:
     name: Test MacOS
     needs: build
     uses: ./.github/workflows/test.yml
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       enable-coverage: true
       platform: macos-latest

--- a/.github/workflows/test-minimal.yml
+++ b/.github/workflows/test-minimal.yml
@@ -180,21 +180,19 @@ jobs:
         with:
           name: pulumi-${{ runner.os }}-${{ runner.arch }}
           path: artifacts/go
-      - name: Install pulumi-language-python-exec
-        run: |
-          mkdir -p bin
-          cp sdk/python/cmd/pulumi-language-python-exec bin/
       - name: Install Pulumi Go Binaries
         run: |
+          echo "Running prep script to put artifacts in bin"
+          ./scripts/prep-for-goreleaser.sh $(go env GOOS)
+
           echo "Checking contents of artifacts/go"
           find artifacts/go
-          mkdir -p bin
           mv artifacts/go/pulumi*/* $PWD/bin/
           chmod a+x $PWD/bin/*
+
           echo "Checking contents of $PWD/bin"
           find $PWD/bin
-      - name: Add ./bin to PATH
-        run: |
+
           LOCAL_PATH=$(./scripts/normpath "${{ github.workspace }}/bin")
           echo "Adding LOCAL_PATH=$LOCAL_PATH to PATH"
           echo $LOCAL_PATH >> $GITHUB_PATH

--- a/.github/workflows/test-minimal.yml
+++ b/.github/workflows/test-minimal.yml
@@ -1,7 +1,8 @@
 name: Partial tests for CLI and SDK binaries PR verification
 
-# This should be kept identical to test.yml except for matrix section
-# that skips some combinations.
+# This should be kept identical to test.yml except for matrix section that skips some combinations.
+#
+# This minimal test suite is used for MacOS, Windows jobs on acceptance tests.
 
 defaults:
   run:
@@ -59,47 +60,6 @@ jobs:
       fail-fast: false
       matrix:
         test-suite:
-          - run: |
-              cd sdk/python
-              make test_fast
-              make test_auto
-              make test_go
-
-          - run: |
-              cd sdk/dotnet
-              make dotnet_test
-              make test_auto
-              make test_go
-
-          - run: |
-              cd sdk/nodejs
-              make sxs_tests
-              make unit_tests
-              make test_auto
-              make test_go
-            test-parallelism: 2
-
-          - run: |
-              cd sdk/go
-              make test_fast
-              make test_auto
-
-          - run: make test_pkg_nodejs
-            require-build: true
-            test-parallelism: 4
-            test-parallelism-windows: 2
-
-          - run: make test_pkg_python
-            require-build: true
-            test-parallelism: 4
-            test-parallelism-windows: 2
-
-          - run: make test_pkg_rest
-            require-build: true
-            test-parallelism: 2
-
-          # test_integration skipped
-
           - run: make test_integration_subpkgs
             require-build: true
             test-parallelism: 4

--- a/.github/workflows/test-windows-cron.yml
+++ b/.github/workflows/test-windows-cron.yml
@@ -19,7 +19,6 @@ jobs:
     name: Test Windows
     needs: build
     uses: ./.github/workflows/test.yml
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       enable-coverage: true
       platform: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,21 +236,19 @@ jobs:
         with:
           name: pulumi-${{ runner.os }}-${{ runner.arch }}
           path: artifacts/go
-      - name: Install pulumi-language-python-exec
-        run: |
-          mkdir -p bin
-          cp sdk/python/cmd/pulumi-language-python-exec bin/
       - name: Install Pulumi Go Binaries
         run: |
+          echo "Running prep script to put artifacts in bin"
+          ./scripts/prep-for-goreleaser.sh $(go env GOOS)
+
           echo "Checking contents of artifacts/go"
           find artifacts/go
-          mkdir -p bin
           mv artifacts/go/pulumi*/* $PWD/bin/
           chmod a+x $PWD/bin/*
+
           echo "Checking contents of $PWD/bin"
           find $PWD/bin
-      - name: Add ./bin to PATH
-        run: |
+
           LOCAL_PATH=$(./scripts/normpath "${{ github.workspace }}/bin")
           echo "Adding LOCAL_PATH=$LOCAL_PATH to PATH"
           echo $LOCAL_PATH >> $GITHUB_PATH

--- a/.goreleaser.build.yml
+++ b/.goreleaser.build.yml
@@ -4,6 +4,7 @@ project_name: pulumi
 
 before:
   hooks:
+    - ./scripts/get-language-providers.sh
     - ./scripts/prep-for-goreleaser.sh
 
 release:

--- a/.goreleaser.build.yml
+++ b/.goreleaser.build.yml
@@ -15,96 +15,67 @@ changelog:
 
 builds:
 
-- id: pulumi
+- &pulumibin
+  id: pulumi
   binary: pulumi
   dir: pkg
   main: ./cmd/pulumi
   gobinary: ../scripts/go-wrapper.sh
-  goarch:
-    - amd64
-    - arm64
-  goos:
-    - darwin
-    - linux
-    - windows
+  env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+  goos: ['linux', 'darwin', 'windows']
+  goarch: ['amd64', 'arm64']
+  goamd64: ['v1']
   ignore:
     - goos: windows
       goarch: arm64
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
   mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-nodejs
-  binary: pulumi-language-nodejs
-  dir: sdk
-  main: ./nodejs/cmd/pulumi-language-nodejs
-  gobinary: ../scripts/go-wrapper.sh
-  goarch:
-    - amd64
-    - arm64
-  goos:
-    - darwin
-    - linux
-    - windows
-  ignore:
-    - goos: windows
-      goarch: arm64
-  ldflags:
-    - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-python
-  binary: pulumi-language-python
-  dir: sdk
-  main: ./python/cmd/pulumi-language-python
-  gobinary: ../scripts/go-wrapper.sh
-  goarch:
-    - amd64
-    - arm64
-  goos:
-    - darwin
-    - linux
-    - windows
-  ignore:
-    - goos: windows
-      goarch: arm64
-  ldflags:
-    - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-dotnet
-  binary: pulumi-language-dotnet
-  dir: sdk
-  main: ./dotnet/cmd/pulumi-language-dotnet
-  gobinary: ../scripts/go-wrapper.sh
-  goarch:
-    - amd64
-    - arm64
-  goos:
-    - darwin
-    - linux
-    - windows
-  ignore:
-    - goos: windows
-      goarch: arm64
-  ldflags:
-    - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-go
+- <<: *pulumibin
+  id: pulumi-language-go
   binary: pulumi-language-go
   dir: sdk
   main: ./go/pulumi-language-go
-  gobinary: ../scripts/go-wrapper.sh
-  goarch:
-    - amd64
-    - arm64
-  goos:
-    - darwin
-    - linux
-    - windows
-  ignore:
+- <<: *pulumibin
+  id: pulumi-language-nodejs
+  binary: pulumi-language-nodejs
+  dir: sdk
+  main: ./nodejs/cmd/pulumi-language-nodejs
+- <<: *pulumibin
+  id: pulumi-language-python
+  binary: pulumi-language-python
+  dir: sdk
+  main: ./python/cmd/pulumi-language-python
+- <<: *pulumibin
+  id: pulumi-language-dotnet
+  binary: pulumi-language-dotnet
+  dir: sdk
+  main: ./dotnet/cmd/pulumi-language-dotnet
+- <<: *pulumibin
+  id: pulumi-language-java
+  binary: pulumi-language-java
+  prebuilt:
+    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+- <<: *pulumibin
+  id: pulumi-language-yaml
+  binary: pulumi-language-yaml
+  prebuilt:
+    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+
+archives:
+- wrap_in_directory: pulumi
+  format_overrides:
     - goos: windows
-      goarch: arm64
-  ldflags:
-    - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
-  mod_timestamp: '{{ .CommitTimestamp }}'
+      format: zip
+  replacements:
+    amd64: x64
+  files:
+    - src: bin/{{ .Os }}/*
+      dst: '.'
+      strip_parent: true
+  name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"

--- a/.goreleaser.build.yml
+++ b/.goreleaser.build.yml
@@ -2,6 +2,10 @@ dist: goreleaser
 
 project_name: pulumi
 
+before:
+  hooks:
+    - ./scripts/prep-for-goreleaser.sh
+
 release:
   disable: true
 

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -11,8 +11,7 @@ blobs:
 - bucket: get.pulumi.com
   folder: releases/sdk/
   ids:
-    - pulumi-unix
-    - pulumi-windows
+    - pulumi
   provider: s3
   region: us-west-2
 
@@ -23,174 +22,53 @@ changelog:
   skip: true
 
 builds:
-- id: pulumi-unix
+- &pulumibin
+  id: pulumi
   binary: pulumi
   builder: prebuilt
-  goos: ['linux', 'darwin']
+  goos: ['linux', 'darwin', 'windows']
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
+  ignore:
+    - goos: windows
+      goarch: arm64
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi
+    path: goreleaser-{{ .Os }}/{{ .Name }}_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/{{ .Name }}{{ .Ext }}
   mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-windows
-  binary: pulumi
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-go-unix
+- <<: *pulumibin
+  id: pulumi-language-go
   binary: pulumi-language-go
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-go-windows
-  binary: pulumi-language-go
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-nodejs-unix
+- <<: *pulumibin
+  id: pulumi-language-nodejs
   binary: pulumi-language-nodejs
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-nodejs-windows
-  binary: pulumi-language-nodejs
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-python-unix
+- <<: *pulumibin
+  id: pulumi-language-python
   binary: pulumi-language-python
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-python-windows
-  binary: pulumi-language-python
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-dotnet-unix
+- <<: *pulumibin
+  id: pulumi-language-dotnet
   binary: pulumi-language-dotnet
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-dotnet-windows
-  binary: pulumi-language-dotnet
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-java-unix
+- <<: *pulumibin
+  id: pulumi-language-java
   binary: pulumi-language-java
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
   prebuilt:
-    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-java
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-java-windows
-  binary: pulumi-language-java
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-java.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-yaml-unix
+    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+- <<: *pulumibin
+  id: pulumi-language-yaml
   binary: pulumi-language-yaml
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
   prebuilt:
-    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-yaml
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-yaml-windows
-  binary: pulumi-language-yaml
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-yaml.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
+    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
 
 archives:
-- id: pulumi-unix
-  wrap_in_directory: pulumi
-  builds:
-    - pulumi-language-dotnet-unix
-    - pulumi-language-go-unix
-    - pulumi-language-python-unix
-    - pulumi-language-nodejs-unix
-    - pulumi-language-java-unix
-    - pulumi-language-yaml-unix
-    - pulumi-unix
+- wrap_in_directory: pulumi
+  format_overrides:
+    - goos: windows
+      format: zip
   replacements:
     amd64: x64
   files:
-    - pulumi-resource-pulumi-nodejs
-    - pulumi-resource-pulumi-python
-    - pulumi-analyzer-policy
-    - pulumi-analyzer-policy-python
-    - pulumi-language-python-exec
-  name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
-- id: pulumi-windows
-  wrap_in_directory: pulumi/bin
-  builds:
-    - pulumi-language-dotnet-windows
-    - pulumi-language-go-windows
-    - pulumi-language-python-windows
-    - pulumi-language-nodejs-windows
-    - pulumi-language-java-windows
-    - pulumi-language-yaml-windows
-    - pulumi-windows
-  replacements:
-    amd64: x64
-  format: zip
-  files:
-    - pulumi-resource-pulumi-nodejs.cmd
-    - pulumi-resource-pulumi-python.cmd
-    - pulumi-python3-shim.cmd
-    - pulumi-python-shim.cmd
-    - pulumi-analyzer-policy.cmd
-    - pulumi-analyzer-policy-python.cmd
-    - pulumi-language-python-exec
+    - src: bin/{{ .Os }}/*
+      dst: '.'
+      strip_parent: true
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 
 snapshot:

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -4,6 +4,7 @@ project_name: pulumi
 
 before:
   hooks:
+    - ./scripts/get-language-providers.sh
     - ./scripts/prep-for-goreleaser.sh
 
 blobs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ project_name: pulumi
 
 before:
   hooks:
+    - ./scripts/get-language-providers.sh
     - ./scripts/prep-for-goreleaser.sh
 
 blobs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,180 +11,58 @@ blobs:
 - bucket: get.pulumi.com
   folder: releases/sdk/
   ids:
-    - pulumi-unix
-    - pulumi-windows
+    - pulumi
   provider: s3
   region: us-west-2
 
 builds:
-- id: pulumi-unix
+- &pulumibin
+  id: pulumi
   binary: pulumi
   builder: prebuilt
-  goos: ['linux', 'darwin']
+  goos: ['linux', 'darwin', 'windows']
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
+  ignore:
+    - goos: windows
+      goarch: arm64
   prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi
+    path: goreleaser-{{ .Os }}/{{ .Name }}_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/{{ .Name }}{{ .Ext }}
   mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-windows
-  binary: pulumi
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-go-unix
+- <<: *pulumibin
+  id: pulumi-language-go
   binary: pulumi-language-go
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-go-windows
-  binary: pulumi-language-go
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-go_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-go.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-nodejs-unix
+- <<: *pulumibin
+  id: pulumi-language-nodejs
   binary: pulumi-language-nodejs
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-nodejs-windows
-  binary: pulumi-language-nodejs
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-nodejs_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-nodejs.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-python-unix
+- <<: *pulumibin
+  id: pulumi-language-python
   binary: pulumi-language-python
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-python-windows
-  binary: pulumi-language-python
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-python_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-python.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-dotnet-unix
+- <<: *pulumibin
+  id: pulumi-language-dotnet
   binary: pulumi-language-dotnet
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-dotnet-windows
-  binary: pulumi-language-dotnet
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-{{ .Os }}/pulumi-language-dotnet_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/pulumi-language-dotnet.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-java-unix
+- <<: *pulumibin
+  id: pulumi-language-java
   binary: pulumi-language-java
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
   prebuilt:
-    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-java
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-java-windows
-  binary: pulumi-language-java
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-java.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-yaml-unix
+    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+- <<: *pulumibin
+  id: pulumi-language-yaml
   binary: pulumi-language-yaml
-  builder: prebuilt
-  goos: ['linux', 'darwin']
-  goarch: ['amd64', 'arm64']
-  goamd64: ['v1']
   prebuilt:
-    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-yaml
-  mod_timestamp: '{{ .CommitTimestamp }}'
-- id: pulumi-language-yaml-windows
-  binary: pulumi-language-yaml
-  builder: prebuilt
-  goos: ['windows']
-  goarch: ['amd64']
-  goamd64: ['v1']
-  prebuilt:
-    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/pulumi-language-yaml.exe
-  mod_timestamp: '{{ .CommitTimestamp }}'
+    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
 
 archives:
-- id: pulumi-unix
-  wrap_in_directory: pulumi
-  builds:
-    - pulumi-language-dotnet-unix
-    - pulumi-language-go-unix
-    - pulumi-language-python-unix
-    - pulumi-language-nodejs-unix
-    - pulumi-language-java-unix
-    - pulumi-language-yaml-unix
-    - pulumi-unix
+- wrap_in_directory: pulumi
+  format_overrides:
+    - goos: windows
+      format: zip
   replacements:
     amd64: x64
   files:
-    - pulumi-resource-pulumi-nodejs
-    - pulumi-resource-pulumi-python
-    - pulumi-analyzer-policy
-    - pulumi-analyzer-policy-python
-    - pulumi-language-python-exec
-  name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
-- id: pulumi-windows
-  wrap_in_directory: pulumi/bin
-  builds:
-    - pulumi-language-dotnet-windows
-    - pulumi-language-go-windows
-    - pulumi-language-python-windows
-    - pulumi-language-nodejs-windows
-    - pulumi-language-java-windows
-    - pulumi-language-yaml-windows
-    - pulumi-windows
-  replacements:
-    amd64: x64
-  format: zip
-  files:
-    - pulumi-resource-pulumi-nodejs.cmd
-    - pulumi-resource-pulumi-python.cmd
-    - pulumi-python3-shim.cmd
-    - pulumi-python-shim.cmd
-    - pulumi-analyzer-policy.cmd
-    - pulumi-analyzer-policy-python.cmd
-    - pulumi-language-python-exec
+    - src: bin/{{ .Os }}/*
+      dst: '.'
+      strip_parent: true
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 
 snapshot:

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -357,7 +357,7 @@ func (b *localBackend) stackPath(stack tokens.Name) string {
 	// We can't use listBucket here for as we need to do a partial prefix match on filename, while the
 	// "dir" option to listBucket is always suffixed with "/". Also means we don't need to save any
 	// results in a slice.
-	plainPath := filepath.Join(path, fsutil.NamePath(stack)) + ".json"
+	plainPath := filepath.ToSlash(filepath.Join(path, fsutil.NamePath(stack)) + ".json")
 	gzipedPath := plainPath + ".gz"
 
 	bucketIter := b.bucket.List(&blob.ListOptions{

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -3,48 +3,58 @@
 set -eo pipefail
 set -x
 
+get_version() {
+  repo="$1"
+  (
+    cd pkg
+    GOWORK=off go list -m all | grep "${repo}" | cut -d" " -f2
+  )
+}
+
 # shellcheck disable=SC2043
-for i in "java v0.5.0" "yaml v0.5.3"; do
+for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yaml"; do
   set -- $i # treat strings in loop as args
-  PULUMI_LANG="$1"
-  TAG="$2"
+  REPO="$1"
+  PULUMI_LANG="$2"
+  TAG=$(get_version "${REPO}")
 
   LANG_DIST="goreleaser-lang/${PULUMI_LANG}"
   mkdir -p "$LANG_DIST"
-  cd "${LANG_DIST}"
+  (
+    # Run in a subshell to ensure we don't alter current working directory.
+    cd "${LANG_DIST}"
 
-  rm -rf ./*
+    rm -rf ./*
 
-  # Currently avoiding a dependency on GH CLI in favor of curl, so
-  # that this script works in the context of the Brew formula:
-  #
-  # https://github.com/Homebrew/homebrew-core/blob/master/Formula/pulumi.rb
-  #
-  # Formerly:
-  #
-  # gh release download "${TAG}" --repo "pulumi/pulumi-${PULUMI_LANG}"
+    # Currently avoiding a dependency on GH CLI in favor of curl, so
+    # that this script works in the context of the Brew formula:
+    #
+    # https://github.com/Homebrew/homebrew-core/blob/master/Formula/pulumi.rb
+    #
+    # Formerly:
+    #
+    # gh release download "${TAG}" --repo "pulumi/pulumi-${PULUMI_LANG}"
 
-  for DIST_OS in darwin linux windows; do
-    for i in "amd64 x64" "arm64 arm64"; do
-      set -- $i # treat strings in loop as args
-      DIST_ARCH="$1"
-      RENAMED_ARCH="$2" # goreleaser in pulumi/pulumi renames amd64 to x64
+    for DIST_OS in darwin linux windows; do
+      for i in "amd64 x64" "arm64 arm64"; do
+        set -- $i # treat strings in loop as args
+        DIST_ARCH="$1"
+        RENAMED_ARCH="$2" # goreleaser in pulumi/pulumi renames amd64 to x64
 
-      ARCHIVE="pulumi-language-${PULUMI_LANG}-${TAG}-${DIST_OS}-${DIST_ARCH}"
+        ARCHIVE="pulumi-language-${PULUMI_LANG}-${TAG}-${DIST_OS}-${DIST_ARCH}"
 
-      # No consistency on whether Windows archives use .zip or
-      # .tar.gz, try both.
+        # No consistency on whether Windows archives use .zip or
+        # .tar.gz, try both.
 
-      curl -OL --fail "https://github.com/pulumi/pulumi-${PULUMI_LANG}/releases/download/${TAG}/${ARCHIVE}.tar.gz" || echo "ignoring download"
-      curl -OL --fail "https://github.com/pulumi/pulumi-${PULUMI_LANG}/releases/download/${TAG}/${ARCHIVE}.zip" || echo "ignoring download"
+        curl -OL --fail "https://github.com/pulumi/pulumi-${PULUMI_LANG}/releases/download/${TAG}/${ARCHIVE}.tar.gz" \
+          || curl -OL --fail "https://github.com/pulumi/pulumi-${PULUMI_LANG}/releases/download/${TAG}/${ARCHIVE}.zip"
 
-      OUTDIR="$DIST_OS-$RENAMED_ARCH"
+        OUTDIR="$DIST_OS-$RENAMED_ARCH"
 
-      mkdir -p $OUTDIR
-      find '.' -name "*-$DIST_OS-$DIST_ARCH.tar.gz" -print0 -exec tar -xzvf {} -C $OUTDIR \;
-      find '.' -name "*-$DIST_OS-$DIST_ARCH.zip" -print0 -exec unzip {} -d $OUTDIR \;
+        mkdir -p $OUTDIR
+        find '.' -name "*-$DIST_OS-$DIST_ARCH.tar.gz" -print0 -exec tar -xzvf {} -C $OUTDIR \;
+        find '.' -name "*-$DIST_OS-$DIST_ARCH.zip" -print0 -exec unzip {} -d $OUTDIR \;
+      done
     done
-  done
-
-  cd ../..
+  )
 done

--- a/scripts/prep-for-goreleaser.sh
+++ b/scripts/prep-for-goreleaser.sh
@@ -1,22 +1,53 @@
 #!/bin/bash
 
+# When run by goreleaser, FILTER_OS and DEST_DIR are blank, so files are installed in:
+#
+# * ./bin/darwin
+# * ./bin/linux
+# * ./bin/windows
+#
+# Allowing us to customize the archives for each.
+#
+# When run by GitHub Actions in tests, we set the first arg, FILTER_OS, so that
+# we install only the current OS's binaries and in the shared "local path" dir, ./bin
+FILTER_OS="$1"
+
 COMMIT_TIME=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d%H%M')
 
 install_file () {
     src="$1"
-    dest=$(basename "$src")
-    cp "$src" "$dest"
-    touch -t "$COMMIT_TIME" "$dest"
+    shift
+
+    for OS in "$@"; do # for each argument after the first:
+        DESTDIR="bin"
+        if [ -n "${FILTER_OS}" ]; then
+            if [ "${FILTER_OS}" != "${OS}" ]; then
+                continue
+            fi
+        else
+            DESTDIR="bin/${OS}"
+        fi
+        mkdir -p "${DESTDIR}"
+        dest=$(basename "${src}")
+        cp "$src" "${DESTDIR}/${dest}"
+        touch -t "${COMMIT_TIME}" "$dest"
+    done
 }
 
-install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
-install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
-install_file sdk/python/dist/pulumi-resource-pulumi-python .
-install_file sdk/python/dist/pulumi-resource-pulumi-python.cmd .
-install_file sdk/python/dist/pulumi-python3-shim.cmd .
-install_file sdk/python/dist/pulumi-python-shim.cmd .
-install_file sdk/nodejs/dist/pulumi-analyzer-policy .
-install_file sdk/nodejs/dist/pulumi-analyzer-policy.cmd .
-install_file sdk/python/dist/pulumi-analyzer-policy-python .
-install_file sdk/python/dist/pulumi-analyzer-policy-python.cmd .
-install_file sdk/python/cmd/pulumi-language-python-exec .
+rm -rf ./bin
+install_file sdk/nodejs/dist/pulumi-analyzer-policy                         linux   darwin
+install_file sdk/nodejs/dist/pulumi-analyzer-policy.cmd                     windows
+
+install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs                  linux   darwin
+install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd              windows
+
+install_file sdk/python/dist/pulumi-analyzer-policy-python                  linux   darwin
+install_file sdk/python/dist/pulumi-analyzer-policy-python.cmd              windows
+
+install_file sdk/python/dist/pulumi-resource-pulumi-python                  linux   darwin
+install_file sdk/python/dist/pulumi-resource-pulumi-python.cmd              windows
+
+install_file sdk/python/dist/pulumi-python-shim.cmd                         windows
+install_file sdk/python/dist/pulumi-python3-shim.cmd                        windows
+
+install_file sdk/python/cmd/pulumi-language-python-exec          linux darwin windows


### PR DESCRIPTION
Run a sampling of integration tests on MacOS and Windows only, and adds that same set of tests to Linux.

This changes the number of test jobs:
* MacOS from 7 to 1
* Windows from 7 to 1
* Linux from 7 to 8

The build jobs which run on MacOS are not changed.

Each commit should be descriptive of its content. The change to the goreleaser configs aims to reduce duplication and aid brevity. The biggest change to goreleaser configuration is the removal of the separate "build IDs" and archives for nix-like and Windows. Instead, the `prepare-for-goreleaser` script prepares `./bin/${GOOS}` directories for the final assembly of extra files into the archives. This simplifies the archive config to the following:

```yaml
archives:
- wrap_in_directory: pulumi
  format_overrides:
    - goos: windows
      format: zip
  replacements:
    amd64: x64
  files:
    - src: bin/{{ .Os }}/*
      dst: '.'
      strip_parent: true
  name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
```

The `prepare-for-goreleaser` script takes an optional GOOS argument now, which if set will put _only_ that target's dependencies in `./bin`.

Attempts to further alter or simplify GoReleaser config were not successful - there isn't an easy way to run a "single target" step that produces the final archives in multiple jobs. An upstream discussion was created here: https://github.com/goreleaser/goreleaser/discussions/3242