### PR TITLE
codegen/go: Ensure docs information matches package name

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,3 +26,6 @@
 
 - [engine]: HTML characters are no longer escaped in JSON output.
   [#10440](https://github.com/pulumi/pulumi/pull/10440)
+
+- [codegen/go] Ensure consistency between go docs information and package name
+  [#10452](https://github.com/pulumi/pulumi/pull/10452)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3606,7 +3606,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			if pkg.pkg.Description != "" {
 				printComment(buffer, pkg.pkg.Description, false)
 			} else {
-				fmt.Fprintf(buffer, "// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.\n", pkg.pkg.Name)
+				fmt.Fprintf(buffer, "// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.\n", name)
 			}
 			fmt.Fprintf(buffer, "\n")
 			fmt.Fprintf(buffer, "package %s\n", name)

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/doc.go
@@ -1,3 +1,3 @@
-// Package foo-bar exports types, functions, subpackages for provisioning foo-bar resources.
+// Package foo exports types, functions, subpackages for provisioning foo resources.
 
 package foo

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/doc.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/doc.go
@@ -1,3 +1,3 @@
-// Package plant exports types, functions, subpackages for provisioning plant resources.
+// Package plantprovider exports types, functions, subpackages for provisioning plantprovider resources.
 
 package plantprovider

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/doc.go
@@ -1,3 +1,3 @@
-// Package foo-bar exports types, functions, subpackages for provisioning foo-bar resources.
+// Package foo exports types, functions, subpackages for provisioning foo resources.
 
 package foo

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/doc.go
@@ -1,3 +1,3 @@
-// Package foobar exports types, functions, subpackages for provisioning foobar resources.
+// Package foo exports types, functions, subpackages for provisioning foo resources.
 
 package foo

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/doc.go
@@ -1,3 +1,3 @@
-// Package example exports types, functions, subpackages for provisioning example resources.
+// Package different exports types, functions, subpackages for provisioning different resources.
 
 package different


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
