### PR TITLE
Move default secret manager to stack

### DIFF
--- a/pkg/backend/filestate/crypto.go
+++ b/pkg/backend/filestate/crypto.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package filestate
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -22,7 +22,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newPassphraseSecretsManager(stackName tokens.Name, configFile string,
+func NewPassphraseSecretsManager(stackName tokens.Name, configFile string,
 	rotatePassphraseSecretsProvider bool) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -104,6 +105,10 @@ func (s *localStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDepl
 
 func (s *localStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
 	return backend.ImportStackDeployment(ctx, s, deployment)
+}
+
+func (s *localStack) DefaultSecretManager(configFile string) (secrets.Manager, error) {
+	return NewPassphraseSecretsManager(s.Ref().Name(), configFile, false /* rotatePassphraseSecretsProvider */)
 }
 
 type localStackSummary struct {

--- a/pkg/backend/httpstate/crypto.go
+++ b/pkg/backend/httpstate/crypto.go
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package httpstate
 
 import (
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -23,7 +22,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newServiceSecretsManager(s httpstate.Stack, stackName tokens.Name, configFile string) (secrets.Manager, error) {
+func NewServiceSecretsManager(s Stack, stackName tokens.Name, configFile string) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
 	if configFile == "" {
@@ -39,7 +38,7 @@ func newServiceSecretsManager(s httpstate.Stack, stackName tokens.Name, configFi
 		return nil, err
 	}
 
-	client := s.Backend().(httpstate.Backend).Client()
+	client := s.Backend().(Backend).Client()
 	id := s.StackIdentifier()
 
 	// We should only save the ProjectStack at this point IF we have changed the

--- a/pkg/backend/httpstate/crypto_test.go
+++ b/pkg/backend/httpstate/crypto_test.go
@@ -1,4 +1,4 @@
-package main
+package httpstate
 
 import (
 	"testing"

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	sdkDisplay "github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -181,6 +182,10 @@ func (s *cloudStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDepl
 
 func (s *cloudStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
 	return backend.ImportStackDeployment(ctx, s, deployment)
+}
+
+func (s *cloudStack) DefaultSecretManager(configFile string) (secrets.Manager, error) {
+	return NewServiceSecretsManager(s, s.Ref().Name(), configFile)
 }
 
 // cloudStackSummary implements the backend.StackSummary interface, by wrapping

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	sdkDisplay "github.com/pulumi/pulumi/sdk/v3/go/common/display"
@@ -355,8 +356,9 @@ type MockStack struct {
 	RenameF  func(ctx context.Context, newName tokens.QName) (StackReference, error)
 	GetLogsF func(ctx context.Context, cfg StackConfiguration,
 		query operations.LogQuery) ([]operations.LogEntry, error)
-	ExportDeploymentF func(ctx context.Context) (*apitype.UntypedDeployment, error)
-	ImportDeploymentF func(ctx context.Context, deployment *apitype.UntypedDeployment) error
+	ExportDeploymentF     func(ctx context.Context) (*apitype.UntypedDeployment, error)
+	ImportDeploymentF     func(ctx context.Context, deployment *apitype.UntypedDeployment) error
+	DefaultSecretManagerF func(configFile string) (secrets.Manager, error)
 }
 
 var _ Stack = (*MockStack)(nil)
@@ -481,6 +483,13 @@ func (ms *MockStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDepl
 func (ms *MockStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
 	if ms.ImportDeploymentF != nil {
 		return ms.ImportDeploymentF(ctx, deployment)
+	}
+	panic("not implemented")
+}
+
+func (ms *MockStack) DefaultSecretManager(configFile string) (secrets.Manager, error) {
+	if ms.DefaultSecretManagerF != nil {
+		return ms.DefaultSecretManagerF(configFile)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -61,6 +62,9 @@ type Stack interface {
 	ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error)
 	// import the given deployment into this stack.
 	ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error
+
+	// Return the default secrets manager to use for this stack.
+	DefaultSecretManager(configFile string) (secrets.Manager, error)
 }
 
 // RemoveStack returns the stack, or returns an error if it cannot.

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -170,14 +170,14 @@ func createSecretsManager(
 			// this will mean the "old" default behaviour will work for us
 			return nil
 		}
-		if _, serviceSecretsErr := newServiceSecretsManager(stack.(httpstate.Stack),
+		if _, serviceSecretsErr := httpstate.NewServiceSecretsManager(stack.(httpstate.Stack),
 			stackRef.Name(), stackConfigFile); serviceSecretsErr != nil {
 			return serviceSecretsErr
 		}
 	}
 
 	if secretsProvider == passphrase.Type {
-		if _, pharseErr := newPassphraseSecretsManager(stackRef.Name(), stackConfigFile,
+		if _, pharseErr := filestate.NewPassphraseSecretsManager(stackRef.Name(), stackConfigFile,
 			rotatePassphraseSecretsProvider); pharseErr != nil {
 			return pharseErr
 		}


### PR DESCRIPTION
This removes a type test for stack type, allowing us to use MockStacks in this area of code.
