### PR TITLE
Skip codegen tests that import az-nature. 

### DIFF
--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -162,6 +162,7 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "typed-enum",
 		Description: "Supply strongly typed enums",
+		Skip:        codegen.NewStringSet(golang),
 	},
 	{
 		Directory:   "python-resource-names",

--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -167,6 +167,7 @@ var PulumiPulumiSDKTests = []*SDKTest{
 	{
 		Directory:   "hyphen-url",
 		Description: "A resource url with a hyphen in its path",
+		Skip:        codegen.NewStringSet(golang),
 	},
 	{
 		Directory:   "output-funcs",
@@ -227,6 +228,7 @@ var PulumiPulumiSDKTests = []*SDKTest{
 	{
 		Directory:   "azure-native-nested-types",
 		Description: "Condensed example of nested collection types from Azure Native",
+		Skip:        codegen.NewStringSet(golang),
 	},
 	{
 		Directory:   "regress-go-8664",

--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -167,7 +167,7 @@ var PulumiPulumiSDKTests = []*SDKTest{
 	{
 		Directory:   "hyphen-url",
 		Description: "A resource url with a hyphen in its path",
-		Skip:        codegen.NewStringSet(golang),
+		Skip:        codegen.NewStringSet("go/any"),
 	},
 	{
 		Directory:   "output-funcs",
@@ -228,7 +228,7 @@ var PulumiPulumiSDKTests = []*SDKTest{
 	{
 		Directory:   "azure-native-nested-types",
 		Description: "Condensed example of nested collection types from Azure Native",
-		Skip:        codegen.NewStringSet(golang),
+		Skip:        codegen.NewStringSet("go/any"),
 	},
 	{
 		Directory:   "regress-go-8664",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Some of our Codegen tests import azure-native, which is a known massive project. AZ Native has finally exceeded the max size permitted by `go mod` for import and has started failing builds as a result. **This issue is blocking release**.

This PR skips the failing tests that use AZ-Native. I tried to leave as much enabled as possible -- I didn't disable tests in other languages that use AZ Native. Unfortunately, I wasn't able to use `SkipCompile` instead of `Skip`, because `go mod tidy` is producing the error, and that happens at generation-time, which is before compile-time.

Also, I didn't disable all tests that use AZ Native -- only the ones that were failing on master.

Marking this PR as "draft" for now because a better solution would be to pin an earlier version of AZ Native, which I might be able to do.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->