### PR TITLE
[ci] Fix extra extension in goreleaser templates

### DIFF
--- a/.goreleaser.build.yml
+++ b/.goreleaser.build.yml
@@ -56,13 +56,15 @@ builds:
 - <<: *pulumibin
   id: pulumi-language-java
   binary: pulumi-language-java
+  builder: prebuilt
   prebuilt:
-    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}
 - <<: *pulumibin
   id: pulumi-language-yaml
   binary: pulumi-language-yaml
+  builder: prebuilt
   prebuilt:
-    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}
 
 archives:
 - wrap_in_directory: pulumi

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -25,15 +25,15 @@ builds:
 - &pulumibin
   id: pulumi
   binary: pulumi
-  builder: prebuilt
   goos: ['linux', 'darwin', 'windows']
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   ignore:
     - goos: windows
       goarch: arm64
+  builder: prebuilt
   prebuilt:
-    path: goreleaser-{{ .Os }}/{{ .Name }}_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-{{ .Os }}/{{ trimsuffix .Name .Ext }}_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/{{ .Name }}
   mod_timestamp: '{{ .CommitTimestamp }}'
 - <<: *pulumibin
   id: pulumi-language-go
@@ -50,13 +50,15 @@ builds:
 - <<: *pulumibin
   id: pulumi-language-java
   binary: pulumi-language-java
+  builder: prebuilt
   prebuilt:
-    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}
 - <<: *pulumibin
   id: pulumi-language-yaml
   binary: pulumi-language-yaml
+  builder: prebuilt
   prebuilt:
-    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}
 
 archives:
 - wrap_in_directory: pulumi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,15 +19,15 @@ builds:
 - &pulumibin
   id: pulumi
   binary: pulumi
-  builder: prebuilt
   goos: ['linux', 'darwin', 'windows']
   goarch: ['amd64', 'arm64']
   goamd64: ['v1']
   ignore:
     - goos: windows
       goarch: arm64
+  builder: prebuilt
   prebuilt:
-    path: goreleaser-{{ .Os }}/{{ .Name }}_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-{{ .Os }}/{{ trimsuffix .Name .Ext }}_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/{{ .Name }}
   mod_timestamp: '{{ .CommitTimestamp }}'
 - <<: *pulumibin
   id: pulumi-language-go
@@ -45,12 +45,12 @@ builds:
   id: pulumi-language-java
   binary: pulumi-language-java
   prebuilt:
-    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-lang/java/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}
 - <<: *pulumibin
   id: pulumi-language-yaml
   binary: pulumi-language-yaml
   prebuilt:
-    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}{{ .Ext }}
+    path: goreleaser-lang/yaml/{{ .Os }}-{{ replace .Arch "amd64" "x64" }}/{{ .Name }}
 
 archives:
 - wrap_in_directory: pulumi


### PR DESCRIPTION
The `{{ .Name }}` template string in GoReleaser includes the extension, which must be stripped to use it in a `prebuilt.path`. 

Verified locally by running all three goreleaser configs with `--debug` for verbose output. The command to run the `.goreleaser.build.yml` against Windows x86-64 is:

```bash
#!/bin/bash

GOWORK=off GORELEASER_CURRENT_TAG=v3.35.0-alpha.1 GOOS=windows GOARCH=amd64 \
  goreleaser build -f .goreleaser.build.yml \
  -p 1 --skip-validate --rm-dist --snapshot --single-target

# rename dir to what .goreleaser.prerelease.yml expects as it copes in artifacts from the build job
mv goreleaser goreleaser-windows

# This will succeed with this PR's commit, where it previously would fail 🎉
GOWORK=off GORELEASER_CURRENT_TAG=v3.35.0-alpha.1 GOOS=windows GOARCH=amd64 \
  goreleaser build -f .goreleaser.prerelease.yml \
  -p 1 --skip-validate --rm-dist --snapshot --single-target
```
