### PR TITLE
fix unmarshalling secrets raw

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,8 @@
+### Breaking
+
+- [engine] Engine always encrypts secret return values in Invoke
+  [#10239](https://github.com/pulumi/pulumi/pull/10239)
+
 ### Improvements
 
 - [auto/go] Adds the ability to capture incremental `stderr`

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -670,6 +670,7 @@ func (rm *resmon) Invoke(ctx context.Context, req *pulumirpc.ResourceInvokeReque
 	mret, err := plugin.MarshalProperties(ret, plugin.MarshalOptions{
 		Label:         label,
 		KeepUnknowns:  true,
+		KeepSecrets:   true,
 		KeepResources: req.GetAcceptResources(),
 	})
 	if err != nil {

--- a/tests/integration/get_resource/dotnet/Program.cs
+++ b/tests/integration/get_resource/dotnet/Program.cs
@@ -7,6 +7,9 @@ using Pulumi.Random;
 
 class GetResource : CustomResource
 {
+    [Output("secret")]
+    public Output<int> Secret { get; private set; } = null!;
+
     [Output("length")]
     public Output<int> Length { get; private set; } = null!;
 
@@ -22,13 +25,21 @@ class Program
     {
         return Deployment.RunAsync(() =>
         {
-            var pet = new RandomPet("cat");
+            var pet = new RandomPet("cat", new RandomPetArgs {
+                Length = 2,
+            });
 
             var getPetLength = pet.Urn.Apply(urn => new GetResource(urn).Length);
+            var secretPet = new RandomPet("secretPet", new RandomPetArgs {
+                Length = Output.CreateSecret(1),
+            });
+
+            var getPetSecretLength = secretPet.Urn.Apply(urn => new GetResource(urn).Length);
             
             return new Dictionary<string, object>
             {
-                {"getPetLength", getPetLength}
+                {"getPetLength", getPetLength},
+                {"secret", getPetSecretLength},
             };
         });
     }

--- a/tests/integration/get_resource/go/main.go
+++ b/tests/integration/get_resource/go/main.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/pulumi/pulumi-random/sdk/v3/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 type MyResource struct {
 	pulumi.ResourceState
 
-	Length pulumi.IntOutput `pulumi:"length"`
+	Length pulumi.IntOutput       `pulumi:"length"`
+	Prefix pulumi.StringPtrOutput `pulumi:"prefix"`
 }
 
 type myResourceArgs struct{}
@@ -33,8 +35,11 @@ func GetResource(ctx *pulumi.Context, urn pulumi.URN) (*MyResource, error) {
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
+		c := config.New(ctx, "")
+		bar := c.RequireSecret("bar")
 		pet, err := random.NewRandomPet(ctx, "cat", &random.RandomPetArgs{
 			Length: pulumi.Int(2),
+			Prefix: bar,
 		})
 		if err != nil {
 			return err
@@ -47,7 +52,15 @@ func main() {
 			}
 			return r.Length, nil
 		})
+		getPetSecret := pet.URN().ApplyT(func(urn pulumi.URN) (pulumi.StringPtrInput, error) {
+			r, err := GetResource(ctx, urn)
+			if err != nil {
+				return nil, err
+			}
+			return r.Prefix, nil
+		})
 		ctx.Export("getPetLength", getPetLength)
+		ctx.Export("secret", getPetSecret)
 
 		return nil
 	})

--- a/tests/integration/get_resource/nodejs/index.ts
+++ b/tests/integration/get_resource/nodejs/index.ts
@@ -17,15 +17,20 @@ class MyResource extends pulumi.dynamic.Resource {
 
 class GetResource extends pulumi.Resource {
     foo: pulumi.Output<string>;
+    bar: pulumi.Output<string>;
 
     constructor(urn: pulumi.URN) {
-        const props = { foo: undefined };
+        const props = {
+            foo: undefined,
+            bar: undefined,
+        };
         super("unused:unused:unused", "unused", true, props, { urn });
     }
 }
 
 const a = new MyResource("a", {
     foo: "foo",
+    bar: pulumi.secret("my-$ecret"),
 });
 
 const getFoo = a.urn.apply(urn => {
@@ -33,4 +38,11 @@ const getFoo = a.urn.apply(urn => {
     return r.foo
 });
 
+const getBar = a.urn.apply(urn => {
+    const r = new GetResource(urn);
+    return r.bar
+});
+
+
 export const foo = getFoo;
+export const secret = getBar;

--- a/tests/integration/get_resource/python/__main__.py
+++ b/tests/integration/get_resource/python/__main__.py
@@ -13,19 +13,25 @@ class MyProvider(ResourceProvider):
 
 class MyResource(Resource):
     foo: Output
+    bar: Output
 
     def __init__(self, name, props, opts = None):
         super().__init__(MyProvider(), name, props, opts)
 
 class GetResource(pulumi.Resource):
     foo: Output
+    bar: Output
 
     def __init__(self, urn):
-        props = {"foo": None}
+        props = {
+            "foo": None,
+            "bar": None,
+        }
         super().__init__("unused", "unused:unused:unused", True, props, ResourceOptions(urn=urn), False, False)
 
 a = MyResource("a", {
     "foo": "foo",
+    "bar": pulumi.Output.secret("my-$ecret"),
 })
 
 async def check_get():
@@ -33,5 +39,8 @@ async def check_get():
     a_get = GetResource(a_urn)
     a_foo = await a_get.foo.future()
     assert a_foo == "foo"
+
+    bar = a_get.bar
+    assert await bar.is_secret()
 
 export("o", check_get())

--- a/tests/integration/integration_dotnet_test.go
+++ b/tests/integration/integration_dotnet_test.go
@@ -593,6 +593,16 @@ func TestGetResourceDotnet(t *testing.T) {
 		Dependencies:             []string{"Pulumi"},
 		Dir:                      filepath.Join("get_resource", "dotnet"),
 		AllowEmptyPreviewChanges: true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stack.Outputs)
+			assert.Equal(t, float64(2), stack.Outputs["getPetLength"])
+
+			out, ok := stack.Outputs["secret"].(map[string]interface{})
+			assert.True(t, ok)
+
+			_, ok = out["ciphertext"]
+			assert.True(t, ok)
+		},
 	})
 }
 

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -694,9 +694,18 @@ func TestGetResourceGo(t *testing.T) {
 		},
 		Dir:                      filepath.Join("get_resource", "go"),
 		AllowEmptyPreviewChanges: true,
+		Secrets: map[string]string{
+			"bar": "this super secret is encrypted",
+		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stack.Outputs)
 			assert.Equal(t, float64(2), stack.Outputs["getPetLength"])
+
+			out, ok := stack.Outputs["secret"].(map[string]interface{})
+			assert.True(t, ok)
+
+			_, ok = out["ciphertext"]
+			assert.True(t, ok)
 		},
 	})
 }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1115,6 +1115,12 @@ func TestGetResourceNode(t *testing.T) {
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stack.Outputs)
 			assert.Equal(t, "foo", stack.Outputs["foo"])
+
+			out, ok := stack.Outputs["secret"].(map[string]interface{})
+			assert.True(t, ok)
+
+			_, ok = out["ciphertext"]
+			assert.True(t, ok)
 		},
 	})
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

During Invoke, secrets are stripped and returned back in cleartext. This PR keeps them encrypted when returning them.

I've added tests and checked `nodejs` `python` sdk's v3.0.0, but was having difficulty checking the go sdk and dotnet SDK at versions v3.0.0
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10172 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
