### PR TITLE
[dotnet/codegen] Override inherited Empty property from arg types

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -68,3 +68,6 @@
 
 - [python] Fix overriding of PATH on Windows.
   [#10236](https://github.com/pulumi/pulumi/pull/10236)
+
+- [dotnet/codegen] Override static `Empty` property to return concrete argument types
+  [#10250](https://github.com/pulumi/pulumi/pull/10250)

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -687,6 +687,10 @@ func (pt *plainType) genInputTypeWithFlags(w io.Writer, level int, generateInput
 	}
 	fmt.Fprintf(w, "%s    }\n", indent)
 
+	// override Empty static property from inherited ResourceArgs
+	// and make it return a concrete args type instead of inherited ResourceArgs
+	fmt.Fprintf(w, "%s    public static new %s Empty => new %s();\n", indent, pt.name, pt.name)
+
 	// Close the class.
 	fmt.Fprintf(w, "%s}\n", indent)
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/DocumentDB/SqlResourceSqlContainer.cs
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/DocumentDB/SqlResourceSqlContainer.cs
@@ -160,5 +160,6 @@ namespace Pulumi.AzureNative.DocumentDB
         public SqlResourceSqlContainerArgs()
         {
         }
+        public static new SqlResourceSqlContainerArgs Empty => new SqlResourceSqlContainerArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.AzureNative
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Inputs/TopLevelArgs.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Inputs/TopLevelArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.FooBar.Inputs
         public TopLevelArgs()
         {
         }
+        public static new TopLevelArgs Empty => new TopLevelArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.FooBar
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Submodule1/ModuleResource.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Submodule1/ModuleResource.cs
@@ -66,5 +66,6 @@ namespace Pulumi.FooBar.Submodule1
         public ModuleResourceArgs()
         {
         }
+        public static new ModuleResourceArgs Empty => new ModuleResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Inputs/ContainerArgs.cs
@@ -28,5 +28,6 @@ namespace Pulumi.Plant.Inputs
         {
             Brightness = Pulumi.Plant.ContainerBrightness.One;
         }
+        public static new ContainerArgs Empty => new ContainerArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Plant
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/Nursery.cs
@@ -83,5 +83,6 @@ namespace Pulumi.Plant.Tree.V1
         public NurseryArgs()
         {
         }
+        public static new NurseryArgs Empty => new NurseryArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/RubberTree.cs
@@ -95,6 +95,7 @@ namespace Pulumi.Plant.Tree.V1
             Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
             Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
         }
+        public static new RubberTreeArgs Empty => new RubberTreeArgs();
     }
 
     public sealed class RubberTreeState : Pulumi.ResourceArgs
@@ -106,5 +107,6 @@ namespace Pulumi.Plant.Tree.V1
         {
             Farm = "(unknown)";
         }
+        public static new RubberTreeState Empty => new RubberTreeState();
     }
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Inputs/ContainerArgs.cs
@@ -28,5 +28,6 @@ namespace Pulumi.Plant.Inputs
         {
             Brightness = Pulumi.Plant.ContainerBrightness.One;
         }
+        public static new ContainerArgs Empty => new ContainerArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Plant
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/Nursery.cs
@@ -83,5 +83,6 @@ namespace Pulumi.Plant.Tree.V1
         public NurseryArgs()
         {
         }
+        public static new NurseryArgs Empty => new NurseryArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/RubberTree.cs
@@ -95,6 +95,7 @@ namespace Pulumi.Plant.Tree.V1
             Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
             Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
         }
+        public static new RubberTreeArgs Empty => new RubberTreeArgs();
     }
 
     public sealed class RubberTreeState : Pulumi.ResourceArgs
@@ -106,5 +107,6 @@ namespace Pulumi.Plant.Tree.V1
         {
             Farm = "(unknown)";
         }
+        public static new RubberTreeState Empty => new RubberTreeState();
     }
 }

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/MyModule/IamResource.cs
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/MyModule/IamResource.cs
@@ -45,5 +45,6 @@ namespace Pulumi.Example.MyModule
         public IamResourceArgs()
         {
         }
+        public static new IamResourceArgs Empty => new IamResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/ArgFunction.cs
@@ -27,6 +27,7 @@ namespace Pulumi.Example
         public ArgFunctionArgs()
         {
         }
+        public static new ArgFunctionArgs Empty => new ArgFunctionArgs();
     }
 
     public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
@@ -37,6 +38,7 @@ namespace Pulumi.Example
         public ArgFunctionInvokeArgs()
         {
         }
+        public static new ArgFunctionInvokeArgs Empty => new ArgFunctionInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Cat.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Cat.cs
@@ -69,5 +69,6 @@ namespace Pulumi.Example
         public CatArgs()
         {
         }
+        public static new CatArgs Empty => new CatArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Component.cs
@@ -107,5 +107,6 @@ namespace Pulumi.Example
         public ComponentArgs()
         {
         }
+        public static new ComponentArgs Empty => new ComponentArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
@@ -56,5 +56,6 @@ namespace Pulumi.Example.Inputs
         public PetArgs()
         {
         }
