### PR TITLE
Correct Python syntax in help text

### DIFF
--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -503,7 +503,7 @@ class Output(Generic[T_co]):
         return """Calling __str__ on an Output[T] is not supported.
 
 To get the value of an Output[T] as an Output[str] consider:
-1. o.apply(lambda v => f"prefix{v}suffix")
+1. o.apply(lambda v: f"prefix{v}suffix")
 
 See https://pulumi.io/help/outputs for more details.
 This function may throw in a future version of Pulumi."""

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -227,7 +227,7 @@ class OutputStrTests(unittest.TestCase):
         self.assertEqual(str(o), """Calling __str__ on an Output[T] is not supported.
 
 To get the value of an Output[T] as an Output[str] consider:
-1. o.apply(lambda v => f"prefix{v}suffix")
+1. o.apply(lambda v: f"prefix{v}suffix")
 
 See https://pulumi.io/help/outputs for more details.
 This function may throw in a future version of Pulumi.""")


### PR DESCRIPTION
# Description

Replace arrow with colon, as is correct for Python

Fixes # (issue)

Fixes a personal user encounter I had today 😄 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
