### PR TITLE
Retry plugin downloads

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -38,6 +38,9 @@
 - [engine] Remove sequence numbers from the engine and provider interfaces.
   [#10203](https://github.com/pulumi/pulumi/pull/10203)
 
+- [engine] The engine will retry plugin downloads that error.
+  [#10248](https://github.com/pulumi/pulumi/pull/10248)
+
 ### Bug Fixes
 
 - [cli] Only log github request headers at log level 11.

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -145,7 +145,8 @@ func newPluginInstallCmd() *cobra.Command {
 						return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", displayOpts.Color)
 					}
 					retry := func(err error, attempt int, limit int, delay time.Duration) {
-						cmdutil.Diag().Warningf(diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
+						cmdutil.Diag().Warningf(
+							diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
 					}
 
 					r, err := workspace.DownloadToFile(install, withProgress, retry)

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -140,14 +141,19 @@ func newPluginInstallCmd() *cobra.Command {
 				var payload workspace.PluginContent
 				var err error
 				if file == "" {
-					var size int64
-					var r io.ReadCloser
-					if r, size, err = install.Download(); err != nil {
+					withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
+						return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", displayOpts.Color)
+					}
+					retry := func(err error, attempt int, limit int, delay time.Duration) {
+						cmdutil.Diag().Warningf(diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
+					}
+
+					r, err := workspace.DownloadToFile(install, withProgress, retry)
+					if err != nil {
 						return fmt.Errorf("%s downloading from %s: %w", label, install.PluginDownloadURL, err)
 					}
-					payload = workspace.TarPlugin(
-						workspace.ReadCloserProgressBar(r, size, "Downloading plugin", displayOpts.Color),
-					)
+
+					payload = workspace.TarPlugin(r)
 				} else {
 					source = file
 					logging.V(1).Infof("%s opening tarball from %s", label, file)

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sync"
@@ -105,67 +104,13 @@ func (l *pluginLoader) ensurePlugin(pkg string, version *semver.Version) error {
 		Version: version,
 	}
 
-	tryDownload := func(dst io.WriteCloser) error {
-		defer dst.Close()
-		tarball, expectedByteCount, err := pkgPlugin.Download()
-		if err != nil {
-			return err
-		}
-		defer tarball.Close()
-		copiedByteCount, err := io.Copy(dst, tarball)
-		if err != nil {
-			return err
-		}
-		if copiedByteCount != expectedByteCount {
-			return fmt.Errorf("Expected %d bytes but copied %d when downloading plugin %s",
-				expectedByteCount, copiedByteCount, pkgPlugin)
-		}
-		return nil
-	}
-
-	tryDownloadToFile := func() (string, error) {
-		file, err := ioutil.TempFile("" /* default temp dir */, "pulumi-plugin-tar")
-		if err != nil {
-			return "", err
-		}
-		err = tryDownload(file)
-		if err != nil {
-			err2 := os.Remove(file.Name())
-			if err2 != nil {
-				return "", fmt.Errorf("Error while removing tempfile: %v. Context: %w", err2, err)
-			}
-			return "", err
-		}
-		return file.Name(), nil
-	}
-
-	downloadToFileWithRetry := func() (string, error) {
-		delay := 80 * time.Millisecond
-		for attempt := 0; ; attempt++ {
-			tempFile, err := tryDownloadToFile()
-			if err == nil {
-				return tempFile, nil
-			}
-
-			if err != nil && attempt >= 5 {
-				return tempFile, err
-			}
-			time.Sleep(delay)
-			delay = delay * 2
-		}
-	}
-
 	if !workspace.HasPlugin(pkgPlugin) {
-		tarball, err := downloadToFileWithRetry()
+		tarball, err := workspace.DownloadToFile(pkgPlugin, nil, nil)
 		if err != nil {
 			return fmt.Errorf("failed to download plugin: %s: %w", pkgPlugin, err)
 		}
-		defer os.Remove(tarball)
-		reader, err := os.Open(tarball)
-		if err != nil {
-			return fmt.Errorf("failed to open downloaded plugin: %s: %w", pkgPlugin, err)
-		}
-		if err := pkgPlugin.InstallWithContext(context.Background(), workspace.TarPlugin(reader), false); err != nil {
+		defer os.Remove(tarball.Name())
+		if err := pkgPlugin.InstallWithContext(context.Background(), workspace.TarPlugin(tarball), false); err != nil {
 			return fmt.Errorf("failed to install plugin %s: %w", pkgPlugin, err)
 		}
 	}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -236,7 +236,8 @@ func installPlugin(ctx context.Context, plugin workspace.PluginInfo) error {
 		return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", cmdutil.GetGlobalColorization())
 	}
 	retry := func(err error, attempt int, limit int, delay time.Duration) {
-		logging.V(preparePluginVerboseLog).Infof("Error downloading plugin: %s\nWill retry in %v [%d/%d]", err, delay, attempt, limit)
+		logging.V(preparePluginVerboseLog).Infof(
+			"Error downloading plugin: %s\nWill retry in %v [%d/%d]", err, delay, attempt, limit)
 	}
 
 	tarball, err := workspace.DownloadToFile(plugin, withProgress, retry)

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -810,7 +810,7 @@ func (info PluginInfo) Install(tgz io.ReadCloser, reinstall bool) error {
 }
 
 // DownloadToFile downloads the given PluginInfo to a temporary file and returns that temporary file.
-// This has some
+// This has some retry logic to re-attempt the download if it errors for any reason.
 func DownloadToFile(
 	pkgPlugin PluginInfo,
 	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We occasionally see network issues (most notably "tls: bad record MAC")
during plugin downloads. When grabbing plugins for codegen we already
had some retry logic. This shares that retry logic to the `pulumi plugin
install` command and the engine.

Fixes https://github.com/pulumi/pulumi/issues/9824

Note, plumbing in the progress bar and support for printing about
retries is a little bit odd but we're going to have to totally rethink
this interface at some point when the engine gets put behind a gRPC
interface and all the display logic has to be ripped out. So it works
good enough for now.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
