### PR TITLE
 fix: Ports Python CONFIG, ROOT, and _SECRET_KEYS to ContextVars 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,9 @@
 - [sdk/python] Makes global SETTINGS values context-aware to not leak state between Pulumi programs running in parallel
   [#10402](https://github.com/pulumi/pulumi/pull/10402)
 
+- [sdk/python] Makes global ROOT, CONFIG, _SECRET_KEYS ContextVars to not leak state between parallel inline Pulumi programs
+  [#10472](https://github.com/pulumi/pulumi/pull/10472)
+
 ### Bug Fixes
 
 - [codegen/go] Fix StackReference codegen.

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -18,6 +18,7 @@ Runtime settings and configuration.
 from __future__ import annotations
 
 import asyncio
+from contextvars import ContextVar
 import os
 from typing import Optional, Union, Any, TYPE_CHECKING
 
@@ -192,23 +193,21 @@ def get_engine() -> Optional[Union[engine_pb2_grpc.EngineStub, Any]]:
     return SETTINGS.engine
 
 
-ROOT: Optional["Resource"] = None
+ROOT: ContextVar[Optional[Resource]] = ContextVar("root_resource", default=None)
 
 
 def get_root_resource() -> Optional["Resource"]:
     """
     Returns the implicit root stack resource for all resources created in this program.
     """
-    global ROOT  # pylint: disable=global-variable-not-assigned
-    return ROOT
+    return ROOT.get()
 
 
 def set_root_resource(root: "Resource"):
     """
     Sets the current root stack resource for all resources subsequently to be created in this program.
     """
-    global ROOT
-    ROOT = root
+    ROOT.set(root)
 
 
 async def monitor_supports_feature(feature: str) -> bool:
@@ -280,8 +279,7 @@ def reset_options(
 ):
     """Resets globals to the values provided."""
 
-    global ROOT
-    ROOT = None
+    ROOT.set(None)
 
     configure(
         Settings(


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR makes our global values that are not more complicated classes (like SETTINGS) ContextVars, and updates their interfaces where appropriate.

Fixes #6052 
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
