### PR TITLE
Fix mislabeling in error message of release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -68,16 +68,16 @@ case "$1" in
     tag)
         git fetch origin master
 
-        SDK_COMMENT=$(git log --format=%B -n 1 origin/master~2)
         REL_COMMENT=$(git log --format=%B -n 1 origin/master~1)
-
+        SDK_COMMENT=$(git log --format=%B -n 1 origin/master~2)
+        
         if [ "$REL_COMMENT" != "Release ${VERSION}" ]; then
-            echo "Aborting, expected origin/master~2 comment to be 'Release ${VERSION}' but got '${REL_COMMENT}'"
+            echo "Aborting, expected origin/master~1 comment to be 'Release ${VERSION}' but got '${REL_COMMENT}'"
             exit 1
         fi
 
         if [ "$SDK_COMMENT" != "Prepare for ${VERSION} release" ]; then
-            echo "Aborting, expected origin/master~1 comment to be 'Prepare for ${VERSION} release' but got '${SDK_COMMENT}'"
+            echo "Aborting, expected origin/master~2 comment to be 'Prepare for ${VERSION} release' but got '${SDK_COMMENT}'"
             exit 1
         fi
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The error message in the release script is mislabeled. This PR corrects the label and reorders the error messages to make tracing feel more linear.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
