### PR TITLE
File state backend must apply validation logic when parsing stack refs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### Bug Fixes
 
 - [engine/backends]: Fix bug where File state backend failed to apply validation to stack names, resulting in a panic.
+  [#10417](https://github.com/pulumi/pulumi/pull/10417)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [engine/backends]: Fix bug where File state backend failed to apply validation to stack names, resulting in a panic.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -276,6 +276,9 @@ func (b *localBackend) SupportsOrganizations() bool {
 }
 
 func (b *localBackend) ParseStackReference(stackRefName string) (backend.StackReference, error) {
+	if err := b.ValidateStackName(stackRefName); err != nil {
+		return nil, err
+	}
 	return localBackendReference{name: tokens.Name(stackRefName)}, nil
 }
 

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -402,3 +402,15 @@ func TestLoginToNonExistingFolderFails(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, b)
 }
+
+// TestParseEmptyStackFails demonstrates that ParseStackReference returns
+// an error when the stack name is the empty string.TestParseEmptyStackFails
+func TestParseEmptyStackFails(t *testing.T) {
+	t.Parallel()
+	// ParseStackReference does use the method receiver
+	// (it is a total function disguisted as a method.)
+	var b *localBackend = nil
+	var stackName = ""
+	var _, err = b.ParseStackReference(stackName)
+	assert.Error(t, err)
+}

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -408,8 +408,8 @@ func TestLoginToNonExistingFolderFails(t *testing.T) {
 func TestParseEmptyStackFails(t *testing.T) {
 	t.Parallel()
 	// ParseStackReference does use the method receiver
-	// (it is a total function disguisted as a method.)
-	var b *localBackend = nil
+	// (it is a total function disguised as a method.)
+	var b *localBackend
 	var stackName = ""
 	var _, err = b.ParseStackReference(stackName)
 	assert.Error(t, err)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR fixes a bug where the File state backend failed to apply validation logic to stack names (validation logic was dead code!) This PR introduces a tiny test to guard against this error, and a fix.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/10405

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
