### PR TITLE
Fix python overriding PATH on Windows

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -52,12 +52,15 @@
 
 - [sdk/go] Remove the `AsName` and `AsQName` asserting functions.
   [#10156](https://github.com/pulumi/pulumi/pull/10156)
-  
+
 - [python] PULUMI_PYTHON_CMD is checked for deciding what python binary to use in a virtual environment.
   [#10155](https://github.com/pulumi/pulumi/pull/10155)
 
 - [cli] Reduced the noisiness of `pulumi new --help` by replacing the list of available templates to just the number.
   [#10164](https://github.com/pulumi/pulumi/pull/10164)
-  
+
 - [cli] Revert "Add last status to `pulumi stack ls` output #10059"
   [#10221](https://github.com/pulumi/pulumi/pull/10221)
+
+- [python] Fix overriding of PATH on Windows.
+  [#10236](https://github.com/pulumi/pulumi/pull/10236)

--- a/sdk/python/python_test.go
+++ b/sdk/python/python_test.go
@@ -68,6 +68,10 @@ func TestActivateVirtualEnv(t *testing.T) {
 			input:    []string{"PYTHONHOME=foo", "FOO=blah"},
 			expected: []string{"FOO=blah", fmt.Sprintf("PATH=%s", venvDir)},
 		},
+		{
+			input:    []string{"PythonHome=foo", "Path=bar"},
+			expected: []string{fmt.Sprintf("Path=%s%sbar", venvDir, string(os.PathListSeparator))},
+		},
 	}
 	//nolint:paralleltest // false positive because range var isn't used directly in t.Run(name) arg
 	for _, test := range tests {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/10102

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
