### PR TITLE
perf: Use a faster check for empty schemas

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,6 +13,9 @@
   This `pulumi-watch` program is now included in releases.
   [#10213](https://github.com/pulumi/pulumi/issues/10213)
 
+- [codegen] Reduce time to execute `pulumi convert` and some YAML programs, depending on providers used, by up to 3 seconds.
+  [#10444](https://github.com/pulumi/pulumi/pull/10444)
+
 ### Bug Fixes
 
 - [engine/backends]: Fix bug where File state backend failed to apply validation to stack names, resulting in a panic.

--- a/pkg/codegen/schema/loader_schema_test.go
+++ b/pkg/codegen/schema/loader_schema_test.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,4 +22,20 @@ func TestEmptySchemaResponse(t *testing.T) {
 	assert.True(t, schemaIsEmpty([]byte("\n		 {   	 	 				}  	\n\n")))
 
 	assert.False(t, schemaIsEmpty([]byte(`{"key": "value"}`)))
+}
+
+func BenchmarkSchemaEmptyCheck(b *testing.B) {
+	schemaPath, err := filepath.Abs("../testing/test/testdata/azure-native.json")
+	assert.NoError(b, err)
+	largeSchema, err := os.ReadFile(schemaPath)
+
+	if err != nil {
+		b.Fatalf("failed to read schema file, ensure that you have run "+
+			"`make get_schemas` to create schema file %q", schemaPath)
+	}
+
+	b.Run("large-schema-empty-check-time", func(b *testing.B) {
+		empty := schemaIsEmpty(largeSchema)
+		assert.False(b, empty)
+	})
 }


### PR DESCRIPTION
Experimentally, this can reduce time taken in calls to load a schema by 1-3 seconds, which for a Pulumi YAML program execution or call to `pulumi convert` (on the order of 5-10s) is a significant performance improvement.

The benchmark showed that prior to this change, the benchmark took 1.1 to 2.5 seconds on a relatively recent Intel laptop processor:

Before:

```
goos: linux
goarch: amd64
pkg: github.com/pulumi/pulumi/pkg/v3/codegen/schema
cpu: 11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz
BenchmarkSchemaEmptyCheck
BenchmarkSchemaEmptyCheck/large-schema-empty-check-time
BenchmarkSchemaEmptyCheck/large-schema-empty-check-time-8
       1	1734625270 ns/op	    6768 B/op	      22 allocs/op
PASS
```

(That's 1.7 seconds/operation, sample size of 1.)

After:

```
BenchmarkSchemaEmptyCheck/large-schema-empty-check-time-8
        1000000000	         0.0000005 ns/op	       0 B/op	       0 allocs/op
```

It's now on the order of a couple instructions, apparently too short for Go benchmarking to analyze (it is definitely not that much shorter than a nanosecond) as for most non-empty schemas we will return "false" within reading the first few bytes of a file.

-----

Addenda: Out of curiosity I changed the regexp to include a `^` at the beginning, and that vastly improved performance. Still, the new approach is clear that we're willing to try to parse almost any document, just not the defaults that some providers have used.

```
BenchmarkSchemaEmptyCheck/large-schema-empty-check-time-8
        1000000000	         0.0000130 ns/op	       0 B/op	       0 allocs/op
PASS
```

Again with the very tiny time per operation, a clock cycle on this computer is on the order of 0.25ns.