### PR TITLE
make provider more tolerant of unexpected command line args

### DIFF
--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -329,7 +329,8 @@ def main(provider: Provider, args: List[str]) -> None:  # args not in use?
     argp.add_argument("--logflow", action="store_true", help="Currently ignored")
     argp.add_argument("--logtostderr", action="store_true", help="Currently ignored")
 
-    engine_address: str = argp.parse_args().engine
+    args, unknown = argp.parse_known_args()
+    engine_address: str = args.engine
 
     async def serve() -> None:
         server = grpc.aio.server(options=_GRPC_CHANNEL_OPTIONS)

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -329,8 +329,8 @@ def main(provider: Provider, args: List[str]) -> None:  # args not in use?
     argp.add_argument("--logflow", action="store_true", help="Currently ignored")
     argp.add_argument("--logtostderr", action="store_true", help="Currently ignored")
 
-    args, unknown = argp.parse_known_args()
-    engine_address: str = args.engine
+    known_args, _ = argp.parse_known_args()
+    engine_address: str = known_args.engine
 
     async def serve() -> None:
         server = grpc.aio.server(options=_GRPC_CHANNEL_OPTIONS)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

When running Component Providers, command line flags are passed. When debugging using `--logflow` `--logtostderr` `-v=5`, `-v=5` is passed to argparse. argparse doesn't expect this and crashes as it is not in the list of parameters the program expects. 

This change makes the program more fault tolerant around unexpected parameters being passed in by callers.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10208 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
