### PR TITLE
Fix C# warnings in test projects

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1804,7 +1804,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 var resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
 
@@ -1813,7 +1813,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Single(state.Deployment.Resources);
             }
             finally
@@ -1867,7 +1867,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 var resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
 
@@ -1879,7 +1879,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Single(state.Deployment.Resources);
             }
             finally
@@ -1933,7 +1933,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 var resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
                 Assert.True(resource.Protect);
@@ -1943,7 +1943,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Equal(2, state.Deployment.Resources.Count);
                 resource = state.Deployment.Resources.Single(r => r.Urn.Contains(type));
                 Assert.False(resource.Protect);
@@ -2008,7 +2008,7 @@ namespace Pulumi.Automation.Tests
 
                 // export state
                 var exportResult = await stack.ExportStackAsync();
-                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                var state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Equal(3, state.Deployment.Resources.Count);
                 var resources = state.Deployment.Resources.Where(x => x.Urn.Contains(type)).ToList();
                 Assert.Equal(2, resources.Count);
@@ -2019,7 +2019,7 @@ namespace Pulumi.Automation.Tests
 
                 // test
                 exportResult = await stack.ExportStackAsync();
-                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions);
+                state = JsonSerializer.Deserialize<StackState>(exportResult.Json.GetRawText(), jsonOptions)!;
                 Assert.Equal(3, state.Deployment.Resources.Count);
                 resources = state.Deployment.Resources.Where(x => x.Urn.Contains(type)).ToList();
                 Assert.Equal(2, resources.Count);
@@ -2092,7 +2092,7 @@ namespace Pulumi.Automation.Tests
             public bool IsEnabled(LogLevel logLevel)
                 => true;
 
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception, string> formatter)
                 => _action();
         }
 

--- a/sdk/dotnet/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -127,8 +127,8 @@ namespace Pulumi.Tests.Serialization
         private static object[] UnknownDefaultValue<T>()
             where T : notnull
         {
-            T inner = default;
-            var outputdata = OutputData.Create(ImmutableHashSet<Resource>.Empty, inner!, isKnown: false, isSecret: false);
+            T inner = default!;
+            var outputdata = OutputData.Create(ImmutableHashSet<Resource>.Empty, inner, isKnown: false, isSecret: false);
             var output = new Output<T>(Task.FromResult(outputdata));
             return new object[]
                 {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10295

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
