### PR TITLE
Remove some dead secret manager code

### DIFF
--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -184,21 +183,6 @@ func createSecretsManager(
 	} else if !isDefaultSecretsProvider {
 		// All other non-default secrets providers are handled by the cloud secrets provider which
 		// uses a URL schema to identify the provider
-
-		// Azure KeyVault never used to require an algorithm and there's no real reason to require it,
-		// but if someone specifies one, don't clobber it.
-		if strings.HasPrefix(secretsProvider, "azurekeyvault://") {
-			parsed, err := url.Parse(secretsProvider)
-			if err != nil {
-				return fmt.Errorf("failed to parse secrets provider URL: %w", err)
-			}
-
-			if parsed.Query().Get("algorithm") == "" {
-				parsed.Query().Set("algorithm", "RSA-OAEP-256")
-				secretsProvider = parsed.String()
-			}
-		}
-
 		if _, secretsErr := newCloudSecretsManager(stackRef.Name(), stackConfigFile, secretsProvider); secretsErr != nil {
 			return secretsErr
 		}


### PR DESCRIPTION
`parsed.Query().Set("algorithm", "RSA-OAEP-256")` is a no-op because `Query()` returns a copy of the query values, not a reference. So this was really just `secretsProvider = url.Parse(secretsProvider).String()`.

Given it's been like this for three years and no-ones complained about azure vault secrets I think it's safe to just remove rather than fix.