+        public static new PetArgs Empty => new PetArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Workload.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Workload.cs
@@ -63,5 +63,6 @@ namespace Pulumi.Example
         public WorkloadArgs()
         {
         }
+        public static new WorkloadArgs Empty => new WorkloadArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Registrygeoreplication
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/RegistryGeoReplication.cs
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/RegistryGeoReplication.cs
@@ -67,5 +67,6 @@ namespace Pulumi.Registrygeoreplication
         public RegistryGeoReplicationArgs()
         {
         }
+        public static new RegistryGeoReplicationArgs Empty => new RegistryGeoReplicationArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Resource.cs
@@ -63,5 +63,6 @@ namespace Pulumi.Example
         public ResourceArgs()
         {
         }
+        public static new ResourceArgs Empty => new ResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/ResourceInput.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/ResourceInput.cs
@@ -63,5 +63,6 @@ namespace Pulumi.Example
         public ResourceInputArgs()
         {
         }
+        public static new ResourceInputArgs Empty => new ResourceInputArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Deeply/nested/module/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Deeply/nested/module/Resource.cs
@@ -79,5 +79,6 @@ namespace Pulumi.FooBar.Deeply/nested/module
         public ResourceArgs()
         {
         }
+        public static new ResourceArgs Empty => new ResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.FooBar
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Nested/module/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Nested/module/Resource.cs
@@ -79,5 +79,6 @@ namespace Pulumi.Foo.Nested/module
         public ResourceArgs()
         {
         }
+        public static new ResourceArgs Empty => new ResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Foo
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/ArgFunction.cs
@@ -28,6 +28,7 @@ namespace Other.Example
         public ArgFunctionArgs()
         {
         }
+        public static new ArgFunctionArgs Empty => new ArgFunctionArgs();
     }
 
     public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
@@ -38,6 +39,7 @@ namespace Other.Example
         public ArgFunctionInvokeArgs()
         {
         }
+        public static new ArgFunctionInvokeArgs Empty => new ArgFunctionInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/BarResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/BarResource.cs
@@ -51,5 +51,6 @@ namespace Other.Example
         public BarResourceArgs()
         {
         }
+        public static new BarResourceArgs Empty => new BarResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/FooResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/FooResource.cs
@@ -51,5 +51,6 @@ namespace Other.Example
         public FooResourceArgs()
         {
         }
+        public static new FooResourceArgs Empty => new FooResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ConfigMapArgs.cs
@@ -19,5 +19,6 @@ namespace Other.Example.Inputs
         public ConfigMapArgs()
         {
         }
+        public static new ConfigMapArgs Empty => new ConfigMapArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectArgs.cs
@@ -54,5 +54,6 @@ namespace Other.Example.Inputs
         public ObjectArgs()
         {
         }
+        public static new ObjectArgs Empty => new ObjectArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -22,5 +22,6 @@ namespace Other.Example.Inputs
         public ObjectWithNodeOptionalInputsArgs()
         {
         }
+        public static new ObjectWithNodeOptionalInputsArgs Empty => new ObjectWithNodeOptionalInputsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -19,5 +19,6 @@ namespace Other.Example.Inputs
         public SomeOtherObjectArgs()
         {
         }
+        public static new SomeOtherObjectArgs Empty => new SomeOtherObjectArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/OtherResource.cs
@@ -51,5 +51,6 @@ namespace Other.Example
         public OtherResourceArgs()
         {
         }
+        public static new OtherResourceArgs Empty => new OtherResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Provider.cs
@@ -44,5 +44,6 @@ namespace Other.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Resource.cs
@@ -81,5 +81,6 @@ namespace Other.Example
         public ResourceArgs()
         {
         }
+        public static new ResourceArgs Empty => new ResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/TypeUses.cs
@@ -80,5 +80,6 @@ namespace Other.Example
         public TypeUsesArgs()
         {
         }
+        public static new TypeUsesArgs Empty => new TypeUsesArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFilters.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFilters.cs
@@ -36,5 +36,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public ConfigurationFilters()
         {
         }
+        public static new ConfigurationFilters Empty => new ConfigurationFilters();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFiltersArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFiltersArgs.cs
@@ -36,5 +36,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public ConfigurationFiltersArgs()
         {
         }
+        public static new ConfigurationFiltersArgs Empty => new ConfigurationFiltersArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetails.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetails.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public CustomerSubscriptionDetails()
         {
         }
+        public static new CustomerSubscriptionDetails Empty => new CustomerSubscriptionDetails();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetailsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetailsArgs.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public CustomerSubscriptionDetailsArgs()
         {
         }
+        public static new CustomerSubscriptionDetailsArgs Empty => new CustomerSubscriptionDetailsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeatures.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeatures.cs
@@ -30,5 +30,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public CustomerSubscriptionRegisteredFeatures()
         {
         }
+        public static new CustomerSubscriptionRegisteredFeatures Empty => new CustomerSubscriptionRegisteredFeatures();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeaturesArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeaturesArgs.cs
@@ -30,5 +30,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public CustomerSubscriptionRegisteredFeaturesArgs()
         {
         }
