### PR TITLE
Fix AddRemoveListPlugins in dotnet automation tests on M1

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -117,24 +117,27 @@ namespace Pulumi.Automation.Tests
         [Fact]
         public async Task AddRemoveListPlugins()
         {
+            // verion for the aws plugin
+            var version = "5.10.0";
+            var plugin = "aws";
             using var workspace = await LocalWorkspace.CreateAsync();
 
             var plugins = await workspace.ListPluginsAsync();
-            if (plugins.Any(p => p.Name == "aws" && p.Version == "3.0.0"))
+            if (plugins.Any(p => p.Name == plugin && p.Version == version))
             {
-                await workspace.RemovePluginAsync("aws", "3.0.0");
+                await workspace.RemovePluginAsync(plugin, version);
                 plugins = await workspace.ListPluginsAsync();
-                Assert.DoesNotContain(plugins, p => p.Name == "aws" && p.Version == "3.0.0");
+                Assert.DoesNotContain(plugins, p => p.Name == plugin && p.Version == version);
             }
 
-            await workspace.InstallPluginAsync("aws", "v3.0.0");
+            await workspace.InstallPluginAsync(plugin, $"v{version}");
             plugins = await workspace.ListPluginsAsync();
-            var aws = plugins.FirstOrDefault(p => p.Name == "aws" && p.Version == "3.0.0");
+            var aws = plugins.FirstOrDefault(p => p.Name == plugin && p.Version == version);
             Assert.NotNull(aws);
 
-            await workspace.RemovePluginAsync("aws", "3.0.0");
+            await workspace.RemovePluginAsync(plugin, version);
             plugins = await workspace.ListPluginsAsync();
-            Assert.DoesNotContain(plugins, p => p.Name == "aws" && p.Version == "3.0.0");
+            Assert.DoesNotContain(plugins, p => p.Name == plugin && p.Version == version);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

This test `AddRemoveListPlugins()` attempts to install `aws` plugin version `3.0.0` and because I am running on M1, it resolves `pulumi-resource-aws-v3.0.0-darwin-arm64.tar.gz` but `pulumi-resource-aws` didn't publish `darwin-arm64` binaries for version `3.0.0` so this PR bumps the version to 5.10.0 which _does_ have `darwin-arm64` binaries published

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
