### PR TITLE
Add a gRPC tracing interceptor

### DIFF
--- a/sdk/go/common/util/rpcutil/debug_interceptor.go
+++ b/sdk/go/common/util/rpcutil/debug_interceptor.go
@@ -1,0 +1,144 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+
+	"google.golang.org/grpc"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// Logs all gRPC converations in JSON format.
+//
+// To enable, PULUMI_DEBUG_GRPC must be set, pointing to a file to
+// append logs to.
+//
+// For example:
+//
+//     PULUMI_DEBUG_GPRC=grpc.json pulumi preview
+//     jq . grpc.json
+//
+func debugServerInterceptor() grpc.UnaryServerInterceptor {
+	return debugInterceptorInstance
+}
+
+type debugInterceptorLogEntry struct {
+	Method   string          `json:"method"`
+	Request  json.RawMessage `json:"request"`
+	Response json.RawMessage `json:"response"`
+	Errors   []string        `json:"errors,omitempty"`
+}
+
+type debugInterceptor struct {
+	logFile string
+	mutex   sync.Mutex
+}
+
+func newDebugInterceptor() *debugInterceptor {
+	logFile := os.Getenv("PULUMI_DEBUG_GRPC")
+	i := &debugInterceptor{logFile: logFile}
+	if logFile != "" {
+		i.clearLogFile()
+	}
+	return i
+}
+
+func (i *debugInterceptor) interceptor() grpc.UnaryServerInterceptor {
+	if i.logFile == "" {
+		return i.noInterceptor()
+	}
+	return i.loggingInterceptor()
+}
+
+func (i *debugInterceptor) loggingInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{},
+		info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		var err error
+		log := debugInterceptorLogEntry{
+			Method: info.FullMethod,
+		}
+		if log.Request, err = i.transcode(req); err != nil {
+			i.track(&log, err)
+		}
+		resp, err := handler(ctx, req)
+		if err != nil {
+			i.track(&log, err)
+		}
+		if log.Response, err = i.transcode(resp); err != nil {
+			i.track(&log, err)
+		}
+		i.record(log)
+		return resp, err
+	}
+}
+
+func (i *debugInterceptor) clearLogFile() {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	err := ioutil.WriteFile(i.logFile, []byte{}, 0644)
+	contract.AssertNoError(err)
+}
+
+func (i *debugInterceptor) record(log debugInterceptorLogEntry) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	f, err := os.OpenFile(i.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	contract.AssertNoError(err)
+	defer contract.IgnoreClose(f)
+
+	err = json.NewEncoder(f).Encode(log)
+	contract.AssertNoError(err)
+}
+
+func (i *debugInterceptor) noInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{},
+		_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		return handler(ctx, req)
+	}
+}
+
+func (*debugInterceptor) track(log *debugInterceptorLogEntry, err error) {
+	log.Errors = append(log.Errors, err.Error())
+}
+
+func (*debugInterceptor) transcode(obj interface{}) (json.RawMessage, error) {
+	m, ok := obj.(proto.Message)
+	if !ok {
+		return json.RawMessage("null"),
+			fmt.Errorf("Failed to decode, expecting proto.Message: %v", m)
+	}
+
+	jsonSer := jsonpb.Marshaler{}
+	buf := bytes.Buffer{}
+	if err := jsonSer.Marshal(&buf, m); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+var debugInterceptorInstance grpc.UnaryServerInterceptor = newDebugInterceptor().interceptor()

--- a/sdk/go/common/util/rpcutil/debug_interceptor.go
+++ b/sdk/go/common/util/rpcutil/debug_interceptor.go
@@ -99,7 +99,7 @@ func (i *debugInterceptor) clearLogFile() {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
 
-	err := ioutil.WriteFile(i.logFile, []byte{}, 0644)
+	err := ioutil.WriteFile(i.logFile, []byte{}, 0600)
 	contract.AssertNoError(err)
 }
 
@@ -107,7 +107,7 @@ func (i *debugInterceptor) record(log debugInterceptorLogEntry) {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
 
-	f, err := os.OpenFile(i.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(i.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	contract.AssertNoError(err)
 	defer contract.IgnoreClose(f)
 

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -15,22 +15,14 @@
 package rpcutil
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"io"
-	"os"
 	"strings"
-	"sync"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
 )
 
 // metadataReaderWriter satisfies both the opentracing.TextMapReader and
@@ -99,70 +91,4 @@ func OpenTracingClientInterceptor(options ...otgrpc.Option) grpc.UnaryClientInte
 			return method != ""
 		}))
 	return otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer(), options...)
