### PR TITLE
Support options.version on pulumi convert

### DIFF
--- a/changelog/pending/20220921--programgen--options-dot-version.yaml
+++ b/changelog/pending/20220921--programgen--options-dot-version.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Support resource option "version" in `pulumi convert` to select specific provider SDK versions.

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -464,8 +464,10 @@ func (g *generator) extractInputPropertyNameMap(r *pcl.Resource) map[string]stri
 	var csharpInputPropertyNameMap = make(map[string]string)
 	if r.Schema != nil {
 		for _, inputProperty := range r.Schema.InputProperties {
-			if val, ok := inputProperty.Language["csharp"]; ok {
-				csharpInputPropertyNameMap[inputProperty.Name] = val.(CSharpPropertyInfo).Name
+			if val1, ok := inputProperty.Language["csharp"]; ok {
+				if val2, ok := val1.(CSharpPropertyInfo); ok {
+					csharpInputPropertyNameMap[inputProperty.Name] = val2.Name
+				}
 			}
 		}
 	}

--- a/pkg/codegen/dotnet/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test.go
@@ -23,3 +23,40 @@ func TestGenerateProgram(t *testing.T) {
 		},
 	)
 }
+
+func TestGenerateProgramVersionSelection(t *testing.T) {
+	t.Parallel()
+
+	expectedVersion := map[string]test.PkgVersionInfo{
+		"aws-resource-options": {
+			Pkg:          "<PackageReference Include=\"Pulumi.Aws\"",
+			OpAndVersion: "Version=\"4.38.0\"",
+		},
+	}
+
+	test.TestProgramCodegen(t,
+		test.ProgramCodegenOptions{
+			Language:   "dotnet",
+			Extension:  "cs",
+			OutputFile: "Program.cs",
+			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				Check(t, path, dependencies, "../../../../../../../sdk/dotnet/Pulumi")
+			},
+			GenProgram: GenerateProgram,
+			TestCases: []test.ProgramTest{
+				{
+					Directory:   "aws-resource-options",
+					Description: "Resource Options",
+					MockPluginVersions: map[string]string{
+						"aws": "4.38.0",
+					},
+				},
+			},
+
+			IsGenProject:    true,
+			GenProject:      GenerateProject,
+			ExpectedVersion: expectedVersion,
+			DependencyFile:  "test.csproj",
+		},
+	)
+}

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -40,6 +40,45 @@ func TestGenerateProgram(t *testing.T) {
 		})
 }
 
+func TestGenerateProgramVersionSelection(t *testing.T) {
+	t.Parallel()
+
+	expectedVersion := map[string]test.PkgVersionInfo{
+		"aws-resource-options": {
+			Pkg:          "github.com/pulumi/pulumi-aws/sdk/v4",
+			OpAndVersion: "v4.38.0",
+		},
+	}
+
+	test.TestProgramCodegen(t,
+		test.ProgramCodegenOptions{
+			Language:   "go",
+			Extension:  "go",
+			OutputFile: "main.go",
+			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				Check(t, path, dependencies, "../../../../../../../sdk")
+			},
+			GenProgram: func(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {
+				// Prevent tests from interfering with each other
+				return GenerateProgramWithOptions(program, GenerateProgramOptions{ExternalCache: NewCache()})
+			},
+			TestCases: []test.ProgramTest{
+				{
+					Directory:   "aws-resource-options",
+					Description: "Resource Options",
+					MockPluginVersions: map[string]string{
+						"aws": "4.38.0",
+					},
+				},
+			},
+
+			IsGenProject:    true,
+			GenProject:      GenerateProject,
+			ExpectedVersion: expectedVersion,
+			DependencyFile:  "go.mod",
+		})
+}
+
 func TestCollectImports(t *testing.T) {
 	t.Parallel()
 
@@ -69,7 +108,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 	}
 
-	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(utils.NewHost(testdataPath)))
+	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(utils.NewHost(testdataPath, nil)))
 	if err != nil {
 		t.Fatalf("could not bind program: %v", err)
 	}

