### PR TITLE
feat: Ability to capture incremental stderr

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,9 @@
 ### Improvements
 
+- [auto/go] Adds the ability to capture incremental `stderr`
+  via the new option `ErrorProgressStreams`.
+  [#10179](https://github.com/pulumi/pulumi/pull/10179)
+
 - [cli/plugins] Warn that using GITHUB_REPOSITORY_OWNER is deprecated.
   [#10142](https://github.com/pulumi/pulumi/pull/10142)
 

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -28,6 +28,7 @@ func runPulumiCommandSync(
 	ctx context.Context,
 	workdir string,
 	additionalOutput []io.Writer,
+	additionalErrorOutput []io.Writer,
 	additionalEnv []string,
 	args ...string,
 ) (string, string, int, error) {
@@ -41,8 +42,9 @@ func runPulumiCommandSync(
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	additionalOutput = append(additionalOutput, &stdout)
+	additionalErrorOutput = append(additionalErrorOutput, &stderr)
 	cmd.Stdout = io.MultiWriter(additionalOutput...)
-	cmd.Stderr = &stderr
+	cmd.Stderr = io.MultiWriter(additionalErrorOutput...)
 
 	code := unknownErrorCode
 	err := cmd.Run()

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -547,7 +547,13 @@ func (l *LocalWorkspace) runPulumiCmdSync(
 			env = append(env, strings.Join(e, "="))
 		}
 	}
-	return runPulumiCommandSync(ctx, l.WorkDir(), nil /* additionalOutputs */, env, args...)
+	return runPulumiCommandSync(ctx,
+		l.WorkDir(),
+		nil, /* additionalOutputs */
+		nil, /* additionalErrorOutputs */
+		env,
+		args...,
+	)
 }
 
 // NewLocalWorkspace creates and configures a LocalWorkspace. LocalWorkspaceOptions can be used to

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -52,10 +52,17 @@ func TargetDependents() Option {
 	})
 }
 
-// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy output
+// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy stdout
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ProgressStreams = writers
+	})
+}
+
+// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental destroy stderr
+func ErrorProgressStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ErrorProgressStreams = writers
 	})
 }
 
@@ -105,8 +112,10 @@ type Options struct {
 	Target []string
 	// Allows updating of dependent targets discovered but not specified in the Target list
 	TargetDependents bool
-	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy output
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy stdout
 	ProgressStreams []io.Writer
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy stderr
+	ErrorProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
 	EventStreams []chan<- events.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -80,10 +80,17 @@ func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	})
 }
 
-// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview output
+// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview stdout
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ProgressStreams = writers
+	})
+}
+
+// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental preview stderr
+func ErrorProgressStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ErrorProgressStreams = writers
 	})
 }
 
@@ -134,8 +141,10 @@ type Options struct {
 	TargetDependents bool
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
-	// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview output
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview stdout
 	ProgressStreams []io.Writer
+	// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental preview stderr
+	ErrorProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
 	EventStreams []chan<- events.EngineEvent
 	// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -52,10 +52,17 @@ func Target(urns []string) Option {
 	})
 }
 
-// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh output
+// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stdout
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ProgressStreams = writers
+	})
+}
+
+// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stderr
+func ErrorProgressStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ErrorProgressStreams = writers
 	})
 }
 
@@ -105,8 +112,10 @@ type Options struct {
 	ExpectNoChanges bool
 	// Specify an exclusive list of resource URNs to re
 	Target []string
-	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh output
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stdout
 	ProgressStreams []io.Writer
+	// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental refresh stderr
+	ErrorProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
 	EventStreams []chan<- events.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -73,10 +73,17 @@ func TargetDependents() Option {
 	})
 }
 
-// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
+// ProgressStreams allows specifying one or more io.Writers to redirect incremental update stdout
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ProgressStreams = writers
+	})
+}
+
+// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental update stderr
+func ErrorProgressStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ErrorProgressStreams = writers
 	})
 }
 
@@ -141,8 +148,10 @@ type Options struct {
 	TargetDependents bool
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
-	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update stdout
 	ProgressStreams []io.Writer
+	// ErrorProgressStreams allows specifying one or more io.Writers to redirect incremental update stderr
+	ErrorProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
 	EventStreams []chan<- events.EngineEvent
 	// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Exposes a new `Option` `ErrorProgressStreams` in the Automation API
that allows `stderr` to be redirected to one or more `io.Writers`.

The option is available for `refresh`, `destroy`, `preview` and `update`
operations. This will allow an enduser to tap into the ongoing stream
for `stderr`. Until now only concatenated `string` of outputs containing
all events was available in the returned result of an operation.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
