### PR TITLE
updated error message to catch syntax errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,9 @@
 - [codegen] Reduce time to execute `pulumi convert` and some YAML programs, depending on providers used, by up to 3 seconds.
   [#10444](https://github.com/pulumi/pulumi/pull/10444)
 
+- [sdk/nodejs] Added stack truncation to `SyntaxError` in nodejs.
+  [#10465](https://github.com/pulumi/pulumi/pull/10465)
+
 ### Bug Fixes
 
 - [codegen/go] Fix StackReference codegen.

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -218,6 +218,23 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
         if (RunError.isInstance(err)) {
             // Always hide the stack for RunErrors.
             log.error(err.message);
+        } else if (
+            err.name === tsnode.TSError.name
+            || err.name === SyntaxError.name) {
+
+            // Hide stack frames as TSError/SyntaxError have messages containing
+            // where the error is located
+            const errOut = err.stack?.toString() || "";
+            let errMsg = err.message;
+
+            const errParts = errOut.split(err.message);
+            if (errParts.length === 2) {
+                errMsg = errParts[0]+err.message;
+            }
+
+            log.error(
+                `Running program '${program}' failed with an unhandled exception:
+${errMsg}`);
         } else if (ResourceError.isInstance(err)) {
             // Hide the stack if requested to by the ResourceError creator.
             const message = err.hideStack ? err.message : defaultMessage;

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -16,6 +16,7 @@ import * as fs from "fs";
 import * as url from "url";
 import * as minimist from "minimist";
 import * as path from "path";
+import * as util from "util";
 import * as tsnode from "ts-node";
 import * as ini from "ini";
 import * as semver from "semver";
@@ -235,9 +236,20 @@ export function run(
         const defaultMessage = err.stack || err.message || ("" + err);
 
         // First, log the error.
-        if (RunError.isInstance(err) || typeof err ==  typeof tsnode.TSError) {
+        if (RunError.isInstance(err)
+           || err.name == tsnode.TSError.name
+           || err.name == SyntaxError.name) {
             // Always hide the stack for RunErrors.
-            log.error(err.message);
+            const errOut = err.stack?.toString() || ""
+
+            let errMsg = err.message;
+            const errParts = errOut.split(err.message);
+            if (errParts.length == 2) {
+                errMsg = errParts[0]+err.message;
+            }
+            log.error(
+                `Running program '${program}' failed with an unhandled exception:
+${errMsg}`);
         }
         else if (ResourceError.isInstance(err)) {
             // Hide the stack if requested to by the ResourceError creator.

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -236,17 +236,22 @@ export function run(
         const defaultMessage = err.stack || err.message || ("" + err);
 
         // First, log the error.
-        if (RunError.isInstance(err)
-           || err.name === tsnode.TSError.name
-           || err.name === SyntaxError.name) {
+        if (RunError.isInstance(err)) {
             // Always hide the stack for RunErrors.
-            const errOut = err.stack?.toString() || ""
+            log.error(err.message);
+        }
+        else if (err.name === tsnode.TSError.name
+            || err.name === SyntaxError.name) {
 
+            // Hide stack frames for SyntaxErrors
+            const errOut = err.stack?.toString() || ""
             let errMsg = err.message;
+
             const errParts = errOut.split(err.message);
             if (errParts.length === 2) {
                 errMsg = errParts[0]+err.message;
             }
+
             log.error(
                 `Running program '${program}' failed with an unhandled exception:
 ${errMsg}`);

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -237,14 +237,14 @@ export function run(
 
         // First, log the error.
         if (RunError.isInstance(err)
-           || err.name == tsnode.TSError.name
-           || err.name == SyntaxError.name) {
+           || err.name === tsnode.TSError.name
+           || err.name === SyntaxError.name) {
             // Always hide the stack for RunErrors.
             const errOut = err.stack?.toString() || ""
 
             let errMsg = err.message;
             const errParts = errOut.split(err.message);
-            if (errParts.length == 2) {
+            if (errParts.length === 2) {
                 errMsg = errParts[0]+err.message;
             }
             log.error(

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -239,12 +239,13 @@ export function run(
         if (RunError.isInstance(err)) {
             // Always hide the stack for RunErrors.
             log.error(err.message);
-        }
-        else if (err.name === tsnode.TSError.name
+        } else if (
+            err.name === tsnode.TSError.name
             || err.name === SyntaxError.name) {
 
-            // Hide stack frames for SyntaxErrors
-            const errOut = err.stack?.toString() || ""
+            // Hide stack frames as TSError/SyntaxError have messages containing
+            // where the error is located
+            const errOut = err.stack?.toString() || "";
             let errMsg = err.message;
 
             const errParts = errOut.split(err.message);
@@ -255,13 +256,11 @@ export function run(
             log.error(
                 `Running program '${program}' failed with an unhandled exception:
 ${errMsg}`);
-        }
-        else if (ResourceError.isInstance(err)) {
+        } else if (ResourceError.isInstance(err)) {
             // Hide the stack if requested to by the ResourceError creator.
             const message = err.hideStack ? err.message : defaultMessage;
             log.error(message, err.resource);
-        }
-        else {
+        } else {
             log.error(
                 `Running program '${program}' failed with an unhandled exception:
 ${defaultMessage}`);

--- a/tests/integration/nodejs/omit-stacktrace/syntax-error/Pulumi.yaml
+++ b/tests/integration/nodejs/omit-stacktrace/syntax-error/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: syntax-error
+runtime: nodejs

--- a/tests/integration/nodejs/omit-stacktrace/syntax-error/index.js
+++ b/tests/integration/nodejs/omit-stacktrace/syntax-error/index.js
@@ -1,0 +1,4 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+// This program should fail with a SyntaxError
+var var

--- a/tests/integration/nodejs/omit-stacktrace/syntax-error/package.json
+++ b/tests/integration/nodejs/omit-stacktrace/syntax-error/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "syntax-error",
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+    },
+    "resolutions": {
+        "@types/node": "4.0.29"
+    }
+}

--- a/tests/integration/nodejs/omit-stacktrace/syntax-error/tsconfig.json
+++ b/tests/integration/nodejs/omit-stacktrace/syntax-error/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+    }
+}

--- a/tests/integration/nodejs/omit-stacktrace/ts-error/Pulumi.yaml
+++ b/tests/integration/nodejs/omit-stacktrace/ts-error/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: ts-error
+runtime: nodejs

--- a/tests/integration/nodejs/omit-stacktrace/ts-error/index.ts
+++ b/tests/integration/nodejs/omit-stacktrace/ts-error/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+// The program should produce a TSError
+thisIsNotADeclaredVariableAndShouldCreateATSError

--- a/tests/integration/nodejs/omit-stacktrace/ts-error/package.json
+++ b/tests/integration/nodejs/omit-stacktrace/ts-error/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "ts-error",
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+    },
+    "resolutions": {
+        "@types/node": "4.0.29"
+    }
+}

--- a/tests/integration/nodejs/omit-stacktrace/ts-error/tsconfig.json
+++ b/tests/integration/nodejs/omit-stacktrace/ts-error/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+    }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
This PR catches and displays SyntaxErrors without stack traces. It also makes the error message more similar to other user errors by outputting in the same format as user errors.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10373 

**New**
[![asciicast](https://asciinema.org/a/EZbFlwgOQriC00G729Sf3AB1c.svg)](https://asciinema.org/a/EZbFlwgOQriC00G729Sf3AB1c)

[![asciicast](https://asciinema.org/a/UdBX4jeoLOKp1vaqy32Fz8Gnz.svg)](https://asciinema.org/a/UdBX4jeoLOKp1vaqy32Fz8Gnz)

**Current**
[![asciicast](https://asciinema.org/a/y36oS26PRgzYyJwZHY0CZ4vHd.svg)](https://asciinema.org/a/y36oS26PRgzYyJwZHY0CZ4vHd)

[![asciicast](https://asciinema.org/a/mx2HYqzm2BQnvQe6kaZU45T4K.svg)](https://asciinema.org/a/mx2HYqzm2BQnvQe6kaZU45T4K)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
