### PR TITLE
Work with all kinds of branch names

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -32,3 +32,6 @@
 
 - [codegen/go] Ensure consistency between go docs information and package name
   [#10452](https://github.com/pulumi/pulumi/pull/10452)
+
+- [auto/go] Clone non-default branches (and tags).
+  [#10285](https://github.com/pulumi/pulumi/pull/10285)

--- a/sdk/go/auto/git.go
+++ b/sdk/go/auto/git.go
@@ -101,6 +101,8 @@ func setupGitRepo(ctx context.Context, workDir string, repoArgs *GitRepo) (strin
 				return "", fmt.Errorf("branch name must be a simple name .e.g., 'main'"+
 					" or a ref e.g., 'refs/heads/main', but got %q", repoArgs.Branch)
 			}
+		case refName.IsTag(): // looks like `refs/tags/v1.0.0` -- respect this even though the field is `.Branch`
+			// nothing to do
 		case !refName.IsBranch(): // not a remote, not refs/heads/branch; treat as a simple branch name
 			refName = plumbing.NewBranchReferenceName(repoArgs.Branch)
 		default:

--- a/sdk/go/auto/git.go
+++ b/sdk/go/auto/git.go
@@ -29,7 +29,8 @@ import (
 
 func setupGitRepo(ctx context.Context, workDir string, repoArgs *GitRepo) (string, error) {
 	cloneOptions := &git.CloneOptions{
-		URL: repoArgs.URL,
+		RemoteName: "origin", // be explicit so we can require it in remote refs
+		URL:        repoArgs.URL,
 	}
 
 	if repoArgs.Auth != nil {
@@ -95,11 +96,10 @@ func setupGitRepo(ctx context.Context, workDir string, repoArgs *GitRepo) (strin
 		case refName.IsRemote(): // e.g., refs/remotes/origin/branch
 			shorter := refName.Short() // this gives "origin/branch"
 			parts := strings.SplitN(shorter, "/", 2)
-			if len(parts) == 2 {
+			if len(parts) == 2 && parts[0] == "origin" {
 				refName = plumbing.NewBranchReferenceName(parts[1])
 			} else {
-				return "", fmt.Errorf("branch name must be a simple name .e.g., 'main'"+
-					" or a ref e.g., 'refs/heads/main', but got %q", repoArgs.Branch)
+				return "", fmt.Errorf("a remote ref must begin with 'refs/remote/origin/', but got %q", repoArgs.Branch)
 			}
 		case refName.IsTag(): // looks like `refs/tags/v1.0.0` -- respect this even though the field is `.Branch`
 			// nothing to do

--- a/sdk/go/auto/git.go
+++ b/sdk/go/auto/git.go
@@ -16,7 +16,9 @@ package auto
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -81,40 +83,53 @@ func setupGitRepo(ctx context.Context, workDir string, repoArgs *GitRepo) (strin
 		}
 	}
 
+	// *Repository.Clone() will do appropriate fetching given a branch name. We must deal with
+	// different varieties, since people have been advised to use these as a workaround while only
+	// "refs/heads/<default>" worked.
+	//
+	// If a reference name is not supplied, then .Clone will fetch all refs (and all objects
+	// referenced by those), and checking out a commit later will work as expected.
+	if repoArgs.Branch != "" {
+		refName := plumbing.ReferenceName(repoArgs.Branch)
+		switch {
+		case refName.IsRemote(): // e.g., refs/remotes/origin/branch
+			shorter := refName.Short() // this gives "origin/branch"
+			parts := strings.SplitN(shorter, "/", 2)
+			if len(parts) == 2 {
+				refName = plumbing.NewBranchReferenceName(parts[1])
+			} else {
+				return "", fmt.Errorf("branch name must be a simple name .e.g., 'main'"+
+					" or a ref e.g., 'refs/heads/main', but got %q", repoArgs.Branch)
+			}
+		case !refName.IsBranch(): // not a remote, not refs/heads/branch; treat as a simple branch name
+			refName = plumbing.NewBranchReferenceName(repoArgs.Branch)
+		default:
+			// already looks like a full branch name, so use as is
+		}
+		cloneOptions.ReferenceName = refName
+	}
+
 	// clone
 	repo, err := git.PlainCloneContext(ctx, workDir, false, cloneOptions)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to clone repo")
 	}
 
-	// checkout branch if specified
-	w, err := repo.Worktree()
-	if err != nil {
-		return "", err
-	}
-
-	var hash string
 	if repoArgs.CommitHash != "" {
-		hash = repoArgs.CommitHash
-	}
-	var refName plumbing.ReferenceName
-	if repoArgs.Branch != "" {
-		refName = plumbing.ReferenceName(repoArgs.Branch)
-		// We might be supplied `/refs/heads/main` or `main`; the first will answer true to
-		// `IsBranch()` and work OK as a reference for Checkout, the second will answer false and
-		// needs to be transformed into a branch ref.
-		if !refName.IsBranch() {
-			refName = plumbing.NewBranchReferenceName(repoArgs.Branch)
+		// checkout commit if specified
+		w, err := repo.Worktree()
+		if err != nil {
+			return "", err
 		}
-	}
 
-	err = w.Checkout(&git.CheckoutOptions{
-		Hash:   plumbing.NewHash(hash),
-		Branch: refName,
-		Force:  true,
-	})
-	if err != nil {
-		return "", errors.Wrap(err, "unable to checkout branch")
+		hash := repoArgs.CommitHash
+		err = w.Checkout(&git.CheckoutOptions{
+			Hash:  plumbing.NewHash(hash),
+			Force: true,
+		})
+		if err != nil {
+			return "", errors.Wrap(err, "unable to checkout commit")
+		}
 	}
 
 	var relPath string

--- a/sdk/go/auto/git_test.go
+++ b/sdk/go/auto/git_test.go
@@ -46,6 +46,10 @@ func TestGitClone(t *testing.T) {
 		Create: true,
 	}))
 
+	// tag the nondefault head so we can test getting a tag too
+	_, err = origin.CreateTag("v0.0.1", nondefaultHead, nil)
+	assert.NoError(t, err)
+
 	assert.NoError(t, w.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName("default"),
 		Create: true,
@@ -75,6 +79,8 @@ func TestGitClone(t *testing.T) {
 		{branchName: "refs/heads/nondefault", expectedHead: nondefaultHead},
 		{branchName: "refs/remotes/origin/default", expectedHead: defaultHead},
 		{branchName: "refs/remotes/origin/nondefault", expectedHead: nondefaultHead},
+		// try the special tag case
+		{branchName: "refs/tags/v0.0.1", expectedHead: nondefaultHead},
 		// ask specifically for the commit hash
 		{testName: "head of default as hash", commitHash: defaultHead.String(), expectedHead: defaultHead},
 		{testName: "head of nondefault as hash", commitHash: nondefaultHead.String(), expectedHead: nondefaultHead},

--- a/sdk/go/auto/git_test.go
+++ b/sdk/go/auto/git_test.go
@@ -3,10 +3,12 @@ package auto
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,21 +16,76 @@ import (
 // git code in isolation; testing the user of the unexported func (NewLocalWorkspace) drags in lots
 // of other factors.
 
-func TestGitShortBranch(t *testing.T) {
+func TestGitBranch(t *testing.T) {
 	t.Parallel()
-	repo := &GitRepo{
-		URL:    "https://github.com/pulumi/test-repo.git",
-		Branch: "master",
-	}
-	tmp, err := os.MkdirTemp("", "pulumi-test")
+
+	// This makes a git repo to clone from, so to avoid relying on something at GitHub that could
+	// change or be inaccessible.
+	tmpDir, err := os.MkdirTemp("", "pulumi-git-test")
 	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
-	_, err = setupGitRepo(context.TODO(), tmp, repo)
+	assert.True(t, len(tmpDir) > 1)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	originDir := filepath.Join(tmpDir, "origin")
+
+	origin, err := git.PlainInit(originDir, false)
+	assert.NoError(t, err)
+	w, err := origin.Worktree()
+	assert.NoError(t, err)
+	nondefaultHead, err := w.Commit("nondefault branch", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "testo",
+			Email: "testo@example.com",
+		},
+	})
 	assert.NoError(t, err)
 
-	r, err := git.PlainOpen(tmp)
+	// this sets up two branches: `nondefault` and `default`, with `default` becoming the "default"
+	// branch when cloning, since it's left as the HEAD of the repo.
+	assert.NoError(t, w.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("nondefault"),
+		Create: true,
+	}))
+
+	assert.NoError(t, w.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("default"),
+		Create: true,
+	}))
+	defaultHead, err := w.Commit("default branch", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "testo",
+			Email: "testo@example.com",
+		},
+	})
 	assert.NoError(t, err)
-	head, err := r.Head()
-	assert.NoError(t, err)
-	assert.Equal(t, plumbing.NewBranchReferenceName("master"), head.Name())
+
+	type testcase struct {
+		branchName   string
+		expectedHead plumbing.Hash
+	}
+
+	for _, tc := range []testcase{
+		{"default", defaultHead},
+		{"nondefault", nondefaultHead},
+	} {
+		tc := tc
+		t.Run(tc.branchName, func(t *testing.T) {
+			t.Parallel()
+			repo := &GitRepo{
+				URL:    originDir,
+				Branch: tc.branchName,
+			}
+
+			tmp, err := os.MkdirTemp(tmpDir, "testcase") // i.e., under the tmp dir from earlier
+			assert.NoError(t, err)
+
+			_, err = setupGitRepo(context.TODO(), tmp, repo)
+			assert.NoError(t, err)
+
+			r, err := git.PlainOpen(tmp)
+			assert.NoError(t, err)
+			head, err := r.Head()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedHead, head.Hash())
+		})
+	}
 }


### PR DESCRIPTION
# Description

This makes `GitRepo.Branch` work for any of the following kinds of value (assuming a default branch of "main" at the upstream repo):

 - `main`
 - `not-main`
 - `refs/heads/main`
 - `refs/heads/not-main`
 - `refs/remotes/origin/main`
 - `refs/remotes/origin/not-main`
 - `refs/tags/v1.0.0`

Fixes #10278.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