--- a/pkg/codegen/importer/hcl2_test.go
+++ b/pkg/codegen/importer/hcl2_test.go
@@ -231,7 +231,7 @@ func readTestCases(path string) (testCases, error) {
 func TestGenerateHCL2Definition(t *testing.T) {
 	t.Parallel()
 
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath, nil))
 	cases, err := readTestCases("testdata/cases.json")
 	if !assert.NoError(t, err) {
 		t.Fatal()

--- a/pkg/codegen/importer/language_test.go
+++ b/pkg/codegen/importer/language_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestGenerateLanguageDefinition(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath, nil))
 
 	cases, err := readTestCases("testdata/cases.json")
 	if !assert.NoError(t, err) {

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -181,6 +181,10 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 		}
 
 		packageName := "@pulumi/" + p.Name
+		err := p.ImportLanguages(map[string]schema.Language{"nodejs": Importer})
+		if err != nil {
+			return err
+		}
 		if langInfo, found := p.Language["nodejs"]; found {
 			nodeInfo, ok := langInfo.(NodePackageInfo)
 			if ok && nodeInfo.PackageName != "" {
@@ -389,6 +393,8 @@ func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics)
 func moduleName(module string, pkg *schema.Package) string {
 	// Normalize module.
 	if pkg != nil {
+		err := pkg.ImportLanguages(map[string]schema.Language{"nodejs": Importer})
+		contract.AssertNoError(err)
 		if lang, ok := pkg.Language["nodejs"]; ok {
 			pkgInfo := lang.(NodePackageInfo)
 			if m, ok := pkgInfo.ModuleToPackage[module]; ok {

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -42,3 +42,39 @@ func testGenerateProgramBatch(t *testing.T, testCases []test.ProgramTest) {
 			TestCases:  testCases,
 		})
 }
+
+func TestGenerateProgramVersionSelection(t *testing.T) {
+	t.Parallel()
+
+	expectedVersion := map[string]test.PkgVersionInfo{
+		"aws-resource-options": {
+			Pkg:          "\"@pulumi/aws\"",
+			OpAndVersion: "\"4.38.0\"",
+		},
+	}
+
+	test.TestProgramCodegen(t,
+		test.ProgramCodegenOptions{
+			Language:   "nodejs",
+			Extension:  "ts",
+			OutputFile: "index.ts",
+			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
+				Check(t, path, dependencies, true)
+			},
+			GenProgram: GenerateProgram,
+			TestCases: []test.ProgramTest{
+				{
+					Directory:   "aws-resource-options",
+					Description: "Resource Options",
+					MockPluginVersions: map[string]string{
+						"aws": "4.38.0",
+					},
+				},
+			},
+
+			IsGenProject:    true,
+			GenProject:      GenerateProject,
+			ExpectedVersion: expectedVersion,
+			DependencyFile:  "package.json",
+		})
+}

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -64,7 +64,10 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	var pkgSchema *packageSchema
 
 	var ok bool
-	pkgSchema, ok = b.options.packageCache.entries[pkg]
+	pkgInfo := PackageInfo{
+		name: pkg,
+	}
+	pkgSchema, ok = b.options.packageCache.entries[pkgInfo]
 	if !ok {
 		return hcl.Diagnostics{unknownPackage(pkg, tokenRange)}
 	}

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -12,10 +12,10 @@ import (
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")
 
 func BenchmarkLoadPackage(b *testing.B) {
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewHost(testdataPath, nil))
 
 	for n := 0; n < b.N; n++ {
-		_, err := NewPackageCache().loadPackageSchema(loader, "aws")
+		_, err := NewPackageCache().loadPackageSchema(loader, "aws", "")
 		contract.AssertNoError(err)
 	}
 }

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 )
 
+var fileToMockPlugins = map[string]map[string]string{
+	"aws-resource-options.pp": {
+		"aws": "4.38.0",
+	},
+}
+
 func TestBindProgram(t *testing.T) {
 	t.Parallel()
 
@@ -55,7 +61,7 @@ func TestBindProgram(t *testing.T) {
 					t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 				}
 
-				_, diags, err := BindProgram(parser.Files, PluginHost(utils.NewHost(testdataPath)))
+				_, diags, err := BindProgram(parser.Files, PluginHost(utils.NewHost(testdataPath, fileToMockPlugins[fileName])))
 				assert.NoError(t, err)
 				if diags.HasErrors() {
 					t.Fatalf("failed to bind program: %v", diags)

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -64,7 +64,10 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return b.zeroSignature(), diagnostics
 	}
 
-	pkgSchema, ok := b.options.packageCache.entries[pkg]
+	pkgInfo := PackageInfo{
+		name: pkg,
+	}
+	pkgSchema, ok := b.options.packageCache.entries[pkgInfo]
 	if !ok {
 		return b.zeroSignature(), hcl.Diagnostics{unknownPackage(pkg, tokenRange)}
 	}

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -307,6 +307,8 @@ func resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) {
 	// Normalize module.
 	if r.Schema != nil {
 		pkg := r.Schema.Package
+		err := pkg.ImportLanguages(map[string]schema.Language{"python": Importer})
+		contract.AssertNoError(err)
 		if lang, ok := pkg.Language["python"]; ok {
 			pkgInfo := lang.(PackageInfo)
 			if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {
@@ -431,9 +433,7 @@ func (g *generator) genResourceOptions(w io.Writer, block *model.Block, hasInput
 func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 	qualifiedMemberName, diagnostics := resourceTypeName(r)
 	g.diagnostics = append(g.diagnostics, diagnostics...)
-
 	optionsBag, temps := g.lowerResourceOptions(r.Options)
-
 	name := r.LogicalName()
 	nameVar := PyName(r.Name())
 

--- a/pkg/codegen/python/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test.go
@@ -22,3 +22,38 @@ func TestGenerateProgram(t *testing.T) {
 			TestCases:  test.PulumiPulumiProgramTests,
 		})
 }
+
+func TestGenerateProgramVersionSelection(t *testing.T) {
+	t.Parallel()
+
+	expectedVersion := map[string]test.PkgVersionInfo{
+		"aws-resource-options": {
+			Pkg:          "pulumi-aws",
+			OpAndVersion: "==4.38.0",
+		},
+	}
+
+	test.TestProgramCodegen(t,
+		test.ProgramCodegenOptions{
+			Language:   "python",
+			Extension:  "py",
+			OutputFile: "__main__.py",
+			Check:      Check,
+			GenProgram: GenerateProgram,
+			TestCases: []test.ProgramTest{
+				{
+					Directory:   "aws-resource-options",
+					Description: "Resource Options",
+					MockPluginVersions: map[string]string{
+						"aws": "4.38.0",
+					},
+				},
+			},
+
+			IsGenProject:    true,
+			GenProject:      GenerateProject,
+			ExpectedVersion: expectedVersion,
+			DependencyFile:  "requirements.txt",
+		},
+	)
+}

--- a/pkg/codegen/python/utilities_test.go
+++ b/pkg/codegen/python/utilities_test.go
@@ -22,7 +22,7 @@ func parseAndBindProgram(t *testing.T, text, name string, options ...pcl.BindOpt
 		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 	}
 
-	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
+	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath, nil)))
 
 	program, diags, err := pcl.BindProgram(parser.Files, options...)
 	if err != nil {

--- a/pkg/codegen/testing/test/testdata/aws-resource-options-pp/aws-resource-options.pp
+++ b/pkg/codegen/testing/test/testdata/aws-resource-options-pp/aws-resource-options.pp
@@ -8,5 +8,6 @@ resource bucket1 "aws:s3:Bucket" {
 		dependsOn = [provider]
 		protect = true
 		ignoreChanges = [bucket, lifecycleRules[0]]
+		version = "4.38.0"
 	}
 }

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -7,9 +7,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
-func NewHost(schemaDirectoryPath string) plugin.Host {
+func NewHost(schemaDirectoryPath string, mockPluginVersions map[string]string) plugin.Host {
 	mockProvider := func(name tokens.Package, loader ProviderLoader) *deploytest.PluginLoader {
-		return deploytest.NewProviderLoader(name, semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+		version := "1.0.0"
+		if mockPluginVersions != nil {
+			if v, ok := mockPluginVersions[name.String()]; ok {
+				version = v
+			}
+		}
+
+		return deploytest.NewProviderLoader(name, semver.MustParse(version), func() (plugin.Provider, error) {
 			return loader(schemaDirectoryPath)
 		}, deploytest.WithPath(schemaDirectoryPath))
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Running pulumi convert when a resource has options.version specified does not generate corresponding code that sets the version on the resource

Fixes #10195 
Fixes #10358 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
