### PR TITLE
Add jq to required build tools and update Go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,20 +29,21 @@ Finally, please limit your pull requests to contain only one feature at a time. 
 
 You'll want to install the following on your machine:
 
-- Go 1.17
+- Go 1.18 or later
 - NodeJS 14.X.X or later
 - Python 3.6 or later
 - [.NET](https://dotnet.microsoft.com/download)
 - [Golangci-lint](https://github.com/golangci/golangci-lint)
 - [Yarn](https://yarnpkg.com/)
 - [Pulumictl](https://github.com/pulumi/pulumictl)
+- [jq](https://stedolan.github.io/jq/)
 
 ### Installing Pulumi dependencies on macOS
 
 You can get all required dependencies with brew and npm
 
 ```bash
-brew install node python@3 typescript yarn go@1.17 golangci/tap/golangci-lint pulumi/tap/pulumictl coreutils
+brew install node python@3 typescript yarn go@1.19 golangci/tap/golangci-lint pulumi/tap/pulumictl coreutils jq
 curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/339862f79e/Casks/dotnet-sdk.rb > dotnet-sdk.rb
 brew install --HEAD -s dotnet-sdk.rb
 rm dotnet-sdk.rb


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Update the build instructions a little based on recent findings during my onboarding, namely, that jq is required.

Also bump the Go version a bit from 1.17 whose end of life is on 8/16.


## Checklist

(documentation only)