### PR TITLE
ci: Build CLI in test using Linux runners, production using macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ on:
         default: false
         required: false
         type: boolean
+      macos-build-platform:
+        description: 'Platform to use when building macOS binaries'
+        default: macos-latest
+        required: false
+        type: string
     secrets: {}
 
 env:
@@ -43,11 +48,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: macos-latest
+          - platform: ${{ inputs.macos-build-platform }}
             os: darwin
             arch: amd64
             artifactName: pulumi-macOS-X64
-          - platform: macos-latest
+          - platform: ${{ inputs.macos-build-platform }}
             os: darwin
             arch: arm64
             artifactName: pulumi-macOS-ARM64

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -192,6 +192,7 @@ jobs:
     with:
       enable-coverage: true
       goreleaser-flags: -p 3 --skip-validate
+      macos-build-platform: ubuntu-latest
 
   test-linux:
     name: Test Linux

--- a/.github/workflows/run-build-and-integration-tests.yml
+++ b/.github/workflows/run-build-and-integration-tests.yml
@@ -67,6 +67,7 @@ jobs:
     with:
       enable-coverage: true
       goreleaser-flags: -p 3 --skip-validate
+      macos-build-platform: ubuntu-latest
 
   test-linux:
     name: Test Linux

--- a/.github/workflows/test-windows-cron.yml
+++ b/.github/workflows/test-windows-cron.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       enable-coverage: true
       goreleaser-flags: -p 3 --skip-validate
+      macos-build-platform: ubuntu-latest
   test-windows:
     name: Test Windows
     needs: build

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -16,14 +16,16 @@ PKG=github.com/pulumi/pulumi/pkg/v3/...
 SDK=github.com/pulumi/pulumi/sdk/v3/...
 COVERPKG="$PKG,$SDK"
 
-case $(go env GOOS) in
-    darwin)
-        export CGO_ENABLED=1
-        ;;
-    *)
-        export CGO_ENABLED=0
-        ;;
-esac
+# If it's a production or local build - building for macOS on macOS - use CGO for DNS resolver functionality.
+#
+# See: https://github.com/golang/go/issues/12524
+if [ "$(go env GOOS)" = "darwin" ] && [ "$(uname)" = "Darwin" ]; then
+    # `go env GOOS` returns "darwin" when cross-compiling to macOS
+    # `uname` returns "Darwin" on macOS
+    export CGO_ENABLED=1
+else
+    export CGO_ENABLED=0
+fi
 
 case "$1" in
     build)


### PR DESCRIPTION
Updated based on team discussion, we will use Linux runners for PR tests and continue building release binaries on macOS.

------

Blocked on #10213, this switches our CI system to build all binaries using cross-compilation from Ubuntu Linux runners, reducing macOS contention.

There is one prominent downside to this that is relevant:

Building on macOS with CGO_ENABLED=1 is required for the CLI to use split-tunnel VPNs on macOS that use per-DNS-name tunneling. This could impact enterprise clients with self-hosted Pulumi services. See:
- https://github.com/golang/go/issues/12524

For that reason, we may want to discuss running builds on Linux in pre-merge checks, and when implementing merge queues in #10091, ensure that merge checks & release builds use macOS builders. 