### PR TITLE
chore: Relax integration test and only check for a valid go version

### DIFF
--- a/tests/about_test.go
+++ b/tests/about_test.go
@@ -16,7 +16,6 @@ package tests
 
 import (
 	"encoding/json"
-	"regexp"
 	"runtime"
 	"testing"
 
@@ -43,7 +42,7 @@ func TestAboutCommands(t *testing.T) {
 		stdout, _ := e.RunCommand("pulumi", "about", "--json")
 		var res interface{}
 		assert.NoError(t, json.Unmarshal([]byte(stdout), &res), "Should be valid json")
-		assert.Contains(t, stdout, runtimeMajorMinor())
+		assert.Regexp(t, `Go Version\s+go\d+.\d+`, stdout)
 		assert.Contains(t, stdout, runtime.Compiler)
 		assert.Contains(t, stdout, "Failed to get information about the current stack:")
 	})
@@ -61,14 +60,7 @@ func TestAboutCommands(t *testing.T) {
 		integration.CreateBasicPulumiRepo(e)
 		e.SetBackend(e.LocalURL())
 		stdout, _ := e.RunCommand("pulumi", "about")
-		assert.Contains(t, stdout, runtimeMajorMinor())
+		assert.Regexp(t, `Go Version\s+go\d+.\d+`, stdout)
 		assert.Contains(t, stdout, runtime.Compiler)
 	})
-}
-
-// Given a runtime version like "go1.17.123", returns "go1.17.", trimming patch and prerelease
-// values.
-func runtimeMajorMinor() string {
-	re := regexp.MustCompile(`go\d+.\d+.`)
-	return re.FindString(runtime.Version())
 }


### PR DESCRIPTION
Following #10357, which updated the build toolchain to use `go1.19`, an integration test failed on master from failing to match the test toolchain's version.

This test too tightly couples our build & release process with tests, so I've relaxed it do a regexp match that `pulumi about` emits *a* Go version.