### PR TITLE
fix: return pass-through case when failing to find project

### DIFF
--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -475,6 +475,10 @@ func readProject() (*workspace.Project, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
+	// Handle failure to find current project.
+	if path == "" {
+		return proj, "", nil
+	}
 
 	return proj, filepath.Dir(path), nil
 }


### PR DESCRIPTION
Fixes the case where we are running `pulumi destroy` outside of the directory. This is an alternative PR to #10430.