### PR TITLE
Improve lock error for filestate

### DIFF
--- a/pkg/backend/filestate/lock.go
+++ b/pkg/backend/filestate/lock.go
@@ -75,7 +75,7 @@ func (b *localBackend) checkForLock(ctx context.Context, stackRef backend.StackR
 
 	if len(lockKeys) > 0 {
 		errorString := fmt.Sprintf("the stack is currently locked by %v lock(s). Either wait for the other "+
-			"process(es) to end or manually delete the lock file(s).", len(lockKeys))
+			"process(es) to end or delete the lock file with `pulumi cancel`.", len(lockKeys))
 
 		for _, lock := range lockKeys {
 			content, err := b.bucket.ReadAll(ctx, lock)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

No need to manually delete lock files anymore, `pulumi cancel` will do this.