+        public static new CustomerSubscriptionRegisteredFeaturesArgs Empty => new CustomerSubscriptionRegisteredFeaturesArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterableProperty.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterableProperty.cs
@@ -36,5 +36,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public FilterableProperty()
         {
         }
+        public static new FilterableProperty Empty => new FilterableProperty();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterablePropertyArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/FilterablePropertyArgs.cs
@@ -36,5 +36,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public FilterablePropertyArgs()
         {
         }
+        public static new FilterablePropertyArgs Empty => new FilterablePropertyArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformation.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformation.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public HierarchyInformation()
         {
         }
+        public static new HierarchyInformation Empty => new HierarchyInformation();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformationArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformationArgs.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Myedgeorder.Inputs
         public HierarchyInformationArgs()
         {
         }
+        public static new HierarchyInformationArgs Empty => new HierarchyInformationArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListConfigurations.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListConfigurations.cs
@@ -56,6 +56,7 @@ namespace Pulumi.Myedgeorder
         public ListConfigurationsArgs()
         {
         }
+        public static new ListConfigurationsArgs Empty => new ListConfigurationsArgs();
     }
 
     public sealed class ListConfigurationsInvokeArgs : Pulumi.InvokeArgs
@@ -87,6 +88,7 @@ namespace Pulumi.Myedgeorder
         public ListConfigurationsInvokeArgs()
         {
         }
+        public static new ListConfigurationsInvokeArgs Empty => new ListConfigurationsInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
@@ -62,6 +62,7 @@ namespace Pulumi.Myedgeorder
         public ListProductFamiliesArgs()
         {
         }
+        public static new ListProductFamiliesArgs Empty => new ListProductFamiliesArgs();
     }
 
     public sealed class ListProductFamiliesInvokeArgs : Pulumi.InvokeArgs
@@ -99,6 +100,7 @@ namespace Pulumi.Myedgeorder
         public ListProductFamiliesInvokeArgs()
         {
         }
+        public static new ListProductFamiliesInvokeArgs Empty => new ListProductFamiliesInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Myedgeorder
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
@@ -86,6 +86,7 @@ namespace Pulumi.Mypkg
         public GetAmiIdsArgs()
         {
         }
+        public static new GetAmiIdsArgs Empty => new GetAmiIdsArgs();
     }
 
     public sealed class GetAmiIdsInvokeArgs : Pulumi.InvokeArgs
@@ -148,6 +149,7 @@ namespace Pulumi.Mypkg
         public GetAmiIdsInvokeArgs()
         {
         }
+        public static new GetAmiIdsInvokeArgs Empty => new GetAmiIdsInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilter.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilter.cs
@@ -26,5 +26,6 @@ namespace Pulumi.Mypkg.Inputs
         public GetAmiIdsFilterArgs()
         {
         }
+        public static new GetAmiIdsFilterArgs Empty => new GetAmiIdsFilterArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilterArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Inputs/GetAmiIdsFilterArgs.cs
@@ -26,5 +26,6 @@ namespace Pulumi.Mypkg.Inputs
         public GetAmiIdsFilterInputArgs()
         {
         }
+        public static new GetAmiIdsFilterInputArgs Empty => new GetAmiIdsFilterInputArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
@@ -50,6 +50,7 @@ namespace Pulumi.Mypkg
         public ListStorageAccountKeysArgs()
         {
         }
+        public static new ListStorageAccountKeysArgs Empty => new ListStorageAccountKeysArgs();
     }
 
     public sealed class ListStorageAccountKeysInvokeArgs : Pulumi.InvokeArgs
@@ -75,6 +76,7 @@ namespace Pulumi.Mypkg
         public ListStorageAccountKeysInvokeArgs()
         {
         }
+        public static new ListStorageAccountKeysInvokeArgs Empty => new ListStorageAccountKeysInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Mypkg
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
@@ -42,6 +42,7 @@ namespace Pulumi.Mypkg
         public FuncWithAllOptionalInputsArgs()
         {
         }
+        public static new FuncWithAllOptionalInputsArgs Empty => new FuncWithAllOptionalInputsArgs();
     }
 
     public sealed class FuncWithAllOptionalInputsInvokeArgs : Pulumi.InvokeArgs
@@ -61,6 +62,7 @@ namespace Pulumi.Mypkg
         public FuncWithAllOptionalInputsInvokeArgs()
         {
         }
+        public static new FuncWithAllOptionalInputsInvokeArgs Empty => new FuncWithAllOptionalInputsInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithConstInput.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithConstInput.cs
@@ -27,5 +27,6 @@ namespace Pulumi.Mypkg
         public FuncWithConstInputArgs()
         {
         }
+        public static new FuncWithConstInputArgs Empty => new FuncWithConstInputArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDefaultValue.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDefaultValue.cs
@@ -37,6 +37,7 @@ namespace Pulumi.Mypkg
         {
             B = "b-default";
         }
