### PR TITLE
refactor: append to env var list instead of overwriting.

### DIFF
--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -106,9 +106,13 @@ func (e *Environment) SetBackend(backend string) {
 	e.Backend = backend
 }
 
-// SetBackend sets the backend to use for commands in this environment.
-func (e *Environment) SetEnvVars(env []string) {
-	e.Env = env
+// SetEnvVars appends to the list of environment variables.
+// According to https://pkg.go.dev/os/exec#Cmd.Env:
+//     If Env contains duplicate environment keys, only the last
+//     value in the slice for each duplicate key is used.
+// So later values take precedence.
+func (e *Environment) SetEnvVars(env ...string) {
+	e.Env = append(e.Env, env...)
 }
 
 // ImportDirectory copies a folder into the test environment.

--- a/sdk/go/common/testing/environment_test.go
+++ b/sdk/go/common/testing/environment_test.go
@@ -36,6 +36,6 @@ func TestEnvOverrideGetCommandResults(t *testing.T) {
 	// We default PULUMI_DEBUG_COMMANDS to true
 	checkDebug("true")
 	// We can override the default
-	e.Env = append(e.Env, "PULUMI_DEBUG_COMMANDS=false")
+	e.SetEnvVars("PULUMI_DEBUG_COMMANDS=false")
 	checkDebug("false")
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -924,7 +924,7 @@ func TestRotatePassphrase(t *testing.T) {
 
 	e.RunCommand("pulumi", "config", "set", "--secret", "foo", "bar")
 
-	e.SetEnvVars([]string{"PULUMI_TEST_PASSPHRASE=true"})
+	e.SetEnvVars("PULUMI_TEST_PASSPHRASE=true")
 	e.Stdin = strings.NewReader("qwerty\nqwerty\n")
 	e.RunCommand("pulumi", "stack", "change-secrets-provider", "passphrase")
 
@@ -1145,7 +1145,7 @@ func TestPassphrasePrompting(t *testing.T) {
 	e.NoPassphrase = true
 	// Setting PULUMI_TEST_PASSPHRASE allows prompting (reading from stdin)
 	// even though the test won't be interactive.
-	e.SetEnvVars([]string{"PULUMI_TEST_PASSPHRASE=true"})
+	e.SetEnvVars("PULUMI_TEST_PASSPHRASE=true")
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Refactor the `testing.Environment` `SetEnvVars` method to append to the slice of env vars, rather than overwriting it with a new slice. As per the behavior of `Cmd.Env`, later env vars will take precedence over newer env vars, and the `Env` field is public anyway so if you really wanted to clear the slice you still can. This enables the possibility of setting env vars in `NewEnvironment` without needing to worry that subsequent calls to `SetEnvVars` will erase those env vars.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