-}
-
-type grpcRequestLog struct {
-	FullMethod string          `json:"fullMethod"`
-	Request    json.RawMessage `json:"request"`
-	Response   json.RawMessage `json:"response"`
-	Errors     []string        `json:"errors,omitempty"`
-}
-
-func (l *grpcRequestLog) transcode(m proto.Message) (json.RawMessage, error) {
-	jsonSer := jsonpb.Marshaler{
-		Indent: "  ",
-	}
-	buf := bytes.Buffer{}
-	if err := jsonSer.Marshal(&buf, m); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-func (l *grpcRequestLog) setRequest(m proto.Message) error {
-	j, err := l.transcode(m)
-	if err != nil {
-		return err
-	}
-	l.Request = j
-	return nil
-}
-
-func (l *grpcRequestLog) setResponse(m proto.Message) error {
-	j, err := l.transcode(m)
-	if err != nil {
-		return err
-	}
-	l.Response = j
-	return nil
-}
-
-func (l *grpcRequestLog) addError(e error) {
-	l.Errors = append(l.Errors, e.Error())
-}
-
-// LoggingServerInterceptor provides a gRPC server interceptor for
-// logging gRPC payloads to the given writer.
-func LoggingServerInterceptor(writer io.Writer) grpc.UnaryServerInterceptor {
-	mu := &sync.Mutex{}
-	jw := json.NewEncoder(writer)
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		log := grpcRequestLog{FullMethod: info.FullMethod}
-		if err := log.setRequest(req.(proto.Message)); err != nil {
-			log.addError(err)
-		}
-		resp, err := handler(ctx, req)
-		if err != nil {
-			log.addError(err)
-		} else if err := log.setResponse(resp.(proto.Message)); err != nil {
-			log.addError(err)
-		}
-		mu.Lock()
-		json.NewEncoder(os.Stderr).Encode(log)
-		if err := jw.Encode(log); err != nil {
-			panic(err)
-		}
-		mu.Unlock()
-		return resp, err
-	}
 }

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -15,10 +15,7 @@
 package rpcutil
 
 import (
-	"fmt"
-	"math/rand"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -72,7 +72,7 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 	srv := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			OpenTracingServerInterceptor(parentSpan, options...),
-			LoggingServerInterceptor(logFile),
+			debugServerInterceptor(),
 		),
 		grpc.MaxRecvMsgSize(maxRPCMessageSize),
 	)

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -63,11 +63,6 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 
 	health := health.NewServer()
 
-	logFile, err := os.Create(fmt.Sprintf("/tmp/grpc-%d.log", rand.Intn(10000)))
-	if err != nil {
-		return 0, nil, err
-	}
-
 	// Now new up a gRPC server and register any RPC interfaces the caller wants.
 	srv := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -117,7 +112,6 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 			done <- nil // send a signal so caller knows we're done, even though it's nil.
 		}
 		close(done)