+        public static new FuncWithDefaultValueArgs Empty => new FuncWithDefaultValueArgs();
     }
 
     public sealed class FuncWithDefaultValueInvokeArgs : Pulumi.InvokeArgs
@@ -51,6 +52,7 @@ namespace Pulumi.Mypkg
         {
             B = "b-default";
         }
+        public static new FuncWithDefaultValueInvokeArgs Empty => new FuncWithDefaultValueInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDictParam.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDictParam.cs
@@ -41,6 +41,7 @@ namespace Pulumi.Mypkg
         public FuncWithDictParamArgs()
         {
         }
+        public static new FuncWithDictParamArgs Empty => new FuncWithDictParamArgs();
     }
 
     public sealed class FuncWithDictParamInvokeArgs : Pulumi.InvokeArgs
@@ -59,6 +60,7 @@ namespace Pulumi.Mypkg
         public FuncWithDictParamInvokeArgs()
         {
         }
+        public static new FuncWithDictParamInvokeArgs Empty => new FuncWithDictParamInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithEmptyOutputs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithEmptyOutputs.cs
@@ -36,6 +36,7 @@ namespace Pulumi.Mypkg
         public FuncWithEmptyOutputsArgs()
         {
         }
+        public static new FuncWithEmptyOutputsArgs Empty => new FuncWithEmptyOutputsArgs();
     }
 
     public sealed class FuncWithEmptyOutputsInvokeArgs : Pulumi.InvokeArgs
@@ -49,6 +50,7 @@ namespace Pulumi.Mypkg
         public FuncWithEmptyOutputsInvokeArgs()
         {
         }
+        public static new FuncWithEmptyOutputsInvokeArgs Empty => new FuncWithEmptyOutputsInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithListParam.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithListParam.cs
@@ -41,6 +41,7 @@ namespace Pulumi.Mypkg
         public FuncWithListParamArgs()
         {
         }
+        public static new FuncWithListParamArgs Empty => new FuncWithListParamArgs();
     }
 
     public sealed class FuncWithListParamInvokeArgs : Pulumi.InvokeArgs
@@ -59,6 +60,7 @@ namespace Pulumi.Mypkg
         public FuncWithListParamInvokeArgs()
         {
         }
+        public static new FuncWithListParamInvokeArgs Empty => new FuncWithListParamInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetBastionShareableLink.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetBastionShareableLink.cs
@@ -56,6 +56,7 @@ namespace Pulumi.Mypkg
         public GetBastionShareableLinkArgs()
         {
         }
+        public static new GetBastionShareableLinkArgs Empty => new GetBastionShareableLinkArgs();
     }
 
     public sealed class GetBastionShareableLinkInvokeArgs : Pulumi.InvokeArgs
@@ -87,6 +88,7 @@ namespace Pulumi.Mypkg
         public GetBastionShareableLinkInvokeArgs()
         {
         }
+        public static new GetBastionShareableLinkInvokeArgs Empty => new GetBastionShareableLinkInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
@@ -56,6 +56,7 @@ namespace Pulumi.Mypkg
         public GetIntegrationRuntimeObjectMetadatumArgs()
         {
         }
+        public static new GetIntegrationRuntimeObjectMetadatumArgs Empty => new GetIntegrationRuntimeObjectMetadatumArgs();
     }
 
     public sealed class GetIntegrationRuntimeObjectMetadatumInvokeArgs : Pulumi.InvokeArgs
@@ -87,6 +88,7 @@ namespace Pulumi.Mypkg
         public GetIntegrationRuntimeObjectMetadatumInvokeArgs()
         {
         }
+        public static new GetIntegrationRuntimeObjectMetadatumInvokeArgs Empty => new GetIntegrationRuntimeObjectMetadatumInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLink.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLink.cs
@@ -24,5 +24,6 @@ namespace Pulumi.Mypkg.Inputs
         public BastionShareableLink()
         {
         }
+        public static new BastionShareableLink Empty => new BastionShareableLink();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLinkArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Inputs/BastionShareableLinkArgs.cs
@@ -24,5 +24,6 @@ namespace Pulumi.Mypkg.Inputs
         public BastionShareableLinkArgs()
         {
         }
+        public static new BastionShareableLinkArgs Empty => new BastionShareableLinkArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/ListStorageAccountKeys.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/ListStorageAccountKeys.cs
@@ -50,6 +50,7 @@ namespace Pulumi.Mypkg
         public ListStorageAccountKeysArgs()
         {
         }
+        public static new ListStorageAccountKeysArgs Empty => new ListStorageAccountKeysArgs();
     }
 
     public sealed class ListStorageAccountKeysInvokeArgs : Pulumi.InvokeArgs
@@ -75,6 +76,7 @@ namespace Pulumi.Mypkg
         public ListStorageAccountKeysInvokeArgs()
         {
         }
+        public static new ListStorageAccountKeysInvokeArgs Empty => new ListStorageAccountKeysInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Mypkg
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
@@ -136,5 +136,6 @@ namespace Pulumi.FooBar
             Required_number = 42;
             Required_string = "buzzer";
         }
