### PR TITLE
Error that version is needed if using --file

### DIFF
--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -76,6 +76,9 @@ func newPluginInstallCmd() *cobra.Command {
 						return fmt.Errorf("invalid plugin semver: %w", err)
 					}
 				}
+				if len(args) < 3 && file != "" {
+					return errors.New("missing plugin version argument, this is required if installing from a file")
+				}
 
 				pluginInfo := workspace.PluginInfo{
 					Kind:              workspace.PluginKind(args[0]),


### PR DESCRIPTION
Just a small error improvement. Previously we would take the given name and kind and try and look it up on github, but that probably doesn't exist if we're installing from a file.