### PR TITLE
feat(codegen/python): Generate config getters with optional default arguments

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,9 @@
 - [sdk/python] Support optional default parameters in pulumi.Config
   [#10344](https://github.com/pulumi/pulumi/pull/10344)
 
+- [codegen/python] Use optional default arguments when generating `pulumi.Config.get` methods
+  [#10346](https://github.com/pulumi/pulumi/pull/10346)
+
 ### Bug Fixes
 
 - [cli] Paginate template options

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -539,12 +539,10 @@ func (g *generator) genConfigVariable(w io.Writer, v *pcl.ConfigVariable) {
 	g.genTemps(w, temps)
 
 	name := PyName(v.Name())
-	g.Fgenf(w, "%s%s = config.%s%s(\"%s\")\n", g.Indent, name, getOrRequire, getType, v.Name())
 	if defaultValue != nil {
-		g.Fgenf(w, "%sif %s is None:\n", g.Indent, name)
-		g.Indented(func() {
-			g.Fgenf(w, "%s%s = %.v\n", g.Indent, name, defaultValue)
-		})
+		g.Fgenf(w, "%s%s = config.%s%s(\"%s\", %.v)\n", g.Indent, name, getOrRequire, getType, v.Name(), defaultValue)
+	} else {
+		g.Fgenf(w, "%s%s = config.%s%s(\"%s\")\n", g.Indent, name, getOrRequire, getType, v.Name())
 	}
 }
 

--- a/pkg/codegen/testing/test/testdata/azure-sa-pp/python/azure-sa.py
+++ b/pkg/codegen/testing/test/testdata/azure-sa-pp/python/azure-sa.py
@@ -5,15 +5,9 @@ config = pulumi.Config()
 storage_account_name_param = config.require("storageAccountNameParam")
 resource_group_name_param = config.require("resourceGroupNameParam")
 resource_group_var = azure.core.get_resource_group(name=resource_group_name_param)
-location_param = config.get("locationParam")
-if location_param is None:
-    location_param = resource_group_var.location
-storage_account_tier_param = config.get("storageAccountTierParam")
-if storage_account_tier_param is None:
-    storage_account_tier_param = "Standard"
-storage_account_type_replication_param = config.get("storageAccountTypeReplicationParam")
-if storage_account_type_replication_param is None:
-    storage_account_type_replication_param = "LRS"
+location_param = config.get("locationParam", resource_group_var.location)
+storage_account_tier_param = config.get("storageAccountTierParam", "Standard")
+storage_account_type_replication_param = config.get("storageAccountTypeReplicationParam", "LRS")
 storage_account_resource = azure.storage.Account("storageAccountResource",
     name=storage_account_name_param,
     account_kind="StorageV2",

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -73,7 +73,11 @@ class Config:
         or None if it doesn't exist.
 
         :param str key: The requested configuration key.
+<<<<<<< HEAD
         :param Optional[str] default: An optional fallback value to use if the given configuration key is not set.
+=======
+        :param Optional[Any] default: An optional fallback value to use if the given configuration key is not set.
+>>>>>>> 46f650ff1 (feat: Supports optional arguments for pulumi.Config getters)
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[str]
         """

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -73,11 +73,7 @@ class Config:
         or None if it doesn't exist.
 
         :param str key: The requested configuration key.
-<<<<<<< HEAD
         :param Optional[str] default: An optional fallback value to use if the given configuration key is not set.
-=======
-        :param Optional[Any] default: An optional fallback value to use if the given configuration key is not set.
->>>>>>> 46f650ff1 (feat: Supports optional arguments for pulumi.Config getters)
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[str]
         """


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10268 

Modifies the existing python codegen logic to support the new `pulumi.Config.get` optional default arguments.  This should result in simpler looking python code when providing a default value.

Note: this PR requires https://github.com/pulumi/pulumi/pull/10344 to be merged first, otherwise we will generate invalid python from the SDK's perspective.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