+        public static new ModuleResourceArgs Empty => new ModuleResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.FooBar
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Foo.cs
@@ -90,5 +90,6 @@ namespace Pulumi.Example
         public FooArgs()
         {
         }
+        public static new FooArgs Empty => new FooArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -43,6 +43,7 @@ namespace Pulumi.Example
         {
             B = "defValue";
         }
+        public static new FuncWithAllOptionalInputsArgs Empty => new FuncWithAllOptionalInputsArgs();
     }
 
     public sealed class FuncWithAllOptionalInputsInvokeArgs : Pulumi.InvokeArgs
@@ -63,6 +64,7 @@ namespace Pulumi.Example
         {
             B = "defValue";
         }
+        public static new FuncWithAllOptionalInputsInvokeArgs Empty => new FuncWithAllOptionalInputsInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettings.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettings.cs
@@ -38,5 +38,6 @@ namespace Pulumi.Example.Inputs
             Driver = Utilities.GetEnv("PULUMI_K8S_HELM_DRIVER") ?? "secret";
             PluginsPath = Utilities.GetEnv("PULUMI_K8S_HELM_PLUGINS_PATH");
         }
+        public static new HelmReleaseSettings Empty => new HelmReleaseSettings();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
@@ -38,5 +38,6 @@ namespace Pulumi.Example.Inputs
             Driver = Utilities.GetEnv("PULUMI_K8S_HELM_DRIVER") ?? "secret";
             PluginsPath = Utilities.GetEnv("PULUMI_K8S_HELM_PLUGINS_PATH");
         }
+        public static new HelmReleaseSettingsArgs Empty => new HelmReleaseSettingsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
@@ -35,5 +35,6 @@ namespace Pulumi.Example.Inputs
             Burst = Utilities.GetEnvInt32("PULUMI_K8S_CLIENT_BURST");
             Qps = Utilities.GetEnvDouble("PULUMI_K8S_CLIENT_QPS");
         }
+        public static new KubeClientSettingsArgs Empty => new KubeClientSettingsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/LayeredTypeArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/LayeredTypeArgs.cs
@@ -51,5 +51,6 @@ namespace Pulumi.Example.Inputs
             Question = Utilities.GetEnv("PULUMI_THE_QUESTION") ?? "<unknown>";
             Thinker = "not a good interaction";
         }
+        public static new LayeredTypeArgs Empty => new LayeredTypeArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/TypArgs.cs
@@ -28,5 +28,6 @@ namespace Pulumi.Example.Inputs
         {
             Val = "mod main";
         }
+        public static new TypArgs Empty => new TypArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod1/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod1/Inputs/TypArgs.cs
@@ -22,5 +22,6 @@ namespace Pulumi.Example.Mod1.Inputs
         {
             Val = Utilities.GetEnv("PULUMI_EXAMPLE_MOD1_DEFAULT") ?? "mod1";
         }
+        public static new TypArgs Empty => new TypArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod2/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod2/Inputs/TypArgs.cs
@@ -25,5 +25,6 @@ namespace Pulumi.Example.Mod2.Inputs
         {
             Val = "mod2";
         }
+        public static new TypArgs Empty => new TypArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/ModuleTest.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/ModuleTest.cs
@@ -65,5 +65,6 @@ namespace Pulumi.Example
         public ModuleTestArgs()
         {
         }
+        public static new ModuleTestArgs Empty => new ModuleTestArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
@@ -51,5 +51,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Foo.cs
@@ -90,5 +90,6 @@ namespace Pulumi.Example
         public FooArgs()
         {
         }
+        public static new FooArgs Empty => new FooArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -44,6 +44,7 @@ namespace Pulumi.Mypkg
         {
             B = "defValue";
         }
+        public static new FuncWithAllOptionalInputsArgs Empty => new FuncWithAllOptionalInputsArgs();
     }
 
     public sealed class FuncWithAllOptionalInputsInvokeArgs : Pulumi.InvokeArgs
@@ -64,6 +65,7 @@ namespace Pulumi.Mypkg
         {
             B = "defValue";
         }
+        public static new FuncWithAllOptionalInputsInvokeArgs Empty => new FuncWithAllOptionalInputsInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettings.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettings.cs
@@ -38,5 +38,6 @@ namespace Pulumi.Example.Inputs
             Driver = Utilities.GetEnv("PULUMI_K8S_HELM_DRIVER") ?? "secret";
             PluginsPath = Utilities.GetEnv("PULUMI_K8S_HELM_PLUGINS_PATH");
         }
+        public static new HelmReleaseSettings Empty => new HelmReleaseSettings();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
@@ -38,5 +38,6 @@ namespace Pulumi.Example.Inputs
             Driver = Utilities.GetEnv("PULUMI_K8S_HELM_DRIVER") ?? "secret";
             PluginsPath = Utilities.GetEnv("PULUMI_K8S_HELM_PLUGINS_PATH");
         }