-		logFile.Close()
 	}()
 
 	return port, done, nil

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -15,7 +15,10 @@
 package rpcutil
 
 import (
+	"fmt"
+	"math/rand"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -60,9 +63,17 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 
 	health := health.NewServer()
 
+	logFile, err := os.Create(fmt.Sprintf("/tmp/grpc-%d.log", rand.Intn(10000)))
+	if err != nil {
+		return 0, nil, err
+	}
+
 	// Now new up a gRPC server and register any RPC interfaces the caller wants.
 	srv := grpc.NewServer(
-		grpc.UnaryInterceptor(OpenTracingServerInterceptor(parentSpan, options...)),
+		grpc.ChainUnaryInterceptor(
+			OpenTracingServerInterceptor(parentSpan, options...),
+			LoggingServerInterceptor(logFile),
+		),
 		grpc.MaxRecvMsgSize(maxRPCMessageSize),
 	)
 	for _, register := range registers {
@@ -106,6 +117,7 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 			done <- nil // send a signal so caller knows we're done, even though it's nil.
 		}
 		close(done)
+		logFile.Close()
 	}()
 
 	return port, done, nil


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

I have been debugging provider issues in a complicated project with remote component resources and it has been quite difficult to make sense of the log output as well as the tracing output in that scenario. What I wanted was primarily a trail of gRPC conversations where requests are correlated to responses and are easy to read and filter/query. This PR adds a debug facility that helped me solve the issue.

Example entry from the log:

```
{
  "method": "/pulumirpc.ResourceMonitor/RegisterResource",
  "request": {
    "type": "aws-apigateway:index:RestAPI",
    "name": "helloWorldApi",
    "parent": "urn:pulumi:tdev::java-repro::pulumi:pulumi:Stack::java-repro-tdev",
    "object": {
      "routes": [
        {
          "eventHandler": {
            "4dabf18193072939515e22adb298388d": "5cf8f73096256a8f31e491e813e4eb8e",
            "id": "helloWorldFunction-91d476c",
            "urn": "urn:pulumi:tdev::java-repro::aws:lambda/function:Function::helloWorldFunction"
          },
          "method": "GET",
          "path": "/"
        }
      ]
    },
    "dependencies": [
      "urn:pulumi:tdev::java-repro::aws:lambda/function:Function::helloWorldFunction"
    ],
    "propertyDependencies": {
      "routes": {
        "urns": [
          "urn:pulumi:tdev::java-repro::aws:lambda/function:Function::helloWorldFunction"
        ]
      }
    },
    "version": "0.0.8",
    "acceptSecrets": true,
    "customTimeouts": {},
    "deleteBeforeReplaceDefined": true,
    "remote": true,
    "acceptResources": true
  },
  "response": {
    "urn": "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI::helloWorldApi",
    "object": {
      "api": {
        "4dabf18193072939515e22adb298388d": "5cf8f73096256a8f31e491e813e4eb8e",
        "id": "",
        "urn": "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI$aws:apigateway/restApi:RestApi::helloWorldApi"
      },
      "deployment": {
        "4dabf18193072939515e22adb298388d": "5cf8f73096256a8f31e491e813e4eb8e",
        "id": "",
        "urn": "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI$aws:apigateway/deployment:Deployment::helloWorldApi"
      },
      "stage": {
        "4dabf18193072939515e22adb298388d": "5cf8f73096256a8f31e491e813e4eb8e",
        "id": "",
        "urn": "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI$aws:apigateway/stage:Stage::helloWorldApi"
      }
    },
    "propertyDependencies": {
      "api": {
        "urns": [
          "urn:pulumi:tdev::java-repro::aws:lambda/function:Function::helloWorldFunction",
          "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI$aws:apigateway/restApi:RestApi::helloWorldApi"
        ]
      },
      "deployment": {
        "urns": [
          "urn:pulumi:tdev::java-repro::aws:lambda/function:Function::helloWorldFunction",
          "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI$aws:apigateway/deployment:Deployment::helloWorldApi"
        ]
      },
      "stage": {
        "urns": [
          "urn:pulumi:tdev::java-repro::aws:lambda/function:Function::helloWorldFunction",
          "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI$aws:apigateway/stage:Stage::helloWorldApi"
        ]
      },
      "url": {
        "urns": [
          "urn:pulumi:tdev::java-repro::aws:lambda/function:Function::helloWorldFunction",
          "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI$aws:apigateway/deployment:Deployment::helloWorldApi"
        ]
      }
    }
  }
}
``` 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
