### PR TITLE
codegen/go: Remove superfluous double forward slash in doc.go

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,3 +13,6 @@
 
 - Revert [Remove api/renewLease from startup crit path](pulumi/pulumi#10168) to fix #10293.
   [#10294](https://github.com/pulumi/pulumi/pull/10294)
+
+- [codegen/go] Remove superfluous double forward slash from doc.go
+  [#10317](https://github.com/pulumi/pulumi/pull/10317)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3568,11 +3568,10 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			buffer := &bytes.Buffer{}
 			if pkg.pkg.Description != "" {
 				printComment(buffer, pkg.pkg.Description, false)
-				fmt.Fprintf(buffer, "//\n")
 			} else {
 				fmt.Fprintf(buffer, "// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.\n", pkg.pkg.Name)
-				fmt.Fprintf(buffer, "//\n")
 			}
+			fmt.Fprintf(buffer, "\n")
 			fmt.Fprintf(buffer, "package %s\n", name)
 
 			setFile(path.Join(mod, "doc.go"), buffer.String())

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/go/azure/doc.go
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/go/azure/doc.go
@@ -1,3 +1,3 @@
 // A native Pulumi package for creating and managing Azure resources.
-//
+
 package azure

--- a/pkg/codegen/testing/test/testdata/cyclic-types/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/doc.go
@@ -1,3 +1,3 @@
 // Package foo-bar exports types, functions, subpackages for provisioning foo-bar resources.
-//
+
 package foo

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/doc.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/doc.go
@@ -1,3 +1,3 @@
 // Package plant exports types, functions, subpackages for provisioning plant resources.
-//
+
 package plantprovider

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/doc.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/doc.go
@@ -1,3 +1,3 @@
 // Package plant exports types, functions, subpackages for provisioning plant resources.
-//
+
 package plant

--- a/pkg/codegen/testing/test/testdata/enum-reference/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/enum-reference/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/doc.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/doc.go
@@ -1,3 +1,3 @@
 // Package repro exports types, functions, subpackages for provisioning repro resources.
-//
+
 package repro

--- a/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/doc.go
+++ b/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/doc.go
@@ -1,3 +1,3 @@
 // Package repro exports types, functions, subpackages for provisioning repro resources.
-//
+
 package repro

--- a/pkg/codegen/testing/test/testdata/hyphen-url/go/registrygeoreplication/doc.go
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/go/registrygeoreplication/doc.go
@@ -1,3 +1,3 @@
 // Package registrygeoreplication exports types, functions, subpackages for provisioning registrygeoreplication resources.
-//
+
 package registrygeoreplication

--- a/pkg/codegen/testing/test/testdata/internal-dependencies-go/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/internal-dependencies-go/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/doc.go
@@ -1,3 +1,3 @@
 // Package foo-bar exports types, functions, subpackages for provisioning foo-bar resources.
-//
+
 package foo

--- a/pkg/codegen/testing/test/testdata/nested-module/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/nested-module/go/foo/doc.go
@@ -1,3 +1,3 @@
 // Package foo exports types, functions, subpackages for provisioning foo resources.
-//
+
 package foo

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/doc.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/doc.go
@@ -1,3 +1,3 @@
 // Package myedgeorder exports types, functions, subpackages for provisioning myedgeorder resources.
-//
+
 package myedgeorder

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/doc.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/doc.go
@@ -1,3 +1,3 @@
 // Package mypkg exports types, functions, subpackages for provisioning mypkg resources.
-//
+
 package mypkg

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/doc.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/doc.go
@@ -1,3 +1,3 @@
 // Package mypkg exports types, functions, subpackages for provisioning mypkg resources.
-//
+
 package mypkg

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/doc.go
@@ -1,3 +1,3 @@
 // Package foobar exports types, functions, subpackages for provisioning foobar resources.
-//
+
 package foo

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/doc.go
@@ -1,3 +1,3 @@
 // Package xyz exports types, functions, subpackages for provisioning xyz resources.
-//
+
 package xyz

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/doc.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/doc.go
@@ -1,3 +1,3 @@
 // Package configstation exports types, functions, subpackages for provisioning configstation resources.
-//
+
 package configstation

--- a/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/doc.go
+++ b/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/doc.go
@@ -1,3 +1,3 @@
 // Package mongodbatlas exports types, functions, subpackages for provisioning mongodbatlas resources.
-//
+
 package mongodbatlas

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/doc.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/doc.go
@@ -1,3 +1,3 @@
 // Package my8664 exports types, functions, subpackages for provisioning my8664 resources.
-//
+
 package my8664

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/doc.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/doc.go
@@ -1,3 +1,3 @@
 // Package my8110 exports types, functions, subpackages for provisioning my8110 resources.
-//
+
 package my8110

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/doc.go
@@ -1,3 +1,3 @@
 // Package plant exports types, functions, subpackages for provisioning plant resources.
-//
+
 package plant

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package different

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/doc.go
@@ -1,3 +1,3 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-//
+
 package example


### PR DESCRIPTION
This is causing golint failures in new version of golangci-lint

```
doc.go:2: File is not `gofmt`-ed with `-s` (gofmt)
//
```

There's nothing else in the file

```
// A Pulumi package for creating and managing artifactory cloud resources.
//
package artifactory
```

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
