### PR TITLE
Revert "Use plugin link instead of PATH manipulation in programtest (#10220)"

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -308,9 +308,6 @@ type ProgramTestOptions struct {
 	// preparation logic by dispatching on whether the project
 	// uses Node, Python, .NET or Go.
 	PrepareProject func(*engine.Projinfo) error
-
-	// Extra provider plugins
-	ProviderPlugins []workspace.PluginOptions
 }
 
 func (opts *ProgramTestOptions) GetDebugLogLevel() int {
@@ -1694,6 +1691,8 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 	}
 	projinfo.Root = projdir
 
+	//Modify the pulumi project file in the temp dir
+	//if it has any local references to plugins
 	dir, err := workspace.DetectProjectPathFrom(projdir)
 	if err != nil {
 		return "", "", err
@@ -1703,15 +1702,6 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 		return "", "", fmt.Errorf("error loading project %q: %w", dir, err)
 	}
 
-	// Add extra provider plugins
-	if len(pt.opts.ProviderPlugins) > 0 {
-		if proj.Plugins == nil {
-			proj.Plugins = &workspace.Plugins{}
-		}
-		proj.Plugins.Providers = append(proj.Plugins.Providers, pt.opts.ProviderPlugins...)
-	}
-
-	//Modify the pulumi project file in the temp dir if it has any local references to plugins
 	if proj.Plugins != nil {
 		for _, provider := range proj.Plugins.Providers {
 			if !filepath.IsAbs(provider.Path) {
@@ -1730,7 +1720,6 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 			}
 		}
 	}
-
 	bytes, err := yaml.Marshal(proj)
 	if err != nil {
 		return "", "", fmt.Errorf("error marshalling project %q: %w", dir, err)

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/python"
 )
 
@@ -561,19 +560,19 @@ func TestConstructPython(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t,
+				filepath.Join("..", "testprovider"),
+				filepath.Join("construct_component", test.componentDir))
 			integration.ProgramTest(t,
-				optsForConstructPython(t, test.expectedResourceCount, test.env,
-					pluginOptions(t, "testprovider", filepath.Join("..", "testprovider")),
-					pluginOptions(t, "testcomponent", filepath.Join("construct_component", test.componentDir))))
+				optsForConstructPython(t, test.expectedResourceCount, append(test.env, pathEnv)...))
 		})
 	}
 }
 
