### PR TITLE
feat: Supports optional arguments for pulumi.Config getters

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - [cli] Updated to the latest version of go-git.
   [#10330](https://github.com/pulumi/pulumi/pull/10330)
 
+- [sdk/python] Support optional default parameters in pulumi.Config
+  [#10344](https://github.com/pulumi/pulumi/pull/10344)
+
 ### Bug Fixes
 
 - [cli] Paginate template options

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -66,21 +66,28 @@ class Config:
         #         f"use `{use.__name__}` instead of `{instead_of.__name__}`")
         return get_config(full_key)
 
-    def get(self, key: str) -> Optional[str]:
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
         """
-        Returns an optional configuration value by its key, or None if it doesn't exist.
+        Returns an optional configuration value by its key,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
 
         :param str key: The requested configuration key.
+        :param Optional[str] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[str]
         """
-        return self._get(key, self.get_secret, self.get)
+        config_candidate = self._get(key, self.get_secret, self.get)
+        return config_candidate if config_candidate is not None else default
 
     def get_secret(self, key: str) -> Optional[Output[str]]:
         """
-        Returns an optional configuration value by its key, marked as a secret, or None if it doesn't exist.
+        Returns an optional configuration value by its key, marked as a secret,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
 
         :param str key: The requested configuration key.
+        :param Optional[str] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[str]
         """
@@ -105,32 +112,41 @@ class Config:
             return False
         raise ConfigTypeError(self.full_key(key), v, "bool")
 
-    def get_bool(self, key: str) -> Optional[bool]:
+    def get_bool(self, key: str, default: Optional[bool] = None) -> Optional[bool]:
         """
-        Returns an optional configuration value, as a bool, by its key, or None if it doesn't exist.
+        Returns an optional configuration value, as a bool, by its key,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
         If the configuration value isn't a legal boolean, this function will throw an error.
 
         :param str key: The requested configuration key.
+        :param Optional[bool] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[bool]
         :raises ConfigTypeError: The configuration value existed but couldn't be coerced to bool.
         """
-        return self._get_bool(key, self.get_secret_bool, self.get_bool)
+        config_candidate = self._get_bool(key, self.get_secret_bool, self.get_bool)
+        return config_candidate if config_candidate is not None else default
 
-    def get_secret_bool(self, key: str) -> Optional[Output[bool]]:
+    def get_secret_bool(
+        self, key: str, default: Optional[bool] = None
+    ) -> Optional[Output[bool]]:
         """
-        Returns an optional configuration value, as a bool, by its key, marked as a secret or None if it doesn't exist.
+        Returns an optional configuration value, as a bool, by its key, marked as a secret,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
         If the configuration value isn't a legal boolean, this function will throw an error.
 
         :param str key: The requested configuration key.
+        :param Optional[bool] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[bool]
         :raises ConfigTypeError: The configuration value existed but couldn't be coerced to bool.
         """
-        v = self._get_bool(key)
+        config_candidate = self._get_bool(key)
+        v = config_candidate if config_candidate is not None else default
         if v is None:
             return None
-
         return Output.secret(v)
 
     def _get_int(
@@ -147,32 +163,41 @@ class Config:
         except Exception as e:
             raise ConfigTypeError(self.full_key(key), v, "int") from e
 
-    def get_int(self, key: str) -> Optional[int]:
+    def get_int(self, key: str, default: Optional[int] = None) -> Optional[int]:
         """
-        Returns an optional configuration value, as an int, by its key, or None if it doesn't exist.
+        Returns an optional configuration value, as an int, by its key,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
         If the configuration value isn't a legal int, this function will throw an error.
 
         :param str key: The requested configuration key.
+        :param Optional[int] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[int]
         :raises ConfigTypeError: The configuration value existed but couldn't be coerced to int.
         """
-        return self._get_int(key, self.get_secret_int, self.get_int)
+        config_candidate = self._get_int(key, self.get_secret_int, self.get_int)
+        return config_candidate if config_candidate is not None else default
 
-    def get_secret_int(self, key: str) -> Optional[Output[int]]:
+    def get_secret_int(
+        self, key: str, default: Optional[int] = None
+    ) -> Optional[Output[int]]:
         """
-        Returns an optional configuration value, as an int, by its key, marked as a secret, or None if it doesn't exist.
+        Returns an optional configuration value, as an int, by its key, marked as a secret,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
         If the configuration value isn't a legal int, this function will throw an error.
 
         :param str key: The requested configuration key.
+        :param Optional[int] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[int]
         :raises ConfigTypeError: The configuration value existed but couldn't be coerced to int.
         """
-        v = self._get_int(key)
+        config_candidate = self._get_int(key)
+        v = config_candidate if config_candidate is not None else default
         if v is None:
             return None
-
         return Output.secret(v)
 
     def _get_float(
@@ -189,32 +214,41 @@ class Config:
         except Exception as e:
             raise ConfigTypeError(self.full_key(key), v, "float") from e
 
-    def get_float(self, key: str) -> Optional[float]:
+    def get_float(self, key: str, default: Optional[float] = None) -> Optional[float]:
         """
-        Returns an optional configuration value, as a float, by its key, or None if it doesn't exist.
+        Returns an optional configuration value, as a float, by its key, marked as a secret,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
         If the configuration value isn't a legal float, this function will throw an error.
 
         :param str key: The requested configuration key.
+        :param Optional[float] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[float]
         :raises ConfigTypeError: The configuration value existed but couldn't be coerced to float.
         """
-        return self._get_float(key, self.get_secret_float, self.get_float)
+        config_candidate = self._get_float(key, self.get_secret_float, self.get_float)
+        return config_candidate if config_candidate is not None else default
 
-    def get_secret_float(self, key: str) -> Optional[Output[float]]:
+    def get_secret_float(
+        self, key: str, default: Optional[float] = None
+    ) -> Optional[Output[float]]:
         """
-        Returns an optional configuration value, as a float, by its key, marked as a secret or None if it doesn't exist.
+        Returns an optional configuration value, as a float, by its key, marked as a secret,
+        a default value if that key is unset and a default is provided,
+        or None if it doesn't exist.
         If the configuration value isn't a legal float, this function will throw an error.
 
         :param str key: The requested configuration key.
+        :param Optional[float] default: An optional fallback value to use if the given configuration key is not set.
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[float]
         :raises ConfigTypeError: The configuration value existed but couldn't be coerced to float.
         """
-        v = self._get_float(key)
+        config_candidate = self._get_float(key)
+        v = config_candidate if config_candidate is not None else default
         if v is None:
             return None
-
         return Output.secret(v)
 
     def _get_object(
@@ -231,21 +265,41 @@ class Config:
         except Exception as e:
             raise ConfigTypeError(self.full_key(key), v, "JSON object") from e
 
-    def get_object(self, key: str) -> Optional[Any]:
+    def get_object(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
         """
-        Returns an optional configuration value, as an object, by its key, or undefined if it
+        Returns an optional configuration value, as an object, by its key,
+        a default value if that key is unset and a default is provided, or undefined if it
         doesn't exist. This routine simply JSON parses and doesn't validate the shape of the
         contents.
-        """
-        return self._get_object(key, self.get_secret_object, self.get_object)
 
-    def get_secret_object(self, key: str) -> Optional[Output[Any]]:
+        :param str key: The requested configuration key.
+        :param Optional[Any] default: An optional fallback value to use if the given configuration key is not set.
+        :return: The configuration key's value, or None if one does not exist.
+        :rtype: Optional[Any]
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to float.
         """
-        Returns an optional configuration value, as an object, by its key, marking it as a secret or
-        undefined if it doesn't exist. This routine simply JSON parses and doesn't validate the
+        config_candidate = self._get_object(
+            key, self.get_secret_object, self.get_object
+        )
+        return config_candidate if config_candidate is not None else default
+
+    def get_secret_object(
+        self, key: str, default: Optional[Any] = None
+    ) -> Optional[Output[Any]]:
+        """
+        Returns an optional configuration value, as an object, by its key, marking it as a secret,
+        a default value if that key is unset and a default is provided,
+        or undefined if it doesn't exist. This routine simply JSON parses and doesn't validate the
         shape of the contents.
+
+        :param str key: The requested configuration key.
+        :param Optional[Any] default: An optional fallback value to use if the given configuration key is not set.
+        :return: The configuration key's value, or None if one does not exist.
+        :rtype: Optional[Any]
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to float.
         """
-        v = self._get_object(key)
+        config_candidate = self._get_object(key)
+        v = config_candidate if config_candidate is not None else default
         if v is None:
             return None
         return Output.secret(v)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import unittest
 from random import random
 from semver import VersionInfo
 from typing import List, Optional
+
+import pytest
 
 from pulumi import Config, export
 from pulumi.automation import (
@@ -734,3 +737,19 @@ def pulumi_program():
     export("exp_static", "foo")
     export("exp_cfg", config.get("bar"))
     export("exp_secret", config.get_secret("buzz"))
+
+@pytest.mark.parametrize("key,default", [("string", None), ("bar", "baz"), ("doesnt-exist", None)])
+def test_config_get_with_defaults(key, default, mock_config, config_settings):
+    assert mock_config.get(key, default) == config_settings.get(f"test-config:{key}", default)
+
+def test_config_get_int(mock_config, config_settings):
+    assert mock_config.get_int("int") == int(config_settings.get("test-config:int"))
+
+def test_config_get_bool(mock_config):
+    assert mock_config.get_bool("bool") is False
+
+def test_config_get_object(mock_config, config_settings):
+    assert mock_config.get_object("object") == json.loads(config_settings.get("test-config:object"))
+
+def test_config_get_float(mock_config, config_settings):
+    assert mock_config.get_float("float") == float(config_settings.get("test-config:float"))

--- a/sdk/python/lib/test/conftest.py
+++ b/sdk/python/lib/test/conftest.py
@@ -1,0 +1,23 @@
+import json
+
+import pytest
+
+from pulumi import Config
+from pulumi.runtime.config import set_all_config
+
+@pytest.fixture
+def config_settings():
+    stack_name = "test-config"
+    return {
+        f"{stack_name}:string": "bar",
+        f"{stack_name}:int": "1",
+        f"{stack_name}:bool": "False",
+        f"{stack_name}:object": json.dumps({"banana": "sundae"}),
+        f"{stack_name}:float": "3.14159"
+    }
+
+
+@pytest.fixture
+def mock_config(config_settings):
+    set_all_config(config_settings)
+    return Config("test-config")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes [#10342 ](https://github.com/pulumi/pulumi/issues/10342)

This adds optional arguments to each `pulumi.Config.get<_object|_int|_float|_bool>` method in the python SDK to handle fallback default values.  This interface is a bit more "pythonic" in that most `get` methods provide a default argument (see `dict.get` for a canonical example), and will allow us to generate both more simple and more idiomatic python code in the future (see https://github.com/pulumi/pulumi/issues/10268)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
