### PR TITLE
Fix and add test for stray %}> sequences in colorizer

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -35,4 +35,6 @@
 
 - [dotnet] Set environment exit code during `Deployment.RunAsync` in case users don't bubble it the program entry point themselves
   [#10217](https://github.com/pulumi/pulumi/pull/10217)
-  
+
+- [cli/display] Fix a panic in the color logic.
+  [#10354](https://github.com/pulumi/pulumi/pull/10354)

--- a/sdk/go/common/diag/colors/colors.go
+++ b/sdk/go/common/diag/colors/colors.go
@@ -172,13 +172,15 @@ func colorizeText(s string, c Colorization, maxLen int) string {
 		textLen += len(text)
 
 		// If we have a start delimiter but no end delimiter, terminate. The partial command will not be present in the
-		// output.
-		nextDirectiveEnd := strings.Index(input, colorRight)
+		// output. Make sure we look for the for end delimiter _after_ the start delimiter.
+		nextDirectiveEnd := strings.Index(input[nextDirectiveStart:], colorRight)
 		if nextDirectiveEnd == -1 {
 			break
 		}
+		// Correct the index given we searched starting from nextDirectiveStart
+		nextDirectiveEnd += nextDirectiveStart
 
-		directive := command(input[nextDirectiveStart+len(colorLeft) : nextDirectiveEnd])
+		directive := input[nextDirectiveStart : nextDirectiveEnd+len(colorRight)]
 		writeDirective(&buf, c, directive)
 		input = input[nextDirectiveEnd+len(colorRight):]
 

--- a/sdk/go/common/diag/colors/colors_test.go
+++ b/sdk/go/common/diag/colors/colors_test.go
@@ -88,6 +88,27 @@ func TestColorizer(t *testing.T) {
 	}
 }
 
+func TestColorizer_10351(t *testing.T) {
+	t.Parallel()
+
+	// Regression test for https://github.com/pulumi/pulumi/issues/10351. If the character codes "%}>" were
+	// present in a string our lookup for color delimiters could crash with out of range errors.
+
+	str := "%}>" + Red + "hello" + Reset + "\n"
+
+	actualRaw := colorizeText(str, Raw, -1)
+	assert.Equal(t, str, actualRaw)
+
+	actualAlways := Always.Colorize(str)
+	assert.Equal(t, "%}>"+codes("38", "5", "1")+"hello"+codes("0")+"\n", actualAlways)
+
+	actualNever := Never.Colorize(str)
+	assert.Equal(t, "%}>hello\n", actualNever)
+
+	actualTrimmed := TrimColorizedString(str, 6)
+	assert.Equal(t, "%}>"+Red+"hel"+Reset, actualTrimmed)
+}
+
 // TestTrimColorizedString provides extra coverage for TrimColorizedString.
 func TestTrimColorizedString(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Partial fix for https://github.com/pulumi/pulumi/issues/10351, it should at least stop the panic. I suspect we're getting mangled or unescaped input from somewhere though and that needs tracking down and fixing as well.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
