### PR TITLE
[cli] Enable single-file Pulumi YAML templates

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -279,6 +279,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			return err
 		}
 
+		contract.Assert(len(workspaceDocument.Content) == 1)
 		projFile, err := yaml.Marshal(workspaceDocument.Content[0])
 		if err != nil {
 			return err

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -287,6 +288,13 @@ func runNew(ctx context.Context, args newArgs) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	appendFileName := "Pulumi.yaml.append"
+	appendFile := filepath.Join(root, appendFileName)
+	os.Remove(appendFile)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
 	}
 
 	// Create the stack, if needed.

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -479,9 +479,9 @@ func readProject() (*workspace.Project, string, error) {
 	return proj, filepath.Dir(path), nil
 }
 
-// readProjectWithPath attempts to detect and read a Pulumi project for the current workspace. If the
-// project is successfully detected and read, it is returned along with the path to its containing
-// directory, which will be used as the root of the project's Pulumi program.
+// readProjectWithPath attempts to detect and read a Pulumi project for the current workspace. If
+// the project is successfully detected and read, it is returned along with the path to the project
+// file, which will be used as the root of the project's Pulumi program.
 func readProjectWithPath() (*workspace.Project, string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -471,6 +471,18 @@ func readProjectForUpdate(clientAddress string) (*workspace.Project, string, err
 // project is successfully detected and read, it is returned along with the path to its containing
 // directory, which will be used as the root of the project's Pulumi program.
 func readProject() (*workspace.Project, string, error) {
+	proj, path, err := readProjectWithPath()
+	if err != nil {
+		return nil, "", err
+	}
+
+	return proj, filepath.Dir(path), nil
+}
+
+// readProjectWithPath attempts to detect and read a Pulumi project for the current workspace. If the
+// project is successfully detected and read, it is returned along with the path to its containing
+// directory, which will be used as the root of the project's Pulumi program.
+func readProjectWithPath() (*workspace.Project, string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return nil, "", err
@@ -489,7 +501,7 @@ func readProject() (*workspace.Project, string, error) {
 		return nil, "", fmt.Errorf("failed to load Pulumi project located at %q: %w", path, err)
 	}
 
-	return proj, filepath.Dir(path), nil
+	return proj, path, nil
 }
 
 // readPolicyProject attempts to detect and read a Pulumi PolicyPack project for the current

--- a/pkg/util/yamlutil/node_tools.go
+++ b/pkg/util/yamlutil/node_tools.go
@@ -1,0 +1,177 @@
+package yamlutil
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+type yamlError struct {
+	*yaml.Node
+	err string
+}
+
+func (e yamlError) Error() string {
+	return fmt.Sprintf("[%v:%v] %v", e.Node.Line, e.Node.Column, e.err)
+}
+
+func YamlErrorf(node *yaml.Node, format string, a ...interface{}) error {
+	return yamlError{Node: node, err: fmt.Sprintf(format, a...)}
+}
+
+// Get attempts to obtain the value at an index in a sequence or in a mapping. Returns the node and true if successful;
+// nil and false if out of bounds or not found; and nil, false, and an error if any error occurs.
+func Get(l *yaml.Node, key interface{}) (*yaml.Node, bool, error) {
+	switch l.Kind {
+	case yaml.DocumentNode:
+		// Automatically recurse as documents contain a single element
+		return Get(l.Content[0], key)
+	case yaml.SequenceNode:
+		if idx, ok := key.(int); ok {
+			if len(l.Content) > idx {
+				return l.Content[idx], true, nil
+			}
+			return nil, false, nil
+		}
+		return nil, false, YamlErrorf(l, "unsupported index type %T, found sequence node and expected int index", key)
+	case yaml.MappingNode:
+		for i, v := range l.Content {
+			if i%2 == 1 {
+				continue
+			}
+
+			switch k := key.(type) {
+			case string:
+				if v.Tag == "str" && v.Value == k {
+					return l.Content[i+1], true, nil
+				}
+			default:
+				return nil, false, YamlErrorf(l, "unsupported key type %T, found mapping node and expected string key", key)
+			}
+		}
+		// failure to get is not an error
+		return nil, false, nil
+	case yaml.ScalarNode:
+		return nil, false, YamlErrorf(l, "failed to get key %v from scalar: %v", key, l.Value)
+	case yaml.AliasNode:
+		return nil, false, YamlErrorf(l, "aliases not supported in project files: %v", l.Value)
+	default:
+		return nil, false, YamlErrorf(l, "failed to parse yaml node: %v", l.Value)
+	}
+}
+
+func Set(l *yaml.Node, value string) error {
+	var newNode yaml.Node
+	err := yaml.Unmarshal([]byte(value), &newNode)
+	if err != nil {
+		return err
+	}
+
+	*l = *newNode.Content[0]
+
+	return nil
+}
+
+func Insert(l *yaml.Node, key interface{}, value string) error {
+	var newNode yaml.Node
+	err := yaml.Unmarshal([]byte(value), &newNode)
+	if err != nil {
+		return err
+	}
+	newNode = *newNode.Content[0]
+
+	switch l.Kind {
+	case yaml.DocumentNode:
+		// Automatically recurse as documents contain a single element
+		return Insert(l.Content[0], key, value)
+	case yaml.SequenceNode:
+		if idx, ok := key.(int); ok {
+			if len(l.Content) > idx {
+				l.Content[idx] = &newNode
+			} else if len(l.Content) == idx {
+				l.Content = append(l.Content, &newNode)
+			}
+			return YamlErrorf(l, "index %v out of bounds of node: %v", idx, l.Value)
+		}
+		return YamlErrorf(l, "unsupported index type %T, found sequence node and expected int index", key)
+	case yaml.MappingNode:
+		for i, v := range l.Content {
+			if i%2 == 1 {
+				continue
+			}
+
+			switch k := key.(type) {
+			case string:
+				if v.Tag == "!!str" && v.Value == k {
+					l.Content[i+1] = &newNode
+					return nil
+				}
+			default:
+				return YamlErrorf(l, "unsupported key type %T, found mapping node and expected string key", key)
+			}
+		}
+
+		var keyNode yaml.Node
+		switch k := key.(type) {
+		case string:
+			err := Set(&keyNode, k)
+			if err != nil {
+				return err
+			}
+			l.Content = append(l.Content, &keyNode, &newNode)
+			return nil
+		default:
+			return YamlErrorf(l, "unsupported key type %T, found mapping node and expected string key", key)
+		}
+	case yaml.ScalarNode:
+		return YamlErrorf(l, "failed to get key %v from scalar: %v", key, l.Content)
+	case yaml.AliasNode:
+		return YamlErrorf(l, "aliases not supported in project files: %v", l.Content)
+	default:
+		return YamlErrorf(l, "failed to parse yaml node: %v", l.Content)
+	}
+}
+
+func Delete(l *yaml.Node, key interface{}) error {
+	switch l.Kind {
+	case yaml.DocumentNode:
+		// Automatically recurse as documents contain a single element
+		return Delete(l.Content[0], key)
+	case yaml.SequenceNode:
+		if idx, ok := key.(int); ok {
+			var content []*yaml.Node
+			content = append(content, l.Content[:idx]...)
+			content = append(content, l.Content[idx+1:]...)
+			l.Content = content
+			return nil
+		}
+		return YamlErrorf(l, "unsupported index type %T, found sequence node and expected int index", key)
+
+	case yaml.MappingNode:
+		for idx, v := range l.Content {
+			if idx%2 == 1 {
+				continue
+			}
+
+			switch k := key.(type) {
+			case string:
+				if v.Tag == "!!str" && v.Value == k {
+					var content []*yaml.Node
+					content = append(content, l.Content[:idx]...)
+					content = append(content, l.Content[idx+2:]...)
+					l.Content = content
+					return nil
+				}
+			default:
+				return YamlErrorf(l, "unsupported key type %T, found mapping node and expected string key", key)
+			}
+		}
+		return nil
+	case yaml.ScalarNode:
+		return YamlErrorf(l, "failed to get key %v from scalar: %v", key, l.Content)
+	case yaml.AliasNode:
+		return YamlErrorf(l, "aliases not supported in project files: %v", l.Content)
+	default:
+		return YamlErrorf(l, "failed to parse yaml node: %v", l.Content)
+	}
+}

--- a/pkg/util/yamlutil/node_tools_test.go
+++ b/pkg/util/yamlutil/node_tools_test.go
@@ -1,0 +1,79 @@
+package yamlutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func assertYaml(t *testing.T, before, after string, mutation func(node *yaml.Node) error) {
+	t.Helper()
+	var beforeNode yaml.Node
+	err := yaml.Unmarshal([]byte(before), &beforeNode)
+	assert.NoError(t, err)
+	err = mutation(&beforeNode)
+	assert.NoError(t, err)
+	afterBytes, err := yaml.Marshal(beforeNode.Content[0])
+	assert.NoError(t, err)
+
+	assert.Equal(t, strings.TrimSpace(after), strings.TrimSpace(string(afterBytes)))
+}
+
+func TestInsertNode(t *testing.T) {
+	t.Parallel()
+
+	assertYaml(t, `
+foo: baz
+`, `
+foo: bar
+`, func(node *yaml.Node) error { return Insert(node, "foo", "bar") })
+}
+
+func TestInsertNodeNew(t *testing.T) {
+	t.Parallel()
+
+	assertYaml(t, `
+# comment
+existing: node # comment
+`, `
+# comment
+existing: node # comment
+foo: bar
+`, func(node *yaml.Node) error { return Insert(node, "foo", "bar") })
+}
+
+func TestInsertNodeOverwrite(t *testing.T) {
+	t.Parallel()
+
+	assertYaml(t, `
+foo: 1
+# header
+bar: 2 # this should become 42
+# trailer
+quux: 3
+`, `
+foo: 1
+# header
+bar: 42
+# trailer
+quux: 3
+`, func(node *yaml.Node) error { return Insert(node, "bar", "42") })
+}
+
+func TestDeleteNode(t *testing.T) {
+	t.Parallel()
+
+	assertYaml(t, `
+foo: 1
+# header
+bar: 2 # this should become 42
+# trailer
+quux: 3
+`, `
+foo: 1
+# trailer
+quux: 3
+`, func(node *yaml.Node) error { return Delete(node, "bar") })
+}


### PR DESCRIPTION
Expands on #10269 with utility functions to preserve existing YAML document structure, including comments, while mutating key fields.

And coincidentally simplifying our templates, changes to how we install dependencies has removed the need to check for the "python" runtime and set a venv field.

With these changes, with or without a `Pulumi.yaml.append` file, `pulumi new aws-yaml` creates a file like so:

```yaml
name: tmp-941fe618-e0bf-4149-ab8b-54ca557202ed
description: A minimal AWS Pulumi YAML program
runtime: yaml
resources:
    # Create an AWS resource (S3 Bucket)
    my-bucket:
        type: aws:s3:Bucket
outputs:
    # Export the name of the bucket
    bucketName: ${my-bucket.id}
```

The new implementation only removes the `.append` file, it does not concatenate it with `Pulumi.yaml`.

Fixes pulumi/pulumi-yaml#303