### PR TITLE
Add token expiration fields

### DIFF
--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -189,7 +189,7 @@ type RenewUpdateLeaseResponse struct {
 	// The renewed token.
 	Token string `json:"token"`
 
-	// TokenExpiration is the UNIX timestamp by which the token will expire.
+	// TokenExpiration is a UNIX timestamp by which the token will expire.
 	TokenExpiration int64 `json:"tokenExpiration,omitempty"`
 }
 

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -16,7 +16,6 @@ package apitype
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
@@ -97,8 +96,8 @@ type StartUpdateResponse struct {
 	// Token is the lease token (if any) to be used to authorize operations on this update.
 	Token string `json:"token,omitempty"`
 
-	// TokenExpiration is the point in time by which the token will expire.
-	TokenExpiration *time.Time `json:"tokenExpiration,omitempty"`
+	// TokenExpiration is a UNIX timestamp by which the token will expire.
+	TokenExpiration int64 `json:"tokenExpiration,omitempty"`
 }
 
 // UpdateEventKind is an enum for the type of update events.
@@ -191,7 +190,7 @@ type RenewUpdateLeaseResponse struct {
 	Token string `json:"token"`
 
 	// TokenExpiration is the point in time by which the token will expire.
-	TokenExpiration *time.Time `json:"tokenExpiration,omitempty"`
+	TokenExpiration int64 `json:"tokenExpiration,omitempty"`
 }
 
 const (

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -189,7 +189,7 @@ type RenewUpdateLeaseResponse struct {
 	// The renewed token.
 	Token string `json:"token"`
 
-	// TokenExpiration is the point in time by which the token will expire.
+	// TokenExpiration is the UNIX timestamp by which the token will expire.
 	TokenExpiration int64 `json:"tokenExpiration,omitempty"`
 }
 

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package apitype
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
@@ -95,6 +96,9 @@ type StartUpdateResponse struct {
 
 	// Token is the lease token (if any) to be used to authorize operations on this update.
 	Token string `json:"token,omitempty"`
+
+	// TokenExpiration is the point in time by which the token will expire.
+	TokenExpiration *time.Time `json:"tokenExpiration,omitempty"`
 }
 
 // UpdateEventKind is an enum for the type of update events.
@@ -185,6 +189,9 @@ type RenewUpdateLeaseRequest struct {
 type RenewUpdateLeaseResponse struct {
 	// The renewed token.
 	Token string `json:"token"`
+
+	// TokenExpiration is the point in time by which the token will expire.
+	TokenExpiration *time.Time `json:"tokenExpiration,omitempty"`
 }
 
 const (


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The new fields will enable servers to decide on and indicate token expiration intervals, which in the future will allow the clients to make fewer assumptions about the token lifetime and optimize renewing tokens based on the server-provided expiration.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
