### PR TITLE
[dotnet/codegen] Prefix referenced Pulumi types with global modifier

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -68,3 +68,6 @@
 
 - [python] Fix overriding of PATH on Windows.
   [#10236](https://github.com/pulumi/pulumi/pull/10236)
+
+- [dotnet/codgen] Allow specified root namespace to be suffixed with "Pulumi" when generating packages
+  [#10245](https://github.com/pulumi/pulumi/pull/10245)

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -660,7 +660,7 @@ func (pt *plainType) genInputTypeWithFlags(w io.Writer, level int, generateInput
 
 	var suffix string
 	if pt.baseClass != "" {
-		suffix = fmt.Sprintf(" : Pulumi.%s", pt.baseClass)
+		suffix = fmt.Sprintf(" : global::Pulumi.%s", pt.baseClass)
 	}
 
 	fmt.Fprintf(w, "%spublic %sclass %s%s\n", indent, sealed, pt.name, suffix)
@@ -857,7 +857,7 @@ func (mod *modContext) getDefaultValue(dv *schema.DefaultValue, t schema.Type) (
 }
 
 func genAlias(w io.Writer, alias *schema.Alias) {
-	fmt.Fprintf(w, "new Pulumi.Alias { ")
+	fmt.Fprintf(w, "new global::Pulumi.Alias { ")
 
 	parts := []string{}
 	if alias.Name != nil {
@@ -898,14 +898,14 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	optionsType := "CustomResourceOptions"
 	switch {
 	case r.IsProvider:
-		baseType = "Pulumi.ProviderResource"
+		baseType = "global::Pulumi.ProviderResource"
 	case mod.isK8sCompatMode():
 		baseType = "KubernetesResource"
 	case r.IsComponent:
-		baseType = "Pulumi.ComponentResource"
+		baseType = "global::Pulumi.ComponentResource"
 		optionsType = "ComponentResourceOptions"
 	default:
-		baseType = "Pulumi.CustomResource"
+		baseType = "global::Pulumi.CustomResource"
 	}
 
 	if r.DeprecationMessage != "" {

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -100,7 +100,7 @@ namespace {{.Namespace}}
         }
     }
 
-    internal sealed class {{.Name}}ResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class {{.Name}}ResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public {{.Name}}ResourceTypeAttribute(string type) : base(type, {{.ClassName}}.Version)
         {

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/DocumentDB/SqlResourceSqlContainer.cs
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/DocumentDB/SqlResourceSqlContainer.cs
@@ -107,7 +107,7 @@ namespace Pulumi.AzureNative.DocumentDB
     /// ```
     /// </summary>
     [AzureNativeResourceType("azure-native:documentdb:SqlResourceSqlContainer")]
-    public partial class SqlResourceSqlContainer : Pulumi.CustomResource
+    public partial class SqlResourceSqlContainer : global::Pulumi.CustomResource
     {
         [Output("resource")]
         public Output<Outputs.SqlContainerGetPropertiesResponseResource?> Resource { get; private set; } = null!;
@@ -155,7 +155,7 @@ namespace Pulumi.AzureNative.DocumentDB
         }
     }
 
-    public sealed class SqlResourceSqlContainerArgs : Pulumi.ResourceArgs
+    public sealed class SqlResourceSqlContainerArgs : global::Pulumi.ResourceArgs
     {
         public SqlResourceSqlContainerArgs()
         {

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.AzureNative
 {
     [AzureNativeResourceType("pulumi:providers:azure-native")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.AzureNative
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.AzureNative
         }
     }
 
-    internal sealed class AzureNativeResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class AzureNativeResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public AzureNativeResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Inputs/TopLevelArgs.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Inputs/TopLevelArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.FooBar.Inputs
 {
 
-    public sealed class TopLevelArgs : Pulumi.ResourceArgs
+    public sealed class TopLevelArgs : global::Pulumi.ResourceArgs
     {
         [Input("buzz")]
         public Input<string>? Buzz { get; set; }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.FooBar
 {
     [FooBarResourceType("pulumi:providers:foo-bar")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.FooBar
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Submodule1/ModuleResource.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Submodule1/ModuleResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.FooBar.Submodule1
 {
     [FooBarResourceType("foo-bar:submodule1:ModuleResource")]
-    public partial class ModuleResource : Pulumi.CustomResource
+    public partial class ModuleResource : global::Pulumi.CustomResource
     {
         [Output("thing")]
         public Output<Pulumi.FooBar.Outputs.TopLevel?> Thing { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.FooBar.Submodule1
         }
     }
 
-    public sealed class ModuleResourceArgs : Pulumi.ResourceArgs
+    public sealed class ModuleResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("thing")]
         public Input<Pulumi.FooBar.Inputs.TopLevelArgs>? Thing { get; set; }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.FooBar
         }
     }
 
-    internal sealed class FooBarResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class FooBarResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public FooBarResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Inputs/ContainerArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Inputs
 {
 
-    public sealed class ContainerArgs : Pulumi.ResourceArgs
+    public sealed class ContainerArgs : global::Pulumi.ResourceArgs
     {
         [Input("brightness")]
         public Input<Pulumi.Plant.ContainerBrightness>? Brightness { get; set; }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant
 {
     [PlantResourceType("pulumi:providers:plant")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Plant
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/Nursery.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Tree.V1
 {
     [PlantResourceType("plant:tree/v1:Nursery")]
-    public partial class Nursery : Pulumi.CustomResource
+    public partial class Nursery : global::Pulumi.CustomResource
     {
         /// <summary>
         /// Create a Nursery resource with the given unique name, arguments, and options.
@@ -54,7 +54,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class NurseryArgs : Pulumi.ResourceArgs
+    public sealed class NurseryArgs : global::Pulumi.ResourceArgs
     {
         [Input("sizes")]
         private InputMap<Pulumi.Plant.Tree.V1.TreeSize>? _sizes;

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/RubberTree.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Tree.V1
 {
     [PlantResourceType("plant:tree/v1:RubberTree")]
-    public partial class RubberTree : Pulumi.CustomResource
+    public partial class RubberTree : global::Pulumi.CustomResource
     {
         [Output("container")]
         public Output<Pulumi.Plant.Outputs.Container?> Container { get; private set; } = null!;
@@ -71,7 +71,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class RubberTreeArgs : Pulumi.ResourceArgs
+    public sealed class RubberTreeArgs : global::Pulumi.ResourceArgs
     {
         [Input("container")]
         public Input<Pulumi.Plant.Inputs.ContainerArgs>? Container { get; set; }
@@ -97,7 +97,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class RubberTreeState : Pulumi.ResourceArgs
+    public sealed class RubberTreeState : global::Pulumi.ResourceArgs
     {
         [Input("farm")]
         public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Plant
         }
     }
 
-    internal sealed class PlantResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class PlantResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public PlantResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Inputs/ContainerArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Inputs
 {
 
-    public sealed class ContainerArgs : Pulumi.ResourceArgs
+    public sealed class ContainerArgs : global::Pulumi.ResourceArgs
     {
         [Input("brightness")]
         public Input<Pulumi.Plant.ContainerBrightness>? Brightness { get; set; }

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant
 {
     [PlantResourceType("pulumi:providers:plant")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Plant
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/Nursery.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Tree.V1
 {
     [PlantResourceType("plant:tree/v1:Nursery")]
-    public partial class Nursery : Pulumi.CustomResource
+    public partial class Nursery : global::Pulumi.CustomResource
     {
         /// <summary>
         /// Create a Nursery resource with the given unique name, arguments, and options.
@@ -54,7 +54,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class NurseryArgs : Pulumi.ResourceArgs
+    public sealed class NurseryArgs : global::Pulumi.ResourceArgs
     {
         [Input("sizes")]
         private InputMap<Pulumi.Plant.Tree.V1.TreeSize>? _sizes;

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/RubberTree.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Tree.V1
 {
     [PlantResourceType("plant:tree/v1:RubberTree")]
-    public partial class RubberTree : Pulumi.CustomResource
+    public partial class RubberTree : global::Pulumi.CustomResource
     {
         [Output("container")]
         public Output<Pulumi.Plant.Outputs.Container?> Container { get; private set; } = null!;
@@ -71,7 +71,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class RubberTreeArgs : Pulumi.ResourceArgs
+    public sealed class RubberTreeArgs : global::Pulumi.ResourceArgs
     {
         [Input("container")]
         public Input<Pulumi.Plant.Inputs.ContainerArgs>? Container { get; set; }
@@ -97,7 +97,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class RubberTreeState : Pulumi.ResourceArgs
+    public sealed class RubberTreeState : global::Pulumi.ResourceArgs
     {
         [Input("farm")]
         public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Plant
         }
     }
 
-    internal sealed class PlantResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class PlantResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public PlantResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/MyModule/IamResource.cs
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/MyModule/IamResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.MyModule
 {
     [ExampleResourceType("example:myModule:IamResource")]
-    public partial class IamResource : Pulumi.ComponentResource
+    public partial class IamResource : global::Pulumi.ComponentResource
     {
         /// <summary>
         /// Create a IamResource resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example.MyModule
         }
     }
 
-    public sealed class IamResourceArgs : Pulumi.ResourceArgs
+    public sealed class IamResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
         public Input<Pulumi.GoogleNative.IAM.V1.Inputs.AuditConfigArgs>? Config { get; set; }

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/ArgFunction.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Example
     }
 
 
-    public sealed class ArgFunctionArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionArgs : global::Pulumi.InvokeArgs
     {
         [Input("name")]
         public Pulumi.Random.RandomPet? Name { get; set; }
@@ -29,7 +29,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("name")]
         public Input<Pulumi.Random.RandomPet>? Name { get; set; }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Cat.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Cat.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Cat")]
-    public partial class Cat : Pulumi.CustomResource
+    public partial class Cat : global::Pulumi.CustomResource
     {
         [Output("name")]
         public Output<string?> Name { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class CatArgs : Pulumi.ResourceArgs
+    public sealed class CatArgs : global::Pulumi.ResourceArgs
     {
         [Input("age")]
         public Input<int>? Age { get; set; }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Component.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Component")]
-    public partial class Component : Pulumi.CustomResource
+    public partial class Component : global::Pulumi.CustomResource
     {
         [Output("provider")]
         public Output<Pulumi.Kubernetes.Provider?> Provider { get; private set; } = null!;
@@ -64,7 +64,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ComponentArgs : Pulumi.ResourceArgs
+    public sealed class ComponentArgs : global::Pulumi.ResourceArgs
     {
         [Input("metadata")]
         public Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? Metadata { get; set; }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class PetArgs : Pulumi.ResourceArgs
+    public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("age")]
         public Input<int>? Age { get; set; }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Workload.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Workload.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Workload")]
-    public partial class Workload : Pulumi.CustomResource
+    public partial class Workload : global::Pulumi.CustomResource
     {
         [Output("pod")]
         public Output<Pulumi.Kubernetes.Types.Outputs.Core.V1.Pod?> Pod { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class WorkloadArgs : Pulumi.ResourceArgs
+    public sealed class WorkloadArgs : global::Pulumi.ResourceArgs
     {
         public WorkloadArgs()
         {

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Registrygeoreplication
 {
     [RegistrygeoreplicationResourceType("pulumi:providers:registrygeoreplication")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Registrygeoreplication
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/RegistryGeoReplication.cs
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/RegistryGeoReplication.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Registrygeoreplication
 {
     [RegistrygeoreplicationResourceType("registrygeoreplication:index:RegistryGeoReplication")]
-    public partial class RegistryGeoReplication : Pulumi.ComponentResource
+    public partial class RegistryGeoReplication : global::Pulumi.ComponentResource
     {
         /// <summary>
         /// The login server url
@@ -56,7 +56,7 @@ namespace Pulumi.Registrygeoreplication
         }
     }
 
-    public sealed class RegistryGeoReplicationArgs : Pulumi.ResourceArgs
+    public sealed class RegistryGeoReplicationArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// The resource group that hosts the component resource

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Registrygeoreplication
         }
     }
 
-    internal sealed class RegistrygeoreplicationResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class RegistrygeoreplicationResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public RegistrygeoreplicationResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Resource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Resource")]
-    public partial class Resource : Pulumi.CustomResource
+    public partial class Resource : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ResourceArgs : Pulumi.ResourceArgs
+    public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         public ResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/ResourceInput.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/ResourceInput.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::ResourceInput")]
-    public partial class ResourceInput : Pulumi.CustomResource
+    public partial class ResourceInput : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ResourceInputArgs : Pulumi.ResourceArgs
+    public sealed class ResourceInputArgs : global::Pulumi.ResourceArgs
     {
         public ResourceInputArgs()
         {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Deeply/nested/module/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Deeply/nested/module/Resource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.FooBar.Deeply/nested/module
 {
     [FooBarResourceType("foo-bar:deeply/nested/module:Resource")]
-    public partial class Resource : Pulumi.CustomResource
+    public partial class Resource : global::Pulumi.CustomResource
     {
         [Output("baz")]
         public Output<string?> Baz { get; private set; } = null!;
@@ -62,7 +62,7 @@ namespace Pulumi.FooBar.Deeply/nested/module
         }
     }
 
-    public sealed class ResourceArgs : Pulumi.ResourceArgs
+    public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
         private Input<string>? _baz;

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.FooBar
 {
     [FooBarResourceType("pulumi:providers:foo-bar")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.FooBar
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.FooBar
         }
     }
 
-    internal sealed class FooBarResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class FooBarResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public FooBarResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Nested/module/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Nested/module/Resource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Foo.Nested/module
 {
     [FooResourceType("foo:nested/module:Resource")]
-    public partial class Resource : Pulumi.CustomResource
+    public partial class Resource : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
@@ -62,7 +62,7 @@ namespace Pulumi.Foo.Nested/module
         }
     }
 
-    public sealed class ResourceArgs : Pulumi.ResourceArgs
+    public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         private Input<string>? _bar;

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Foo
 {
     [FooResourceType("pulumi:providers:foo")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Foo
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Foo
         }
     }
 
-    internal sealed class FooResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class FooResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public FooResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/ArgFunction.cs
@@ -20,7 +20,7 @@ namespace Other.Example
     }
 
 
-    public sealed class ArgFunctionArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Other.Example.Resource? Arg1 { get; set; }
@@ -30,7 +30,7 @@ namespace Other.Example
         }
     }
 
-    public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Input<Other.Example.Resource>? Arg1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/BarResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/BarResource.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example
 {
     [ExampleResourceType("bar::BarResource")]
-    public partial class BarResource : Pulumi.ComponentResource
+    public partial class BarResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Other.Example.Resource?> Foo { get; private set; } = null!;
@@ -43,7 +43,7 @@ namespace Other.Example
         }
     }
 
-    public sealed class BarResourceArgs : Pulumi.ResourceArgs
+    public sealed class BarResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Input<Other.Example.Resource>? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/FooResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/FooResource.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example
 {
     [ExampleResourceType("foo::FooResource")]
-    public partial class FooResource : Pulumi.ComponentResource
+    public partial class FooResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Other.Example.Resource?> Foo { get; private set; } = null!;
@@ -43,7 +43,7 @@ namespace Other.Example
         }
     }
 
-    public sealed class FooResourceArgs : Pulumi.ResourceArgs
+    public sealed class FooResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Input<Other.Example.Resource>? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ConfigMapArgs.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example.Inputs
 {
 
-    public sealed class ConfigMapArgs : Pulumi.ResourceArgs
+    public sealed class ConfigMapArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
         public Input<string>? Config { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectArgs.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example.Inputs
 {
 
-    public sealed class ObjectArgs : Pulumi.ResourceArgs
+    public sealed class ObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<string>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example.Inputs
 {
 
-    public sealed class ObjectWithNodeOptionalInputsArgs : Pulumi.ResourceArgs
+    public sealed class ObjectWithNodeOptionalInputsArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<int>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example.Inputs
 {
 
-    public sealed class SomeOtherObjectArgs : Pulumi.ResourceArgs
+    public sealed class SomeOtherObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
         public Input<string>? Baz { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/OtherResource.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example
 {
     [ExampleResourceType("example::OtherResource")]
-    public partial class OtherResource : Pulumi.ComponentResource
+    public partial class OtherResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Other.Example.Resource?> Foo { get; private set; } = null!;
@@ -43,7 +43,7 @@ namespace Other.Example
         }
     }
 
-    public sealed class OtherResourceArgs : Pulumi.ResourceArgs
+    public sealed class OtherResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Input<Other.Example.Resource>? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Provider.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -39,7 +39,7 @@ namespace Other.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Resource.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example
 {
     [ExampleResourceType("example::Resource")]
-    public partial class Resource : Pulumi.CustomResource
+    public partial class Resource : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
@@ -64,7 +64,7 @@ namespace Other.Example
         }
     }
 
-    public sealed class ResourceArgs : Pulumi.ResourceArgs
+    public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         private Input<string>? _bar;

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/TypeUses.cs
@@ -11,7 +11,7 @@ using Pulumi;
 namespace Other.Example
 {
     [ExampleResourceType("example::TypeUses")]
-    public partial class TypeUses : Pulumi.CustomResource
+    public partial class TypeUses : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<Outputs.SomeOtherObject?> Bar { get; private set; } = null!;
@@ -66,7 +66,7 @@ namespace Other.Example
         }
     }
 
-    public sealed class TypeUsesArgs : Pulumi.ResourceArgs
+    public sealed class TypeUsesArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<Inputs.SomeOtherObjectArgs>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Utilities.cs
@@ -75,7 +75,7 @@ namespace Other.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFilters.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFilters.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Configuration filters
     /// </summary>
-    public sealed class ConfigurationFilters : Pulumi.InvokeArgs
+    public sealed class ConfigurationFilters : global::Pulumi.InvokeArgs
     {
         [Input("filterableProperty")]
         private List<Inputs.FilterableProperty>? _filterableProperty;

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFiltersArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFiltersArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Configuration filters
     /// </summary>
-    public sealed class ConfigurationFiltersArgs : Pulumi.ResourceArgs
+    public sealed class ConfigurationFiltersArgs : global::Pulumi.ResourceArgs
     {
         [Input("filterableProperty")]
         private InputList<Inputs.FilterablePropertyArgs>? _filterableProperty;

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetails.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetails.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Holds Customer subscription details. Clients can display available products to unregistered customers by explicitly passing subscription details
     /// </summary>
-    public sealed class CustomerSubscriptionDetails : Pulumi.InvokeArgs
+    public sealed class CustomerSubscriptionDetails : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Location placement Id of a subscription

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetailsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetailsArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Holds Customer subscription details. Clients can display available products to unregistered customers by explicitly passing subscription details
     /// </summary>
-    public sealed class CustomerSubscriptionDetailsArgs : Pulumi.ResourceArgs
+    public sealed class CustomerSubscriptionDetailsArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// Location placement Id of a subscription

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeatures.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeatures.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Represents subscription registered features
     /// </summary>
-    public sealed class CustomerSubscriptionRegisteredFeatures : Pulumi.InvokeArgs
+    public sealed class CustomerSubscriptionRegisteredFeatures : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Name of subscription registered feature

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeaturesArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeaturesArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Represents subscription registered features
     /// </summary>
-    public sealed class CustomerSubscriptionRegisteredFeaturesArgs : Pulumi.ResourceArgs
+    public sealed class CustomerSubscriptionRegisteredFeaturesArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// Name of subscription registered feature

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterableProperty.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterableProperty.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Different types of filters supported and its values.
     /// </summary>
-    public sealed class FilterableProperty : Pulumi.InvokeArgs
+    public sealed class FilterableProperty : global::Pulumi.InvokeArgs
     {
         [Input("supportedValues", required: true)]
         private List<string>? _supportedValues;

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterablePropertyArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterablePropertyArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Different types of filters supported and its values.
     /// </summary>
-    public sealed class FilterablePropertyArgs : Pulumi.ResourceArgs
+    public sealed class FilterablePropertyArgs : global::Pulumi.ResourceArgs
     {
         [Input("supportedValues", required: true)]
         private InputList<string>? _supportedValues;

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformation.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformation.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Holds details about product hierarchy information
     /// </summary>
-    public sealed class HierarchyInformation : Pulumi.InvokeArgs
+    public sealed class HierarchyInformation : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Represents configuration name that uniquely identifies configuration

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformationArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformationArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Myedgeorder.Inputs
     /// <summary>
     /// Holds details about product hierarchy information
     /// </summary>
-    public sealed class HierarchyInformationArgs : Pulumi.ResourceArgs
+    public sealed class HierarchyInformationArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// Represents configuration name that uniquely identifies configuration

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListConfigurations.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListConfigurations.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Myedgeorder
     }
 
 
-    public sealed class ListConfigurationsArgs : Pulumi.InvokeArgs
+    public sealed class ListConfigurationsArgs : global::Pulumi.InvokeArgs
     {
         [Input("configurationFilters", required: true)]
         private List<Inputs.ConfigurationFilters>? _configurationFilters;
@@ -58,7 +58,7 @@ namespace Pulumi.Myedgeorder
         }
     }
 
-    public sealed class ListConfigurationsInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ListConfigurationsInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("configurationFilters", required: true)]
         private InputList<Inputs.ConfigurationFiltersArgs>? _configurationFilters;

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Myedgeorder
     }
 
 
-    public sealed class ListProductFamiliesArgs : Pulumi.InvokeArgs
+    public sealed class ListProductFamiliesArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
@@ -64,7 +64,7 @@ namespace Pulumi.Myedgeorder
         }
     }
 
-    public sealed class ListProductFamiliesInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ListProductFamiliesInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Myedgeorder
 {
     [MyedgeorderResourceType("pulumi:providers:myedgeorder")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Myedgeorder
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Myedgeorder
         }
     }
 
-    internal sealed class MyedgeorderResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class MyedgeorderResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public MyedgeorderResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class GetAmiIdsArgs : Pulumi.InvokeArgs
+    public sealed class GetAmiIdsArgs : global::Pulumi.InvokeArgs
     {
         [Input("executableUsers")]
         private List<string>? _executableUsers;
@@ -88,7 +88,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class GetAmiIdsInvokeArgs : Pulumi.InvokeArgs
+    public sealed class GetAmiIdsInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("executableUsers")]
         private InputList<string>? _executableUsers;

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilter.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilter.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Mypkg.Inputs
 {
 
-    public sealed class GetAmiIdsFilterArgs : Pulumi.InvokeArgs
+    public sealed class GetAmiIdsFilterArgs : global::Pulumi.InvokeArgs
     {
         [Input("name", required: true)]
         public string Name { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilterArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilterArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Mypkg.Inputs
 {
 
-    public sealed class GetAmiIdsFilterInputArgs : Pulumi.ResourceArgs
+    public sealed class GetAmiIdsFilterInputArgs : global::Pulumi.ResourceArgs
     {
         [Input("name", required: true)]
         public Input<string> Name { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class ListStorageAccountKeysArgs : Pulumi.InvokeArgs
+    public sealed class ListStorageAccountKeysArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
@@ -52,7 +52,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class ListStorageAccountKeysInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ListStorageAccountKeysInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Mypkg
 {
     [MypkgResourceType("pulumi:providers:mypkg")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    internal sealed class MypkgResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class MypkgResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public MypkgResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class FuncWithAllOptionalInputsArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithAllOptionalInputsArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Property A
@@ -44,7 +44,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class FuncWithAllOptionalInputsInvokeArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithAllOptionalInputsInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Property A

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithConstInput.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithConstInput.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class FuncWithConstInputArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithConstInputArgs : global::Pulumi.InvokeArgs
     {
         [Input("plainInput")]
         public string? PlainInput { get; set; }

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDefaultValue.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDefaultValue.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class FuncWithDefaultValueArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithDefaultValueArgs : global::Pulumi.InvokeArgs
     {
         [Input("a", required: true)]
         public string A { get; set; } = null!;
@@ -39,7 +39,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class FuncWithDefaultValueInvokeArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithDefaultValueInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("a", required: true)]
         public Input<string> A { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDictParam.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDictParam.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class FuncWithDictParamArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithDictParamArgs : global::Pulumi.InvokeArgs
     {
         [Input("a")]
         private Dictionary<string, string>? _a;
@@ -43,7 +43,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class FuncWithDictParamInvokeArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithDictParamInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("a")]
         private InputMap<string>? _a;

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithEmptyOutputs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithEmptyOutputs.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class FuncWithEmptyOutputsArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithEmptyOutputsArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The Name of the FeatureGroup.
@@ -38,7 +38,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class FuncWithEmptyOutputsInvokeArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithEmptyOutputsInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The Name of the FeatureGroup.

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithListParam.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithListParam.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class FuncWithListParamArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithListParamArgs : global::Pulumi.InvokeArgs
     {
         [Input("a")]
         private List<string>? _a;
@@ -43,7 +43,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class FuncWithListParamInvokeArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithListParamInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("a")]
         private InputList<string>? _a;

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetBastionShareableLink.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetBastionShareableLink.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class GetBastionShareableLinkArgs : Pulumi.InvokeArgs
+    public sealed class GetBastionShareableLinkArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The name of the Bastion Host.
@@ -58,7 +58,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class GetBastionShareableLinkInvokeArgs : Pulumi.InvokeArgs
+    public sealed class GetBastionShareableLinkInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The name of the Bastion Host.

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class GetIntegrationRuntimeObjectMetadatumArgs : Pulumi.InvokeArgs
+    public sealed class GetIntegrationRuntimeObjectMetadatumArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The factory name.
@@ -58,7 +58,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class GetIntegrationRuntimeObjectMetadatumInvokeArgs : Pulumi.InvokeArgs
+    public sealed class GetIntegrationRuntimeObjectMetadatumInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The factory name.

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLink.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLink.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Mypkg.Inputs
     /// <summary>
     /// Bastion Shareable Link.
     /// </summary>
-    public sealed class BastionShareableLink : Pulumi.InvokeArgs
+    public sealed class BastionShareableLink : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Reference of the virtual machine resource.

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLinkArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLinkArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Mypkg.Inputs
     /// <summary>
     /// Bastion Shareable Link.
     /// </summary>
-    public sealed class BastionShareableLinkArgs : Pulumi.ResourceArgs
+    public sealed class BastionShareableLinkArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// Reference of the virtual machine resource.

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/ListStorageAccountKeys.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/ListStorageAccountKeys.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class ListStorageAccountKeysArgs : Pulumi.InvokeArgs
+    public sealed class ListStorageAccountKeysArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
@@ -52,7 +52,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class ListStorageAccountKeysInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ListStorageAccountKeysInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Mypkg
 {
     [MypkgResourceType("pulumi:providers:mypkg")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    internal sealed class MypkgResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class MypkgResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public MypkgResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.FooBar
 {
     [FooBarResourceType("foobar::ModuleResource")]
-    public partial class ModuleResource : Pulumi.CustomResource
+    public partial class ModuleResource : global::Pulumi.CustomResource
     {
         /// <summary>
         /// Create a ModuleResource resource with the given unique name, arguments, and options.
@@ -63,7 +63,7 @@ namespace Pulumi.FooBar
         }
     }
 
-    public sealed class ModuleResourceArgs : Pulumi.ResourceArgs
+    public sealed class ModuleResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("optional_bool")]
         public Input<bool>? Optional_bool { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.FooBar
 {
     [FooBarResourceType("pulumi:providers:foobar")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.FooBar
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.FooBar
         }
     }
 
-    internal sealed class FooBarResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class FooBarResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public FooBarResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Foo.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example
     /// test new feature with resoruces
     /// </summary>
     [ExampleResourceType("example:index:Foo")]
-    public partial class Foo : Pulumi.CustomResource
+    public partial class Foo : global::Pulumi.CustomResource
     {
         /// <summary>
         /// A test for plain types
@@ -64,7 +64,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class FooArgs : Pulumi.ResourceArgs
+    public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         [Input("argument")]
         public string? Argument { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -25,7 +25,7 @@ namespace Pulumi.Example
     }
 
 
-    public sealed class FuncWithAllOptionalInputsArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithAllOptionalInputsArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Property A
@@ -45,7 +45,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class FuncWithAllOptionalInputsInvokeArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithAllOptionalInputsInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Property A

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettings.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettings.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// BETA FEATURE - Options to configure the Helm Release resource.
     /// </summary>
-    public sealed class HelmReleaseSettings : Pulumi.InvokeArgs
+    public sealed class HelmReleaseSettings : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// BETA FEATURE - Options to configure the Helm Release resource.
     /// </summary>
-    public sealed class HelmReleaseSettingsArgs : Pulumi.ResourceArgs
+    public sealed class HelmReleaseSettingsArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// Options for tuning the Kubernetes client used by a Provider.
     /// </summary>
-    public sealed class KubeClientSettingsArgs : Pulumi.ResourceArgs
+    public sealed class KubeClientSettingsArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// Maximum burst for throttle. Default value is 10.

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/LayeredTypeArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/LayeredTypeArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// Make sure that defaults propagate through types
     /// </summary>
-    public sealed class LayeredTypeArgs : Pulumi.ResourceArgs
+    public sealed class LayeredTypeArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// The answer to the question

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/TypArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// A test for namespaces (mod main)
     /// </summary>
-    public sealed class TypArgs : Pulumi.ResourceArgs
+    public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
         public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod1/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod1/Inputs/TypArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Mod1.Inputs
     /// <summary>
     /// A test for namespaces (mod 1)
     /// </summary>
-    public sealed class TypArgs : Pulumi.ResourceArgs
+    public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("val")]
         public Input<string>? Val { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod2/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod2/Inputs/TypArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Mod2.Inputs
     /// <summary>
     /// A test for namespaces (mod 2)
     /// </summary>
-    public sealed class TypArgs : Pulumi.ResourceArgs
+    public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
         public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/ModuleTest.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/ModuleTest.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example:index:moduleTest")]
-    public partial class ModuleTest : Pulumi.CustomResource
+    public partial class ModuleTest : global::Pulumi.CustomResource
     {
         /// <summary>
         /// Create a ModuleTest resource with the given unique name, arguments, and options.
@@ -54,7 +54,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ModuleTestArgs : Pulumi.ResourceArgs
+    public sealed class ModuleTestArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
         public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example
     /// The provider type for the kubernetes package.
     /// </summary>
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -40,7 +40,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// BETA FEATURE - Options to configure the Helm Release resource.

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Foo.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example
     /// test new feature with resoruces
     /// </summary>
     [ExampleResourceType("example:index:Foo")]
-    public partial class Foo : Pulumi.CustomResource
+    public partial class Foo : global::Pulumi.CustomResource
     {
         /// <summary>
         /// A test for plain types
@@ -64,7 +64,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class FooArgs : Pulumi.ResourceArgs
+    public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         [Input("argument")]
         public string? Argument { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Mypkg
     }
 
 
-    public sealed class FuncWithAllOptionalInputsArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithAllOptionalInputsArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Property A
@@ -46,7 +46,7 @@ namespace Pulumi.Mypkg
         }
     }
 
-    public sealed class FuncWithAllOptionalInputsInvokeArgs : Pulumi.InvokeArgs
+    public sealed class FuncWithAllOptionalInputsInvokeArgs : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// Property A

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettings.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettings.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// BETA FEATURE - Options to configure the Helm Release resource.
     /// </summary>
-    public sealed class HelmReleaseSettings : Pulumi.InvokeArgs
+    public sealed class HelmReleaseSettings : global::Pulumi.InvokeArgs
     {
         /// <summary>
         /// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// BETA FEATURE - Options to configure the Helm Release resource.
     /// </summary>
-    public sealed class HelmReleaseSettingsArgs : Pulumi.ResourceArgs
+    public sealed class HelmReleaseSettingsArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// Options for tuning the Kubernetes client used by a Provider.
     /// </summary>
-    public sealed class KubeClientSettingsArgs : Pulumi.ResourceArgs
+    public sealed class KubeClientSettingsArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// Maximum burst for throttle. Default value is 10.

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/LayeredTypeArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/LayeredTypeArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// Make sure that defaults propagate through types
     /// </summary>
-    public sealed class LayeredTypeArgs : Pulumi.ResourceArgs
+    public sealed class LayeredTypeArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// The answer to the question

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/TypArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     /// <summary>
     /// A test for namespaces (mod main)
     /// </summary>
-    public sealed class TypArgs : Pulumi.ResourceArgs
+    public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
         public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod1/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod1/Inputs/TypArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Mod1.Inputs
     /// <summary>
     /// A test for namespaces (mod 1)
     /// </summary>
-    public sealed class TypArgs : Pulumi.ResourceArgs
+    public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("val")]
         public Input<string>? Val { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod2/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod2/Inputs/TypArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Mod2.Inputs
     /// <summary>
     /// A test for namespaces (mod 2)
     /// </summary>
-    public sealed class TypArgs : Pulumi.ResourceArgs
+    public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
         public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/ModuleTest.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/ModuleTest.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example:index:moduleTest")]
-    public partial class ModuleTest : Pulumi.CustomResource
+    public partial class ModuleTest : global::Pulumi.CustomResource
     {
         /// <summary>
         /// Create a ModuleTest resource with the given unique name, arguments, and options.
@@ -54,7 +54,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ModuleTestArgs : Pulumi.ResourceArgs
+    public sealed class ModuleTestArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
         public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example
     /// The provider type for the kubernetes package.
     /// </summary>
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -40,7 +40,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// BETA FEATURE - Options to configure the Helm Release resource.

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Inputs/FooArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Xyz.Inputs
 {
 
-    public sealed class FooArgs : Pulumi.ResourceArgs
+    public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         [Input("a")]
         public Input<bool>? A { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Xyz
 {
     [XyzResourceType("pulumi:providers:xyz")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Xyz
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/StaticPage.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/StaticPage.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Xyz
 {
     [XyzResourceType("xyz:index:StaticPage")]
-    public partial class StaticPage : Pulumi.ComponentResource
+    public partial class StaticPage : global::Pulumi.ComponentResource
     {
         /// <summary>
         /// The bucket resource.
@@ -50,7 +50,7 @@ namespace Pulumi.Xyz
         }
     }
 
-    public sealed class StaticPageArgs : Pulumi.ResourceArgs
+    public sealed class StaticPageArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Inputs.FooArgs? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Xyz
         }
     }
 
-    internal sealed class XyzResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class XyzResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public XyzResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Configstation
 {
     [ConfigstationResourceType("pulumi:providers:configstation")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Configstation
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
         /// this is a relaxed string enum which can also be set via env var

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Configstation
         }
     }
 
-    internal sealed class ConfigstationResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ConfigstationResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ConfigstationResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/GetCustomDbRoles.cs
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/GetCustomDbRoles.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Mongodbatlas
     }
 
 
-    public sealed class GetCustomDbRolesArgs : Pulumi.InvokeArgs
+    public sealed class GetCustomDbRolesArgs : global::Pulumi.InvokeArgs
     {
         public GetCustomDbRolesArgs()
         {

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Mongodbatlas
 {
     [MongodbatlasResourceType("pulumi:providers:mongodbatlas")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Mongodbatlas
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Mongodbatlas
         }
     }
 
-    internal sealed class MongodbatlasResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class MongodbatlasResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public MongodbatlasResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/ExampleFunc.cs
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/ExampleFunc.cs
@@ -16,7 +16,7 @@ namespace Pulumi.My8110
     }
 
 
-    public sealed class ExampleFuncArgs : Pulumi.InvokeArgs
+    public sealed class ExampleFuncArgs : global::Pulumi.InvokeArgs
     {
         [Input("enums")]
         private List<Union<string, Pulumi.My8110.MyEnum>>? _enums;

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.My8110
 {
     [My8110ResourceType("pulumi:providers:my8110")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.My8110
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.My8110
         }
     }
 
-    internal sealed class My8110ResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class My8110ResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public My8110ResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Cat.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Cat.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Cat")]
-    public partial class Cat : Pulumi.CustomResource
+    public partial class Cat : global::Pulumi.CustomResource
     {
         [Output("foes")]
         public Output<ImmutableDictionary<string, Outputs.Toy>?> Foes { get; private set; } = null!;
@@ -83,7 +83,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class CatArgs : Pulumi.ResourceArgs
+    public sealed class CatArgs : global::Pulumi.ResourceArgs
     {
         public CatArgs()
         {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Dog.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Dog.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Dog")]
-    public partial class Dog : Pulumi.CustomResource
+    public partial class Dog : global::Pulumi.CustomResource
     {
         [Output("bone")]
         public Output<string?> Bone { get; private set; } = null!;
@@ -62,7 +62,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class DogArgs : Pulumi.ResourceArgs
+    public sealed class DogArgs : global::Pulumi.ResourceArgs
     {
         public DogArgs()
         {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/God.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/God.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::God")]
-    public partial class God : Pulumi.CustomResource
+    public partial class God : global::Pulumi.CustomResource
     {
         [Output("backwards")]
         public Output<Pulumi.Example.Dog?> Backwards { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class GodArgs : Pulumi.ResourceArgs
+    public sealed class GodArgs : global::Pulumi.ResourceArgs
     {
         public GodArgs()
         {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/NoRecursive.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/NoRecursive.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::NoRecursive")]
-    public partial class NoRecursive : Pulumi.CustomResource
+    public partial class NoRecursive : global::Pulumi.CustomResource
     {
         [Output("rec")]
         public Output<Outputs.Rec?> Rec { get; private set; } = null!;
@@ -65,7 +65,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class NoRecursiveArgs : Pulumi.ResourceArgs
+    public sealed class NoRecursiveArgs : global::Pulumi.ResourceArgs
     {
         public NoRecursiveArgs()
         {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/ToyStore.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/ToyStore.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::ToyStore")]
-    public partial class ToyStore : Pulumi.CustomResource
+    public partial class ToyStore : global::Pulumi.CustomResource
     {
         [Output("chew")]
         public Output<Outputs.Chew?> Chew { get; private set; } = null!;
@@ -75,7 +75,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ToyStoreArgs : Pulumi.ResourceArgs
+    public sealed class ToyStoreArgs : global::Pulumi.ResourceArgs
     {
         public ToyStoreArgs()
         {

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Inputs/PetArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class PetArgs : Pulumi.ResourceArgs
+    public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
         public Input<string>? Name { get; set; }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Person.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Person.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Person")]
-    public partial class Person : Pulumi.CustomResource
+    public partial class Person : global::Pulumi.CustomResource
     {
         [Output("name")]
         public Output<string?> Name { get; private set; } = null!;
@@ -61,7 +61,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class PersonArgs : Pulumi.ResourceArgs
+    public sealed class PersonArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
         public Input<string>? Name { get; set; }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pet.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pet.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Pet")]
-    public partial class Pet : Pulumi.CustomResource
+    public partial class Pet : global::Pulumi.CustomResource
     {
         [Output("name")]
         public Output<string?> Name { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class PetArgs : Pulumi.ResourceArgs
+    public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
         public Input<string>? Name { get; set; }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Inputs/PetArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class PetArgs : Pulumi.ResourceArgs
+    public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
         public Input<string>? Name { get; set; }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Person.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Person.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Person")]
-    public partial class Person : Pulumi.CustomResource
+    public partial class Person : global::Pulumi.CustomResource
     {
         [Output("name")]
         public Output<string?> Name { get; private set; } = null!;
@@ -61,7 +61,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class PersonArgs : Pulumi.ResourceArgs
+    public sealed class PersonArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
         public Input<string>? Name { get; set; }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pet.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pet.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Pet")]
-    public partial class Pet : Pulumi.CustomResource
+    public partial class Pet : global::Pulumi.CustomResource
     {
         [Output("name")]
         public Output<string?> Name { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class PetArgs : Pulumi.ResourceArgs
+    public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
         public Input<string>? Name { get; set; }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Rec.cs
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Rec.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Rec")]
-    public partial class Rec : Pulumi.CustomResource
+    public partial class Rec : global::Pulumi.CustomResource
     {
         [Output("rec")]
         public Output<Pulumi.Example.Rec?> Rec { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class RecArgs : Pulumi.ResourceArgs
+    public sealed class RecArgs : global::Pulumi.ResourceArgs
     {
         public RecArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Inputs
 {
 
-    public sealed class ContainerArgs : Pulumi.ResourceArgs
+    public sealed class ContainerArgs : global::Pulumi.ResourceArgs
     {
         [Input("brightness")]
         public Input<Pulumi.Plant.ContainerBrightness>? Brightness { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant
 {
     [PlantResourceType("pulumi:providers:plant")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Plant
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/Nursery.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Tree.V1
 {
     [PlantResourceType("plant:tree/v1:Nursery")]
-    public partial class Nursery : Pulumi.CustomResource
+    public partial class Nursery : global::Pulumi.CustomResource
     {
         /// <summary>
         /// Create a Nursery resource with the given unique name, arguments, and options.
@@ -54,7 +54,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class NurseryArgs : Pulumi.ResourceArgs
+    public sealed class NurseryArgs : global::Pulumi.ResourceArgs
     {
         [Input("sizes")]
         private InputMap<Pulumi.Plant.Tree.V1.TreeSize>? _sizes;

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Plant.Tree.V1
 {
     [PlantResourceType("plant:tree/v1:RubberTree")]
-    public partial class RubberTree : Pulumi.CustomResource
+    public partial class RubberTree : global::Pulumi.CustomResource
     {
         [Output("container")]
         public Output<Pulumi.Plant.Outputs.Container?> Container { get; private set; } = null!;
@@ -71,7 +71,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class RubberTreeArgs : Pulumi.ResourceArgs
+    public sealed class RubberTreeArgs : global::Pulumi.ResourceArgs
     {
         [Input("container")]
         public Input<Pulumi.Plant.Inputs.ContainerArgs>? Container { get; set; }
@@ -97,7 +97,7 @@ namespace Pulumi.Plant.Tree.V1
         }
     }
 
-    public sealed class RubberTreeState : Pulumi.ResourceArgs
+    public sealed class RubberTreeState : global::Pulumi.ResourceArgs
     {
         [Input("farm")]
         public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Plant
         }
     }
 
-    internal sealed class PlantResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class PlantResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public PlantResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Foo.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Foo")]
-    public partial class Foo : Pulumi.ComponentResource
+    public partial class Foo : global::Pulumi.ComponentResource
     {
         /// <summary>
         /// Create a Foo resource with the given unique name, arguments, and options.
@@ -40,7 +40,7 @@ namespace Pulumi.Example
             => Pulumi.Deployment.Instance.Call<FooGetKubeconfigResult>("example::Foo/getKubeconfig", args ?? new FooGetKubeconfigArgs(), this).Apply(v => v.Kubeconfig);
     }
 
-    public sealed class FooArgs : Pulumi.ResourceArgs
+    public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         public FooArgs()
         {
@@ -50,7 +50,7 @@ namespace Pulumi.Example
     /// <summary>
     /// The set of arguments for the <see cref="Foo.GetKubeconfig"/> method.
     /// </summary>
-    public sealed class FooGetKubeconfigArgs : Pulumi.CallArgs
+    public sealed class FooGetKubeconfigArgs : global::Pulumi.CallArgs
     {
         [Input("profileName")]
         public Input<string>? ProfileName { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Foo.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Foo")]
-    public partial class Foo : Pulumi.ComponentResource
+    public partial class Foo : global::Pulumi.ComponentResource
     {
         /// <summary>
         /// Create a Foo resource with the given unique name, arguments, and options.
@@ -52,7 +52,7 @@ namespace Pulumi.Example
             => Pulumi.Deployment.Instance.Call<FooGenerateKubeconfigResult>("example::Foo/generateKubeconfig", args ?? new FooGenerateKubeconfigArgs(), this);
     }
 
-    public sealed class FooArgs : Pulumi.ResourceArgs
+    public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         public FooArgs()
         {
@@ -62,7 +62,7 @@ namespace Pulumi.Example
     /// <summary>
     /// The set of arguments for the <see cref="Foo.Bar"/> method.
     /// </summary>
-    public sealed class FooBarArgs : Pulumi.CallArgs
+    public sealed class FooBarArgs : global::Pulumi.CallArgs
     {
         [Input("baz")]
         public Input<Pulumi.Example.Nested.Inputs.BazArgs>? Baz { get; set; }
@@ -123,7 +123,7 @@ namespace Pulumi.Example
     /// <summary>
     /// The set of arguments for the <see cref="Foo.GenerateKubeconfig"/> method.
     /// </summary>
-    public sealed class FooGenerateKubeconfigArgs : Pulumi.CallArgs
+    public sealed class FooGenerateKubeconfigArgs : global::Pulumi.CallArgs
     {
         [Input("boolValue", required: true)]
         public bool BoolValue { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/Baz.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/Baz.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Nested.Inputs
 {
 
-    public sealed class Baz : Pulumi.InvokeArgs
+    public sealed class Baz : global::Pulumi.InvokeArgs
     {
         [Input("hello")]
         public string? Hello { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/BazArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/BazArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Nested.Inputs
 {
 
-    public sealed class BazArgs : Pulumi.ResourceArgs
+    public sealed class BazArgs : global::Pulumi.ResourceArgs
     {
         [Input("hello")]
         public Input<string>? Hello { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Component.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Component")]
-    public partial class Component : Pulumi.ComponentResource
+    public partial class Component : global::Pulumi.ComponentResource
     {
         [Output("a")]
         public Output<bool> A { get; private set; } = null!;
@@ -65,7 +65,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ComponentArgs : Pulumi.ResourceArgs
+    public sealed class ComponentArgs : global::Pulumi.ResourceArgs
     {
         [Input("a", required: true)]
         public bool A { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Inputs/FooArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class FooArgs : Pulumi.ResourceArgs
+    public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         [Input("a", required: true)]
         public bool A { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Component.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Component")]
-    public partial class Component : Pulumi.ComponentResource
+    public partial class Component : global::Pulumi.ComponentResource
     {
         [Output("a")]
         public Output<bool> A { get; private set; } = null!;
@@ -65,7 +65,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ComponentArgs : Pulumi.ResourceArgs
+    public sealed class ComponentArgs : global::Pulumi.ResourceArgs
     {
         [Input("a", required: true)]
         public bool A { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/DoFoo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/DoFoo.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Example
     }
 
 
-    public sealed class DoFooArgs : Pulumi.InvokeArgs
+    public sealed class DoFooArgs : global::Pulumi.InvokeArgs
     {
         [Input("foo", required: true)]
         public Inputs.Foo Foo { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/Foo.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class Foo : Pulumi.InvokeArgs
+    public sealed class Foo : global::Pulumi.InvokeArgs
     {
         [Input("a", required: true)]
         public bool A { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class FooArgs : Pulumi.ResourceArgs
+    public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         [Input("a", required: true)]
         public bool A { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Example
     }
 
 
-    public sealed class ArgFunctionArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Pulumi.Example.Resource? Arg1 { get; set; }
@@ -29,7 +29,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Input<Pulumi.Example.Resource>? Arg1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/OtherResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::OtherResource")]
-    public partial class OtherResource : Pulumi.ComponentResource
+    public partial class OtherResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Pulumi.Example.Resource?> Foo { get; private set; } = null!;
@@ -41,7 +41,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class OtherResourceArgs : Pulumi.ResourceArgs
+    public sealed class OtherResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Input<Pulumi.Example.Resource>? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Resource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Resource")]
-    public partial class Resource : Pulumi.CustomResource
+    public partial class Resource : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
@@ -58,7 +58,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ResourceArgs : Pulumi.ResourceArgs
+    public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<string>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/ArgFunction.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Example
     }
 
 
-    public sealed class ArgFunctionArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Pulumi.Example.Resource? Arg1 { get; set; }
@@ -29,7 +29,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Input<Pulumi.Example.Resource>? Arg1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/BarResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/BarResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("bar::BarResource")]
-    public partial class BarResource : Pulumi.ComponentResource
+    public partial class BarResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Pulumi.Example.Resource?> Foo { get; private set; } = null!;
@@ -42,7 +42,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class BarResourceArgs : Pulumi.ResourceArgs
+    public sealed class BarResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Input<Pulumi.Example.Resource>? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/FooResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/FooResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("foo::FooResource")]
-    public partial class FooResource : Pulumi.ComponentResource
+    public partial class FooResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Pulumi.Example.Resource?> Foo { get; private set; } = null!;
@@ -42,7 +42,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class FooResourceArgs : Pulumi.ResourceArgs
+    public sealed class FooResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Input<Pulumi.Example.Resource>? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ConfigMapArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class ConfigMapArgs : Pulumi.ResourceArgs
+    public sealed class ConfigMapArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
         public Input<string>? Config { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class ObjectArgs : Pulumi.ResourceArgs
+    public sealed class ObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<string>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class ObjectWithNodeOptionalInputsArgs : Pulumi.ResourceArgs
+    public sealed class ObjectWithNodeOptionalInputsArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<int>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class SomeOtherObjectArgs : Pulumi.ResourceArgs
+    public sealed class SomeOtherObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
         public Input<string>? Baz { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/OtherResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::OtherResource")]
-    public partial class OtherResource : Pulumi.ComponentResource
+    public partial class OtherResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Pulumi.Example.Resource?> Foo { get; private set; } = null!;
@@ -42,7 +42,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class OtherResourceArgs : Pulumi.ResourceArgs
+    public sealed class OtherResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
         public Input<Pulumi.Example.Resource>? Foo { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -38,7 +38,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Resource")]
-    public partial class Resource : Pulumi.CustomResource
+    public partial class Resource : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
@@ -67,7 +67,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ResourceArgs : Pulumi.ResourceArgs
+    public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         private Input<string>? _bar;

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/TypeUses.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::TypeUses")]
-    public partial class TypeUses : Pulumi.CustomResource
+    public partial class TypeUses : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<Outputs.SomeOtherObject?> Bar { get; private set; } = null!;
@@ -65,7 +65,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class TypeUsesArgs : Pulumi.ResourceArgs
+    public sealed class TypeUsesArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<Inputs.SomeOtherObjectArgs>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Utilities.cs
@@ -75,7 +75,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/ArgFunction.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Example
     }
 
 
-    public sealed class ArgFunctionArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Pulumi.Example.Resource? Arg1 { get; set; }
@@ -29,7 +29,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
+    public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
         public Input<Pulumi.Example.Resource>? Arg1 { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ConfigMapArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class ConfigMapArgs : Pulumi.ResourceArgs
+    public sealed class ConfigMapArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
         public Input<string>? Config { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class ObjectArgs : Pulumi.ResourceArgs
+    public sealed class ObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<string>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class ObjectWithNodeOptionalInputsArgs : Pulumi.ResourceArgs
+    public sealed class ObjectWithNodeOptionalInputsArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<int>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example.Inputs
 {
 
-    public sealed class SomeOtherObjectArgs : Pulumi.ResourceArgs
+    public sealed class SomeOtherObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
         public Input<string>? Baz { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/OtherResource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::OtherResource")]
-    public partial class OtherResource : Pulumi.ComponentResource
+    public partial class OtherResource : global::Pulumi.ComponentResource
     {
         [Output("foo")]
         public Output<Pulumi.Example.Resource?> Foo { get; private set; } = null!;
@@ -41,7 +41,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class OtherResourceArgs : Pulumi.ResourceArgs
+    public sealed class OtherResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         private List<Input<string>>? _bar;

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("pulumi:providers:example")]
-    public partial class Provider : Pulumi.ProviderResource
+    public partial class Provider : global::Pulumi.ProviderResource
     {
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
@@ -37,7 +37,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ProviderArgs : Pulumi.ResourceArgs
+    public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Resource.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::Resource")]
-    public partial class Resource : Pulumi.CustomResource
+    public partial class Resource : global::Pulumi.CustomResource
     {
         [Output("bar")]
         public Output<string?> Bar { get; private set; } = null!;
@@ -62,7 +62,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class ResourceArgs : Pulumi.ResourceArgs
+    public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         private Input<string>? _bar;

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/TypeUses.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.Example
 {
     [ExampleResourceType("example::TypeUses")]
-    public partial class TypeUses : Pulumi.CustomResource
+    public partial class TypeUses : global::Pulumi.CustomResource
     {
         [Output("alpha")]
         public Output<Pulumi.Example.OutputOnlyEnumType?> Alpha { get; private set; } = null!;
@@ -79,7 +79,7 @@ namespace Pulumi.Example
         }
     }
 
-    public sealed class TypeUsesArgs : Pulumi.ResourceArgs
+    public sealed class TypeUsesArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
         public Input<Inputs.SomeOtherObjectArgs>? Bar { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Utilities.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Utilities.cs
@@ -74,7 +74,7 @@ namespace Pulumi.Example
         }
     }
 
-    internal sealed class ExampleResourceTypeAttribute : Pulumi.ResourceTypeAttribute
+    internal sealed class ExampleResourceTypeAttribute : global::Pulumi.ResourceTypeAttribute
     {
         public ExampleResourceTypeAttribute(string type) : base(type, Utilities.Version)
         {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When specifying a root namespace that is suffixed "Pulumi" (i.e. `Cloud.Pulumi`) for a provider to be generated, it messes up the references to fully qualified types from the Pulumi SDK because dotnet can't decide whether these are coming from `Pulumi` or `Cloud.Pulumi`. 

This PR fixes it by annotating referenced types from Pulumi with `global::` so that dotnet no longer looks up the types under `Cloud.Pulumi` but look at the Pulumi SDK 

Fixes #9876

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
