### PR TITLE
[import] Parent and Provider improvements

### DIFF
--- a/pkg/codegen/importer/hcl2.go
+++ b/pkg/codegen/importer/hcl2.go
@@ -125,7 +125,7 @@ func makeResourceOptions(state *resource.State, names NameTable) (*model.Block, 
 		if !providers.IsDefaultProvider(ref.URN()) {
 			name, ok := names[ref.URN()]
 			if !ok {
-				return nil, fmt.Errorf("no name for provider %v", state.Parent)
+				return nil, fmt.Errorf("no name for provider %v", state.Provider)
 			}
 			resourceOptions = appendResourceOption(resourceOptions, "provider", newVariableReference(name))
 		}


### PR DESCRIPTION
Allow passing raw URN instead of `name=URN` for parent and provider, defaulting name to `parent` and `provider` respectively.

Report an error if the names of the parent and provider are the same (instead of silently overwriting the parent with the provider).

Provide better error messages if the provided URN is not a URN - specifically if it is a provider reference.

Fix up an error message that included a parent instead of provider URN.

Also update the help text with some additional examples.

Fixes #5958.
Contributes to #10288.
