### PR TITLE
refactor: simplify error handling in readProject API

### DIFF
--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -132,7 +133,8 @@ func newDestroyCmd() *cobra.Command {
 
 			proj, root, err := readProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
-				// Allow destroy outside of a project using backend to resolve.
+				logging.Warningf("failed to find current Pulumi project, continuing using stack %v from backend %v",
+					s.Ref().Name(), s.Backend().Name())
 				proj = &workspace.Project{}
 				root = ""
 			} else if err != nil {

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -133,7 +133,7 @@ func newDestroyCmd() *cobra.Command {
 
 			proj, root, err := readProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
-				logging.Warningf("failed to find current Pulumi project, continuing using stack %v from backend %v",
+				logging.Warningf("failed to find current Pulumi project, continuing continuing with an empty project using stack %v from backend %v",
 					s.Ref().Name(), s.Backend().Name())
 				proj = &workspace.Project{}
 				root = ""

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func newDestroyCmd() *cobra.Command {
@@ -130,7 +131,11 @@ func newDestroyCmd() *cobra.Command {
 			}
 
 			proj, root, err := readProject()
-			if err != nil {
+			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
+				// Allow destroy outside of a project using backend to resolve.
+				proj = &workspace.Project{}
+				root = ""
+			} else if err != nil {
 				return result.FromError(err)
 			}
 

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -133,7 +133,7 @@ func newDestroyCmd() *cobra.Command {
 
 			proj, root, err := readProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
-				logging.Warningf("failed to find current Pulumi project, continuing continuing with an empty project using stack %v from backend %v",
+				logging.Warningf("failed to find current Pulumi project, continuing with an empty project using stack %v from backend %v",
 					s.Ref().Name(), s.Backend().Name())
 				proj = &workspace.Project{}
 				root = ""

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -475,10 +475,6 @@ func readProject() (*workspace.Project, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	// Handle failure to find current project.
-	if path == "" {
-		return proj, "", nil
-	}
 
 	return proj, filepath.Dir(path), nil
 }
@@ -486,19 +482,18 @@ func readProject() (*workspace.Project, string, error) {
 // readProjectWithPath attempts to detect and read a Pulumi project for the current workspace. If
 // the project is successfully detected and read, it is returned along with the path to the project
 // file, which will be used as the root of the project's Pulumi program.
+//
+// If a project is not found while searching and no other error occurs, workspace.ErrProjectNotFound
+// is returned.
 func readProjectWithPath() (*workspace.Project, string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return nil, "", err
 	}
-
 	// Now that we got here, we have a path, so we will try to load it.
 	path, err := workspace.DetectProjectPathFrom(pwd)
 	if err != nil {
-		logging.Warningf("failed to find current Pulumi project because of "+
-			"an error when searching for the Pulumi.yaml file (searching upwards from %s)"+": %s"+
-			"continuing with an empty project", pwd, err.Error())
-		return &workspace.Project{}, "", nil
+		return nil, "", err
 	}
 	proj, err := workspace.LoadProject(path)
 	if err != nil {

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -123,6 +123,8 @@ func DetectProjectStackPath(stackName tokens.QName) (string, error) {
 	return filepath.Join(filepath.Dir(projPath), fileName), nil
 }
 
+var ErrProjectNotFound = errors.New("no project file found")
+
 // DetectProjectPathFrom locates the closest project from the given path, searching "upwards" in the directory
 // hierarchy.  If no project is found, an empty path is returned.
 func DetectProjectPathFrom(path string) (string, error) {
@@ -130,12 +132,13 @@ func DetectProjectPathFrom(path string) (string, error) {
 		return true
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to locate Pulumi.yaml project file: %w", err)
 	}
 	if path == "" {
+		// Embed/wrap ErrProjectNotFound
 		return "", fmt.Errorf(
 			"no Pulumi.yaml project file found (searching upwards from %s). If you have not "+
-				"created a project yet, use `pulumi new` to do so", path)
+				"created a project yet, use `pulumi new` to do so: %w", path, ErrProjectNotFound)
 	}
 	return path, nil
 }


### PR DESCRIPTION
Simplifies some error handling by bubbling up a named & wrapped error which `pulumi destroy` can handle as a special case. Removes the need for handling a return value with an empty project and no error in commands that cannot handle that case.