### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -155,15 +155,14 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	defer func() {
-		err = os.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
+		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
 		_, err := b.RemoveStack(ctx, aStack, true)
 		assert.NoError(t, err)
 	}()
 	deployment, err := makeUntypedDeployment("a", "abc123",
 		"v1:4iF78gb0nF0=:v1:Co6IbTWYs/UdrjgY:FSrAWOFZnj9ealCUDdJL7LrUKXX9BA==")
 	assert.NoError(t, err)
-	err = os.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
-	assert.NoError(t, err)
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
 	err = b.ImportDeployment(ctx, aStack, deployment)
 	assert.NoError(t, err)
 
@@ -174,15 +173,14 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, bStack)
 	defer func() {
-		err = os.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
+		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
 		_, err := b.RemoveStack(ctx, bStack, true)
 		assert.NoError(t, err)
 	}()
 	deployment, err = makeUntypedDeployment("b", "123abc",
 		"v1:C7H2a7/Ietk=:v1:yfAd1zOi6iY9DRIB:dumdsr+H89VpHIQWdB01XEFqYaYjAg==")
 	assert.NoError(t, err)
-	err = os.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
-	assert.NoError(t, err)
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
 	err = b.ImportDeployment(ctx, bStack, deployment)
 	assert.NoError(t, err)
 

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -14,7 +14,6 @@
 package httpstate
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,8 +29,7 @@ func TestValueOrDefaultURL(t *testing.T) {
 		assert.Equal(t, "https://api-test2.pulumi.com", ValueOrDefaultURL("https://api-test2.pulumi.com"))
 
 		// Validate trailing slash in pre-set env var is unchanged
-		os.Setenv("PULUMI_API", "https://api-test3.pulumi.com/")
+		t.Setenv("PULUMI_API", "https://api-test3.pulumi.com/")
 		assert.Equal(t, "https://api-test3.pulumi.com/", ValueOrDefaultURL(""))
-		os.Unsetenv("PULUMI_API")
 	})
 }

