### PR TITLE
Accept options.version on pulumi convert

### DIFF
--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -331,7 +331,11 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 					t = model.NewListType(ResourcePropertyType)
 					resourceOptions.IgnoreChanges = item.Value
 				case "version":
-					continue
+					t = model.StringType
+					resourceOptions.Version = item.Value
+				case "pluginDownloadURL":
+					t = model.StringType
+					resourceOptions.PluginDownloadURL = item.Value
 				default:
 					diagnostics = append(diagnostics, unsupportedAttribute(item.Name, item.Syntax.NameRange))
 					continue

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -39,6 +39,10 @@ type ResourceOptions struct {
 	Protect model.Expression
 	// A list of properties that are not considered when diffing the resource.
 	IgnoreChanges model.Expression
+	// The version of the provider for this resource.
+	Version model.Expression
+	// The plugin download URL for this resource.
+	PluginDownloadURL model.Expression
 }
 
 // Resource represents a resource instantiation inside of a program or component.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Unfinished change to unblock failing tests for https://github.com/pulumi/pulumi-yaml/pull/291
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
