### PR TITLE
fix: PluginLink program tests clobber YAML keys in Project.yaml files

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
 	"github.com/pulumi/pulumi/pkg/v3/engine"

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -116,6 +116,9 @@ type Project struct {
 	Options *ProjectOptions `json:"options,omitempty" yaml:"options,omitempty"`
 
 	Plugins *Plugins `json:"plugins,omitempty" yaml:"plugins,omitempty"`
+
+	// Handle additional keys, albeit in a way that will remove comments and trivia.
+	AdditionalKeys map[string]interface{} `yaml:",inline"`
 }
 
 func (proj *Project) Validate() error {


### PR DESCRIPTION
Determined by bisecting on this repo, the change here https://github.com/pulumi/pulumi/commit/bb84532fe6077979566101a3ebce89e18f99a87b#diff-58bdc2879a0109885b20b1ac1c52e30423b544b4a0b3e4326c1b79a063c7ce14R1694-R1731 breaks most YAML ProgramTest tests by turning them into no-ops, as reading and then writing the project file removes the `resources`, `variables`, `config`, and `outputs` keys that YAML adds to the project file.

ProgramTests with a validation step that check for `outputs` would fail, because there would be no outputs.

Adding a fallback map for all additional keys to the project type and using yaml.v3 enables us to load, mutate, and write back the project file in programtest, albeit in a manner that clobbers comments. 

I had an alternative patch that used `yamlutil` methods to do a comment-preserving mutation, but it felt overly complex for programtest and not as easily maintained. That patch for posterity is here: https://github.com/pulumi/pulumi/commit/d26e8e083