+        public static new HelmReleaseSettingsArgs Empty => new HelmReleaseSettingsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
@@ -35,5 +35,6 @@ namespace Pulumi.Example.Inputs
             Burst = Utilities.GetEnvInt32("PULUMI_K8S_CLIENT_BURST");
             Qps = Utilities.GetEnvDouble("PULUMI_K8S_CLIENT_QPS");
         }
+        public static new KubeClientSettingsArgs Empty => new KubeClientSettingsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/LayeredTypeArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/LayeredTypeArgs.cs
@@ -51,5 +51,6 @@ namespace Pulumi.Example.Inputs
             Question = Utilities.GetEnv("PULUMI_THE_QUESTION") ?? "<unknown>";
             Thinker = "not a good interaction";
         }
+        public static new LayeredTypeArgs Empty => new LayeredTypeArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/TypArgs.cs
@@ -28,5 +28,6 @@ namespace Pulumi.Example.Inputs
         {
             Val = "mod main";
         }
+        public static new TypArgs Empty => new TypArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod1/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod1/Inputs/TypArgs.cs
@@ -22,5 +22,6 @@ namespace Pulumi.Example.Mod1.Inputs
         {
             Val = "mod1";
         }
+        public static new TypArgs Empty => new TypArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod2/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod2/Inputs/TypArgs.cs
@@ -25,5 +25,6 @@ namespace Pulumi.Example.Mod2.Inputs
         {
             Val = "mod2";
         }
+        public static new TypArgs Empty => new TypArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/ModuleTest.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/ModuleTest.cs
@@ -65,5 +65,6 @@ namespace Pulumi.Example
         public ModuleTestArgs()
         {
         }
+        public static new ModuleTestArgs Empty => new ModuleTestArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
@@ -51,5 +51,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Inputs/FooArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.Xyz.Inputs
         public FooArgs()
         {
         }
+        public static new FooArgs Empty => new FooArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Xyz
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/StaticPage.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/StaticPage.cs
@@ -64,5 +64,6 @@ namespace Pulumi.Xyz
         public StaticPageArgs()
         {
         }
+        public static new StaticPageArgs Empty => new StaticPageArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Provider.cs
@@ -49,5 +49,6 @@ namespace Pulumi.Configstation
         {
             FavoriteColor = Utilities.GetEnv("FAVE_COLOR");
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/GetCustomDbRoles.cs
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/GetCustomDbRoles.cs
@@ -21,6 +21,7 @@ namespace Pulumi.Mongodbatlas
         public GetCustomDbRolesArgs()
         {
         }
+        public static new GetCustomDbRolesArgs Empty => new GetCustomDbRolesArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Mongodbatlas
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/ExampleFunc.cs
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/ExampleFunc.cs
@@ -29,5 +29,6 @@ namespace Pulumi.My8110
         public ExampleFuncArgs()
         {
         }
+        public static new ExampleFuncArgs Empty => new ExampleFuncArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.My8110
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Cat.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Cat.cs
@@ -88,5 +88,6 @@ namespace Pulumi.Example
         public CatArgs()
         {
         }
+        public static new CatArgs Empty => new CatArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Dog.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Dog.cs
@@ -67,5 +67,6 @@ namespace Pulumi.Example
         public DogArgs()
         {
         }
+        public static new DogArgs Empty => new DogArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/God.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/God.cs
@@ -63,5 +63,6 @@ namespace Pulumi.Example
         public GodArgs()
         {
         }
+        public static new GodArgs Empty => new GodArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/NoRecursive.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/NoRecursive.cs
@@ -70,5 +70,6 @@ namespace Pulumi.Example
         public NoRecursiveArgs()
         {
         }
+        public static new NoRecursiveArgs Empty => new NoRecursiveArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/ToyStore.cs
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/ToyStore.cs
@@ -80,5 +80,6 @@ namespace Pulumi.Example
         public ToyStoreArgs()
         {
         }
+        public static new ToyStoreArgs Empty => new ToyStoreArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Inputs/PetArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.Example.Inputs
         public PetArgs()
         {
         }
+        public static new PetArgs Empty => new PetArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Person.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Person.cs
@@ -77,5 +77,6 @@ namespace Pulumi.Example
         public PersonArgs()
         {
         }
+        public static new PersonArgs Empty => new PersonArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pet.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pet.cs
@@ -66,5 +66,6 @@ namespace Pulumi.Example
         public PetArgs()
         {
         }
+        public static new PetArgs Empty => new PetArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Inputs/PetArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.Example.Inputs
         public PetArgs()
         {
         }
+        public static new PetArgs Empty => new PetArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Person.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Person.cs
@@ -77,5 +77,6 @@ namespace Pulumi.Example
         public PersonArgs()
         {
         }
+        public static new PersonArgs Empty => new PersonArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pet.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pet.cs
@@ -66,5 +66,6 @@ namespace Pulumi.Example
         public PetArgs()
         {
         }
+        public static new PetArgs Empty => new PetArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Rec.cs
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Rec.cs
@@ -63,5 +63,6 @@ namespace Pulumi.Example
         public RecArgs()
         {
         }
+        public static new RecArgs Empty => new RecArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
@@ -28,5 +28,6 @@ namespace Pulumi.Plant.Inputs
         {
             Brightness = Pulumi.Plant.ContainerBrightness.One;
         }
+        public static new ContainerArgs Empty => new ContainerArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Plant
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/Nursery.cs
@@ -83,5 +83,6 @@ namespace Pulumi.Plant.Tree.V1
         public NurseryArgs()
         {
         }
+        public static new NurseryArgs Empty => new NurseryArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
@@ -95,6 +95,7 @@ namespace Pulumi.Plant.Tree.V1
             Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
             Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
         }
