### PR TITLE
 Fix x-plat issues with watch, use watchexec-derived binary

### DIFF
--- a/.goreleaser.build.yml
+++ b/.goreleaser.build.yml
@@ -75,7 +75,12 @@ archives:
   replacements:
     amd64: x64
   files:
+      # OS specific scripts, not compiled
     - src: bin/{{ .Os }}/*
+      dst: '.'
+      strip_parent: true
+      # binaries
+    - src: bin/{{ .Os }}-{{ .Arch }}/*
       dst: '.'
       strip_parent: true
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -69,7 +69,12 @@ archives:
   replacements:
     amd64: x64
   files:
+      # OS specific scripts, not compiled
     - src: bin/{{ .Os }}/*
+      dst: '.'
+      strip_parent: true
+      # binaries
+    - src: bin/{{ .Os }}-{{ .Arch }}/*
       dst: '.'
       strip_parent: true
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,12 @@ archives:
   replacements:
     amd64: x64
   files:
+      # OS specific scripts, not compiled
     - src: bin/{{ .Os }}/*
+      dst: '.'
+      strip_parent: true
+      # binaries
+    - src: bin/{{ .Os }}-{{ .Arch }}/*
       dst: '.'
       strip_parent: true
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,8 @@
 ### Improvements
 
+- [cli/watch] `pulumi watch` now uses relies on a program built on [`watchexec`](https://github.com/watchexec/watchexec)
+  to implement recursive file watching, improving performance and cross-platform compatibility.
+  This `pulumi-watch` program is now included in releases.
+  [#10213](https://github.com/pulumi/pulumi/issues/10213)
+
 ### Bug Fixes

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386
 	github.com/pulumi/pulumi/sdk/v3 v3.38.0
-	github.com/rjeczalik/notify v0.9.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -689,8 +689,6 @@ github.com/pulumi/ssh-agent v0.5.1 h1:7DT4FcZNHWBAp9BFI+k0+HeBYGWbJvilJ29ra/4FlR
 github.com/pulumi/ssh-agent v0.5.1/go.mod h1:e6cyz/FUcE3PcJZ0tiuygkRsnHnCZcSQoQU+APbnrVA=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
-github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
@@ -959,7 +957,6 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/scripts/get-pulumi-watch.sh
+++ b/scripts/get-pulumi-watch.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -eo pipefail
+set -x
+
+# When run by goreleaser, the arguments are absent, so files are installed in:
+#
+# * ./bin/darwin-amd64
+# * ./bin/darwin-arm64
+# * ./bin/linux-amd64
+# * ./bin/linux-arm64
+# * ./bin/windows-amd64
+#
+# Allowing us to customize the archives for each.
+#
+# When run by GitHub Actions in tests, we set the args so that we install only the current OS's
+# binaries and in the shared "local path" dir, ./bin
+FILTER_TARGET="${1}"
+
+if [ "${FILTER_TARGET}" = "local" ]; then
+  FILTER_TARGET="$(go env GOOS)-$(go env GOARCH)"
+fi
+
+TAG="v0.1.4"
+
+for i in \
+  "darwin-amd64   x86_64-apple-darwin            tar.gz" \
+  "darwin-arm64   aarch64-apple-darwin           tar.gz" \
+  "linux-amd64    x86_64-unknown-linux-gnu       tar.gz" \
+  "linux-arm64    aarch64-unknown-linux-gnu      tar.gz" \
+  "windows-amd64  x86_64-pc-windows-msvc         zip"; do # Windows is synonymous with ".exe" as well
+  set -- $i # read loop strings as args
+  TARGET="$1"
+  FILE="$2"
+  EXT="$3"
+
+  DIST_DIR="./bin/${TARGET}"
+  if [ -n "${FILTER_TARGET}" ]; then
+    if [ "${TARGET}" != "${FILTER_TARGET}" ]; then
+      continue
+    else
+      DIST_DIR="./bin"
+    fi
+  fi
+
+  mkdir -p "${DIST_DIR}"
+
+  FILENAME="pulumi-watch-${TAG}-${FILE}.${EXT}"
+
+  OUTDIR="$(mktemp -d)"
+  case "${EXT}" in
+    "tar.gz")
+      curl -OL --fail "https://github.com/pulumi/watchutil-rs/releases/download/${TAG}/${FILENAME}"
+      tar -xzvf "${FILENAME}" --strip-components=1 -C "${OUTDIR}"
+      mv "${OUTDIR}/pulumi-watch" "${DIST_DIR}"
+      rm "${FILENAME}"
+      ;;
+    "zip")
+      curl -OL --fail "https://github.com/pulumi/watchutil-rs/releases/download/${TAG}/${FILENAME}"
+      unzip -j "${FILENAME}" -d "${OUTDIR}"
+      mv "${OUTDIR}/pulumi-watch.exe" "${DIST_DIR}"
+      rm "${FILENAME}"
+      ;;
+    *) exit
+      ;;
+  esac
+done

--- a/scripts/prep-for-goreleaser.sh
+++ b/scripts/prep-for-goreleaser.sh
@@ -51,3 +51,6 @@ install_file sdk/python/dist/pulumi-python-shim.cmd                         wind
 install_file sdk/python/dist/pulumi-python3-shim.cmd                        windows
 
 install_file sdk/python/cmd/pulumi-language-python-exec          linux darwin windows
+
+# Get pulumi-watch binaries
+./scripts/get-pulumi-watch.sh

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -121,7 +121,6 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -664,8 +664,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
-github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
@@ -926,7 +924,6 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Replaces library used to implement recursive file watching with https://github.com/pulumi/pulumi-watch, which is itself a shim around https://github.com/watchexec/watchexec.

This solves our cross-platform build issues, and allows us to build our CLIs on any platform and cross-compile to macOS.

Fixes #9326
