### PR TITLE
Revert "[cli] Allow Pulumi.yaml files to contain additional, preserved keys"

### DIFF
--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -116,9 +116,6 @@ type Project struct {
 	Options *ProjectOptions `json:"options,omitempty" yaml:"options,omitempty"`
 
 	Plugins *Plugins `json:"plugins,omitempty" yaml:"plugins,omitempty"`
-
-	// Additional keys that may be set by other programs sharing the same document.
-	AdditionalData map[string]interface{} `yaml:",inline"`
 }
 
 func (proj *Project) Validate() error {

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -38,37 +38,3 @@ func TestProjectRuntimeInfoRoundtripYAML(t *testing.T) {
 	doTest(yaml.Marshal, yaml.Unmarshal)
 	doTest(json.Marshal, json.Unmarshal)
 }
-
-func TestProjectArbitraryExtraData(t *testing.T) {
-	t.Parallel()
-
-	doTest := func(marshal func(interface{}) ([]byte, error), unmarshal func([]byte, interface{}) error, repr string) {
-		p := Project{
-			AdditionalData: map[string]interface{}{
-				"resources": map[interface{}]interface{}{
-					"foo": map[interface{}]interface{}{
-						"type": "example:Resource",
-					},
-				},
-			},
-		}
-		byts, err := marshal(p)
-		assert.NoError(t, err)
-
-		var pRoundtrip Project
-		err = unmarshal(byts, &pRoundtrip)
-		assert.NoError(t, err)
-		assert.Equal(t, "example:Resource",
-			pRoundtrip.AdditionalData["resources"].(map[interface{}]interface{})["foo"].(map[interface{}]interface{})["type"])
-
-		assert.Equal(t, string(byts), repr)
-	}
-
-	doTest(yaml.Marshal, yaml.Unmarshal,
-		`name: ""
-runtime: ""
-resources:
-  foo:
-    type: example:Resource
-`)
-}


### PR DESCRIPTION
Without some changes to `pulumi new` behavior, this has the surprising and incorrect behavior of causing the `resources` block to be duplicated in templates.

Reverts pulumi/pulumi#10269