+        public static new RubberTreeArgs Empty => new RubberTreeArgs();
     }
 
     public sealed class RubberTreeState : Pulumi.ResourceArgs
@@ -106,5 +107,6 @@ namespace Pulumi.Plant.Tree.V1
         {
             Farm = "(unknown)";
         }
+        public static new RubberTreeState Empty => new RubberTreeState();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Foo.cs
@@ -45,6 +45,7 @@ namespace Pulumi.Example
         public FooArgs()
         {
         }
+        public static new FooArgs Empty => new FooArgs();
     }
 
     /// <summary>
@@ -61,6 +62,7 @@ namespace Pulumi.Example
         public FooGetKubeconfigArgs()
         {
         }
+        public static new FooGetKubeconfigArgs Empty => new FooGetKubeconfigArgs();
     }
 
     /// <summary>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Foo.cs
@@ -57,6 +57,7 @@ namespace Pulumi.Example
         public FooArgs()
         {
         }
+        public static new FooArgs Empty => new FooArgs();
     }
 
     /// <summary>
@@ -103,6 +104,7 @@ namespace Pulumi.Example
         public FooBarArgs()
         {
         }
+        public static new FooBarArgs Empty => new FooBarArgs();
     }
 
     /// <summary>
@@ -131,6 +133,7 @@ namespace Pulumi.Example
         public FooGenerateKubeconfigArgs()
         {
         }
+        public static new FooGenerateKubeconfigArgs Empty => new FooGenerateKubeconfigArgs();
     }
 
     /// <summary>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/Baz.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/Baz.cs
@@ -21,5 +21,6 @@ namespace Pulumi.Example.Nested.Inputs
         public Baz()
         {
         }
+        public static new Baz Empty => new Baz();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/BazArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/BazArgs.cs
@@ -21,5 +21,6 @@ namespace Pulumi.Example.Nested.Inputs
         public BazArgs()
         {
         }
+        public static new BazArgs Empty => new BazArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Component.cs
@@ -102,5 +102,6 @@ namespace Pulumi.Example
         public ComponentArgs()
         {
         }
+        public static new ComponentArgs Empty => new ComponentArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Inputs/FooArgs.cs
@@ -33,5 +33,6 @@ namespace Pulumi.Example.Inputs
         public FooArgs()
         {
         }
+        public static new FooArgs Empty => new FooArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Component.cs
@@ -110,5 +110,6 @@ namespace Pulumi.Example
         public ComponentArgs()
         {
         }
+        public static new ComponentArgs Empty => new ComponentArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/DoFoo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/DoFoo.cs
@@ -24,5 +24,6 @@ namespace Pulumi.Example
         public DoFooArgs()
         {
         }
+        public static new DoFooArgs Empty => new DoFooArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/Foo.cs
@@ -33,5 +33,6 @@ namespace Pulumi.Example.Inputs
         public Foo()
         {
         }
+        public static new Foo Empty => new Foo();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
@@ -33,5 +33,6 @@ namespace Pulumi.Example.Inputs
         public FooArgs()
         {
         }
+        public static new FooArgs Empty => new FooArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
@@ -27,6 +27,7 @@ namespace Pulumi.Example
         public ArgFunctionArgs()
         {
         }
+        public static new ArgFunctionArgs Empty => new ArgFunctionArgs();
     }
 
     public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
@@ -37,6 +38,7 @@ namespace Pulumi.Example
         public ArgFunctionInvokeArgs()
         {
         }
+        public static new ArgFunctionInvokeArgs Empty => new ArgFunctionInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/OtherResource.cs
@@ -49,5 +49,6 @@ namespace Pulumi.Example
         public OtherResourceArgs()
         {
         }
+        public static new OtherResourceArgs Empty => new OtherResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Resource.cs
@@ -66,5 +66,6 @@ namespace Pulumi.Example
         public ResourceArgs()
         {
         }
+        public static new ResourceArgs Empty => new ResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/ArgFunction.cs
@@ -27,6 +27,7 @@ namespace Pulumi.Example
         public ArgFunctionArgs()
         {
         }
+        public static new ArgFunctionArgs Empty => new ArgFunctionArgs();
     }
 
     public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
@@ -37,6 +38,7 @@ namespace Pulumi.Example
         public ArgFunctionInvokeArgs()
         {
         }