-func optsForConstructPython(t *testing.T, expectedResourceCount int, env []string, providers ...workspace.PluginOptions) *integration.ProgramTestOptions {
+func optsForConstructPython(t *testing.T, expectedResourceCount int, env ...string) *integration.ProgramTestOptions {
 	return &integration.ProgramTestOptions{
-		ProviderPlugins: providers,
-		Env:             env,
-		Dir:             filepath.Join("construct_component", "python"),
+		Env: env,
+		Dir: filepath.Join("construct_component", "python"),
 		Dependencies: []string{
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
@@ -622,6 +621,8 @@ func optsForConstructPython(t *testing.T, expectedResourceCount int, env []strin
 
 // Test remote component construction with a child resource that takes a long time to be created, ensuring it's created.
 func TestConstructSlowPython(t *testing.T) {
+	pathEnv := testComponentSlowPathEnv(t)
+
 	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
 	// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
 	// module to run `yarn install && yarn link @pulumi/pulumi` in the Python program's directory, allowing
@@ -631,9 +632,8 @@ func TestConstructSlowPython(t *testing.T) {
 	const testYarnLinkPulumiEnv = "PULUMI_TEST_YARN_LINK_PULUMI=true"
 
 	opts := &integration.ProgramTestOptions{
-		ProviderPlugins: []workspace.PluginOptions{testComponentSlowOptions(t)},
-		Env:             []string{testYarnLinkPulumiEnv},
-		Dir:             filepath.Join("construct_component_slow", "python"),
+		Env: []string{pathEnv, testYarnLinkPulumiEnv},
+		Dir: filepath.Join("construct_component_slow", "python"),
 		Dependencies: []string{
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
@@ -683,16 +683,17 @@ func TestConstructPlainPython(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t,
+				filepath.Join("..", "testprovider"),
+				filepath.Join("construct_component_plain", test.componentDir))
 			integration.ProgramTest(t,
-				optsForConstructPlainPython(t, test.expectedResourceCount, test.env,
-					pluginOptions(t, "testprovider", filepath.Join("..", "testprovider")),
-					pluginOptions(t, "testcomponent", filepath.Join("construct_component_plain", test.componentDir))))
+				optsForConstructPlainPython(t, test.expectedResourceCount, append(test.env, pathEnv)...))
 		})
 	}
 }
 
 func optsForConstructPlainPython(t *testing.T, expectedResourceCount int,
-	env []string, providers ...workspace.PluginOptions) *integration.ProgramTestOptions {
+	env ...string) *integration.ProgramTestOptions {
 	return &integration.ProgramTestOptions{
 		Env: env,
 		Dir: filepath.Join("construct_component_plain", "python"),
@@ -731,10 +732,9 @@ func TestConstructMethodsPython(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t, filepath.Join("construct_component_methods", test.componentDir))
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testcomponent", filepath.Join("construct_component_methods", test.componentDir)),
-				},
+				Env: []string{pathEnv},
 				Dir: filepath.Join("construct_component_methods", "python"),
 				Dependencies: []string{
 					filepath.Join("..", "..", "sdk", "python", "env", "src"),
@@ -779,10 +779,9 @@ func TestConstructProviderPython(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t, filepath.Join(testDir, test.componentDir))
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testcomponent", filepath.Join(testDir, test.componentDir)),
-				},
+				Env: []string{pathEnv},
 				Dir: filepath.Join(testDir, "python"),
 				Dependencies: []string{
 					filepath.Join("..", "..", "sdk", "python", "env", "src"),

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -618,26 +619,31 @@ func TestConfigPaths(t *testing.T) {
 }
 
 //nolint:deadcode
-func pluginOptions(t *testing.T, name string, path string) workspace.PluginOptions {
-	path, err := filepath.Abs(path)
-	if err != nil {
-		t.Fatal(err)
-		return workspace.PluginOptions{}
+func pathEnv(t *testing.T, path ...string) string {
+	pathEnv := []string{os.Getenv("PATH")}
+	for _, p := range path {
+		absPath, err := filepath.Abs(p)
+		if err != nil {
+			t.Fatal(err)
+			return ""
+		}
+		pathEnv = append(pathEnv, absPath)
 	}
-	return workspace.PluginOptions{
-		Name: name,
-		Path: path,
+	pathSeparator := ":"
+	if runtime.GOOS == "windows" {
+		pathSeparator = ";"
 	}
+	return "PATH=" + strings.Join(pathEnv, pathSeparator)
 }
 
 //nolint:deadcode
-func testComponentSlowOptions(t *testing.T) workspace.PluginOptions {
-	return pluginOptions(t, "testcomponent", filepath.Join("construct_component_slow", "testcomponent"))
+func testComponentSlowPathEnv(t *testing.T) string {
+	return pathEnv(t, filepath.Join("construct_component_slow", "testcomponent"))
 }
 
 //nolint:deadcode
-func testComponentPlainOptions(t *testing.T) workspace.PluginOptions {
-	return pluginOptions(t, "testcomponent", filepath.Join("construct_component_plain", "testcomponent"))
+func testComponentPlainPathEnv(t *testing.T) string {
+	return pathEnv(t, filepath.Join("construct_component_plain", "testcomponent"))
 }
 
 // nolint: unused,deadcode
@@ -727,7 +733,11 @@ func testConstructUnknown(t *testing.T, lang string, dependencies ...string) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t,
+				filepath.Join("..", "testprovider"),
+				filepath.Join(testDir, test.componentDir))
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Env:                    []string{pathEnv},
 				Dir:                    filepath.Join(testDir, lang),
 				Dependencies:           dependencies,
 				SkipRefresh:            true,
@@ -736,10 +746,6 @@ func testConstructUnknown(t *testing.T, lang string, dependencies ...string) {
 				SkipExportImport:       true,
 				SkipEmptyPreviewUpdate: true,
 				Quick:                  false,
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testprovider", filepath.Join("..", "testprovider")),
-					pluginOptions(t, "testcomponent", filepath.Join(testDir, test.componentDir)),
-				},
 			})
 		})
 	}
@@ -767,7 +773,11 @@ func testConstructMethodsUnknown(t *testing.T, lang string, dependencies ...stri
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t,
+				filepath.Join("..", "testprovider"),
+				filepath.Join(testDir, test.componentDir))
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Env:                    []string{pathEnv},
 				Dir:                    filepath.Join(testDir, lang),
 				Dependencies:           dependencies,
 				SkipRefresh:            true,
@@ -776,10 +786,6 @@ func testConstructMethodsUnknown(t *testing.T, lang string, dependencies ...stri
 				SkipExportImport:       true,
 				SkipEmptyPreviewUpdate: true,
 				Quick:                  false,
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testprovider", filepath.Join("..", "testprovider")),
-					pluginOptions(t, "testcomponent", filepath.Join(testDir, test.componentDir)),
-				},
 			})
 		})
 	}
