### PR TITLE
Fix negative page size panic

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,7 +3,7 @@
 - [cli] Clarify highlighting of confirmation text in `confirmPrompt`.
   [#10413](https://github.com/pulumi/pulumi/pull/10413)
 
-- [provider/python]: Improved exception display. The traceback is now shorter and it always starts with user code.  
+- [provider/python]: Improved exception display. The traceback is now shorter and it always starts with user code.
   [#10336](https://github.com/pulumi/pulumi/pull/10336)
 
 - [sdk/python] Update PyYAML to 6.0
@@ -35,3 +35,7 @@
 
 - [auto/go] Clone non-default branches (and tags).
   [#10285](https://github.com/pulumi/pulumi/pull/10285)
+
+- [cli] Fixes `survey.v1` panics in Terminal UI introduced in
+  [#10130](https://github.com/pulumi/pulumi/issues/10130) in v3.38.0.
+  [#10475](https://github.com/pulumi/pulumi/pull/10475)

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -31,7 +31,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 
@@ -808,20 +807,10 @@ func chooseTemplate(templates []workspace.Template, opts display.Options) (works
 	var selectedOption workspace.Template
 
 	for {
-
-		const buffer = 5
-		_, height, err := terminal.GetSize(0)
-		if err != nil {
-			height = 15
-		}
-
 		options, optionToTemplateMap := templatesToOptionArrayAndMap(templates, true)
-		if height > len(options) {
-			height = len(options)
-		}
-
-		height = height - buffer
-		message := fmt.Sprintf("\rPlease choose a template (%d/%d shown):\n", height, len(options))
+		nopts := len(options)
+		pageSize := optimalPageSize(optimalPageSizeOpts{nopts: nopts})
+		message := fmt.Sprintf("\rPlease choose a template (%d/%d shown):\n", pageSize, nopts)
 		message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
 
 		cmdutil.EndKeypadTransmitMode()
@@ -830,7 +819,7 @@ func chooseTemplate(templates []workspace.Template, opts display.Options) (works
 		if err := survey.AskOne(&survey.Select{
 			Message:  message,
 			Options:  options,
-			PageSize: height,
+			PageSize: pageSize,
 		}, &option, nil); err != nil {
 			return workspace.Template{}, errors.New(chooseTemplateErr)
 		}

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/nodejs/npm"
 	"github.com/pulumi/pulumi/sdk/v3/python"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 )
@@ -295,19 +294,11 @@ func choosePolicyPackTemplate(templates []workspace.PolicyPackTemplate,
 
 	cmdutil.EndKeypadTransmitMode()
 
-	_, height, err := terminal.GetSize(0)
-	if err != nil {
-		height = 15
-	}
-	if height > len(options) {
-		height = len(options)
-	}
-
 	var option string
 	if err := survey.AskOne(&survey.Select{
 		Message:  message,
 		Options:  options,
-		PageSize: height - 5,
+		PageSize: optimalPageSize(optimalPageSizeOpts{nopts: len(options)}),
 	}, &option, nil); err != nil {
 		return workspace.PolicyPackTemplate{}, errors.New(chooseTemplateErr)
 	}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 )
@@ -101,19 +100,11 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 
 	cmdutil.EndKeypadTransmitMode()
 
-	_, height, err := terminal.GetSize(0)
-	if err != nil {
-		height = 15
-	}
-	if height > len(options) {
-		height = len(options)
-	}
-
 	var option string
 	if err := survey.AskOne(&survey.Select{
 		Message:  prompt,
 		Options:  options,
-		PageSize: height - 5,
+		PageSize: optimalPageSize(optimalPageSizeOpts{nopts: len(options)}),
 	}, &option, nil); err != nil {
 		return nil, errors.New("no resource selected")
 	}

--- a/pkg/cmd/pulumi/terminal.go
+++ b/pkg/cmd/pulumi/terminal.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Terminal detection utilities.
+package main
+
+import (
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+type optimalPageSizeOpts struct {
+	nopts          int
+	terminalHeight int
+}
+
+// Computes how many options to display in a Terminal UI multi-select.
+// Tries to auto-detect and take terminal height into account.
+func optimalPageSize(opts optimalPageSizeOpts) int {
+	pageSize := 15
+	if opts.terminalHeight != 0 {
+		pageSize = opts.terminalHeight
+	} else if _, height, err := terminal.GetSize(0); err == nil {
+		pageSize = height
+	}
+	if pageSize > opts.nopts {
+		pageSize = opts.nopts
+	}
+	const buffer = 5
+	if pageSize > buffer {
+		pageSize = pageSize - buffer
+	}
+	return pageSize
+}

--- a/pkg/cmd/pulumi/terminal_test.go
+++ b/pkg/cmd/pulumi/terminal_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Terminal detection utilities.
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptimalPageSize(t *testing.T) {
+	opt := func(nopts, termHeight int) int {
+		return optimalPageSize(optimalPageSizeOpts{
+			nopts:          nopts,
+			terminalHeight: termHeight,
+		})
+	}
+
+	// Case 1: termHeight > nopts
+	assert.Equal(t, 0, opt(0, 15))
+	assert.Equal(t, 1, opt(1, 15))
+	assert.Equal(t, 2, opt(2, 15))
+	assert.Equal(t, 3, opt(3, 15))
+	assert.Equal(t, 4, opt(4, 15))
+	assert.Equal(t, 5, opt(5, 15))
+	assert.Equal(t, 1, opt(6, 15))
+	assert.Equal(t, 2, opt(7, 15))
+	assert.Equal(t, 3, opt(8, 15))
+
+	// Case 2: termHeight <= nopts
+	assert.Equal(t, 10, opt(15, 15))
+	assert.Equal(t, 10, opt(16, 15))
+	assert.Equal(t, 10, opt(17, 15))
+}

--- a/pkg/cmd/pulumi/terminal_test.go
+++ b/pkg/cmd/pulumi/terminal_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestOptimalPageSize(t *testing.T) {
+	t.Parallel()
 	opt := func(nopts, termHeight int) int {
 		return optimalPageSize(optimalPageSizeOpts{
 			nopts:          nopts,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

https://github.com/pulumi/pulumi/pull/10130 introduced a Terminal UI fix to optimize the pageSize parameter when displaying large selectors via the `survey` library. Unfortunately under certain conditions the logic results in a negative pageSize which causes `survey` library to panic. The fix here centralizes the logic introduced in 10130 into a helper function and makes sure that its return values are non-negative.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes [#10540](https://github.com/pulumi/pulumi/issues/10450)


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
