### PR TITLE
Thread context through cmd more consistently

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -78,7 +78,7 @@ func newAboutCmd() *cobra.Command {
 				" - the current backend\n",
 			Args: cmdutil.MaximumNArgs(0),
 			Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-				ctx := context.Background()
+				ctx := cmd.Context()
 				summary := getSummaryAbout(ctx, transitiveDependencies, stack)
 				if jsonOut {
 					return printJSON(summary)
@@ -161,12 +161,12 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 	}
 
 	var backend backend.Backend
-	backend, err = currentBackend(display.Options{Color: cmdutil.GetGlobalColorization()})
+	backend, err = currentBackend(ctx, display.Options{Color: cmdutil.GetGlobalColorization()})
 	if err != nil {
 		addError(err, "Could not access the backend")
 	} else {
 		var stack currentStackAbout
-		if stack, err = getCurrentStackAbout(backend, selectedStack); err != nil {
+		if stack, err = getCurrentStackAbout(ctx, backend, selectedStack); err != nil {
 			addError(err, "Failed to get information about the current stack")
 		} else {
 			result.CurrentStack = &stack
@@ -330,19 +330,18 @@ type aboutState struct {
 	URN  string `json:"urn"`
 }
 
-func getCurrentStackAbout(b backend.Backend, selectedStack string) (currentStackAbout, error) {
-	context := commandContext()
+func getCurrentStackAbout(ctx context.Context, b backend.Backend, selectedStack string) (currentStackAbout, error) {
 	var stack backend.Stack
 	var err error
 	if selectedStack == "" {
-		stack, err = state.CurrentStack(context, b)
+		stack, err = state.CurrentStack(ctx, b)
 	} else {
 		var ref backend.StackReference
 		ref, err = b.ParseStackReference(selectedStack)
 		if err != nil {
 			return currentStackAbout{}, err
 		}
-		stack, err = b.GetStack(context, ref)
+		stack, err = b.GetStack(ctx, ref)
 	}
 	if err != nil {
 		return currentStackAbout{}, err
@@ -353,7 +352,7 @@ func getCurrentStackAbout(b backend.Backend, selectedStack string) (currentStack
 
 	name := stack.Ref().String()
 	var snapshot *deploy.Snapshot
-	snapshot, err = stack.Snapshot(context)
+	snapshot, err = stack.Snapshot(ctx)
 	if err != nil {
 		return currentStackAbout{}, err
 	} else if snapshot == nil {

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -78,7 +78,7 @@ func newAboutCmd() *cobra.Command {
 				" - the current backend\n",
 			Args: cmdutil.MaximumNArgs(0),
 			Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-				ctx := cmd.Context()
+				ctx := commandContext()
 				summary := getSummaryAbout(ctx, transitiveDependencies, stack)
 				if jsonOut {
 					return printJSON(summary)

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -42,6 +42,7 @@ func newCancelCmd() *cobra.Command {
 			"After this command completes successfully, the stack will be ready for further\n" +
 			"updates.",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
 				if stack != "" {
@@ -55,7 +56,7 @@ func newCancelCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -69,7 +70,7 @@ func newCancelCmd() *cobra.Command {
 			}
 
 			// Cancel the update.
-			if err := s.Backend().CancelCurrentUpdate(commandContext(), s.Ref()); err != nil {
+			if err := s.Backend().CancelCurrentUpdate(ctx, s.Ref()); err != nil {
 				return result.FromError(err)
 			}
 

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -42,7 +42,7 @@ func newCancelCmd() *cobra.Command {
 			"After this command completes successfully, the stack will be ready for further\n" +
 			"updates.",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
 				if stack != "" {

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -52,7 +52,7 @@ func newConfigCmd() *cobra.Command {
 			"for a specific configuration key, use `pulumi config get <key-name>`.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -101,7 +101,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 			"then all of the config from the current stack will be copied to the destination stack.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -255,7 +255,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 			"if the value of `names` is a list.",
 		Args: cmdutil.SpecificArgs([]string{"key"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -297,7 +297,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 			"if the value of `names` is a list.",
 		Args: cmdutil.SpecificArgs([]string{"key"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -346,7 +346,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 			"    `outer.inner`, `foo[0]` and `key1` keys",
 		Args: cmdutil.MinimumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -390,7 +390,7 @@ func newConfigRefreshCmd(stack *string) *cobra.Command {
 		Short: "Update the local configuration based on the most recent deployment of the stack",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -475,7 +475,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			"    `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.RangeArgs(1, 2),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -586,7 +586,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			"    value of `parent.name` to a map `nested.name: value`.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -34,7 +34,7 @@ func newConsoleCmd() *cobra.Command {
 		Short: "Opens the current stack in the Pulumi Console",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -34,15 +34,14 @@ func newConsoleCmd() *cobra.Command {
 		Short: "Opens the current stack in the Pulumi Console",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			currentBackend, err := currentBackend(opts)
+			currentBackend, err := currentBackend(ctx, opts)
 			if err != nil {
 				return err
 			}
-
-			ctx := commandContext()
 
 			// Do a type assertion in order to determine if this is a cloud backend based on whether the assertion
 			// succeeds or not.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -72,6 +72,7 @@ func newDestroyCmd() *cobra.Command {
 			"Warning: this command is generally irreversible and should be used with great care.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			yes = yes || skipPreview || skipConfirmations()
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes {
@@ -123,7 +124,7 @@ func newDestroyCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(stack, false, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, false, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -138,7 +139,7 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
-			snap, err := s.Snapshot(commandContext())
+			snap, err := s.Snapshot(ctx)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -149,7 +150,7 @@ func newDestroyCmd() *cobra.Command {
 				sm = snap.SecretsManager
 			}
 
-			cfg, err := getStackConfiguration(s, sm)
+			cfg, err := getStackConfiguration(ctx, s, sm)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 
@@ -177,7 +178,7 @@ func newDestroyCmd() *cobra.Command {
 			var protectedCount int
 			if excludeProtected {
 				contract.Assert(len(targetUrns) == 0)
-				targetUrns, protectedCount, err = handleExcludeProtected(s)
+				targetUrns, protectedCount, err = handleExcludeProtected(ctx, s)
 				if err != nil {
 					return result.FromError(err)
 				} else if protectedCount > 0 && len(targetUrns) == 0 {
@@ -204,7 +205,7 @@ func newDestroyCmd() *cobra.Command {
 				DisableOutputValues:       disableOutputValues(),
 			}
 
-			_, res := s.Destroy(commandContext(), backend.UpdateOperation{
+			_, res := s.Destroy(ctx, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,
@@ -339,9 +340,9 @@ func seperateProtected(resources []*resource.State) (
 }
 
 // Returns the number of protected resources that remain. Appends all unprotected resources to `targetUrns`.
-func handleExcludeProtected(s backend.Stack) ([]resource.URN, int, error) {
+func handleExcludeProtected(ctx context.Context, s backend.Stack) ([]resource.URN, int, error) {
 	// Get snapshot
-	snapshot, err := s.Snapshot(commandContext())
+	snapshot, err := s.Snapshot(ctx)
 	if err != nil {
 		return nil, 0, err
 	} else if snapshot == nil {

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -72,7 +72,7 @@ func newDestroyCmd() *cobra.Command {
 			"Warning: this command is generally irreversible and should be used with great care.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipPreview || skipConfirmations()
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -363,7 +363,7 @@ func newImportCmd() *cobra.Command {
 			"If a resource does not specify any properties the default behaviour is to\n" +
 			"import using all required properties.\n",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 
 			var importFile importFile
 			if importFilePath != "" {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -363,7 +363,7 @@ func newImportCmd() *cobra.Command {
 			"If a resource does not specify any properties the default behaviour is to\n" +
 			"import using all required properties.\n",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := commandContext()
+			ctx := cmd.Context()
 
 			var importFile importFile
 			if importFilePath != "" {
@@ -477,7 +477,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack.
-			s, err := requireStack(stack, false, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, false, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -492,7 +492,7 @@ func newImportCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
-			cfg, err := getStackConfiguration(s, sm)
+			cfg, err := getStackConfiguration(ctx, s, sm)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -87,7 +87,7 @@ func newLoginCmd() *cobra.Command {
 			"    $ pulumi login azblob://my-pulumi-state-bucket\n",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			displayOptions := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -87,6 +87,7 @@ func newLoginCmd() *cobra.Command {
 			"    $ pulumi login azblob://my-pulumi-state-bucket\n",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			displayOptions := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -140,7 +141,7 @@ func newLoginCmd() *cobra.Command {
 					return fmt.Errorf("unable to set default org for this type of backend")
 				}
 			} else {
-				be, err = httpstate.Login(commandContext(), cmdutil.Diag(), cloudURL, displayOptions)
+				be, err = httpstate.Login(ctx, cmdutil.Diag(), cloudURL, displayOptions)
 				// if the user has specified a default org to associate with the backend
 				if defaultOrg != "" {
 					cloudURL, err := workspace.GetCurrentCloudURL()

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -52,7 +52,7 @@ func newLogsCmd() *cobra.Command {
 			"CloudWatch Logs for log data relevant to resources in a stack.\n",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -52,11 +52,12 @@ func newLogsCmd() *cobra.Command {
 			"CloudWatch Logs for log data relevant to resources in a stack.\n",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -66,7 +67,7 @@ func newLogsCmd() *cobra.Command {
 				return fmt.Errorf("getting secrets manager: %w", err)
 			}
 
-			cfg, err := getStackConfiguration(s, sm)
+			cfg, err := getStackConfiguration(ctx, s, sm)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -97,7 +98,7 @@ func newLogsCmd() *cobra.Command {
 			// rendered now even though they are technically out of order.
 			shown := map[operations.LogEntry]bool{}
 			for {
-				logs, err := s.GetLogs(commandContext(), cfg, operations.LogQuery{
+				logs, err := s.GetLogs(ctx, cfg, operations.LogQuery{
 					StartTime:      startTime,
 					ResourceFilter: resourceFilter,
 				})

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -45,9 +45,7 @@ func panicHandler() {
 
 func main() {
 	defer panicHandler()
-	cmd := NewPulumiCmd()
-	ctx := commandContext()
-	if err := cmd.ExecuteContext(ctx); err != nil {
+	if err := NewPulumiCmd().Execute(); err != nil {
 		_, err = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		contract.IgnoreError(err)
 		os.Exit(1)

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -45,7 +45,9 @@ func panicHandler() {
 
 func main() {
 	defer panicHandler()
-	if err := NewPulumiCmd().Execute(); err != nil {
+	cmd := NewPulumiCmd()
+	ctx := commandContext()
+	if err := cmd.ExecuteContext(ctx); err != nil {
 		_, err = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		contract.IgnoreError(err)
 		os.Exit(1)

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -422,7 +422,7 @@ func newNewCmd() *cobra.Command {
 			"* `pulumi new https://github.com/<user>/<repo>/tree/<branch>`\n",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]
 			}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -115,14 +115,14 @@ func runNew(ctx context.Context, args newArgs) error {
 	// If we're going to be creating a stack, get the current backend, which
 	// will kick off the login flow (if not already logged-in).
 	if !args.generateOnly {
-		if _, err = currentBackend(opts); err != nil {
+		if _, err = currentBackend(ctx, opts); err != nil {
 			return err
 		}
 	}
 
 	// Ensure the project doesn't already exist.
 	if args.name != "" {
-		if err := validateProjectName(args.name, args.generateOnly, opts); err != nil {
+		if err := validateProjectName(ctx, args.name, args.generateOnly, opts); err != nil {
 			return err
 		}
 	}
@@ -174,7 +174,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		if err != nil {
 			return err
 		}
-		existingStack, existingName, existingDesc, err := getStack(stackName, opts)
+		existingStack, existingName, existingDesc, err := getStack(ctx, stackName, opts)
 		if err != nil {
 			return err
 		}
@@ -205,7 +205,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	// Prompt for the project name, if it wasn't already specified.
 	if args.name == "" {
 		defaultValue := workspace.ValueOrSanitizedDefaultProjectName(args.name, template.ProjectName, filepath.Base(cwd))
-		if err := validateProjectName(defaultValue, args.generateOnly, opts); err != nil {
+		if err := validateProjectName(ctx, defaultValue, args.generateOnly, opts); err != nil {
 			// If --yes is given error out now that the default value is invalid. If we allow prompt to catch
 			// this case it can lead to a confusing error message because we set the defaultValue to "" below.
 			// See https://github.com/pulumi/pulumi/issues/8747.
@@ -216,7 +216,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			// Do not suggest an invalid or existing name as the default project name.
 			defaultValue = ""
 		}
-		validate := func(s string) error { return validateProjectName(s, args.generateOnly, opts) }
+		validate := func(s string) error { return validateProjectName(ctx, s, args.generateOnly, opts) }
 		args.name, err = args.prompt(args.yes, "project name", defaultValue, false, validate, opts)
 		if err != nil {
 			return err
@@ -291,7 +291,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Create the stack, if needed.
 	if !args.generateOnly && s == nil {
-		if s, err = promptAndCreateStack(args.prompt,
+		if s, err = promptAndCreateStack(ctx, args.prompt,
 			args.stack, args.name, true /*setCurrent*/, args.yes, opts, args.secretsProvider); err != nil {
 			return err
 		}
@@ -422,7 +422,7 @@ func newNewCmd() *cobra.Command {
 			"* `pulumi new https://github.com/<user>/<repo>/tree/<branch>`\n",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]
 			}
@@ -520,19 +520,19 @@ func errorIfNotEmptyDirectory(path string) error {
 	return nil
 }
 
-func validateProjectName(projectName string, generateOnly bool, opts display.Options) error {
+func validateProjectName(ctx context.Context, projectName string, generateOnly bool, opts display.Options) error {
 	err := workspace.ValidateProjectName(projectName)
 	if err != nil {
 		return err
 	}
 
 	if !generateOnly {
-		b, err := currentBackend(opts)
+		b, err := currentBackend(ctx, opts)
 		if err != nil {
 			return err
 		}
 
-		exists, err := b.DoesProjectExist(commandContext(), projectName)
+		exists, err := b.DoesProjectExist(ctx, projectName)
 		if err != nil {
 			return err
 		}
@@ -546,8 +546,8 @@ func validateProjectName(projectName string, generateOnly bool, opts display.Opt
 }
 
 // getStack gets a stack and the project name & description, or returns nil if the stack doesn't exist.
-func getStack(stack string, opts display.Options) (backend.Stack, string, string, error) {
-	b, err := currentBackend(opts)
+func getStack(ctx context.Context, stack string, opts display.Options) (backend.Stack, string, string, error) {
+	b, err := currentBackend(ctx, opts)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -557,7 +557,7 @@ func getStack(stack string, opts display.Options) (backend.Stack, string, string
 		return nil, "", "", err
 	}
 
-	s, err := b.GetStack(commandContext(), stackRef)
+	s, err := b.GetStack(ctx, stackRef)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -575,11 +575,11 @@ func getStack(stack string, opts display.Options) (backend.Stack, string, string
 }
 
 // promptAndCreateStack creates and returns a new stack (prompting for the name as needed).
-func promptAndCreateStack(prompt promptForValueFunc,
+func promptAndCreateStack(ctx context.Context, prompt promptForValueFunc,
 	stack string, projectName string, setCurrent bool, yes bool, opts display.Options,
 	secretsProvider string) (backend.Stack, error) {
 
-	b, err := currentBackend(opts)
+	b, err := currentBackend(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -589,7 +589,7 @@ func promptAndCreateStack(prompt promptForValueFunc,
 		if err != nil {
 			return nil, err
 		}
-		s, err := stackInit(b, stackName, setCurrent, secretsProvider)
+		s, err := stackInit(ctx, b, stackName, setCurrent, secretsProvider)
 		if err != nil {
 			return nil, err
 		}
@@ -614,7 +614,7 @@ func promptAndCreateStack(prompt promptForValueFunc,
 		if err != nil {
 			return nil, err
 		}
-		s, err := stackInit(b, formattedStackName, setCurrent, secretsProvider)
+		s, err := stackInit(ctx, b, formattedStackName, setCurrent, secretsProvider)
 		if err != nil {
 			if !yes {
 				// Let the user know about the error and loop around to try again.
@@ -628,12 +628,14 @@ func promptAndCreateStack(prompt promptForValueFunc,
 }
 
 // stackInit creates the stack.
-func stackInit(b backend.Backend, stackName string, setCurrent bool, secretsProvider string) (backend.Stack, error) {
+func stackInit(
+	ctx context.Context, b backend.Backend, stackName string,
+	setCurrent bool, secretsProvider string) (backend.Stack, error) {
 	stackRef, err := b.ParseStackReference(stackName)
 	if err != nil {
 		return nil, err
 	}
-	return createStack(b, stackRef, nil, setCurrent, secretsProvider)
+	return createStack(ctx, b, stackRef, nil, setCurrent, secretsProvider)
 }
 
 // saveConfig saves the config for the stack.

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -220,8 +220,9 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 //nolint:paralleltest // mutates environment variables
 func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
+	ctx := context.Background()
 
-	b, err := currentBackend(display.Options{})
+	b, err := currentBackend(ctx, display.Options{})
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
 
@@ -255,7 +256,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	_, err = os.Stat(filepath.Join(fileStateDir, workspace.BookkeepingDir, workspace.StackDir, stackName+".json"))
 	assert.NoError(t, err)
 
-	b, err = currentBackend(display.Options{})
+	b, err = currentBackend(ctx, display.Options{})
 	require.NoError(t, err)
 	assert.Equal(t, backendURL, b.URL())
 }
@@ -872,7 +873,8 @@ func loadProject(t *testing.T, dir string) *workspace.Project {
 }
 
 func currentUser(t *testing.T) string {
-	b, err := currentBackend(display.Options{})
+	ctx := context.Background()
+	b, err := currentBackend(ctx, display.Options{})
 	assert.NoError(t, err)
 	currentUser, _, err := b.CurrentUser()
 	assert.NoError(t, err)
@@ -886,7 +888,8 @@ func loadStackName(t *testing.T) string {
 }
 
 func removeStack(t *testing.T, name string) {
-	b, err := currentBackend(display.Options{})
+	ctx := context.Background()
+	b, err := currentBackend(ctx, display.Options{})
 	assert.NoError(t, err)
 	ref, err := b.ParseStackReference(name)
 	assert.NoError(t, err)

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -77,7 +77,7 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			"If you try and set a default organization for a backend that does not \n" +
 			"support create organizations, then an error will be returned by the CLI",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -119,7 +119,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 			"\n" +
 			"Currently, only the managed and self-hosted backends support organizations.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -77,13 +77,14 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			"If you try and set a default organization for a backend that does not \n" +
 			"support create organizations, then an error will be returned by the CLI",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			orgName = args[0]
 
-			currentBe, err := currentBackend(displayOpts)
+			currentBe, err := currentBackend(ctx, displayOpts)
 			if err != nil {
 				return err
 			}
@@ -118,11 +119,12 @@ func newOrgGetDefaultCmd() *cobra.Command {
 			"\n" +
 			"Currently, only the managed and self-hosted backends support organizations.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			currentBe, err := currentBackend(displayOpts)
+			currentBe, err := currentBackend(ctx, displayOpts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -54,7 +54,7 @@ func newPluginInstallCmd() *cobra.Command {
 			"If you let Pulumi compute the set to download, it is conservative and may end up\n" +
 			"downloading more plugins than is strictly necessary.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -55,6 +54,7 @@ func newPluginInstallCmd() *cobra.Command {
 			"If you let Pulumi compute the set to download, it is conservative and may end up\n" +
 			"downloading more plugins than is strictly necessary.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			displayOpts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -167,7 +167,7 @@ func newPluginInstallCmd() *cobra.Command {
 					}
 				}
 				logging.V(1).Infof("%s installing tarball ...", label)
-				if err = install.InstallWithContext(context.Background(), payload, reinstall); err != nil {
+				if err = install.InstallWithContext(ctx, payload, reinstall); err != nil {
 					return fmt.Errorf("installing %s from %s: %w", label, source, err)
 				}
 			}

--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -34,7 +34,7 @@ func newPolicyDisableCmd() *cobra.Command {
 		Short: "Disable a Policy Pack for a Pulumi organization",
 		Long:  "Disable a Policy Pack for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
 			var err error
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0])

--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -34,15 +34,16 @@ func newPolicyDisableCmd() *cobra.Command {
 		Short: "Disable a Policy Pack for a Pulumi organization",
 		Long:  "Disable a Policy Pack for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
+			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
 			var err error
-			policyPack, err := requirePolicyPack(cliArgs[0])
+			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {
 				return err
 			}
 
 			// Attempt to disable the Policy Pack.
-			return policyPack.Disable(commandContext(), args.policyGroup, backend.PolicyPackOperation{
+			return policyPack.Disable(ctx, args.policyGroup, backend.PolicyPackOperation{
 				VersionTag: &args.version, Scopes: cancellationScopes})
 		}),
 	}

--- a/pkg/cmd/pulumi/policy_enable.go
+++ b/pkg/cmd/pulumi/policy_enable.go
@@ -41,8 +41,9 @@ func newPolicyEnableCmd() *cobra.Command {
 		Long: "Enable a Policy Pack for a Pulumi organization. " +
 			"Can specify latest to enable the latest version of the Policy Pack or a specific version number.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
+			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
-			policyPack, err := requirePolicyPack(cliArgs[0])
+			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {
 				return err
 			}
@@ -63,7 +64,7 @@ func newPolicyEnableCmd() *cobra.Command {
 			}
 
 			// Attempt to enable the Policy Pack.
-			return policyPack.Enable(commandContext(), args.policyGroup,
+			return policyPack.Enable(ctx, args.policyGroup,
 				backend.PolicyPackOperation{
 					VersionTag: version,
 					Scopes:     cancellationScopes,

--- a/pkg/cmd/pulumi/policy_enable.go
+++ b/pkg/cmd/pulumi/policy_enable.go
@@ -41,7 +41,7 @@ func newPolicyEnableCmd() *cobra.Command {
 		Long: "Enable a Policy Pack for a Pulumi organization. " +
 			"Can specify latest to enable the latest version of the Policy Pack or a specific version number.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 
@@ -46,8 +45,9 @@ func newPolicyGroupLsCmd() *cobra.Command {
 		Short: "List all Policy Groups for a Pulumi organization",
 		Long:  "List all Policy Groups for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
+			ctx := cmd.Context()
 			// Get backend.
-			b, err := currentBackend(display.Options{Color: cmdutil.GetGlobalColorization()})
+			b, err := currentBackend(ctx, display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return fmt.Errorf("failed to get current backend: %w", err)
 			}
@@ -64,7 +64,6 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			}
 
 			// Gather all Policy Groups for the organization.
-			ctx := context.Background()
 			var (
 				allPolicyGroups []apitype.PolicyGroupSummary
 				inContToken     backend.ContinuationToken

--- a/pkg/cmd/pulumi/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy_group_ls.go
@@ -45,7 +45,7 @@ func newPolicyGroupLsCmd() *cobra.Command {
 		Short: "List all Policy Groups for a Pulumi organization",
 		Long:  "List all Policy Groups for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			// Get backend.
 			b, err := currentBackend(ctx, display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -35,7 +35,7 @@ func newPolicyLsCmd() *cobra.Command {
 		Short: "List all Policy Packs for a Pulumi organization",
 		Long:  "List all Policy Packs for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			// Get backend.
 			b, err := currentBackend(ctx, display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -36,8 +35,9 @@ func newPolicyLsCmd() *cobra.Command {
 		Short: "List all Policy Packs for a Pulumi organization",
 		Long:  "List all Policy Packs for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
+			ctx := cmd.Context()
 			// Get backend.
-			b, err := currentBackend(display.Options{Color: cmdutil.GetGlobalColorization()})
+			b, err := currentBackend(ctx, display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return err
 			}
@@ -54,7 +54,6 @@ func newPolicyLsCmd() *cobra.Command {
 			}
 
 			// Gather all Policy Packs for the organization.
-			ctx := context.Background()
 			var (
 				allPolicyPacks []apitype.PolicyPackWithVersions
 				inContToken    backend.ContinuationToken

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -64,10 +64,11 @@ func newPolicyNewCmd() *cobra.Command {
 			"Only organization administrators can publish a Policy Pack.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
+			ctx := cmd.Context()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]
 			}
-			return runNewPolicyPack(context.Background(), args)
+			return runNewPolicyPack(ctx, args)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -64,7 +64,7 @@ func newPolicyNewCmd() *cobra.Command {
 			"Only organization administrators can publish a Policy Pack.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]
 			}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -39,7 +39,7 @@ func newPolicyPublishCmd() *cobra.Command {
 			"\n" +
 			"If an organization name is not specified, the current user account is used.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 
 			var orgName string
 			if len(args) > 0 {

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -35,9 +35,10 @@ func newPolicyRmCmd() *cobra.Command {
 		Long: "Removes a Policy Pack from a Pulumi organization. " +
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
-			policyPack, err := requirePolicyPack(args[0])
+			policyPack, err := requirePolicyPack(ctx, args[0])
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -58,7 +59,7 @@ func newPolicyRmCmd() *cobra.Command {
 			}
 
 			// Attempt to remove the Policy Pack.
-			err = policyPack.Remove(commandContext(), backend.PolicyPackOperation{
+			err = policyPack.Remove(ctx, backend.PolicyPackOperation{
 				VersionTag: version, Scopes: cancellationScopes})
 			if err != nil {
 				return result.FromError(err)

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -35,7 +35,7 @@ func newPolicyRmCmd() *cobra.Command {
 		Long: "Removes a Policy Pack from a Pulumi organization. " +
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
 			policyPack, err := requirePolicyPack(ctx, args[0])

--- a/pkg/cmd/pulumi/policy_validate.go
+++ b/pkg/cmd/pulumi/policy_validate.go
@@ -32,7 +32,7 @@ func newPolicyValidateCmd() *cobra.Command {
 		Short: "Validate a Policy Pack configuration",
 		Long:  "Validate a Policy Pack configuration against the configuration schema of the specified version.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
 			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {

--- a/pkg/cmd/pulumi/policy_validate.go
+++ b/pkg/cmd/pulumi/policy_validate.go
@@ -32,8 +32,9 @@ func newPolicyValidateCmd() *cobra.Command {
 		Short: "Validate a Policy Pack configuration",
 		Long:  "Validate a Policy Pack configuration against the configuration schema of the specified version.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
+			ctx := cmd.Context()
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
-			policyPack, err := requirePolicyPack(cliArgs[0])
+			policyPack, err := requirePolicyPack(ctx, cliArgs[0])
 			if err != nil {
 				return err
 			}
@@ -50,7 +51,7 @@ func newPolicyValidateCmd() *cobra.Command {
 				}
 			}
 
-			err = policyPack.Validate(commandContext(),
+			err = policyPack.Validate(ctx,
 				backend.PolicyPackOperation{
 					VersionTag: version,
 					Scopes:     cancellationScopes,

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -81,6 +81,7 @@ func newPreviewCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			var displayType = display.DisplayProgress
 			if diffDisplay {
 				displayType = display.DisplayDiff
@@ -122,7 +123,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(stack, true, displayOpts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, true, displayOpts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -147,7 +148,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
-			cfg, err := getStackConfiguration(s, sm)
+			cfg, err := getStackConfiguration(ctx, s, sm)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
@@ -190,7 +191,7 @@ func newPreviewCmd() *cobra.Command {
 				Display: displayOpts,
 			}
 
-			plan, changes, res := s.Preview(commandContext(), backend.UpdateOperation{
+			plan, changes, res := s.Preview(ctx, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -81,7 +81,7 @@ func newPreviewCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			var displayType = display.DisplayProgress
 			if diffDisplay {
 				displayType = display.DisplayDiff

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -218,7 +219,8 @@ func NewPulumiCmd() *cobra.Command {
 				// If there is a new version to report, we will do so after the command has finished.
 				waitForUpdateCheck = true
 				go func() {
-					updateCheckResult <- checkForUpdate()
+					ctx := cmd.Context()
+					updateCheckResult <- checkForUpdate(ctx)
 					close(updateCheckResult)
 				}()
 			}
@@ -366,7 +368,7 @@ func NewPulumiCmd() *cobra.Command {
 
 // checkForUpdate checks to see if the CLI needs to be updated, and if so emits a warning, as well as information
 // as to how it can be upgraded.
-func checkForUpdate() *diag.Diag {
+func checkForUpdate(ctx context.Context) *diag.Diag {
 	curVer, err := semver.ParseTolerant(version.Version)
 	if err != nil {
 		logging.V(3).Infof("error parsing current version: %s", err)
@@ -377,7 +379,7 @@ func checkForUpdate() *diag.Diag {
 		return nil
 	}
 
-	latestVer, oldestAllowedVer, err := getCLIVersionInfo()
+	latestVer, oldestAllowedVer, err := getCLIVersionInfo(ctx)
 	if err != nil {
 		logging.V(3).Infof("error fetching latest version information: %s", err)
 	}
@@ -391,14 +393,14 @@ func checkForUpdate() *diag.Diag {
 
 // getCLIVersionInfo returns information about the latest version of the CLI and the oldest version that should be
 // allowed without warning. It caches data from the server for a day.
-func getCLIVersionInfo() (semver.Version, semver.Version, error) {
+func getCLIVersionInfo(ctx context.Context) (semver.Version, semver.Version, error) {
 	latest, oldest, err := getCachedVersionInfo()
 	if err == nil {
 		return latest, oldest, err
 	}
 
 	client := client.NewClient(httpstate.DefaultURL(), "", cmdutil.Diag())
-	latest, oldest, err = client.GetCLIVersionInfo(commandContext())
+	latest, oldest, err = client.GetCLIVersionInfo(ctx)
 	if err != nil {
 		return semver.Version{}, semver.Version{}, err
 	}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -219,7 +219,7 @@ func NewPulumiCmd() *cobra.Command {
 				// If there is a new version to report, we will do so after the command has finished.
 				waitForUpdateCheck = true
 				go func() {
-					ctx := cmd.Context()
+					ctx := commandContext()
 					updateCheckResult <- checkForUpdate(ctx)
 					close(updateCheckResult)
 				}()

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -46,7 +46,7 @@ func newQueryCmd() *cobra.Command {
 		Args:   cmdutil.NoArgs,
 		Hidden: !hasExperimentalCommands() && !hasDebugCommands(),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			interactive := cmdutil.Interactive()
 
 			opts := backend.UpdateOptions{}

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -46,6 +46,7 @@ func newQueryCmd() *cobra.Command {
 		Args:   cmdutil.NoArgs,
 		Hidden: !hasExperimentalCommands() && !hasDebugCommands(),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			interactive := cmdutil.Interactive()
 
 			opts := backend.UpdateOptions{}
@@ -55,7 +56,7 @@ func newQueryCmd() *cobra.Command {
 				Type:          display.DisplayQuery,
 			}
 
-			b, err := currentBackend(opts.Display)
+			b, err := currentBackend(ctx, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -67,7 +68,7 @@ func newQueryCmd() *cobra.Command {
 
 			opts.Engine = engine.UpdateOptions{}
 
-			res := b.Query(commandContext(), backend.QueryOperation{
+			res := b.Query(ctx, backend.QueryOperation{
 				Proj:   proj,
 				Root:   root,
 				Opts:   opts,

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -65,7 +65,7 @@ func newRefreshCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipPreview || skipConfirmations()
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes {

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -65,6 +65,7 @@ func newRefreshCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			yes = yes || skipPreview || skipConfirmations()
 			interactive := cmdutil.Interactive()
 			if !interactive && !yes {
@@ -114,7 +115,7 @@ func newRefreshCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, true, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -134,7 +135,7 @@ func newRefreshCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
-			cfg, err := getStackConfiguration(s, sm)
+			cfg, err := getStackConfiguration(ctx, s, sm)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
@@ -154,7 +155,7 @@ func newRefreshCmd() *cobra.Command {
 				RefreshTargets:            targetUrns,
 			}
 
-			changes, res := s.Refresh(commandContext(), backend.UpdateOperation{
+			changes, res := s.Refresh(ctx, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -48,7 +48,7 @@ func newStackCmd() *cobra.Command {
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -48,11 +48,12 @@ func newStackCmd() *cobra.Command {
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stackName, true, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, true, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -62,7 +63,7 @@ func newStackCmd() *cobra.Command {
 				return nil
 			}
 
-			snap, err := s.Snapshot(commandContext())
+			snap, err := s.Snapshot(ctx)
 			if err != nil {
 				return err
 			}
@@ -143,7 +144,7 @@ func newStackCmd() *cobra.Command {
 				}
 
 				if showSecrets {
-					log3rdPartySecretsProviderDecryptionEvent(commandContext(), s, "", "pulumi stack")
+					log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack")
 				}
 			}
 

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -53,7 +53,7 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			"\"gcpkms://projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>\"`\n" +
 			"* `pulumi stack change-secrets-provider \"hashivault://mykey\"`",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -53,6 +53,7 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			"\"gcpkms://projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>\"`\n" +
 			"* `pulumi stack change-secrets-provider \"hashivault://mykey\"`",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -63,13 +64,13 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			}
 
 			// Get the current backend
-			b, err := currentBackend(opts)
+			b, err := currentBackend(ctx, opts)
 			if err != nil {
 				return err
 			}
 
 			// Get the current stack and its project
-			currentStack, err := requireStack(stack, false, opts, false /*setCurrent*/)
+			currentStack, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -95,13 +96,13 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			secretsProvider := args[0]
 			rotatePassphraseProvider := secretsProvider == "passphrase"
 			// Create the new secrets provider and set to the currentStack
-			if err := createSecretsManager(b, currentStack.Ref(), secretsProvider, rotatePassphraseProvider); err != nil {
+			if err := createSecretsManager(ctx, b, currentStack.Ref(), secretsProvider, rotatePassphraseProvider); err != nil {
 				return err
 			}
 
 			// Fixup the checkpoint
 			fmt.Printf("Migrating old configuration and state to new secrets provider\n")
-			return migrateOldConfigAndCheckpointToNewSecretsProvider(commandContext(), currentStack, currentConfig, decrypter)
+			return migrateOldConfigAndCheckpointToNewSecretsProvider(ctx, currentStack, currentConfig, decrypter)
 		}),
 	}
 

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -45,7 +45,7 @@ func newStackExportCmd() *cobra.Command {
 			"in a stack's state due to failed deployments, manual changes to cloud\n" +
 			"resources, etc.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -45,13 +45,13 @@ func newStackExportCmd() *cobra.Command {
 			"in a stack's state due to failed deployments, manual changes to cloud\n" +
 			"resources, etc.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -53,15 +53,16 @@ func newStackGraphCmd() *cobra.Command {
 			"emitted when it was run. This graph is output in the DOT format. This command operates\n" +
 			"on your stack's most recent deployment.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
-			snap, err := s.Snapshot(commandContext())
+			snap, err := s.Snapshot(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -53,7 +53,7 @@ func newStackGraphCmd() *cobra.Command {
 			"emitted when it was run. This graph is output in the DOT format. This command operates\n" +
 			"on your stack's most recent deployment.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -37,7 +37,7 @@ func newStackHistoryCmd() *cobra.Command {
 
 This command displays data about previous updates for a stack.`,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -37,15 +37,16 @@ func newStackHistoryCmd() *cobra.Command {
 
 This command displays data about previous updates for a stack.`,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(stack, false /*offerNew */, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, false /*offerNew */, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
 			b := s.Backend()
-			updates, err := b.GetHistory(commandContext(), s.Ref(), pageSize, page)
+			updates, err := b.GetHistory(ctx, s.Ref(), pageSize, page)
 			if err != nil {
 				return fmt.Errorf("getting history: %w", err)
 			}
@@ -59,7 +60,7 @@ This command displays data about previous updates for a stack.`,
 			}
 
 			if showSecrets {
-				log3rdPartySecretsProviderDecryptionEvent(commandContext(), s, "", "pulumi stack history")
+				log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack history")
 			}
 
 			if jsonOut {

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -46,13 +46,13 @@ func newStackImportCmd() *cobra.Command {
 			"to cloud resources, etc. can be reimported to the stack using this command.\n" +
 			"The updated deployment will be read from standard in.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext()
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Fetch the current stack and import a deployment.
-			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -46,7 +46,7 @@ func newStackImportCmd() *cobra.Command {
 			"to cloud resources, etc. can be reimported to the stack using this command.\n" +
 			"The updated deployment will be read from standard in.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -67,7 +67,7 @@ func newStackInitCmd() *cobra.Command {
 			"`--copy-config-from` flag.\n" +
 			"* `pulumi stack init --copy-config-from dev`",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -67,11 +67,12 @@ func newStackInitCmd() *cobra.Command {
 			"`--copy-config-from` flag.\n" +
 			"* `pulumi stack init --copy-config-from dev`",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			b, err := currentBackend(opts)
+			b, err := currentBackend(ctx, opts)
 			if err != nil {
 				return err
 			}
@@ -117,14 +118,14 @@ func newStackInitCmd() *cobra.Command {
 			}
 
 			var createOpts interface{} // Backend-specific config options, none currently.
-			newStack, err := createStack(b, stackRef, createOpts, true /*setCurrent*/, secretsProvider)
+			newStack, err := createStack(ctx, b, stackRef, createOpts, true /*setCurrent*/, secretsProvider)
 			if err != nil {
 				return err
 			}
 
 			if stackToCopy != "" {
 				// load the old stack and its project
-				copyStack, err := requireStack(stackToCopy, false, opts, false /*setCurrent*/)
+				copyStack, err := requireStack(ctx, stackToCopy, false, opts, false /*setCurrent*/)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -55,7 +55,7 @@ func newStackLsCmd() *cobra.Command {
 			"'environment=production' or just 'gcp:project'.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			cmdArgs := stackLSArgs{
 				jsonOut:    jsonOut,
 				allStacks:  allStacks,

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -53,7 +54,8 @@ func newStackLsCmd() *cobra.Command {
 			"the tag name as well as the tag value, separated by an equals sign. For example\n" +
 			"'environment=production' or just 'gcp:project'.",
 		Args: cmdutil.NoArgs,
-		Run: cmdutil.RunFunc(func(_ *cobra.Command, _ []string) error {
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 			cmdArgs := stackLSArgs{
 				jsonOut:    jsonOut,
 				allStacks:  allStacks,
@@ -61,7 +63,7 @@ func newStackLsCmd() *cobra.Command {
 				projFilter: projFilter,
 				tagFilter:  tagFilter,
 			}
-			return runStackLS(cmdArgs)
+			return runStackLS(ctx, cmdArgs)
 		}),
 	}
 	cmd.PersistentFlags().BoolVarP(
@@ -88,7 +90,7 @@ type stackLSArgs struct {
 	tagFilter  string
 }
 
-func runStackLS(args stackLSArgs) error {
+func runStackLS(ctx context.Context, args stackLSArgs) error {
 	// Build up the stack filters. We do not support accepting empty strings as filters
 	// from command-line arguments, though the API technically supports it.
 	strPtrIfSet := func(s string) *string {
@@ -126,14 +128,14 @@ func runStackLS(args stackLSArgs) error {
 	}
 
 	// Get the current backend.
-	b, err := currentBackend(display.Options{Color: cmdutil.GetGlobalColorization()})
+	b, err := currentBackend(ctx, display.Options{Color: cmdutil.GetGlobalColorization()})
 	if err != nil {
 		return err
 	}
 
 	// Get the current stack so we can print a '*' next to it.
 	var current string
-	if s, _ := state.CurrentStack(commandContext(), b); s != nil {
+	if s, _ := state.CurrentStack(ctx, b); s != nil {
 		// If we couldn't figure out the current stack, just don't print the '*' later on instead of failing.
 		current = s.Ref().String()
 	}
@@ -150,7 +152,7 @@ func runStackLS(args stackLSArgs) error {
 		inContToken       backend.ContinuationToken
 	)
 	for {
-		summaries, outContToken, err := b.ListStacks(commandContext(), filter, inContToken)
+		summaries, outContToken, err := b.ListStacks(ctx, filter, inContToken)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack_ls_test.go
@@ -157,11 +157,12 @@ func TestListStacksPagination(t *testing.T) {
 
 	// Execute the command, which will use our mocked backend. Confirm the expected number of
 	// backend calls were made.
-	var args = stackLSArgs{
+	ctx := context.Background()
+	args := stackLSArgs{
 		orgFilter:  testOrgName,
 		projFilter: testProjName,
 	}
-	if err := runStackLS(args); err != nil {
+	if err := runStackLS(ctx, args); err != nil {
 		t.Fatalf("runStackLS returned an error: %v", err)
 	}
 	if len(requestsMade) != 4 {

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -40,16 +40,17 @@ func newStackOutputCmd() *cobra.Command {
 			"By default, this command lists all output properties exported from a stack.\n" +
 			"If a specific property-name is supplied, just that property's value is shown.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Fetch the current stack and its output properties.
-			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
-			snap, err := s.Snapshot(commandContext())
+			snap, err := s.Snapshot(ctx)
 			if err != nil {
 				return err
 			}
@@ -86,7 +87,7 @@ func newStackOutputCmd() *cobra.Command {
 			}
 
 			if showSecrets {
-				log3rdPartySecretsProviderDecryptionEvent(commandContext(), s, "", "pulumi stack output")
+				log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack output")
 			}
 
 			return nil

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -40,7 +40,7 @@ func newStackOutputCmd() *cobra.Command {
 			"By default, this command lists all output properties exported from a stack.\n" +
 			"If a specific property-name is supplied, just that property's value is shown.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -45,12 +45,13 @@ func newStackRenameCmd() *cobra.Command {
 			"'robot-co/new-project-name/production'. However in order to update the stack again, you would also need\n" +
 			"to update the name field of Pulumi.yaml, so the project names match.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
 			// Look up the stack to be moved, and find the path to the project file's location.
-			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -61,7 +62,7 @@ func newStackRenameCmd() *cobra.Command {
 
 			// Now perform the rename and get ready to rename the existing configuration to the new project file.
 			newStackName := args[0]
-			newStackRef, err := s.Rename(commandContext(), tokens.QName(newStackName))
+			newStackRef, err := s.Rename(ctx, tokens.QName(newStackName))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -45,7 +45,7 @@ func newStackRenameCmd() *cobra.Command {
 			"'robot-co/new-project-name/production'. However in order to update the stack again, you would also need\n" +
 			"to update the name field of Pulumi.yaml, so the project names match.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -46,6 +46,7 @@ func newStackRmCmd() *cobra.Command {
 			"\n" +
 			"After this command completes, the stack will no longer be available for updates.",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {
@@ -59,7 +60,7 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -71,7 +72,7 @@ func newStackRmCmd() *cobra.Command {
 				return result.Bail()
 			}
 
-			hasResources, err := s.Remove(commandContext(), force)
+			hasResources, err := s.Remove(ctx, force)
 			if err != nil {
 				if hasResources {
 					return result.Errorf(

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -46,7 +46,7 @@ func newStackRmCmd() *cobra.Command {
 			"\n" +
 			"After this command completes, the stack will no longer be available for updates.",
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			// Use the stack provided or, if missing, default to the current one.
 			if len(args) > 0 {

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -43,7 +43,7 @@ func newStackSelectCmd() *cobra.Command {
 			"If provided stack name is not found you may pass the --create flag to create and select it",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -43,11 +43,12 @@ func newStackSelectCmd() *cobra.Command {
 			"If provided stack name is not found you may pass the --create flag to create and select it",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			b, err := currentBackend(opts)
+			b, err := currentBackend(ctx, opts)
 			if err != nil {
 				return err
 			}
@@ -67,7 +68,7 @@ func newStackSelectCmd() *cobra.Command {
 					return stackErr
 				}
 
-				s, stackErr := b.GetStack(commandContext(), stackRef)
+				s, stackErr := b.GetStack(ctx, stackRef)
 				if stackErr != nil {
 					return stackErr
 				} else if s != nil {
@@ -75,7 +76,7 @@ func newStackSelectCmd() *cobra.Command {
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
-					s, err := stackInit(b, stack, false, secretsProvider)
+					s, err := stackInit(ctx, b, stack, false, secretsProvider)
 					if err != nil {
 						return err
 					}
@@ -86,7 +87,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			// If no stack was given, prompt the user to select a name from the available ones.
-			stack, err := chooseStack(b, true, opts, true /*setCurrent*/)
+			stack, err := chooseStack(ctx, b, true, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -58,7 +58,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 		Short: "Get a single stack tag value",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			name := args[0]
 
 			opts := display.Options{
@@ -92,7 +92,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 		Short: "List all stack tags",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
@@ -148,7 +148,7 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 		Short: "Remove a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			name := args[0]
 
 			opts := display.Options{
@@ -178,7 +178,7 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 		Short: "Set a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name", "value"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			name := args[0]
 			value := args[1]
 

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -58,12 +58,13 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 		Short: "Get a single stack tag value",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			name := args[0]
 
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(*stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -91,11 +92,12 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 		Short: "List all stack tags",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -146,12 +148,13 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 		Short: "Remove a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			name := args[0]
 
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -164,7 +167,7 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 			tags := s.Tags()
 			delete(tags, name)
 
-			return backend.UpdateStackTags(commandContext(), s, tags)
+			return backend.UpdateStackTags(ctx, s, tags)
 		}),
 	}
 }
@@ -175,13 +178,14 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 		Short: "Set a stack tag",
 		Args:  cmdutil.SpecificArgs([]string{"name", "value"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			name := args[0]
 			value := args[1]
 
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -197,7 +201,7 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 			}
 			tags[name] = value
 
-			return backend.UpdateStackTags(commandContext(), s, tags)
+			return backend.UpdateStackTags(ctx, s, tags)
 		}),
 	}
 }

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -121,8 +122,10 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 }
 
 // runStateEdit runs the given state edit function on a resource with the given URN in a given stack.
-func runStateEdit(stackName string, showPrompt bool, urn resource.URN, operation edit.OperationFunc) result.Result {
-	return runTotalStateEdit(stackName, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
+func runStateEdit(
+	ctx context.Context, stackName string, showPrompt bool,
+	urn resource.URN, operation edit.OperationFunc) result.Result {
+	return runTotalStateEdit(ctx, stackName, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
 		res, err := locateStackResource(opts, snap, urn)
 		if err != nil {
 			return err
@@ -135,16 +138,16 @@ func runStateEdit(stackName string, showPrompt bool, urn resource.URN, operation
 // runTotalStateEdit runs a snapshot-mutating function on the entirety of the given stack's snapshot.
 // Before mutating, the user may be prompted to for confirmation if the current session is interactive.
 func runTotalStateEdit(
-	stackName string, showPrompt bool,
+	ctx context.Context, stackName string, showPrompt bool,
 	operation func(opts display.Options, snap *deploy.Snapshot) error) result.Result {
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
-	s, err := requireStack(stackName, true, opts, false /*setCurrent*/)
+	s, err := requireStack(ctx, stackName, true, opts, false /*setCurrent*/)
 	if err != nil {
 		return result.FromError(err)
 	}
-	snap, err := s.Snapshot(commandContext())
+	snap, err := s.Snapshot(ctx)
 	if err != nil {
 		return result.FromError(err)
 	}
@@ -192,5 +195,5 @@ func runTotalStateEdit(
 		Version:    apitype.DeploymentSchemaVersionCurrent,
 		Deployment: bytes,
 	}
-	return result.WrapIfNonNil(s.ImportDeployment(commandContext(), &dep))
+	return result.WrapIfNonNil(s.ImportDeployment(ctx, &dep))
 }

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -37,10 +37,10 @@ func newStateDeleteCommand() *cobra.Command {
 		Short: "Deletes a resource from a stack's state",
 		Long: `Deletes a resource from a stack's state
 
-This command deletes a resource from a stack's state, as long as it is safe to do so. The resource is specified 
+This command deletes a resource from a stack's state, as long as it is safe to do so. The resource is specified
 by its Pulumi URN (use ` + "`pulumi stack --show-urns`" + ` to get it).
 
-Resources can't be deleted if there exist other resources that depend on it or are parented to it. Protected resources 
+Resources can't be deleted if there exist other resources that depend on it or are parented to it. Protected resources
 will not be deleted unless it is specifically requested using the --force flag.
 
 Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.
@@ -50,12 +50,13 @@ pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 `,
 		Args: cmdutil.ExactArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			urn := resource.URN(args[0])
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 
-			res := runStateEdit(stack, showPrompt, urn, func(snap *deploy.Snapshot, res *resource.State) error {
+			res := runStateEdit(ctx, stack, showPrompt, urn, func(snap *deploy.Snapshot, res *resource.State) error {
 				if !force {
 					return edit.DeleteResource(snap, res)
 				}

--- a/pkg/cmd/pulumi/state_delete.go
+++ b/pkg/cmd/pulumi/state_delete.go
@@ -50,7 +50,7 @@ pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 `,
 		Args: cmdutil.ExactArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			urn := resource.URN(args[0])
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -50,7 +50,7 @@ func newStateRenameCommand() *cobra.Command {
 		Short: "Renames a resource from a stack's state",
 		Long: `Renames a resource from a stack's state
 
-This command renames a resource from a stack's state. The resource is specified 
+This command renames a resource from a stack's state. The resource is specified
 by its Pulumi URN (use ` + "`pulumi stack --show-urns`" + ` to get it) and the new name of the resource.
 
 Make sure that URNs are single-quoted to avoid having characters unexpectedly interpreted by the shell.
@@ -60,6 +60,7 @@ pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 `,
 		Args: cmdutil.ExactArgs(2),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			urn := resource.URN(args[0])
 			newResourceName := args[1]
@@ -70,7 +71,7 @@ pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 				return result.Error("The provided input URN is not valid")
 			}
 
-			res := runTotalStateEdit(stack, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
+			res := runTotalStateEdit(ctx, stack, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
 				// Check whether the input URN corresponds to an existing resource
 				existingResources := edit.LocateResource(snap, urn)
 				if len(existingResources) != 1 {

--- a/pkg/cmd/pulumi/state_rename.go
+++ b/pkg/cmd/pulumi/state_rename.go
@@ -60,7 +60,7 @@ pulumi state rename 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 `,
 		Args: cmdutil.ExactArgs(2),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			urn := resource.URN(args[0])
 			newResourceName := args[1]

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -41,12 +42,13 @@ func newStateUnprotectCommand() *cobra.Command {
 This command clears the 'protect' bit on one or more resources, allowing those resources to be deleted.`,
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 			yes = yes || skipConfirmations()
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 
 			if unprotectAll {
-				return unprotectAllResources(stack, showPrompt)
+				return unprotectAllResources(ctx, stack, showPrompt)
 			}
 
 			if len(args) != 1 {
@@ -54,7 +56,7 @@ This command clears the 'protect' bit on one or more resources, allowing those r
 			}
 
 			urn := resource.URN(args[0])
-			return unprotectResource(stack, urn, showPrompt)
+			return unprotectResource(ctx, stack, urn, showPrompt)
 		}),
 	}
 
@@ -67,8 +69,8 @@ This command clears the 'protect' bit on one or more resources, allowing those r
 	return cmd
 }
 
-func unprotectAllResources(stackName string, showPrompt bool) result.Result {
-	res := runTotalStateEdit(stackName, showPrompt, func(_ display.Options, snap *deploy.Snapshot) error {
+func unprotectAllResources(ctx context.Context, stackName string, showPrompt bool) result.Result {
+	res := runTotalStateEdit(ctx, stackName, showPrompt, func(_ display.Options, snap *deploy.Snapshot) error {
 		// Protects against Panic when a user tries to unprotect non-existing resources
 		if snap == nil {
 			return fmt.Errorf("no resources found to unprotect")
@@ -89,8 +91,8 @@ func unprotectAllResources(stackName string, showPrompt bool) result.Result {
 	return nil
 }
 
-func unprotectResource(stackName string, urn resource.URN, showPrompt bool) result.Result {
-	res := runStateEdit(stackName, showPrompt, urn, edit.UnprotectResource)
+func unprotectResource(ctx context.Context, stackName string, urn resource.URN, showPrompt bool) result.Result {
+	res := runStateEdit(ctx, stackName, showPrompt, urn, edit.UnprotectResource)
 	if res != nil {
 		return res
 	}

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -42,7 +42,7 @@ func newStateUnprotectCommand() *cobra.Command {
 This command clears the 'protect' bit on one or more resources, allowing those resources to be deleted.`,
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipConfirmations()
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -394,7 +394,7 @@ func newUpCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			yes = yes || skipPreview || skipConfirmations()
 
 			interactive := cmdutil.Interactive()

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -63,6 +63,7 @@ func newWatchCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := cmd.Context()
 
 			opts, err := updateFlagsToOptions(false /* interactive */, true /* skippreview*/, true /* autoapprove*/)
 			if err != nil {
@@ -85,7 +86,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, true, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -110,7 +111,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
-			cfg, err := getStackConfiguration(s, sm)
+			cfg, err := getStackConfiguration(ctx, s, sm)
 			if err != nil {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
@@ -126,7 +127,7 @@ func newWatchCmd() *cobra.Command {
 				DisableOutputValues:       disableOutputValues(),
 			}
 
-			res := s.Watch(commandContext(), backend.UpdateOperation{
+			res := s.Watch(ctx, backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
 				M:                  m,

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -63,7 +63,7 @@ func newWatchCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
-			ctx := cmd.Context()
+			ctx := commandContext()
 
 			opts, err := updateFlagsToOptions(false /* interactive */, true /* skippreview*/, true /* autoapprove*/)
 			if err != nil {

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -34,11 +34,12 @@ func newWhoAmICmd() *cobra.Command {
 			"Displays the username of the currently logged in user.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			b, err := currentBackend(opts)
+			b, err := currentBackend(ctx, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/whoami.go
+++ b/pkg/cmd/pulumi/whoami.go
@@ -34,7 +34,7 @@ func newWhoAmICmd() *cobra.Command {
 			"Displays the username of the currently logged in user.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
+			ctx := commandContext()
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}


### PR DESCRIPTION
Pretty simple change, just fix up a load of places through /cmd where we either used context.Background, or assumed commandContext.

Now all helper methods take an explicit `ctx context.Context` and all cobra commands use `cmd.Context()` to get a context. The correct command context is set once in main.go.