### PR TITLE
Avoid importing typescript unless necessary

### DIFF
--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
 import * as grpc from "@grpc/grpc-js";
 import { isGrpcError, ResourceError, RunError } from "../errors";
 import * as log from "../log";
-import * as runtime from "../runtime";
+import * as settings from "../runtime/settings";
+import * as stack from "../runtime/stack";
+import * as runtimeConfig from "../runtime/config";
+import * as debuggable from "../runtime/debuggable";
 
 const langproto = require("../proto/language_pb.js");
 const plugproto = require("../proto/plugin_pb.js");
@@ -40,19 +43,19 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
 
         // set a bit in runtime settings to indicate that we're running in inline mode.
         // this allows us to detect and fail fast for side by side pulumi scenarios.
-        runtime.setInline();
+        settings.setInline();
     }
 
     onPulumiExit(hasError: boolean) {
         // check for leaks once the CLI exits but skip if the program otherwise errored to keep error output clean
         if (!hasError) {
-            const [leaks, leakMessage] = runtime.leakedPromises();
+            const [leaks, leakMessage] = debuggable.leakedPromises();
             if (leaks.size !== 0) {
                 throw new Error(leakMessage);
             }
         }
         // these are globals and we need to clean up after ourselves
-        runtime.resetOptions("", "", -1, "", "", false);
+        settings.resetOptions("", "", -1, "", "", false);
     }
 
     getRequiredPlugins(call: any, callback: any): void {
@@ -73,14 +76,14 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
             const args = req.getArgsList();
             const engineAddr = args && args.length > 0 ? args[0] : "";
 
-            runtime.resetOptions(req.getProject(), req.getStack(), req.getParallel(), engineAddr,
+            settings.resetOptions(req.getProject(), req.getStack(), req.getParallel(), engineAddr,
                 req.getMonitorAddress(), req.getDryrun());
 
             const config: {[key: string]: string} = {};
             for (const [k, v] of req.getConfigMap()?.entries() || []) {
                 config[<string>k] = <string>v;
             }
-            runtime.setAllConfig(config, req.getConfigsecretkeysList() || []);
+            runtimeConfig.setAllConfig(config, req.getConfigsecretkeysList() || []);
 
             process.on("uncaughtException", uncaughtHandler);
             // @ts-ignore 'unhandledRejection' will almost always invoke uncaughtHandler with an Error. so
@@ -88,12 +91,12 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
             process.on("unhandledRejection", uncaughtHandler);
 
             try {
-                await runtime.runInPulumiStack(this.program);
-                await runtime.disconnect();
+                await stack.runInPulumiStack(this.program);
+                await settings.disconnect();
                 process.off("uncaughtException", uncaughtHandler);
                 process.off("unhandledRejection", uncaughtHandler);
             } catch (e) {
-                await runtime.disconnect();
+                await settings.disconnect();
                 process.off("uncaughtException", uncaughtHandler);
                 process.off("unhandledRejection", uncaughtHandler);
 

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 import * as grpc from "@grpc/grpc-js";
 
 import * as dynamic from "../../dynamic";
-import * as runtime from "../../runtime";
+import * as rpc from "../../runtime/rpc";
 import { version } from "../../version";
 
 const requireFromString = require("require-from-string");
@@ -109,7 +109,7 @@ async function checkRPC(call: any, callback: any): Promise<void> {
 
         const olds = req.getOlds().toJavaScript();
         const news = req.getNews().toJavaScript();
-        const provider = getProvider(news[providerKey] === runtime.unknownValue ? olds : news);
+        const provider = getProvider(news[providerKey] === rpc.unknownValue ? olds : news);
 
         let inputs: any = news;
         let failures: any[] = [];
@@ -169,7 +169,7 @@ async function diffRPC(call: any, callback: any): Promise<void> {
         // time the provider was updated.
         const olds = req.getOlds().toJavaScript();
         const news = req.getNews().toJavaScript();
-        const provider = getProvider(news[providerKey] === runtime.unknownValue ? olds : news);
+        const provider = getProvider(news[providerKey] === rpc.unknownValue ? olds : news);
         if (provider.diff) {
             const result: any = await provider.diff(req.getId(), olds, news);
 

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -16,7 +16,7 @@ import * as fs from "fs";
 import * as minimist from "minimist";
 import * as path from "path";
 import * as tsnode from "ts-node";
-import { parseConfigFileTextToJson } from "typescript";
+import * as tsutils from "../../tsutils";
 import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
 import * as settings from "../../runtime/settings";
@@ -165,18 +165,10 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
     // just tell ts-node to not load project options at all. This helps with cases like
     // pulumi/pulumi#1772.
     const tsConfigPath = "tsconfig.json";
-    const skipProject = !fs.existsSync(tsConfigPath);
-
-    let compilerOptions: object;
-    try {
-        const tsConfigString = fs.readFileSync(tsConfigPath).toString();
-        const tsConfig = parseConfigFileTextToJson(tsConfigPath, tsConfigString).config;
-        compilerOptions = tsConfig["compilerOptions"] ?? {};
-    } catch (e) {
-        compilerOptions = {};
-    }
 
     if (opts.typeScript) {
+        const skipProject = !fs.existsSync(tsConfigPath);
+        const compilerOptions: object = tsutils.loadTypeScriptCompilerOptions(tsConfigPath);
         tsnode.register({
             typeCheck: true,
             skipProject: skipProject,

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -169,7 +169,8 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
     if (opts.typeScript) {
         const skipProject = !fs.existsSync(tsConfigPath);
         const compilerOptions: object = tsutils.loadTypeScriptCompilerOptions(tsConfigPath);
-        tsnode.register({
+        const tsn: typeof tsnode = require("ts-node");
+        tsn.register({
             typeCheck: true,
             skipProject: skipProject,
             compilerOptions: {

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ import * as tsnode from "ts-node";
 import { parseConfigFileTextToJson } from "typescript";
 import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
-import * as runtime from "../../runtime";
+import * as settings from "../../runtime/settings";
+import * as stack from "../../runtime/stack";
 
 // Keep track if we already logged the information about an unhandled error to the user..  If
 // so, we end with a different exit code.  The language host recognizes this and will not print
@@ -242,7 +243,7 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
     // @ts-ignore 'unhandledRejection' will almost always invoke uncaughtHandler with an Error. so
     // just suppress the TS strictness here.
     process.on("unhandledRejection", uncaughtHandler);
-    process.on("exit", runtime.disconnectSync);
+    process.on("exit", settings.disconnectSync);
 
     opts.programStarted();
 
@@ -286,5 +287,5 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
         }
     };
 
-    return opts.runInStack ? runtime.runInPulumiStack(runProgram) : runProgram();
+    return opts.runInStack ? stack.runInPulumiStack(runProgram) : runProgram();
 }

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -189,8 +189,8 @@ export function run(
     if (typeScript) {
         const transpileOnly = (process.env["PULUMI_NODEJS_TRANSPILE_ONLY"] ?? "false") === "true";
         const compilerOptions = tsutils.loadTypeScriptCompilerOptions(tsConfigPath);
-
-        tsnode.register({
+        const tsn: typeof tsnode = require("ts-node");
+        tsn.register({
             transpileOnly,
             // PULUMI_NODEJS_TSCONFIG_PATH might be set to a config file such as "tsconfig.pulumi.yaml" which
             // would not get picked up by tsnode by default, so we explicitly tell tsnode which config file to

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -23,6 +23,7 @@ import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
 import * as stack from "../../runtime/stack";
 import * as settings from "../../runtime/settings";
+import * as tsutils from "../../tsutils";
 import { Inputs } from "../../output";
 
 import * as mod from ".";
@@ -187,7 +188,7 @@ export function run(
 
     if (typeScript) {
         const transpileOnly = (process.env["PULUMI_NODEJS_TRANSPILE_ONLY"] ?? "false") === "true";
-        const compilerOptions = loadCompilerOptions(tsConfigPath);
+        const compilerOptions = tsutils.loadTypeScriptCompilerOptions(tsConfigPath);
 
         tsnode.register({
             transpileOnly,
@@ -363,18 +364,4 @@ ${defaultMessage}`);
 
     // Construct a `Stack` resource to represent the outputs of the program.
     return stack.runInPulumiStack(runProgram);
-}
-
-function loadCompilerOptions(tsConfigPath: string): object {
-    try {
-        const tsConfigString = fs.readFileSync(tsConfigPath).toString();
-        // Using local `require("typescript")` to avoid always loading
-        // and only load on-demand, avoid up to 300s overhead in Node runtime.
-        const typescript = require("typescript");
-        const tsConfig = typescript.parseConfigFileTextToJson(tsConfigPath, tsConfigString).config;
-        return tsConfig["compilerOptions"] ?? {};
-    } catch (err) {
-        log.debug(`Ignoring error in loadCompilerOptions(${tsConfigPath}}): ${err}`);
-        return {};
-    }
 }

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ import * as path from "path";
 import * as tsnode from "ts-node";
 import * as ini from "ini";
 import * as semver from "semver";
-import { parseConfigFileTextToJson } from "typescript";
 import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
-import * as runtime from "../../runtime";
+import * as stack from "../../runtime/stack";
+import * as settings from "../../runtime/settings";
 import { Inputs } from "../../output";
 
 import * as mod from ".";
@@ -185,18 +185,10 @@ export function run(
     const tsConfigPath: string = process.env["PULUMI_NODEJS_TSCONFIG_PATH"] ?? defaultTsConfigPath;
     const skipProject = !fs.existsSync(tsConfigPath);
 
-    const transpileOnly = (process.env["PULUMI_NODEJS_TRANSPILE_ONLY"] ?? "false") === "true";
-
-    let compilerOptions: object;
-    try {
-        const tsConfigString = fs.readFileSync(tsConfigPath).toString();
-        const tsConfig = parseConfigFileTextToJson(tsConfigPath, tsConfigString).config;
-        compilerOptions = tsConfig["compilerOptions"] ?? {};
-    } catch (e) {
-        compilerOptions = {};
-    }
-
     if (typeScript) {
+        const transpileOnly = (process.env["PULUMI_NODEJS_TRANSPILE_ONLY"] ?? "false") === "true";
+        const compilerOptions = loadCompilerOptions(tsConfigPath);
+
         tsnode.register({
             transpileOnly,
             // PULUMI_NODEJS_TSCONFIG_PATH might be set to a config file such as "tsconfig.pulumi.yaml" which
@@ -264,7 +256,7 @@ ${defaultMessage}`);
     // @ts-ignore 'unhandledRejection' will almost always invoke uncaughtHandler with an Error. so
     // just suppress the TS strictness here.
     process.on("unhandledRejection", uncaughtHandler);
-    process.on("exit", runtime.disconnectSync);
+    process.on("exit", settings.disconnectSync);
 
     programStarted();
 
@@ -370,5 +362,19 @@ ${defaultMessage}`);
     };
 
     // Construct a `Stack` resource to represent the outputs of the program.
-    return runtime.runInPulumiStack(runProgram);
+    return stack.runInPulumiStack(runProgram);
+}
+
+function loadCompilerOptions(tsConfigPath: string): object {
+    try {
+        const tsConfigString = fs.readFileSync(tsConfigPath).toString();
+        // Using local `require("typescript")` to avoid always loading
+        // and only load on-demand, avoid up to 300s overhead in Node runtime.
+        const typescript = require("typescript");
+        const tsConfig = typescript.parseConfigFileTextToJson(tsConfigPath, tsConfigString).config;
+        return tsConfig["compilerOptions"] ?? {};
+    } catch (err) {
+        log.debug(`Ignoring error in loadCompilerOptions(${tsConfigPath}}): ${err}`);
+        return {};
+    }
 }

--- a/sdk/nodejs/config.ts
+++ b/sdk/nodejs/config.ts
@@ -15,7 +15,7 @@
 import { RunError } from "./errors";
 import { getProject } from "./metadata";
 import { Output } from "./output";
-import { getConfig } from "./runtime";
+import { getConfig } from "./runtime/config";
 
 function makeSecret<T>(value: T): Output<T> {
     return new Output(

--- a/sdk/nodejs/metadata.ts
+++ b/sdk/nodejs/metadata.ts
@@ -14,17 +14,17 @@
 
 // This file exports metadata about the context in which a program is being run.
 
-import * as runtime from "./runtime";
+import * as settings from "./runtime/settings";
 
 /**
  * getProject returns the current project name.  It throws an exception if none is registered.
  */
 export function getProject(): string {
-    return runtime.getProject();
+    return settings.getProject();
 }
 /**
  * getStack returns the current stack name.  It throws an exception if none is registered.
  */
 export function getStack(): string {
-    return runtime.getStack();
+    return settings.getStack();
 }

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { Resource } from "./resource";
-import * as runtime from "./runtime";
+import * as settings from "./runtime/settings";
 import * as utils from "./utils";
 
 /* eslint-disable no-shadow, @typescript-eslint/no-shadow */
@@ -357,7 +357,7 @@ async function liftInnerOutput(allResources: Set<Resource>, value: any, isKnown:
 async function applyHelperAsync<T, U>(
     allResources: Set<Resource>, value: T, isKnown: boolean, isSecret: boolean,
     func: (t: T) => Input<U>, runWithUnknowns: boolean) {
-    if (runtime.isDryRun()) {
+    if (settings.isDryRun()) {
         // During previews only perform the apply if the engine was able to give us an actual value
         // for this Output.
         const applyDuringPreview = isKnown || runWithUnknowns;

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -16,7 +16,7 @@ import { ResourceError } from "./errors";
 import { Input, Inputs, interpolate, Output, output } from "./output";
 import { getResource, readResource, registerResource, registerResourceOutputs } from "./runtime/resource";
 import { getProject, getStack } from "./runtime/settings";
-import * as stack from "./runtime/stack";
+import * as stacklib from "./runtime/stack";
 import { unknownValue } from "./runtime/rpc";
 import * as utils from "./utils";
 import * as log from "./log";
@@ -1113,6 +1113,6 @@ export function parseResourceReference(ref: string): [string, string] {
 
 function getStackResource(): ComponentResource | undefined {
     // break the module import cycle between this module and "./runtime/stack".
-    const s: typeof stack = require("./runtime/stack");
-    return s.getStackResource();
+    const stack: typeof stacklib = require("./runtime/stack");
+    return stack.getStackResource();
 }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -16,7 +16,7 @@ import { ResourceError } from "./errors";
 import { Input, Inputs, interpolate, Output, output } from "./output";
 import { getResource, readResource, registerResource, registerResourceOutputs } from "./runtime/resource";
 import { getProject, getStack } from "./runtime/settings";
-import { getStackResource } from "./runtime/stack";
+import * as stack from "./runtime/stack";
 import { unknownValue } from "./runtime/rpc";
 import * as utils from "./utils";
 import * as log from "./log";
@@ -1109,4 +1109,10 @@ export function parseResourceReference(ref: string): [string, string] {
     const urn = ref.slice(0, lastSep);
     const id = ref.slice(lastSep+2);
     return [urn, id];
+}
+
+function getStackResource(): ComponentResource | undefined {
+    // break the module import cycle between this module and "./runtime/stack".
+    const s: typeof stack = require("./runtime/stack");
+    return s.getStackResource();
 }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -14,9 +14,10 @@
 
 import { ResourceError } from "./errors";
 import { Input, Inputs, interpolate, Output, output } from "./output";
-import { getStackResource, unknownValue } from "./runtime";
 import { getResource, readResource, registerResource, registerResourceOutputs } from "./runtime/resource";
 import { getProject, getStack } from "./runtime/settings";
+import { getStackResource } from "./runtime/stack";
+import { unknownValue } from "./runtime/rpc";
 import * as utils from "./utils";
 import * as log from "./log";
 

--- a/sdk/nodejs/tsutils.ts
+++ b/sdk/nodejs/tsutils.ts
@@ -1,0 +1,32 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as fs from "fs";
+import * as typescript from "typescript";
+
+import * as log from "./log";
+
+export function loadTypeScriptCompilerOptions(tsConfigPath: string): object {
+    try {
+        const tsConfigString = fs.readFileSync(tsConfigPath).toString();
+        // Using local `require("typescript")` to avoid always loading
+        // and only load on-demand, avoid up to 300s overhead in Node runtime.
+        const ts: typeof typescript = require("typescript");
+        const tsConfig = ts.parseConfigFileTextToJson(tsConfigPath, tsConfigString).config;
+        return tsConfig["compilerOptions"] ?? {};
+    } catch (err) {
+        log.debug(`Ignoring error in loadCompilerOptions(${tsConfigPath}}): ${err}`);
+        return {};
+    }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The key motivation for this change is speeding up startup of small JavaScript programs. That is:

```
pulumi new javascript

# edit Pulumi.yaml to have:
# runtime:
#  name: nodejs
#  options:
#    typescript: false

time pulumi preview
# before : 1.9s
# after: 1.6s
# 300ms gained or 15%
```

This 300ms is simply is the cost of adding ts-node and typescript dependency to the imports.

Importing `"runtime"` directly considered harmful because it imports "typescript" indirectly via "closure" support.


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
