### PR TITLE
Add flag to specify whether to install dependencies on `pulumi convert`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,9 @@
 - [backends] When logging in to a file backend, validate that the bucket is accessible.
   [#10012](https://github.com/pulumi/pulumi/pull/10012)
 
+- [cli] Add flag to specify whether to install dependencies on `pulumi convert`.
+  [#10198](https://github.com/pulumi/pulumi/pull/10198)
+
 ### Bug Fixes
 
 - [cli] Only log github request headers at log level 11.

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -38,6 +38,7 @@ type projectGeneratorFunc func(directory string, project workspace.Project, p *p
 func newConvertCmd() *cobra.Command {
 	var outDir string
 	var language string
+	var installDeps bool
 
 	cmd := &cobra.Command{
 		Use:   "convert",
@@ -109,8 +110,10 @@ func newConvertCmd() *cobra.Command {
 
 			defer ctx.Close()
 
-			if err := installDependencies(ctx, &proj.Runtime, pwd); err != nil {
-				return result.FromError(err)
+			if installDeps {
+				if err := installDependencies(ctx, &proj.Runtime, pwd); err != nil {
+					return result.FromError(err)
+				}
 			}
 
 			return nil
@@ -127,6 +130,10 @@ func newConvertCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		//nolint:lll
 		&outDir, "out", ".", "The output directory to write the convert project to")
+
+	cmd.PersistentFlags().BoolVar(
+		//nolint:lll
+		&installDeps, "install-dependencies", true, "Whether to install dependencies specified in the pulumi project")
 
 	return cmd
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Add `install-dependencies` flag to allow user to opt out of installing dependencies on `pulumi convert` if they only want the generated files. Defaults to `true.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Addresses #10196 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
