### PR TITLE
[sdk/nodejs] emit colorized stack traces

### DIFF
--- a/changelog/pending/20230216--cli-display--display-now-shows-default-colorized-stacktraces-in-nodejs.yaml
+++ b/changelog/pending/20230216--cli-display--display-now-shows-default-colorized-stacktraces-in-nodejs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Display now shows default colorized stacktraces in NodeJS.

--- a/pkg/backend/display/events_test.go
+++ b/pkg/backend/display/events_test.go
@@ -1,0 +1,26 @@
+package display
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+// This test checks that the ANSI control codes are removed from EngineEvents
+// converted to be sent to the Pulumi Service API.
+func TestRemoveANSI(t *testing.T) {
+	t.Parallel()
+	input := "\033[31mHello, World!\033[0m"
+	expected := "Hello, World!"
+	e := engine.NewEvent(
+		engine.DiagEvent,
+		engine.DiagEventPayload{
+			Message: input,
+		},
+	)
+
+	res, err := ConvertEngineEvent(e, false /* showSecrets */)
+	assert.NoError(t, err, "unable to convert engine event")
+	assert.Equal(t, expected, res.DiagnosticEvent.Message)
+}

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as fs from "fs";
+import * as util from "util";
 import * as minimist from "minimist";
 import * as path from "path";
 import * as tsnode from "ts-node";
@@ -207,12 +208,15 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
 
         errorSet.add(err);
 
+        // colorize stack trace if exists
+        const stackMessage = err.stack && util.inspect(err, {colors: true});
+
         // Default message should be to include the full stack (which includes the message), or
         // fallback to just the message if we can't get the stack.
         //
         // If both the stack and message are empty, then just stringify the err object itself. This
         // is also necessary as users can throw arbitrary things in JS (including non-Errors).
-        const defaultMessage = err.stack || err.message || ("" + err);
+        const defaultMessage = stackMessage || err.message || ("" + err);
 
         // First, log the error.
         if (RunError.isInstance(err)) {

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as fs from "fs";
+import * as util from "util";
 import * as url from "url";
 import * as minimist from "minimist";
 import * as path from "path";
@@ -253,12 +254,16 @@ export function run(
             return;
         }
 
+
+        // colorize stack trace if exists
+        const stackMessage = err.stack && util.inspect(err, {colors: true});
+
         // Default message should be to include the full stack (which includes the message), or
         // fallback to just the message if we can't get the stack.
         //
         // If both the stack and message are empty, then just stringify the err object itself. This
         // is also necessary as users can throw arbitrary things in JS (including non-Errors).
-        const defaultMessage = err.stack || err.message || ("" + err);
+        const defaultMessage = stackMessage || err.message || ("" + err);
 
         // First, log the error.
         if (RunError.isInstance(err)) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
This PR changes pulumi nodejs error logging to emit colorized stack traces to match nodejs's default behavior.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10379 

New:
[![asciicast](https://asciinema.org/a/wh2tFUZXqm8cXqVo5WcHEexii.svg)](https://asciinema.org/a/wh2tFUZXqm8cXqVo5WcHEexii)

Current:
[![asciicast](https://asciinema.org/a/IvTzhNHfsAj82FT115bXT4XSN.svg)](https://asciinema.org/a/IvTzhNHfsAj82FT115bXT4XSN)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