+        public static new ArgFunctionInvokeArgs Empty => new ArgFunctionInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/BarResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/BarResource.cs
@@ -50,5 +50,6 @@ namespace Pulumi.Example
         public BarResourceArgs()
         {
         }
+        public static new BarResourceArgs Empty => new BarResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/FooResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/FooResource.cs
@@ -50,5 +50,6 @@ namespace Pulumi.Example
         public FooResourceArgs()
         {
         }
+        public static new FooResourceArgs Empty => new FooResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ConfigMapArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.Example.Inputs
         public ConfigMapArgs()
         {
         }
+        public static new ConfigMapArgs Empty => new ConfigMapArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectArgs.cs
@@ -53,5 +53,6 @@ namespace Pulumi.Example.Inputs
         public ObjectArgs()
         {
         }
+        public static new ObjectArgs Empty => new ObjectArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -21,5 +21,6 @@ namespace Pulumi.Example.Inputs
         public ObjectWithNodeOptionalInputsArgs()
         {
         }
+        public static new ObjectWithNodeOptionalInputsArgs Empty => new ObjectWithNodeOptionalInputsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.Example.Inputs
         public SomeOtherObjectArgs()
         {
         }
+        public static new SomeOtherObjectArgs Empty => new SomeOtherObjectArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/OtherResource.cs
@@ -50,5 +50,6 @@ namespace Pulumi.Example
         public OtherResourceArgs()
         {
         }
+        public static new OtherResourceArgs Empty => new OtherResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Provider.cs
@@ -43,5 +43,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
@@ -84,5 +84,6 @@ namespace Pulumi.Example
         public ResourceArgs()
         {
         }
+        public static new ResourceArgs Empty => new ResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/TypeUses.cs
@@ -79,5 +79,6 @@ namespace Pulumi.Example
         public TypeUsesArgs()
         {
         }
+        public static new TypeUsesArgs Empty => new TypeUsesArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/ArgFunction.cs
@@ -27,6 +27,7 @@ namespace Pulumi.Example
         public ArgFunctionArgs()
         {
         }
+        public static new ArgFunctionArgs Empty => new ArgFunctionArgs();
     }
 
     public sealed class ArgFunctionInvokeArgs : Pulumi.InvokeArgs
@@ -37,6 +38,7 @@ namespace Pulumi.Example
         public ArgFunctionInvokeArgs()
         {
         }
+        public static new ArgFunctionInvokeArgs Empty => new ArgFunctionInvokeArgs();
     }
 
 

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ConfigMapArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.Example.Inputs
         public ConfigMapArgs()
         {
         }
+        public static new ConfigMapArgs Empty => new ConfigMapArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectArgs.cs
@@ -53,5 +53,6 @@ namespace Pulumi.Example.Inputs
         public ObjectArgs()
         {
         }
+        public static new ObjectArgs Empty => new ObjectArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -21,5 +21,6 @@ namespace Pulumi.Example.Inputs
         public ObjectWithNodeOptionalInputsArgs()
         {
         }
+        public static new ObjectWithNodeOptionalInputsArgs Empty => new ObjectWithNodeOptionalInputsArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -18,5 +18,6 @@ namespace Pulumi.Example.Inputs
         public SomeOtherObjectArgs()
         {
         }
+        public static new SomeOtherObjectArgs Empty => new SomeOtherObjectArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/OtherResource.cs
@@ -57,5 +57,6 @@ namespace Pulumi.Example
         public OtherResourceArgs()
         {
         }
+        public static new OtherResourceArgs Empty => new OtherResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Provider.cs
@@ -42,5 +42,6 @@ namespace Pulumi.Example
         public ProviderArgs()
         {
         }
+        public static new ProviderArgs Empty => new ProviderArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Resource.cs
@@ -79,5 +79,6 @@ namespace Pulumi.Example
         public ResourceArgs()
         {
         }
+        public static new ResourceArgs Empty => new ResourceArgs();
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/TypeUses.cs
@@ -96,5 +96,6 @@ namespace Pulumi.Example
         public TypeUsesArgs()
         {
         }
+        public static new TypeUsesArgs Empty => new TypeUsesArgs();
     }
 }

--- a/sdk/dotnet/Pulumi.Tests/Serialization/ListOutputCompletionSourceTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/ListOutputCompletionSourceTests.cs
@@ -27,6 +27,14 @@ namespace Pulumi.Tests.Serialization
             AssertEx.SequenceEqual(ImmutableArray<bool>.Empty.Add(true), data.Value);
             Assert.True(data.IsKnown);
         }
+        
+        [Fact]
+        public async Task ListInitializedByDefault()
+        {
+            var data = Converter.ConvertValue<ImmutableArray<string>>(NoWarn, "", await SerializeToValueAsync(default(ImmutableArray<string>)));
+            AssertEx.SequenceEqual(ImmutableArray<string>.Empty, data.Value);
+            Assert.True(data.IsKnown);
+        }
 
         [Fact]
         public async Task SecretListWithElement()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10115 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
