### PR TITLE
[dotnet/sdk] Serialize immutable arrays initialized by default

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -68,3 +68,6 @@
 
 - [python] Fix overriding of PATH on Windows.
   [#10236](https://github.com/pulumi/pulumi/pull/10236)
+
+- [dotnet/sdk] Serialize immutable arrays initialized by default.
+  [#10247](https://github.com/pulumi/pulumi/pull/10247)

--- a/sdk/dotnet/Pulumi.Tests/Serialization/ListOutputCompletionSourceTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/ListOutputCompletionSourceTests.cs
@@ -27,6 +27,14 @@ namespace Pulumi.Tests.Serialization
             AssertEx.SequenceEqual(ImmutableArray<bool>.Empty.Add(true), data.Value);
             Assert.True(data.IsKnown);
         }
+        
+        [Fact]
+        public async Task ListInitializedByDefault()
+        {
+            var data = Converter.ConvertValue<ImmutableArray<string>>(NoWarn, "", await SerializeToValueAsync(default(ImmutableArray<string>)));
+            AssertEx.SequenceEqual(ImmutableArray<string>.Empty, data.Value);
+            Assert.True(data.IsKnown);
+        }
 
         [Fact]
         public async Task SecretListWithElement()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10125 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