--- a/pkg/backend/httpstate/console_test.go
+++ b/pkg/backend/httpstate/console_test.go
@@ -25,13 +25,8 @@ func TestConsoleURL(t *testing.T) {
 
 	//nolint:paralleltest // sets env var, must be run in isolation
 	t.Run("HonorEnvVar", func(t *testing.T) {
-		initial := os.Getenv("PULUMI_CONSOLE_DOMAIN")
-		defer func() {
-			os.Setenv("PULUMI_CONSOLE_DOMAIN", initial)
-		}()
-
 		// Honor the PULUMI_CONSOLE_DOMAIN environment variable.
-		os.Setenv("PULUMI_CONSOLE_DOMAIN", "pulumi-console.contoso.com")
+		t.Setenv("PULUMI_CONSOLE_DOMAIN", "pulumi-console.contoso.com")
 		assert.Equal(t,
 			"https://pulumi-console.contoso.com/1/2",
 			cloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -230,12 +230,8 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 
 	// Now override to local filesystem backend
 	backendURL := "file://" + filepath.ToSlash(fileStateDir)
-	_ = os.Setenv("PULUMI_CONFIG_PASSPHRASE", "how now brown cow")
-	_ = os.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
-	defer func() {
-		_ = os.Unsetenv(workspace.PulumiBackendURLEnvVar)
-		_ = os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
-	}()
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "how now brown cow")
+	t.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
 
 	backendInstance = nil
 	tempdir, _ := ioutil.TempDir("", "test-env-local")

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -42,10 +42,7 @@ func assertEnvValue(t *testing.T, md *backend.UpdateMetadata, key, val string) {
 func TestReadingGitRepo(t *testing.T) {
 	// Disable our CI/CD detection code, since if this unit test is ran under CI
 	// it will change the expected behavior.
-	os.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
-	defer func() {
-		os.Unsetenv("PULUMI_DISABLE_CI_DETECTION")
-	}()
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
 
 	e := pul_testing.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
@@ -163,26 +160,10 @@ func TestReadingGitRepo(t *testing.T) {
 
 	// Confirm that data can be inferred from the CI system if unavailable.
 	// Fake running under Travis CI.
-	varsToSave := []string{"TRAVIS", "TRAVIS_BRANCH"}
-	origEnvVars := make(map[string]string)
-	for _, varName := range varsToSave {
-		origEnvVars[varName] = os.Getenv(varName)
-	}
-	defer func() {
-		for _, varName := range varsToSave {
-			orig := origEnvVars[varName]
-			if orig == "" {
-				os.Unsetenv(varName)
-			} else {
-				os.Setenv(varName, orig)
-			}
-		}
-	}()
-
 	os.Unsetenv("PULUMI_DISABLE_CI_DETECTION") // Restore our CI/CD detection logic.
-	os.Setenv("TRAVIS", "1")
-	os.Setenv("TRAVIS_BRANCH", "branch-from-ci")
-	os.Setenv("GITHUB_REF", "branch-from-ci")
+	t.Setenv("TRAVIS", "1")
+	t.Setenv("TRAVIS_BRANCH", "branch-from-ci")
+	t.Setenv("GITHUB_REF", "branch-from-ci")
 
 	{
 		test := &backend.UpdateMetadata{
@@ -203,10 +184,7 @@ func TestReadingGitRepo(t *testing.T) {
 func TestReadingGitLabMetadata(t *testing.T) {
 	// Disable our CI/CD detection code, since if this unit test is ran under CI
 	// it will change the expected behavior.
-	os.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
-	defer func() {
-		os.Unsetenv("PULUMI_DISABLE_CI_DETECTION")
-	}()
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
 
 	e := pul_testing.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go-extras/tests/codegen_test.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go-extras/tests/codegen_test.go
@@ -16,7 +16,6 @@ package codegentest
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -77,7 +76,7 @@ func TestTransitiveObjectDefaults(t *testing.T) {
 
 // We already have that defaults for resources. We test that they translate through objects.
 func TestDefaultResource(t *testing.T) {
-	os.Setenv("PULUMI_K8S_CLIENT_BURST", "42")
+	t.Setenv("PULUMI_K8S_CLIENT_BURST", "42")
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := example.NewFoo(ctx, "foo", &example.FooArgs{
 			KubeClientSettings:       example.KubeClientSettingsPtr(&example.KubeClientSettingsArgs{}),

--- a/sdk/go/common/workspace/plugins_install_nodejs_test.go
+++ b/sdk/go/common/workspace/plugins_install_nodejs_test.go
@@ -18,7 +18,6 @@
 package workspace
 
 import (
-	"os"
 	"testing"
 )
 
@@ -34,6 +33,6 @@ func TestNodeNPMInstall(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables
 func TestNodeYarnInstall(t *testing.T) {
-	os.Setenv("PULUMI_PREFER_YARN", "true")
+	t.Setenv("PULUMI_PREFER_YARN", "true")
 	testPluginInstall(t, "node_modules", tarball)
 }

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -287,7 +286,7 @@ func TestPluginDownload(t *testing.T) {
 	token := "RaNd0m70K3n_"
 
 	t.Run("Test Downloading From Pulumi GitHub Releases", func(t *testing.T) {
-		os.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "")
 		version := semver.MustParse("4.30.0")
 		info := PluginInfo{
 			PluginDownloadURL: "",
@@ -379,9 +378,9 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From GitHub Private Releases", func(t *testing.T) {
-		os.Setenv("PULUMI_EXPERIMENTAL", "true")
-		os.Setenv("GITHUB_REPOSITORY_OWNER", "private")
-		os.Setenv("GITHUB_TOKEN", token)
+		t.Setenv("PULUMI_EXPERIMENTAL", "true")
+		t.Setenv("GITHUB_REPOSITORY_OWNER", "private")
+		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("1.22.0")
 		info := PluginInfo{
 			PluginDownloadURL: "",
@@ -429,7 +428,7 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From Private Pulumi GitHub Releases", func(t *testing.T) {
-		os.Setenv("GITHUB_TOKEN", token)
+		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
 		info := PluginInfo{
 			PluginDownloadURL: "",
@@ -472,7 +471,7 @@ func TestPluginDownload(t *testing.T) {
 		assert.Equal(t, expectedBytes, readBytes)
 	})
 	t.Run("Test Downloading From Internal GitHub Releases", func(t *testing.T) {
-		os.Setenv("GITHUB_TOKEN", token)
+		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
 		info := PluginInfo{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
@@ -526,7 +525,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	token := "RaNd0m70K3n_"
 
 	t.Run("Test GetLatestVersion From Pulumi GitHub Releases", func(t *testing.T) {
-		os.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "")
 		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",
@@ -561,9 +560,9 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, "GetLatestVersion is not supported for plugins using PluginDownloadURL", err.Error())
 	})
 	t.Run("Test GetLatestVersion From GitHub Private Releases", func(t *testing.T) {
-		os.Setenv("PULUMI_EXPERIMENTAL", "true")
-		os.Setenv("GITHUB_REPOSITORY_OWNER", "private")
-		os.Setenv("GITHUB_TOKEN", token)
+		t.Setenv("PULUMI_EXPERIMENTAL", "true")
+		t.Setenv("GITHUB_REPOSITORY_OWNER", "private")
+		t.Setenv("GITHUB_TOKEN", token)
 		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "private",
@@ -594,7 +593,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, expectedVersion, *version)
 	})
 	t.Run("Test GetLatestVersion From Private Pulumi GitHub Releases", func(t *testing.T) {
-		os.Setenv("GITHUB_TOKEN", token)
+		t.Setenv("GITHUB_TOKEN", token)
 		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "mock-private",
@@ -620,7 +619,7 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, expectedVersion, *version)
 	})
 	t.Run("Test GetLatestVersion From Internal GitHub Releases", func(t *testing.T) {
-		os.Setenv("GITHUB_TOKEN", token)
+		t.Setenv("GITHUB_TOKEN", token)
 		info := PluginInfo{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mock-private",

--- a/sdk/nodejs/npm/npm_test.go
+++ b/sdk/nodejs/npm/npm_test.go
@@ -44,7 +44,7 @@ func TestNPMInstall(t *testing.T) {
 
 //nolint:paralleltest // mutates environment variables, changes working directory
 func TestYarnInstall(t *testing.T) {
-	os.Setenv("PULUMI_PREFER_YARN", "true")
+	t.Setenv("PULUMI_PREFER_YARN", "true")
 	testInstall(t, "yarn", false /*production*/)
 	testInstall(t, "yarn", true /*production*/)
 }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -734,7 +734,7 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 
 	workingTestOptions := testOptions.With(integration.ProgramTestOptions{
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
+			t.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
 			secretsProvider := stackInfo.Deployment.SecretsProviders
 			assert.NotNil(t, secretsProvider)
 			assert.Equal(t, secretsProvider.Type, "passphrase")
@@ -747,7 +747,6 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 
 			_, ok = out["ciphertext"]
 			assert.True(t, ok)
-			os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
 		},
 	})
 

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -37,7 +37,7 @@ func TestPolicyWithConfig(t *testing.T) {
 	policyPackName := fmt.Sprintf("%s-%x", "test-policy-pack", time.Now().UnixNano())
 	e.ImportDirectory("policy_pack_w_config")
 	e.RunCommand("yarn", "install")
-	os.Setenv("TEST_POLICY_PACK", policyPackName)
+	t.Setenv("TEST_POLICY_PACK", policyPackName)
 
 	// Publish the Policy Pack twice.
 	publishPolicyPackWithVersion(e, orgName, `"0.0.1"`)
@@ -114,7 +114,7 @@ func TestPolicyWithoutConfig(t *testing.T) {
 	policyPackName := fmt.Sprintf("%s-%x", "test-policy-pack", time.Now().UnixNano())
 	e.ImportDirectory("policy_pack_wo_config")
 	e.RunCommand("yarn", "install")
-	os.Setenv("TEST_POLICY_PACK", policyPackName)
+	t.Setenv("TEST_POLICY_PACK", policyPackName)
 
 	// Publish the Policy Pack twice.
 	e.RunCommand("pulumi", "policy", "publish", orgName)

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -271,7 +271,7 @@ func TestStackCommands(t *testing.T) {
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		os.Setenv("PULUMI_CONFIG_PASSPHRASE", "correct horse battery staple")
+		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "correct horse battery staple")
 		snap, err := stack.DeserializeUntypedDeployment(
 			context.Background(),
 			&deployment, stack.DefaultSecretsProvider)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~: Tests refactoring only, no new features added.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] ~~I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change~~: This PR is a non user-facing change.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] ~~Yes, there are changes in this PR that warrants bumping the Pulumi Service API version~~: N/A
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
