### PR TITLE
Make sure import pulumi/pulumi does not necessarily import typescript

### DIFF
--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ import { ResourceError } from "../../errors";
 import { Input, isSecretOutput, Output } from "../../output";
 import * as resource from "../../resource";
 import { hasTrueBooleanMember } from "../../utils";
-import { CapturedPropertyChain, CapturedPropertyInfo, CapturedVariableMap, parseFunction } from "./parseFunction";
+import { CapturedPropertyChain, CapturedPropertyInfo, CapturedVariableMap } from "./parseFunction";
+import * as parseFunctionModule from "./parseFunction";
 import { rewriteSuperReferences } from "./rewriteSuper";
 import { getModuleFromPath } from "./package";
 import * as utils from "./utils";
@@ -412,7 +413,9 @@ async function analyzeFunctionInfoAsync(
         // either a "function (...) { ... }" form, or a "(...) => ..." form.  In other words, all
         // 'funky' functions (like classes and whatnot) will be transformed to reasonable forms we can
         // process down the pipeline.
-        const [error, parsedFunction] = parseFunction(functionString);
+
+        const pf: typeof parseFunctionModule = require("./parseFunction");
+        const [error, parsedFunction] = pf.parseFunction(functionString);
         if (error) {
             throwSerializationError(func, context, error);
         }

--- a/sdk/nodejs/runtime/closure/rewriteSuper.ts
+++ b/sdk/nodejs/runtime/closure/rewriteSuper.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as ts from "typescript";
+import * as typescript from "typescript";
 import * as utils from "./utils";
 
 /** @internal */
 export function rewriteSuperReferences(code: string, isStatic: boolean): string {
+    const ts: typeof typescript = require("typescript");
     const sourceFile = ts.createSourceFile(
         "", code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 
@@ -29,11 +30,11 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
 
     return output;
 
-    function rewriteSuperCallsWorker(transformationContext: ts.TransformationContext) {
-        const newNodes = new Set<ts.Node>();
+    function rewriteSuperCallsWorker(transformationContext: typescript.TransformationContext) {
+        const newNodes = new Set<typescript.Node>();
         let firstFunctionDeclaration = true;
 
-        function visitor(node: ts.Node): ts.Node {
+        function visitor(node: typescript.Node): typescript.Node {
             // Convert the top level function so it doesn't have a name. We want to convert the user
             // function to an anonymous function so that interior references to the same function
             // bind properly.  i.e. if we start with "function f() { f(); }" then this gets converted to
@@ -116,6 +117,6 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
             return rewritten;
         }
 
-        return (node: ts.Node) => ts.visitNode(node, visitor);
+        return (node: typescript.Node) => ts.visitNode(node, visitor);
     }
 }

--- a/sdk/nodejs/runtime/closure/utils.ts
+++ b/sdk/nodejs/runtime/closure/utils.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as ts from "typescript";
+import * as typescript from "typescript";
 
 const legalNameRegex = /^[a-zA-Z_][0-9a-zA-Z_]*$/;
 
@@ -26,7 +26,7 @@ export function isLegalFunctionName(n: string) {
     if (!isLegalMemberName(n)) {
         return false;
     }
-
+    const ts: typeof typescript = require("typescript");
     const scanner = ts.createScanner(
         ts.ScriptTarget.Latest, /*skipTrivia:*/false, ts.LanguageVariant.Standard, n);
     const tokenKind = scanner.scan();


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Continues the earlier work of trying not to pay for importing typescript when unused. Unfortunately further changes are needed. This statement, common in our JavaScript templates and many programs:

```
require("@pulumi/pulumi");
```

Pulls in "./runtime" which in turn pulls in "./closure/serializeClosure" which pulls in "typescript". 

This is only done so "./runtime" can re-export these two functions:

```
export {
    serializeFunctionAsync,
    serializeFunction,
    SerializedFunction,
    SerializeFunctionArgs,
}  from "./closure/serializeClosure";
```

I thought about making a lazy re-export here but I'm a bit rusty with my node to figure out how to safely do that. So instead I just mechanically switched "./closure" code to lazy-import either "typescript" or parts of itself until the problem went away.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
