### PR TITLE
Support PULUMI_PYTHON_CMD with venvs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,3 +18,6 @@
 - [codegen/go] Support program generation, `pulumi convert` for programs that create explicit
   provider resources.
   [#10132](https://github.com/pulumi/pulumi/issues/10132)
+
+- [python] PULUMI_PYTHON_CMD is checked for deciding what python binary to use in a virtual environment.
+  [#10155](https://github.com/pulumi/pulumi/pull/10155)

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -604,7 +604,13 @@ func runPythonCommand(ctx context.Context, virtualenv, cwd string, arg ...string
 	var err error
 	var cmd *exec.Cmd
 	if virtualenv != "" {
-		cmd = python.VirtualEnvCommand(virtualenv, "python", arg...)
+		// Default to the "python" executable in the virtual environment, but allow the user to override it
+		// with PULUMI_PYTHON_CMD.
+		pythonCmd := os.Getenv("PULUMI_PYTHON_CMD")
+		if pythonCmd == "" {
+			pythonCmd = "python"
+		}
+		cmd = python.VirtualEnvCommand(virtualenv, pythonCmd, arg...)
 	} else {
 		cmd, err = python.Command(ctx, arg...)
 		if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When not using a virtual environment we look at the PULUMI_PYTHON_CMD to control what python binary to run (defaulting to looking for "python" or "python3" if it's not set).

This adds a check for this variable when using a virtual environment allowing a user to change from "python", if for example they want to force something like "python39".

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
