### PR TITLE
Revert "Add last status to `pulumi stack ls` output"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -57,4 +57,4 @@
   [#10164](https://github.com/pulumi/pulumi/pull/10164)
 
 - [cli] Revert "Add last status to `pulumi stack ls` output #10059"
-  [#](https://github.com/pulumi/pulumi/pull/)
+  [#10221](https://github.com/pulumi/pulumi/pull/10221)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -55,3 +55,6 @@
 
 - [cli] Reduced the noisiness of `pulumi new --help` by replacing the list of available templates to just the number.
   [#10164](https://github.com/pulumi/pulumi/pull/10164)
+
+- [cli] Revert "Add last status to `pulumi stack ls` output #10059"
+  [#](https://github.com/pulumi/pulumi/pull/)

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -216,11 +216,6 @@ func formatStackSummariesJSON(b backend.Backend, currentStack string, stackSumma
 		}
 
 		if httpBackend, ok := b.(httpstate.Backend); ok {
-			if stackHistory, err := httpBackend.GetHistory(commandContext(), summary.Name(), 1, 1); err == nil {
-				if len(stackHistory) > 0 {
-					summaryJSON.LastStatus = string(stackHistory[0].Result)
-				}
-			}
 			if consoleURL, err := httpBackend.StackConsoleURL(summary.Name()); err == nil {
 				summaryJSON.URL = consoleURL
 			}

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -194,7 +194,6 @@ type stackSummaryJSON struct {
 	Current          bool   `json:"current"`
 	LastUpdate       string `json:"lastUpdate,omitempty"`
 	UpdateInProgress bool   `json:"updateInProgress"`
-	LastStatus       string `json:"lastStatus,omitempty"`
 	ResourceCount    *int   `json:"resourceCount,omitempty"`
 	URL              string `json:"url,omitempty"`
 }
@@ -237,7 +236,7 @@ func formatStackSummariesConsole(b backend.Backend, currentStack string, stackSu
 	_, showURLColumn := b.(httpstate.Backend)
 
 	// Header string and formatting options to align columns.
-	headers := []string{"NAME", "LAST UPDATE", "LAST STATUS", "RESOURCE COUNT"}
+	headers := []string{"NAME", "LAST UPDATE", "RESOURCE COUNT"}
 	if showURLColumn {
 		headers = append(headers, "URL")
 	}
@@ -263,17 +262,6 @@ func formatStackSummariesConsole(b backend.Backend, currentStack string, stackSu
 			}
 		}
 
-		// Last status column
-		lastStatus := none
-		if httpBackend, ok := b.(httpstate.Backend); ok {
-			if stackHistory, err := httpBackend.GetHistory(commandContext(), summary.Name(),
-				len(stackSummaries), 1); err == nil {
-				if len(stackHistory) > 0 {
-					lastStatus = string(stackHistory[0].Result)
-				}
-			}
-		}
-
 		// ResourceCount column
 		resourceCount := none
 		if stackResourceCount := summary.ResourceCount(); stackResourceCount != nil {
@@ -281,7 +269,7 @@ func formatStackSummariesConsole(b backend.Backend, currentStack string, stackSu
 		}
 
 		// Render the columns.
-		columns := []string{name, lastUpdate, lastStatus, resourceCount}
+		columns := []string{name, lastUpdate, resourceCount}
 		if showURLColumn {
 			url := none
 			if httpBackend, ok := b.(httpstate.Backend); ok {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Reverts [PR #10059](https://github.com/pulumi/pulumi/pull/10059); performance was significantly impacted due to calling `GetStatus` on every list status 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
