### PR TITLE
Expose external package cache

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,3 +22,6 @@
 
 - [codegen/go] Remove superfluous double forward slash from doc.go
   [#10317](https://github.com/pulumi/pulumi/pull/10317)
+
+- [codegen/go] Add an external package cache option to `GenerateProgramOptions`.
+  [#10340](https://github.com/pulumi/pulumi/pull/10340)

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -98,7 +98,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 
 // GeneratePackagesMap generates a map of Go packages for resources, functions and types.
 func (d *DocLanguageHelper) GeneratePackagesMap(pkg *schema.Package, tool string, goInfo GoPackageInfo) {
-	d.packages = generatePackageContextMap(tool, pkg, goInfo)
+	d.packages = generatePackageContextMap(tool, pkg, goInfo, nil)
 }
 
 // GetPropertyName returns the property name specific to Go.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -747,9 +747,7 @@ func (pkg *pkgContext) contextForExternalReference(t schema.Type) (*pkgContext, 
 	}
 
 	var maps map[string]*pkgContext
-	if pkg.externalPackages == nil {
-		pkg.externalPackages = globalCache
-	}
+
 	hash := newExternalPackageHash(extPkg)
 	if extMap, ok := pkg.externalPackages.lookupContextMap(hash); ok {
 		maps = extMap
@@ -759,6 +757,7 @@ func (pkg *pkgContext) contextForExternalReference(t schema.Type) (*pkgContext, 
 	}
 	extPkgCtx := maps[""]
 	extPkgCtx.pkgImportAliases = pkgImportAliases
+	extPkgCtx.externalPackages = pkg.externalPackages
 	mod := tokenToPackage(extPkg, goInfo.ModuleToPackage, token)
 
 	return extPkgCtx, *maps[mod].detailsForType(t)

--- a/pkg/codegen/go/gen_crd2pulumi.go
+++ b/pkg/codegen/go/gen_crd2pulumi.go
@@ -18,7 +18,7 @@ func CRDTypes(tool string, pkg *schema.Package) (map[string]*bytes.Buffer, error
 	if goInfo, ok := pkg.Language["go"].(GoPackageInfo); ok {
 		goPkgInfo = goInfo
 	}
-	packages := generatePackageContextMap(tool, pkg, goPkgInfo)
+	packages := generatePackageContextMap(tool, pkg, goPkgInfo, nil)
 
 	var pkgMods []string
 	for mod := range packages {

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -65,12 +65,13 @@ func GenerateProgramWithOptions(program *pcl.Program, opts GenerateProgramOption
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, pkg := range packageDefs {
-		packages[pkg.Name], contexts[pkg.Name] = pkg, getPackages("tool", pkg)
-	}
 
 	if opts.ExternalCache == nil {
 		opts.ExternalCache = globalCache
+	}
+
+	for _, pkg := range packageDefs {
+		packages[pkg.Name], contexts[pkg.Name] = pkg, getPackages("tool", pkg, opts.ExternalCache)
 	}
 
 	g := &generator{
@@ -244,7 +245,7 @@ require (
 
 var packageContexts sync.Map
 
-func getPackages(tool string, pkg *schema.Package) map[string]*pkgContext {
+func getPackages(tool string, pkg *schema.Package, cache *Cache) map[string]*pkgContext {
 	if v, ok := packageContexts.Load(pkg); ok {
 		return v.(map[string]*pkgContext)
 	}
@@ -257,7 +258,7 @@ func getPackages(tool string, pkg *schema.Package) map[string]*pkgContext {
 	if goInfo, ok := pkg.Language["go"].(GoPackageInfo); ok {
 		goPkgInfo = goInfo
 	}
-	v := generatePackageContextMap(tool, pkg, goPkgInfo, nil)
+	v := generatePackageContextMap(tool, pkg, goPkgInfo, cache)
 	packageContexts.Store(pkg, v)
 	return v
 }

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -27,21 +27,21 @@ import (
 type generator struct {
 	// The formatter to use when generating code.
 	*format.Formatter
-	program              *pcl.Program
-	packages             map[string]*schema.Package
-	contexts             map[string]map[string]*pkgContext
-	diagnostics          hcl.Diagnostics
-	spills               *spills
-	jsonTempSpiller      *jsonSpiller
-	ternaryTempSpiller   *tempSpiller
-	readDirTempSpiller   *readDirSpiller
-	splatSpiller         *splatSpiller
-	optionalSpiller      *optionalSpiller
-	scopeTraversalRoots  codegen.StringSet
-	arrayHelpers         map[string]*promptToInputArrayHelper
-	isErrAssigned        bool
-	configCreated        bool
-	externalPackageCache ExternalPackages
+	program             *pcl.Program
+	packages            map[string]*schema.Package
+	contexts            map[string]map[string]*pkgContext
+	diagnostics         hcl.Diagnostics
+	spills              *spills
+	jsonTempSpiller     *jsonSpiller
+	ternaryTempSpiller  *tempSpiller
+	readDirTempSpiller  *readDirSpiller
+	splatSpiller        *splatSpiller
+	optionalSpiller     *optionalSpiller
+	scopeTraversalRoots codegen.StringSet
+	arrayHelpers        map[string]*promptToInputArrayHelper
+	isErrAssigned       bool
+	configCreated       bool
+	externalCache       *Cache
 
 	// User-configurable options
 	assignResourcesToVariables bool // Assign resource to a new variable instead of _.
@@ -50,7 +50,7 @@ type generator struct {
 // GenerateProgramOptions are used to configure optional generator behavior.
 type GenerateProgramOptions struct {
 	AssignResourcesToVariables bool // Assign resource to a new variable instead of _.
-	ExternalPackageCache       ExternalPackages
+	ExternalCache              *Cache
 }
 
 func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {
@@ -69,23 +69,23 @@ func GenerateProgramWithOptions(program *pcl.Program, opts GenerateProgramOption
 		packages[pkg.Name], contexts[pkg.Name] = pkg, getPackages("tool", pkg)
 	}
 
-	if opts.ExternalPackageCache == nil {
-		opts.ExternalPackageCache = ExternalPackages{}
+	if opts.ExternalCache == nil {
+		opts.ExternalCache = globalCache
 	}
 
 	g := &generator{
-		program:              program,
-		packages:             packages,
-		contexts:             contexts,
-		spills:               &spills{counts: map[string]int{}},
-		jsonTempSpiller:      &jsonSpiller{},
-		ternaryTempSpiller:   &tempSpiller{},
-		readDirTempSpiller:   &readDirSpiller{},
-		splatSpiller:         &splatSpiller{},
-		optionalSpiller:      &optionalSpiller{},
-		scopeTraversalRoots:  codegen.NewStringSet(),
-		arrayHelpers:         make(map[string]*promptToInputArrayHelper),
-		externalPackageCache: opts.ExternalPackageCache,
+		program:             program,
+		packages:            packages,
+		contexts:            contexts,
+		spills:              &spills{counts: map[string]int{}},
+		jsonTempSpiller:     &jsonSpiller{},
+		ternaryTempSpiller:  &tempSpiller{},
+		readDirTempSpiller:  &readDirSpiller{},
+		splatSpiller:        &splatSpiller{},
+		optionalSpiller:     &optionalSpiller{},
+		scopeTraversalRoots: codegen.NewStringSet(),
+		arrayHelpers:        make(map[string]*promptToInputArrayHelper),
+		externalCache:       opts.ExternalCache,
 	}
 
 	// Apply any generate options.

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -738,7 +738,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 	}
 
 	if schemaType, ok := pcl.GetSchemaForType(destType); ok {
-		pkg := &pkgContext{pkg: &schema.Package{Name: "main"}}
+		pkg := &pkgContext{pkg: &schema.Package{Name: "main"}, externalPackages: g.externalPackageCache}
 		return pkg.argsType(schemaType)
 	}
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -738,7 +738,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 	}
 
 	if schemaType, ok := pcl.GetSchemaForType(destType); ok {
-		pkg := &pkgContext{pkg: &schema.Package{Name: "main"}, externalPackages: g.externalPackageCache}
+		pkg := &pkgContext{pkg: &schema.Package{Name: "main"}, externalPackages: g.externalCache}
 		return pkg.argsType(schemaType)
 	}
 

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,8 +32,11 @@ func TestGenerateProgram(t *testing.T) {
 			Check: func(t *testing.T, path string, dependencies codegen.StringSet) {
 				Check(t, path, dependencies, "../../../../../../../sdk")
 			},
-			GenProgram: GenerateProgram,
-			TestCases:  test.PulumiPulumiProgramTests,
+			GenProgram: func(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {
+				// Prevent tests from interfering with each other
+				return GenerateProgramWithOptions(program, GenerateProgramOptions{ExternalCache: NewCache()})
+			},
+			TestCases: test.PulumiPulumiProgramTests,
 		})
 }
 

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -135,7 +135,7 @@ func TestGenerateTypeNames(t *testing.T) {
 		if goInfo, ok := pkg.Language["go"].(GoPackageInfo); ok {
 			goPkgInfo = goInfo
 		}
-		packages := generatePackageContextMap("test", pkg, goPkgInfo)
+		packages := generatePackageContextMap("test", pkg, goPkgInfo, nil)
 
 		root, ok := packages[""]
 		require.True(t, ok)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

As of #9933 we maintain a cache of globally analyzed external packages necessary for name resolution. To avoid unacceptable performance degradations, we cache that set of packages. 

This worked fine for SDK generation, but the cache didn't persist between ProgramGen calls (used to generate examples), which make up the vast majority of time spent.

This PR exposes that cache as a option to allow keeping the cache between invocations of ProgramGen. 

I'm including the new performance graph below for comparison. It doesn't render well here but can be downloaded to view.
![profile001](https://user-images.githubusercontent.com/22222529/183877747-969a7bc9-793f-49c1-9b36-cdd84742a10a.svg)

Fixes #10308 

The performance improvement does require this patch to TF-bridge:
```patch
 pkg/tf2pulumi/convert/convert.go | 6 +++++-
 pkg/tfgen/docs.go                | 1 +
 pkg/tfgen/generate.go            | 2 ++
 3 files changed, 8 insertions(+), 1 deletion(-)

diff --git a/pkg/tf2pulumi/convert/convert.go b/pkg/tf2pulumi/convert/convert.go
index b5ba4db..a29888c 100644
--- a/pkg/tf2pulumi/convert/convert.go
+++ b/pkg/tf2pulumi/convert/convert.go
@@ -136,7 +136,9 @@ func Convert(opts Options) (map[string][]byte, Diagnostics, error) {
 		generatedFiles, genDiags, err = hcl2dotnet.GenerateProgram(program)
 		diagnostics = append(diagnostics, genDiags...)
 	case LanguageGo:
-		generatedFiles, genDiags, err = hcl2go.GenerateProgram(program)
+		generatedFiles, genDiags, err = hcl2go.GenerateProgramWithOptions(program, hcl2go.GenerateProgramOptions{
+			ExternalPackageCache: opts.GoPkgCache,
+		})
 		diagnostics = append(diagnostics, genDiags...)
 	case LanguageYaml:
 		generatedFiles, genDiags, err = hcl2yaml.GenerateProgram(program)
@@ -198,6 +200,8 @@ type Options struct {
 
 	// TargetOptions captures any target-specific options.
 	TargetOptions interface{}
+
+	GoPkgCache hcl2go.ExternalPackages
 }
 
 // logf writes a formatted message to the configured logger, if any.
diff --git a/pkg/tfgen/docs.go b/pkg/tfgen/docs.go
index 8fd40e7..cf56631 100644
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1162,6 +1162,7 @@ func (g *Generator) convert(input afero.Fs, languageName string) (files map[stri
 		ProviderInfoSource:       g.infoSource,
 		SkipResourceTypechecking: true,
 		TerraformVersion:         g.terraformVersion,
+		GoPkgCache:               g.goPkgCache,
 	})
 
 	return
diff --git a/pkg/tfgen/generate.go b/pkg/tfgen/generate.go
index 5b93f83..7e7c66f 100644
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -68,6 +68,7 @@ type Generator struct {
 	skipDocs         bool
 	skipExamples     bool
 	coverageTracker  *CoverageTracker
+	goPkgCache       gogen.ExternalPackages
 
 	convertedCode map[string][]byte
 }
@@ -716,6 +717,7 @@ func NewGenerator(opts GeneratorOptions) (*Generator, error) {
 		skipDocs:         opts.SkipDocs,
 		skipExamples:     opts.SkipExamples,
 		coverageTracker:  opts.CoverageTracker,
+		goPkgCache:       gogen.ExternalPackages{},
 	}, nil
 }
 
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
