### PR TITLE
Expose context.Context from pulumi.Context

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,9 @@
 - [backends] When logging in to a file backend, validate that the bucket is accessible.
   [#10012](https://github.com/pulumi/pulumi/pull/10012)
 
+- [backends] Expose context.Context from pulumi.Context
+  [#10190](https://github.com/pulumi/pulumi/pull/10190)
+
 ### Bug Fixes
 
 - [cli] Only log github request headers at log level 11.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,7 +20,7 @@
 - [backends] When logging in to a file backend, validate that the bucket is accessible.
   [#10012](https://github.com/pulumi/pulumi/pull/10012)
 
-- [backends] Expose context.Context from pulumi.Context
+- [sdk/go] Expose context.Context from pulumi.Context
   [#10190](https://github.com/pulumi/pulumi/pull/10190)
 
 ### Bug Fixes

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -146,6 +146,12 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 	return context, nil
 }
 
+
+// Context returns the base context used to instantiate the current context.
+func (ctx *Context) Context() context.Context {
+	return ctx.ctx
+}
+
 // Close implements io.Closer and relinquishes any outstanding resources held by the context.
 func (ctx *Context) Close() error {
 	if ctx.engineConn != nil {
@@ -248,6 +254,131 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 		return err
 	}
 	if provider := providers[getPackage(tok)]; provider != nil {
+		pr, err := ctx.resolveProviderReference(provider)
+		if err != nil {
+			return err
+		}
+		providerRef = pr
+	}
+
+	// Serialize arguments. Outputs will not be awaited: instead, an error will be returned if any Outputs are present.
+	if args == nil {
+		args = struct{}{}
+	}
+	resolvedArgs, _, err := marshalInput(args, anyType, false)
+	if err != nil {
+		return fmt.Errorf("marshaling arguments: %w", err)
+	}
+
+	resolvedArgsMap := resource.PropertyMap{}
+	if resolvedArgs.IsObject() {
+		resolvedArgsMap = resolvedArgs.ObjectValue()
+	}
+
+	rpcArgs, err := plugin.MarshalProperties(
+		resolvedArgsMap,
+		ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+			KeepSecrets:   true,
+			KeepResources: ctx.keepResources,
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("marshaling arguments: %w", err)
+	}
+
+	// Now, invoke the RPC to the provider synchronously.
+	logging.V(9).Infof("Invoke(%s, #args=%d): RPC call being made synchronously", tok, len(resolvedArgsMap))
+	resp, err := ctx.monitor.Invoke(ctx.ctx, &pulumirpc.ResourceInvokeRequest{
+		Tok:               tok,
+		Args:              rpcArgs,
+		Provider:          providerRef,
+		Version:           options.Version,
+		PluginDownloadURL: options.PluginDownloadURL,
+		AcceptResources:   !disableResourceReferences,
+	})
+	if err != nil {
+		logging.V(9).Infof("Invoke(%s, ...): error: %v", tok, err)
+		return err
+	}
+
+	// If there were any failures from the provider, return them.
+	if len(resp.Failures) > 0 {
+		logging.V(9).Infof("Invoke(%s, ...): success: w/ %d failures", tok, len(resp.Failures))
+		var ferr error
+		for _, failure := range resp.Failures {
+			ferr = multierror.Append(ferr,
+				fmt.Errorf("%s invoke failed: %s (%s)", tok, failure.Reason, failure.Property))
+		}
+		return ferr
+	}
+
+	// Otherwise, simply unmarshal the output properties and return the result.
+	outProps, err := plugin.UnmarshalProperties(
+		resp.Return,
+		ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+			KeepSecrets:   true,
+			KeepResources: true,
+		}),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	// fail if there are secrets returned from the invoke
+	hasSecret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), resultV.Elem())
+	if err != nil {
+		return err
+	}
+	if hasSecret {
+		return errors.New("unexpected secret result returned to invoke call")
+	}
+	logging.V(9).Infof("Invoke(%s, ...): success: w/ %d outs (err=%v)", tok, len(outProps), err)
+	return nil
+}
+
+// Invoke will invoke a provider's function, identified by its token tok. This function call is synchronous.
+//
+// args and result must be pointers to struct values fields and appropriately tagged and typed for use with Pulumi.
+func (ctx *Context) InvokeYAML(tok string, args interface{}, result interface{}, opts map[string]map[string]string) (err error) {
+	if tok == "" {
+		return errors.New("invoke token must not be empty")
+	}
+
+	resultV := reflect.ValueOf(result)
+	if !(resultV.Kind() == reflect.Ptr &&
+		(resultV.Elem().Kind() == reflect.Struct ||
+			(resultV.Elem().Kind() == reflect.Map && resultV.Elem().Type().Key().Kind() == reflect.String))) {
+		return errors.New("result must be a pointer to a struct or map value")
+	}
+
+	options := &invokeOptions{}
+	for k1, v1 := range opts {
+		switch k1 {
+		case "provider", "Provider":
+			options.Provider = &ProviderResourceState{}
+			for k2, v2 := range v1 {
+				switch k2 {
+					case ""
+				case "region":
+				}
+			}
+		}
+	}
+
+	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.
+	if err = ctx.beginRPC(); err != nil {
+		return err
+	}
+	defer ctx.endRPC(err)
+
+	var providerRef string
+	providers, err := ctx.mergeProviders(tok, options.Parent, options.Provider, nil)
+	if err != nil {
+		return err
+	}
+	if provider := providers[getPackage(tok)]; provider != nil {
+		provider.addTransformation()
 		pr, err := ctx.resolveProviderReference(provider)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Expose context.Context from pulumi.Context via getter method

Addresses #10162 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
