### PR TITLE
Remove As[Q]Name functions

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,3 +18,6 @@
 - [codegen/go] Support program generation, `pulumi convert` for programs that create explicit
   provider resources.
   [#10132](https://github.com/pulumi/pulumi/issues/10132)
+
+- [sdk/go] Remove the `AsName` and `AsQName` asserting functions.
+  [#10156](https://github.com/pulumi/pulumi/pull/10156)

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -350,7 +350,7 @@ func (d *defaultProviders) handleRequest(req providers.ProviderRequest) (provide
 	}
 	if denyCreation {
 		logging.V(5).Infof("denied default provider request for package %s", req)
-		return providers.NewDenyDefaultProvider(tokens.AsQName(string(req.Package().Name()))), nil
+		return providers.NewDenyDefaultProvider(tokens.QName(string(req.Package().Name()))), nil
 	}
 
 	// Have we loaded this provider before? Use the existing reference, if so.

--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -43,12 +43,6 @@ func IsName(s string) bool {
 	return s != "" && NameRegexp.FindString(s) == s
 }
 
-// AsName converts a given string to a Name, asserting its validity.
-func AsName(s string) Name {
-	contract.Assertf(IsName(s), "Expected string '%v' to be a name (%v)", s, NameRegexpPattern)
-	return Name(s)
-}
-
 // QName is a qualified identifier.  The "/" character optionally delimits different pieces of the name.  Each element
 // conforms to NameRegexpPattern.  For example, "pulumi/pulumi/stack".
 type QName string
@@ -89,13 +83,7 @@ func IntoQName(s string) QName {
 	if result == "" {
 		result = "_"
 	}
-	return AsQName(result)
-}
-
-// AsQName converts a given string to a QName, asserting its validity.
-func AsQName(s string) QName {
-	contract.Assertf(IsQName(s), "Expected string '%v' to be a name (%v)", s, QNameRegexpPattern)
-	return QName(s)
+	return QName(result)
 }
 
 // Name extracts the Name portion of a QName (dropping any namespace).

--- a/sdk/go/common/tokens/names_test.go
+++ b/sdk/go/common/tokens/names_test.go
@@ -39,7 +39,6 @@ func TestIsAsName(t *testing.T) {
 	}
 	for _, nm := range goodNames {
 		assert.True(t, IsName(nm), "IsName expected to be true: %v", nm)
-		assert.Equal(t, nm, string(AsName(nm)), "AsName expected to echo back: %v", nm)
 	}
 
 	var goodQNames = []string{
@@ -50,7 +49,6 @@ func TestIsAsName(t *testing.T) {
 	for _, nm := range goodQNames {
 		assert.True(t, IsQName(nm), "IsQName expected to be true: %v", nm)
 		assert.False(t, IsName(nm), "IsName expected to be false: %v", nm)
-		assert.Equal(t, nm, string(AsQName(nm)), "AsQName expected to echo back: %v", nm)
 	}
 
 	var badNames = []string{
@@ -66,17 +64,17 @@ func TestIsAsName(t *testing.T) {
 
 func TestNameSimple(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "simple", string(AsName("simple")))
-	assert.Equal(t, "complex", string(AsQName("namespace/complex").Name()))
-	assert.Equal(t, "complex", string(AsQName("ns1/ns2/ns3/ns4/complex").Name()))
-	assert.Equal(t, "c0Mpl3x_", string(AsQName("_/_/_/_/a0/c0Mpl3x_").Name()))
+	assert.Equal(t, "simple", string(Name("simple")))
+	assert.Equal(t, "complex", string(QName("namespace/complex").Name()))
+	assert.Equal(t, "complex", string(QName("ns1/ns2/ns3/ns4/complex").Name()))
+	assert.Equal(t, "c0Mpl3x_", string(QName("_/_/_/_/a0/c0Mpl3x_").Name()))
 }
 
 func TestNameNamespace(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "namespace", string(AsQName("namespace/complex").Namespace()))
-	assert.Equal(t, "ns1/ns2/ns3/ns4", string(AsQName("ns1/ns2/ns3/ns4/complex").Namespace()))
-	assert.Equal(t, "_/_/_/_/a0", string(AsQName("_/_/_/_/a0/c0Mpl3x_").Namespace()))
+	assert.Equal(t, "namespace", string(QName("namespace/complex").Namespace()))
+	assert.Equal(t, "ns1/ns2/ns3/ns4", string(QName("ns1/ns2/ns3/ns4/complex").Namespace()))
+	assert.Equal(t, "_/_/_/_/a0", string(QName("_/_/_/_/a0/c0Mpl3x_").Namespace()))
 }
 
 func TestIntoQName(t *testing.T) {
@@ -98,7 +96,7 @@ func TestIntoQName(t *testing.T) {
 		c := c
 		t.Run(c.input, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, AsQName(c.expected), IntoQName(c.input))
+			assert.Equal(t, QName(c.expected), IntoQName(c.input))
 		})
 	}
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Doesn't look like these are used by anything, so preferring to just remove them rather than documenting them as dangerous.

Fixes https://github.com/pulumi/pulumi/issues/10052

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
