### PR TITLE
Use explict ProjectPlugins rather than partially filling PluginInfo

### DIFF
--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -177,7 +177,7 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 // ensurePluginsAreInstalled inspects all plugins in the plugin set and, if any plugins are not currently installed,
 // uses the given backend client to install them. Installations are processed in parallel, though
 // ensurePluginsAreInstalled does not return until all installations are completed.
-func ensurePluginsAreInstalled(ctx context.Context, plugins pluginSet, projectPlugins []*workspace.PluginInfo) error {
+func ensurePluginsAreInstalled(ctx context.Context, plugins pluginSet, projectPlugins []workspace.ProjectPlugin) error {
 	logging.V(preparePluginLog).Infof("ensurePluginsAreInstalled(): beginning")
 	var installTasks errgroup.Group
 	for _, plug := range plugins.Values() {

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -420,7 +420,7 @@ func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
 	return host.languageRuntime.GetRequiredPlugins(info)
 }
 
-func (host *pluginHost) GetProjectPlugins() []*workspace.PluginInfo {
+func (host *pluginHost) GetProjectPlugins() []workspace.ProjectPlugin {
 	return nil
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -79,7 +79,7 @@ func (host *testPluginHost) ResolvePlugin(
 	return nil, nil
 }
 
-func (host *testPluginHost) GetProjectPlugins() []*workspace.PluginInfo {
+func (host *testPluginHost) GetProjectPlugins() []workspace.ProjectPlugin {
 	return nil
 }
 

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -77,7 +77,7 @@ type Host interface {
 	// ResolvePlugin resolves a plugin kind, name, and optional semver to a candidate plugin to load.
 	ResolvePlugin(kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
 
-	GetProjectPlugins() []*workspace.PluginInfo
+	GetProjectPlugins() []workspace.ProjectPlugin
 
 	// SignalCancellation asks all resource providers to gracefully shut down and abort any ongoing
 	// operations. Operation aborted in this way will return an error (e.g., `Update` and `Create`
@@ -94,7 +94,7 @@ type Host interface {
 func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 	disableProviderPreview bool, plugins *workspace.Plugins) (Host, error) {
 	// Create plugin info from providers
-	projectPlugins := make([]*workspace.PluginInfo, 0)
+	projectPlugins := make([]workspace.ProjectPlugin, 0)
 	if plugins != nil {
 		for _, providerOpts := range plugins.Providers {
 			info, err := parsePluginOpts(providerOpts, workspace.ResourcePlugin)
@@ -159,22 +159,22 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]interface{},
 	return host, nil
 }
 
-func parsePluginOpts(providerOpts workspace.PluginOptions, k workspace.PluginKind) (*workspace.PluginInfo, error) {
+func parsePluginOpts(providerOpts workspace.PluginOptions, k workspace.PluginKind) (workspace.ProjectPlugin, error) {
 	var v *semver.Version
 	if providerOpts.Version != "" {
 		ver, err := semver.Parse(providerOpts.Version)
 		if err != nil {
-			return nil, err
+			return workspace.ProjectPlugin{}, err
 		}
 		v = &ver
 	}
 
 	_, err := os.Stat(providerOpts.Path)
 	if err != nil {
-		return nil, fmt.Errorf("could not find provider folder at path %s", providerOpts.Path)
+		return workspace.ProjectPlugin{}, fmt.Errorf("could not find provider folder at path %s", providerOpts.Path)
 	}
 
-	pluginInfo := &workspace.PluginInfo{
+	pluginInfo := workspace.ProjectPlugin{
 		Name:    providerOpts.Name,
 		Path:    filepath.Clean(providerOpts.Path),
 		Kind:    k,
@@ -209,7 +209,7 @@ type defaultHost struct {
 	disableProviderPreview  bool                             // true if provider plugins should disable provider preview
 
 	closer         *sync.Once
-	projectPlugins []*workspace.PluginInfo
+	projectPlugins []workspace.ProjectPlugin
 }
 
 var _ Host = (*defaultHost)(nil)
@@ -437,7 +437,7 @@ func (host *defaultHost) ResolvePlugin(
 	return workspace.GetPluginInfo(kind, name, version, host.GetProjectPlugins())
 }
 
-func (host *defaultHost) GetProjectPlugins() []*workspace.PluginInfo {
+func (host *defaultHost) GetProjectPlugins() []workspace.ProjectPlugin {
 	return host.projectPlugins
 }
 


### PR DESCRIPTION
Rather than partially filling in a PluginInfo object, this now uses a type that carries exactly what is needed for a project plugin specification.