### PR TITLE
Add mock pulumi package

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,9 @@
 - [cli/config] Allow `pulumi config cp --path` between objects.
   [#10147](https://github.com/pulumi/pulumi/pull/10147)
 
+- [codegen/schema] Support stack reference as a resource
+  [#10163](https://github.com/pulumi/pulumi/pull/10163)
+
 ### Bug Fixes
 
 - [cli] Only log github request headers at log level 11.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,7 +11,7 @@
   [#10147](https://github.com/pulumi/pulumi/pull/10147)
 
 - [codegen/schema] Support stack reference as a resource
-  [#10163](https://github.com/pulumi/pulumi/pull/10163)
+  [#10171](https://github.com/pulumi/pulumi/pull/10171)
 
 ### Bug Fixes
 

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -198,6 +198,10 @@ func schemaIsEmpty(schemaBytes []byte) bool {
 }
 
 func (l *pluginLoader) LoadPackageReference(pkg string, version *semver.Version) (PackageReference, error) {
+	if pkg == "pulumi" {
+		return DefaultPulumiPackageReference, nil
+	}
+
 	l.m.Lock()
 	defer l.m.Unlock()
 

--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -1,0 +1,121 @@
+package schema
+
+import (
+	"github.com/blang/semver"
+)
+
+const (
+	pulumiPkgName = "pulumi"
+)
+
+type pulumiPackageReference struct {
+	name        string
+	version     *semver.Version
+	description string
+	types       PackageTypes
+	config      []*Property
+	provider    *Resource
+	resources   PackageResources
+	functions   PackageFunctions
+	module      string
+	packageFull *Package
+}
+
+func newPulumiPackageReference(name string, version *semver.Version, description string, types PackageTypes,
+	config []*Property, provider *Resource, resources PackageResources,
+	functions PackageFunctions, module string, packageFull *Package) *pulumiPackageReference {
+	return &pulumiPackageReference{
+		name:        name,
+		version:     version,
+		description: description,
+		types:       types,
+		config:      config,
+		provider:    provider,
+		resources:   resources,
+		functions:   functions,
+		module:      module,
+		packageFull: packageFull,
+	}
+}
+
+func (p *pulumiPackageReference) Name() string {
+	return p.name
+}
+
+func (p *pulumiPackageReference) Version() *semver.Version {
+	return p.version
+}
+
+func (p *pulumiPackageReference) Description() string {
+	return p.description
+}
+
+func (p *pulumiPackageReference) Config() ([]*Property, error) {
+	return p.config, nil
+}
+
+func (p *pulumiPackageReference) Provider() (*Resource, error) {
+	return p.provider, nil
+}
+
+func (p *pulumiPackageReference) Resources() PackageResources {
+	return p.resources
+}
+
+func (p *pulumiPackageReference) Functions() PackageFunctions {
+	return p.functions
+}
+
+func (p *pulumiPackageReference) Types() PackageTypes {
+	return p.types
+}
+
+func (p *pulumiPackageReference) TokenToModule(token string) string {
+	return p.module
+}
+
+func (p *pulumiPackageReference) Definition() (*Package, error) {
+	return p.packageFull, nil
+}
+
+var DefaultPulumiPackageReference = newPulumiPackageReference(DefaultPulumiPackage.Name,
+	DefaultPulumiPackage.Version, DefaultPulumiPackage.Description, DefaultPulumiPackage.Reference().Types(),
+	DefaultPulumiPackage.Config, DefaultPulumiPackage.Provider, DefaultPulumiPackage.Reference().Resources(),
+	DefaultPulumiPackage.Reference().Functions(), pulumiPkgName, &DefaultPulumiPackage)
+
+var DefaultPulumiPackage = Package{
+	Name:        pulumiPkgName,
+	DisplayName: "Pulumi",
+	Version: &semver.Version{
+		Major: 1,
+		Minor: 0,
+		Patch: 0,
+	},
+	Description: "mock pulumi package",
+	Types:       []Type{},
+	Config:      []*Property{},
+	Provider:    &Resource{},
+	Resources: []*Resource{
+		&stackReferenceResource,
+	},
+
+	resourceTable: map[string]*Resource{
+		"pulumi:pulumi:StackReference": &stackReferenceResource,
+	},
+}
+
+var stackReferenceResource = Resource{
+	Token: "pulumi:pulumi:StackReference",
+	InputProperties: []*Property{
+		{
+			Name: "name",
+			Type: StringType,
+		},
+	},
+	Properties: []*Property{
+		{
+			Name: "outputs",
+			Type: &MapType{},
+		},
+	},
+}


### PR DESCRIPTION
# Description

Return a mocked pulumi package so in pulumi-yaml, resources such as `StackReference` can be instantiated, rather than relying on `Fn::StackReference`

Fixes # (issue)

Addresses `pulumi-yaml`[#198](https://github.com/pulumi/pulumi-yaml/issues/198)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
