### PR TITLE
Fix error check in newDeployment

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -150,10 +150,10 @@ func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions
 	projinfo := &Projinfo{Proj: proj, Root: info.Update.GetRoot()}
 	pwd, main, plugctx, err := ProjectInfoContext(projinfo, opts.Host, target,
 		opts.Diag, opts.StatusDiag, opts.DisableProviderPreview, info.TracingSpan)
-	plugctx = plugctx.WithCancelChannel(ctx.Cancel.Canceled())
 	if err != nil {
 		return nil, err
 	}
+	plugctx = plugctx.WithCancelChannel(ctx.Cancel.Canceled())
 
 	opts.trustDependencies = proj.TrustResourceDependencies()
 	// Now create the state source.  This may issue an error if it can't create the source.  This entails,


### PR DESCRIPTION
Stumbled on this while mucking around with plugins.
If ProjectInfoContext failed and returned a nil context and error, we would first try to call `WithCancelChannel` on that nil context before checking the error, which clearly went bang.
Simple flip to check the error value first.

Wouldn't discriminate result types be nice...