### PR TITLE
Remove api/renewLease from startup crit path

### DIFF
--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -57,11 +57,11 @@ func newTokenSource(
 
 	requests, done := make(chan tokenRequest), make(chan bool)
 	ts := &tokenSource{requests: requests, done: done}
-	go ts.handleRequsts(ctx, initialToken, backend.client, update, duration)
+	go ts.handleRequests(ctx, initialToken, backend.client, update, duration)
 	return ts, nil
 }
 
-func (ts *tokenSource) handleRequsts(
+func (ts *tokenSource) handleRequests(
 	ctx context.Context,
 	initialToken string,
 	client *client.Client,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Before the changes, the trace of `pulumi preview` on new AWS project shows `api/renewLease` call on the critical path-to-first-resource, something we are trying to optimize. After the changes the call either never happens on short programs. This seems like a small win. For me this is about 120ms.

Relevant context on where tokens come from and how it flows through the code:

```go
   func (b *cloudBackend) apply(...) {

        // createAndStartUpdate makes the initial token
        // it is Seen as "api/startUpdate" operation in the trace
        // example:
        //
        // POST /api/stacks/t0yv0/perf-js-test/dev/update/6c834f3e-2fba-4286-b317-1ec66cb8e697

	..., token, ... := b.createAndStartUpdate(...) // POST /update/..
        b.runEngineAction(... token ...)
   }

   func (b *cloudBackend) runEngineAction(... token ...) {
	.. := b.newUpdate(... token ...)
   }

   func (b *cloudBackend) newUpdate(... token ...) {
	// Create a token source for this update if necessary.
	var tokenSource *tokenSource
	if token != "" {
		ts, err := newTokenSource(ctx, token, b, update, 5*time.Minute)
		if err != nil {
			return nil, err
		}
		tokenSource = ts
	}
   }
```

It seems that newTokenSource should not refresh the token right away it should be fresh still.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
