### PR TITLE
wip benchmarks

### DIFF
--- a/tests/benchmarks/.gitignore
+++ b/tests/benchmarks/.gitignore
@@ -1,0 +1,2 @@
+*/node_modules
+*/package-lock.json

--- a/tests/benchmarks/mini-js/Pulumi.yaml
+++ b/tests/benchmarks/mini-js/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: mini-js
+runtime:
+  name: nodejs
+  options:
+    typescript: false
+description: A minimal JavaScript Pulumi program

--- a/tests/benchmarks/mini-js/index.js
+++ b/tests/benchmarks/mini-js/index.js
@@ -1,3 +1,2 @@
 "use strict";
-// const pulumi = require("@pulumi/pulumi");
-// TODO: the above still pulls in "typescript" dependency...
+const pulumi = require("@pulumi/pulumi");

--- a/tests/benchmarks/mini-js/index.js
+++ b/tests/benchmarks/mini-js/index.js
@@ -1,0 +1,3 @@
+"use strict";
+// const pulumi = require("@pulumi/pulumi");
+// TODO: the above still pulls in "typescript" dependency...

--- a/tests/benchmarks/mini-js/package.json
+++ b/tests/benchmarks/mini-js/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "mini-js",
+    "main": "index.js",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/tests/benchmarks/mini-js/package.json
+++ b/tests/benchmarks/mini-js/package.json
@@ -3,5 +3,6 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0"
-    }
+    },
+    "license": "Apache-2.0"
 }

--- a/tests/benchmarks/mini-js/package.json
+++ b/tests/benchmarks/mini-js/package.json
@@ -2,7 +2,7 @@
     "name": "mini-js",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0"
+        "@pulumi/pulumi": "=3.6.0"
     },
     "license": "Apache-2.0"
 }

--- a/tests/benchmarks/script/benchmark.sh
+++ b/tests/benchmarks/script/benchmark.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+bench() {
+    hyperfine --prepare "../script/setup-benchmark.sh" \
+              --cleanup "pulumi destroy -y" \
+              "pulumi up -y"
+}
+
+pushd "$1"
+pulumi stack rm -y || echo "preparing.."
+
+pulumi stack init benchmark
+
+echo "Control: $(pulumi version)"
+bench
+
+export PATH=~/.pulumi-dev/bin:$PATH
+yarn link @pulumi/pulumi
+yarn install
+echo "Test: $(pulumi version)"
+bench
+yarn unlink @pulumi/pulumi
+yarn install --force
+
+pulumi stack rm -y
+
+popd

--- a/tests/benchmarks/script/benchmark.sh
+++ b/tests/benchmarks/script/benchmark.sh
@@ -3,27 +3,27 @@
 set -euo pipefail
 
 bench() {
-    hyperfine --prepare "../script/setup-benchmark.sh" \
+    hyperfine -n "$1 pulumi:$(pulumi version) command:'pulumi up -y'" \
+              --prepare "../script/setup-benchmark.sh" \
               --cleanup "pulumi destroy -y" \
               "pulumi up -y"
 }
 
 pushd "$1"
-pulumi stack rm -y || echo "preparing.."
 
+../script/setup-benchmark.sh
 pulumi stack init benchmark
 
-echo "Control: $(pulumi version)"
-bench
+bench control
 
 export PATH=~/.pulumi-dev/bin:$PATH
-yarn link @pulumi/pulumi
-yarn install
-echo "Test: $(pulumi version)"
-bench
-yarn unlink @pulumi/pulumi
-yarn install --force
+yarn -s link @pulumi/pulumi
+yarn -s install
 
-pulumi stack rm -y
+bench test
+
+yarn -s unlink @pulumi/pulumi
+yarn -s install --force
+pulumi stack rm -y >/dev/null
 
 popd

--- a/tests/benchmarks/script/setup-benchmark.sh
+++ b/tests/benchmarks/script/setup-benchmark.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Purge hardware cache (MacOS specific)
+sync && sudo purge


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Prototyping. Still a bit of work to do tidy up. Thanks @AaronFriel and @RobbieMcKinstry for hyperfine suggestion. Thanks Robbie for researching the benchmark setup script I'm copying it verbatim from your instructions.

```
$ ./script/benchark.sh mini-js

Created stack 'benchmark'
Benchmark 1: control pulumi:v3.36.0 command:'pulumi up -y'
  Time (mean ± σ):      4.473 s ±  0.066 s    [User: 0.752 s, System: 0.639 s]
  Range (min … max):    4.335 s …  4.577 s    10 runs

Benchmark 1: test pulumi:3.37.0-alpha.1658432973+98555086 command:'pulumi up -y'
  Time (mean ± σ):      4.092 s ±  0.189 s    [User: 0.716 s, System: 0.577 s]
  Range (min … max):    3.837 s …  4.537 s    10 runs
```
Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
