### PR TITLE
Update PyYAML to v6.0

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
+- [sdk/python] Update PyYAML to 6.0
+
 ### Bug Fixes

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -42,6 +42,6 @@ setup(name='pulumi',
           'dill~=0.3',
           'six~=1.12',
           'semver~=2.8',
-          'pyyaml~=5.3'
+          'pyyaml~=6.0'
       ],
       zip_safe=False)

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -5,7 +5,7 @@ grpcio==1.47
 dill~=0.3
 six~=1.12
 semver~=2.8
-pyyaml~=5.3
+pyyaml~=6.0
 
 # Dev packages only needed during development.
 pylint


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR upgrades the version of PyYAML from v5.3 to v6.0.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/10396

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