@@ -807,7 +813,11 @@ func testConstructMethodsResources(t *testing.T, lang string, dependencies ...st
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t,
+				filepath.Join("..", "testprovider"),
+				filepath.Join(testDir, test.componentDir))
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Env:          []string{pathEnv},
 				Dir:          filepath.Join(testDir, lang),
 				Dependencies: dependencies,
 				Quick:        true,
@@ -826,10 +836,6 @@ func testConstructMethodsResources(t *testing.T, lang string, dependencies ...st
 					}
 					assert.True(t, hasExpectedResource)
 					assert.Equal(t, result, stackInfo.Outputs["result"])
-				},
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testprovider", filepath.Join("..", "testprovider")),
-					pluginOptions(t, "testcomponent", filepath.Join(testDir, test.componentDir)),
 				},
 			})
 		})
@@ -861,7 +867,9 @@ func testConstructMethodsErrors(t *testing.T, lang string, dependencies ...strin
 			stderr := &bytes.Buffer{}
 			expectedError := "the failure reason (the failure property)"
 
+			pathEnv := pathEnv(t, filepath.Join(testDir, test.componentDir))
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Env:           []string{pathEnv},
 				Dir:           filepath.Join(testDir, lang),
 				Dependencies:  dependencies,
 				Quick:         true,
@@ -870,9 +878,6 @@ func testConstructMethodsErrors(t *testing.T, lang string, dependencies ...strin
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					output := stderr.String()
 					assert.Contains(t, output, expectedError)
-				},
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testcomponent", filepath.Join(testDir, test.componentDir)),
 				},
 			})
 		})
@@ -1038,14 +1043,14 @@ func testConstructOutputValues(t *testing.T, lang string, dependencies ...string
 	for _, test := range tests {
 		test := test
 		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := pathEnv(t,
+				filepath.Join("..", "testprovider"),
+				filepath.Join(testDir, test.componentDir))
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Env:          []string{pathEnv},
 				Dir:          filepath.Join(testDir, lang),
 				Dependencies: dependencies,
 				Quick:        true,
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testprovider", filepath.Join("..", "testprovider")),
-					pluginOptions(t, "testcomponent", filepath.Join(testDir, test.componentDir)),
-				},
 			})
 		})
 	}
@@ -1095,16 +1100,15 @@ func TestProviderDownloadURL(t *testing.T) {
 	for _, lang := range languages {
 		lang := lang
 		t.Run(lang.name, func(t *testing.T) {
+			env := pathEnv(t, filepath.Join("..", "testprovider"))
 			dir := filepath.Join("gather_plugin", lang.name)
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
 				Dir:                    dir,
+				Env:                    []string{env},
 				ExportStateValidator:   validate,
 				SkipPreview:            true,
 				SkipEmptyPreviewUpdate: true,
 				Dependencies:           []string{lang.dependency},
-				ProviderPlugins: []workspace.PluginOptions{
-					pluginOptions(t, "testprovider", filepath.Join("..", "testprovider")),
-				},
 			})
 		})
 	}


### PR DESCRIPTION
This reverts commit c97aa71443c92eab8486fe46adc75f9a712899bc.

Seems that while a load of these worked on my machine, CI is unhappy with them. I'll revert this and wait till the /run-integration-tests command is working to confirm it's all good before putting in.