### PR TITLE
Split PluginInfo in Info and Spec

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -223,15 +223,13 @@ type pluginAbout struct {
 }
 
 func getPluginsAbout() ([]pluginAbout, error) {
-	var pluginInfo []workspace.PluginInfo
-	var err error
-	pluginInfo, err = getProjectPluginsSilently()
+	pluginSpec, err := getProjectPluginsSilently()
 
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(pluginInfo, func(i, j int) bool {
-		pi, pj := pluginInfo[i], pluginInfo[j]
+	sort.Slice(pluginSpec, func(i, j int) bool {
+		pi, pj := pluginSpec[i], pluginSpec[j]
 		if pi.Name < pj.Name {
 			return true
 		} else if pi.Name == pj.Name && pi.Kind == pj.Kind &&
@@ -241,8 +239,8 @@ func getPluginsAbout() ([]pluginAbout, error) {
 		return false
 	})
 
-	var plugins = make([]pluginAbout, len(pluginInfo))
-	for i, p := range pluginInfo {
+	var plugins = make([]pluginAbout, len(pluginSpec))
+	for i, p := range pluginSpec {
 		plugins[i] = pluginAbout{
 			Name:    p.Name,
 			Version: p.Version,
@@ -550,7 +548,7 @@ func (runtime projectRuntimeAbout) String() string {
 
 // This is necessary because dotnet invokes build during the call to
 // getProjectPlugins.
-func getProjectPluginsSilently() ([]workspace.PluginInfo, error) {
+func getProjectPluginsSilently() ([]workspace.PluginSpec, error) {
 	_, w, err := os.Pipe()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -60,7 +60,7 @@ func newPluginInstallCmd() *cobra.Command {
 			}
 
 			// Parse the kind, name, and version, if specified.
-			var installs []workspace.PluginInfo
+			var installs []workspace.PluginSpec
 			if len(args) > 0 {
 				if !workspace.IsPluginKind(args[0]) {
 					return fmt.Errorf("unrecognized plugin kind: %s", args[0])
@@ -80,7 +80,7 @@ func newPluginInstallCmd() *cobra.Command {
 					return errors.New("missing plugin version argument, this is required if installing from a file")
 				}
 
-				pluginInfo := workspace.PluginInfo{
+				pluginSpec := workspace.PluginSpec{
 					Kind:              workspace.PluginKind(args[0]),
 					Name:              args[1],
 					Version:           version,
@@ -89,14 +89,14 @@ func newPluginInstallCmd() *cobra.Command {
 
 				// If we don't have a version try to look one up
 				if version == nil {
-					latestVersion, err := pluginInfo.GetLatestVersion()
+					latestVersion, err := pluginSpec.GetLatestVersion()
 					if err != nil {
 						return err
 					}
-					pluginInfo.Version = latestVersion
+					pluginSpec.Version = latestVersion
 				}
 
-				installs = append(installs, pluginInfo)
+				installs = append(installs, pluginSpec)
 			} else {
 				if file != "" {
 					return errors.New("--file (-f) is only valid if a specific package is being installed")
@@ -188,7 +188,7 @@ func newPluginInstallCmd() *cobra.Command {
 	return cmd
 }
 
-func getFilePayload(file string, info workspace.PluginInfo) (workspace.PluginContent, error) {
+func getFilePayload(file string, spec workspace.PluginSpec) (workspace.PluginContent, error) {
 	source := file
 	stat, err := os.Stat(file)
 	if err != nil {
@@ -216,7 +216,7 @@ func getFilePayload(file string, info workspace.PluginInfo) (workspace.PluginCon
 		if (stat.Mode() & 0100) == 0 {
 			return nil, fmt.Errorf("%s is not executable", source)
 		}
-		return workspace.SingleFilePlugin(f, info), nil
+		return workspace.SingleFilePlugin(f, spec), nil
 	}
 	return workspace.TarPlugin(f), nil
 }

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -38,7 +38,12 @@ func newPluginLsCmd() *cobra.Command {
 			var plugins []workspace.PluginInfo
 			var err error
 			if projectOnly {
-				if plugins, err = getProjectPlugins(); err != nil {
+				var pluginSpecs []workspace.PluginSpec
+				if pluginSpecs, err = getProjectPlugins(); err != nil {
+					return fmt.Errorf("loading project plugins: %w", err)
+				}
+				plugins, err = resolvePlugins(pluginSpecs)
+				if err != nil {
 					return fmt.Errorf("loading project plugins: %w", err)
 				}
 			} else {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -97,7 +97,7 @@ func (l *pluginLoader) ensurePlugin(pkg string, version *semver.Version) error {
 		return nil
 	}
 
-	pkgPlugin := workspace.PluginInfo{
+	pkgPlugin := workspace.PluginSpec{
 		Kind:    workspace.ResourcePlugin,
 		Name:    pkg,
 		Version: version,

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1358,7 +1358,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		plugins  []workspace.PluginInfo
+		plugins  []workspace.PluginSpec
 		snapshot *deploy.Snapshot
 		validate func(t *testing.T, r *resource.State)
 		versions []string
@@ -1373,7 +1373,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 		{
 			name:     "default-version",
 			versions: []string{"1.0.0", "1.1.0"},
-			plugins: []workspace.PluginInfo{{
+			plugins: []workspace.PluginSpec{{
 				Name:              "pkgA",
 				Version:           &semver.Version{Major: 1, Minor: 1},
 				PluginDownloadURL: "example.com/default",
@@ -1390,7 +1390,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 		{
 			name:     "specified-provider",
 			versions: []string{"1.0.0", "1.1.0"},
-			plugins: []workspace.PluginInfo{{
+			plugins: []workspace.PluginSpec{{
 				Name:    "pkgA",
 				Version: &semver.Version{Major: 1, Minor: 1},
 				Kind:    workspace.ResourcePlugin,
@@ -1408,7 +1408,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 			name:     "higher-in-snapshot",
 			versions: []string{"1.3.0", "1.1.0"},
 			prog:     prog(),
-			plugins: []workspace.PluginInfo{{
+			plugins: []workspace.PluginSpec{{
 				Name:    "pkgA",
 				Version: &semver.Version{Major: 1, Minor: 1},
 				Kind:    workspace.ResourcePlugin,

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -4823,7 +4823,7 @@ func TestPluginsAreDownloaded(t *testing.T) {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
 		assert.NoError(t, err)
 		return nil
-	}, workspace.PluginInfo{Name: "pkgA"}, workspace.PluginInfo{Name: "pkgB", Version: &semver10})
+	}, workspace.PluginSpec{Name: "pkgA"}, workspace.PluginSpec{Name: "pkgB", Version: &semver10})
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -40,10 +40,10 @@ const (
 )
 
 // pluginSet represents a set of plugins.
-type pluginSet map[string]workspace.PluginInfo
+type pluginSet map[string]workspace.PluginSpec
 
 // Add adds a plugin to this plugin set.
-func (p pluginSet) Add(plug workspace.PluginInfo) {
+func (p pluginSet) Add(plug workspace.PluginSpec) {
 	p[plug.String()] = plug
 }
 
@@ -64,9 +64,9 @@ func (p pluginSet) Union(other pluginSet) pluginSet {
 // For example, the plugin aws would be removed if there was an already existing plugin
 // aws-5.4.0.
 func (p pluginSet) Deduplicate() pluginSet {
-	existing := map[string]workspace.PluginInfo{}
+	existing := map[string]workspace.PluginSpec{}
 	newSet := newPluginSet()
-	add := func(p workspace.PluginInfo) {
+	add := func(p workspace.PluginSpec) {
 		prev, ok := existing[p.Name]
 		if ok {
 			// If either `pluginDownloadURL`, `Version` or both are set we consider the
@@ -97,8 +97,8 @@ func (p pluginSet) Deduplicate() pluginSet {
 }
 
 // Values returns a slice of all of the plugins contained within this set.
-func (p pluginSet) Values() []workspace.PluginInfo {
-	var plugins []workspace.PluginInfo
+func (p pluginSet) Values() []workspace.PluginSpec {
+	var plugins []workspace.PluginSpec
 	for _, value := range p {
 		plugins = append(plugins, value)
 	}
@@ -106,8 +106,8 @@ func (p pluginSet) Values() []workspace.PluginInfo {
 }
 
 // newPluginSet creates a new empty pluginSet.
-func newPluginSet(plugins ...workspace.PluginInfo) pluginSet {
-	var s pluginSet = make(map[string]workspace.PluginInfo, len(plugins))
+func newPluginSet(plugins ...workspace.PluginSpec) pluginSet {
+	var s pluginSet = make(map[string]workspace.PluginSpec, len(plugins))
 	for _, p := range plugins {
 		s.Add(p)
 	}
@@ -164,7 +164,7 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 		}
 		logging.V(preparePluginLog).Infof(
 			"gatherPluginsFromSnapshot(): plugin %s %s is required by first-class provider %q", pkg, version, urn)
-		set.Add(workspace.PluginInfo{
+		set.Add(workspace.PluginSpec{
 			Name:              pkg.String(),
 			Kind:              workspace.ResourcePlugin,
 			Version:           version,
@@ -209,7 +209,7 @@ func ensurePluginsAreLoaded(plugctx *plugin.Context, plugins pluginSet, kinds pl
 }
 
 // installPlugin installs a plugin from the given backend client.
-func installPlugin(ctx context.Context, plugin workspace.PluginInfo) error {
+func installPlugin(ctx context.Context, plugin workspace.PluginSpec) error {
 	logging.V(preparePluginLog).Infof("installPlugin(%s, %s): beginning install", plugin.Name, plugin.Version)
 	if plugin.Kind == workspace.LanguagePlugin {
 		logging.V(preparePluginLog).Infof(
@@ -276,7 +276,7 @@ func installPlugin(ctx context.Context, plugin workspace.PluginInfo) error {
 // that the engine uses to determine which version of a particular provider to load.
 //
 // it is critical that this function be 100% deterministic.
-func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[tokens.Package]workspace.PluginInfo {
+func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[tokens.Package]workspace.PluginSpec {
 	// Language hosts are not required to specify the full set of plugins they depend on. If the set of plugins received
 	// from the language host does not include any resource providers, fall back to the full set of plugins.
 	languageReportedProviderPlugins := false
@@ -293,7 +293,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 		sourceSet = allPlugins
 	}
 
-	defaultProviderPlugins := make(map[tokens.Package]workspace.PluginInfo)
+	defaultProviderPlugins := make(map[tokens.Package]workspace.PluginSpec)
 
 	// Sort the set of source plugins by version, so that we iterate over the set of plugins in a deterministic order.
 	// Sorting by version gets us two properties:
@@ -305,7 +305,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 	// Despite these properties, the below loop explicitly handles those cases to preserve correct behavior even if the
 	// sort is not functioning properly.
 	sourcePlugins := sourceSet.Values()
-	sort.Sort(workspace.SortedPluginInfo(sourcePlugins))
+	sort.Sort(workspace.SortedPluginSpec(sourcePlugins))
 	for _, p := range sourcePlugins {
 		logging.V(preparePluginLog).Infof("computeDefaultProviderPlugins(): considering %s", p)
 		if p.Kind != workspace.ResourcePlugin {
@@ -333,9 +333,9 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 				continue
 			}
 
-			contract.Failf("Should not have seen an older plugin if sorting is correct!\n  %s-%s %s\n  %s-%s - %s",
-				p.Name, p.Version.String(), p.Path,
-				seenPlugin.Name, seenPlugin.Version.String(), seenPlugin.Path)
+			contract.Failf("Should not have seen an older plugin if sorting is correct!\n  %s-%s\n  %s-%s",
+				p.Name, p.Version.String(),
+				seenPlugin.Name, seenPlugin.Version.String())
 		}
 
 		logging.V(preparePluginLog).Infof(
@@ -350,7 +350,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 		}
 	}
 
-	defaultProviderInfo := make(map[tokens.Package]workspace.PluginInfo)
+	defaultProviderInfo := make(map[tokens.Package]workspace.PluginSpec)
 	for name, plugin := range defaultProviderPlugins {
 		defaultProviderInfo[name] = plugin
 	}

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -34,12 +34,12 @@ func TestDefaultProvidersSingle(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name:              "kubernetes",
 		Version:           mustMakeVersion("0.22.0"),
 		Kind:              workspace.ResourcePlugin,
@@ -68,12 +68,12 @@ func TestDefaultProvidersOverrideNoVersion(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: nil,
 		Kind:    workspace.ResourcePlugin,
@@ -92,17 +92,17 @@ func TestDefaultProvidersOverrideNewerVersion(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.0"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.2-dev.1553126336"),
 		Kind:    workspace.ResourcePlugin,
@@ -121,12 +121,12 @@ func TestDefaultProvidersSnapshotOverrides(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginInfo{
+	languagePlugins.Add(workspace.PluginSpec{
 		Name: "python",
 		Kind: workspace.LanguagePlugin,
 	})
 	snapshotPlugins := newPluginSet()
-	snapshotPlugins.Add(workspace.PluginInfo{
+	snapshotPlugins.Add(workspace.PluginSpec{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.0"),
 		Kind:    workspace.ResourcePlugin,
@@ -147,41 +147,41 @@ func TestPluginSetDeduplicate(t *testing.T) {
 		input    pluginSet
 		expected pluginSet
 	}{{
-		input: newPluginSet(workspace.PluginInfo{
+		input: newPluginSet(workspace.PluginSpec{
 			Name:    "foo",
 			Version: &semver.Version{Major: 1},
-		}, workspace.PluginInfo{
+		}, workspace.PluginSpec{
 			Name: "foo",
 		}),
-		expected: newPluginSet(workspace.PluginInfo{
+		expected: newPluginSet(workspace.PluginSpec{
 			Name:    "foo",
 			Version: &semver.Version{Major: 1},
 		}),
 	}, {
-		input: newPluginSet(workspace.PluginInfo{
+		input: newPluginSet(workspace.PluginSpec{
 			Name:    "bar",
 			Version: &semver.Version{Minor: 3},
-		}, workspace.PluginInfo{
+		}, workspace.PluginSpec{
 			Name:              "bar",
 			PluginDownloadURL: "example.com/bar",
-		}, workspace.PluginInfo{
+		}, workspace.PluginSpec{
 			Name:              "bar",
 			Version:           &semver.Version{Patch: 3},
 			PluginDownloadURL: "example.com",
-		}, workspace.PluginInfo{
+		}, workspace.PluginSpec{
 			Name: "foo",
 		}),
-		expected: newPluginSet(workspace.PluginInfo{
+		expected: newPluginSet(workspace.PluginSpec{
 			Name:    "bar",
 			Version: &semver.Version{Minor: 3},
-		}, workspace.PluginInfo{
+		}, workspace.PluginSpec{
 			Name:              "bar",
 			PluginDownloadURL: "example.com/bar",
-		}, workspace.PluginInfo{
+		}, workspace.PluginSpec{
 			Name:              "bar",
 			Version:           &semver.Version{Patch: 3},
 			PluginDownloadURL: "example.com",
-		}, workspace.PluginInfo{
+		}, workspace.PluginSpec{
 			Name: "foo",
 		}),
 	}}
@@ -198,20 +198,20 @@ func TestPluginSetDeduplicate(t *testing.T) {
 func TestDefaultProviderPluginsSorting(t *testing.T) {
 	t.Parallel()
 	v1 := semver.MustParse("0.0.1-alpha.10")
-	p1 := workspace.PluginInfo{
+	p1 := workspace.PluginSpec{
 		Name:    "foo",
 		Version: &v1,
 		Kind:    workspace.ResourcePlugin,
 	}
 	v2 := semver.MustParse("0.0.1-alpha.10+dirty")
-	p2 := workspace.PluginInfo{
+	p2 := workspace.PluginSpec{
 		Name:    "foo",
 		Version: &v2,
 		Kind:    workspace.ResourcePlugin,
 	}
 	plugins := newPluginSet(p1, p2)
 	result := computeDefaultProviderPlugins(plugins, plugins)
-	assert.Equal(t, map[tokens.Package]workspace.PluginInfo{
+	assert.Equal(t, map[tokens.Package]workspace.PluginSpec{
 		"foo": p2,
 	}, result)
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -208,7 +208,7 @@ func RunInstallPlugins(
 
 func installPlugins(
 	proj *workspace.Project, pwd, main string, target *deploy.Target,
-	plugctx *plugin.Context, returnInstallErrors bool) (pluginSet, map[tokens.Package]workspace.PluginInfo, error) {
+	plugctx *plugin.Context, returnInstallErrors bool) (pluginSet, map[tokens.Package]workspace.PluginSpec, error) {
 
 	// Before launching the source, ensure that we have all of the plugins that we need in order to proceed.
 	//

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -197,9 +197,9 @@ func addDefaultProviders(target *Target, source Source, prev *Snapshot) error {
 	}
 
 	// Pull the versions we'll use for default providers from the snapshot's manifest.
-	defaultProviderInfo := make(map[tokens.Package]workspace.PluginInfo)
+	defaultProviderInfo := make(map[tokens.Package]workspace.PluginSpec)
 	for _, p := range prev.Manifest.Plugins {
-		defaultProviderInfo[tokens.Package(p.Name)] = p
+		defaultProviderInfo[tokens.Package(p.Name)] = p.Spec()
 	}
 
 	// Determine the necessary set of default providers and inject references to default providers as appropriate.

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -24,7 +24,7 @@ import (
 
 type ProgramFunc func(runInfo plugin.RunInfo, monitor *ResourceMonitor) error
 
-func NewLanguageRuntime(program ProgramFunc, requiredPlugins ...workspace.PluginInfo) plugin.LanguageRuntime {
+func NewLanguageRuntime(program ProgramFunc, requiredPlugins ...workspace.PluginSpec) plugin.LanguageRuntime {
 	return &languageRuntime{
 		requiredPlugins: requiredPlugins,
 		program:         program,
@@ -32,7 +32,7 @@ func NewLanguageRuntime(program ProgramFunc, requiredPlugins ...workspace.Plugin
 }
 
 type languageRuntime struct {
-	requiredPlugins []workspace.PluginInfo
+	requiredPlugins []workspace.PluginSpec
 	program         ProgramFunc
 }
 
@@ -40,7 +40,7 @@ func (p *languageRuntime) Close() error {
 	return nil
 }
 
-func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginInfo, error) {
+func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginSpec, error) {
 	return p.requiredPlugins, nil
 }
 

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -393,7 +393,7 @@ func (host *pluginHost) CloseProvider(provider plugin.Provider) error {
 	delete(host.plugins, provider)
 	return nil
 }
-func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
+func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
 	return nil
 }
 func (host *pluginHost) ResolvePlugin(
@@ -416,7 +416,7 @@ func (host *pluginHost) ResolvePlugin(
 	return nil, nil
 }
 func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
-	kinds plugin.Flags) ([]workspace.PluginInfo, error) {
+	kinds plugin.Flags) ([]workspace.PluginSpec, error) {
 	return host.languageRuntime.GetRequiredPlugins(info)
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -71,7 +71,7 @@ func (host *testPluginHost) CloseProvider(provider plugin.Provider) error {
 func (host *testPluginHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
 	return nil, errors.New("unsupported")
 }
-func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
+func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
 	return nil
 }
 func (host *testPluginHost) ResolvePlugin(

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -58,7 +58,7 @@ type EvalRunInfo struct {
 // a confgiuration map.  This evaluation is performed using the given plugin context and may optionally use the
 // given plugin host (or the default, if this is nil).  Note that closing the eval source also closes the host.
 func NewEvalSource(plugctx *plugin.Context, runinfo *EvalRunInfo,
-	defaultProviderInfo map[tokens.Package]workspace.PluginInfo, dryRun bool) Source {
+	defaultProviderInfo map[tokens.Package]workspace.PluginSpec, dryRun bool) Source {
 
 	return &evalSource{
 		plugctx:             plugctx,
@@ -71,7 +71,7 @@ func NewEvalSource(plugctx *plugin.Context, runinfo *EvalRunInfo,
 type evalSource struct {
 	plugctx             *plugin.Context                         // the plugin context.
 	runinfo             *EvalRunInfo                            // the directives to use when running the program.
-	defaultProviderInfo map[tokens.Package]workspace.PluginInfo // the default provider versions for this source.
+	defaultProviderInfo map[tokens.Package]workspace.PluginSpec // the default provider versions for this source.
 	dryRun              bool                                    // true if this is a dry-run operation only.
 }
 
@@ -246,7 +246,7 @@ func (iter *evalSourceIterator) forkRun(opts Options, config map[config.Key]stri
 type defaultProviders struct {
 	// A map of package identifiers to versions, used to disambiguate which plugin to load if no version is provided
 	// by the language host.
-	defaultProviderInfo map[tokens.Package]workspace.PluginInfo
+	defaultProviderInfo map[tokens.Package]workspace.PluginSpec
 
 	// A map of ProviderRequest strings to provider references, used to keep track of the set of default providers that
 	// have already been loaded.

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -45,7 +45,7 @@ type QuerySource interface {
 // NewQuerySource creates a `QuerySource` for some target runtime environment specified by
 // `runinfo`, and supported by language plugins provided in `plugctx`.
 func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client BackendClient,
-	runinfo *EvalRunInfo, defaultProviderVersions map[tokens.Package]workspace.PluginInfo,
+	runinfo *EvalRunInfo, defaultProviderVersions map[tokens.Package]workspace.PluginSpec,
 	provs ProviderSource) (QuerySource, error) {
 
 	// Create a new builtin provider. This provider implements features such as `getStack`.
@@ -195,7 +195,7 @@ func runLangPlugin(src *querySource) result.Result {
 // newQueryResourceMonitor creates a new resource monitor RPC server intended to be used in Pulumi's
 // "query mode".
 func newQueryResourceMonitor(
-	builtins *builtinProvider, defaultProviderInfo map[tokens.Package]workspace.PluginInfo,
+	builtins *builtinProvider, defaultProviderInfo map[tokens.Package]workspace.PluginSpec,
 	provs ProviderSource, reg *providers.Registry, plugctx *plugin.Context,
 	providerRegErrChan chan<- result.Result, tracingSpan opentracing.Span, runinfo *EvalRunInfo) (*queryResmon, error) {
 

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -73,7 +73,7 @@ type Host interface {
 
 	// EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
 	// and/or there are errors loading one or more plugins, a non-nil error is returned.
-	EnsurePlugins(plugins []workspace.PluginInfo, kinds Flags) error
+	EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) error
 	// ResolvePlugin resolves a plugin kind, name, and optional semver to a candidate plugin to load.
 	ResolvePlugin(kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
 
@@ -398,7 +398,7 @@ func (host *defaultHost) LanguageRuntime(runtime string) (LanguageRuntime, error
 
 // EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
 // and/or there are errors loading one or more plugins, a non-nil error is returned.
-func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds Flags) error {
+func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) error {
 	// Use a multieerror to track failures so we can return one big list of all failures at the end.
 	var result error
 	for _, plugin := range plugins {
@@ -518,8 +518,8 @@ const (
 var AllPlugins = AnalyzerPlugins | LanguagePlugins | ResourcePlugins
 
 // GetRequiredPlugins lists a full set of plugins that will be required by the given program.
-func GetRequiredPlugins(host Host, info ProgInfo, kinds Flags) ([]workspace.PluginInfo, error) {
-	var plugins []workspace.PluginInfo
+func GetRequiredPlugins(host Host, info ProgInfo, kinds Flags) ([]workspace.PluginSpec, error) {
+	var plugins []workspace.PluginSpec
 
 	if kinds&LanguagePlugins != 0 {
 		// First make sure the language plugin is present.  We need this to load the required resource plugins.
@@ -528,7 +528,7 @@ func GetRequiredPlugins(host Host, info ProgInfo, kinds Flags) ([]workspace.Plug
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load language plugin %s", info.Proj.Runtime.Name())
 		}
-		plugins = append(plugins, workspace.PluginInfo{
+		plugins = append(plugins, workspace.PluginSpec{
 			Name: info.Proj.Runtime.Name(),
 			Kind: workspace.LanguagePlugin,
 		})

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -28,7 +28,7 @@ type LanguageRuntime interface {
 	// Closer closes any underlying OS resources associated with this plugin (like processes, RPC channels, etc).
 	io.Closer
 	// GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
-	GetRequiredPlugins(info ProgInfo) ([]workspace.PluginInfo, error)
+	GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, error)
 	// Run executes a program in the language runtime for planning or deployment purposes.  If
 	// info.DryRun is true, the code must not assume that side-effects or final values resulting
 	// from resource deployments are actually available.  If it is false, on the other hand, a real

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -106,7 +106,7 @@ func NewLanguageRuntimeClient(ctx *Context, runtime string, client pulumirpc.Lan
 func (h *langhost) Runtime() string { return h.runtime }
 
 // GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
-func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginInfo, error) {
+func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, error) {
 	proj := string(info.Proj.Name)
 	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(proj=%s,pwd=%s,program=%s) executing",
 		h.runtime, proj, info.Pwd, info.Program)
@@ -129,7 +129,7 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginInfo, er
 		return nil, rpcError
 	}
 
-	var results []workspace.PluginInfo
+	var results []workspace.PluginSpec
 	for _, info := range resp.GetPlugins() {
 		var version *semver.Version
 		if v := info.GetVersion(); v != "" {
@@ -142,7 +142,7 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginInfo, er
 		if !workspace.IsPluginKind(info.GetKind()) {
 			return nil, errors.Errorf("unrecognized plugin kind: %s", info.GetKind())
 		}
-		results = append(results, workspace.PluginInfo{
+		results = append(results, workspace.PluginSpec{
 			Name:              info.GetName(),
 			Kind:              workspace.PluginKind(info.GetKind()),
 			Version:           version,

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -514,44 +514,45 @@ type ProjectPlugin struct {
 	Path    string          // the path that a plugin is to be loaded from (this will always be a directory)
 }
 
-// PluginInfo provides basic information about a plugin.  Each plugin gets installed into a system-wide
-// location, by default `~/.pulumi/plugins/<kind>-<name>-<version>/`.  A plugin may contain multiple files,
-// however the primary loadable executable must be named `pulumi-<kind>-<name>`.
-type PluginInfo struct {
+// Return a PluginSpec object for this project plugin.
+func (pp ProjectPlugin) Spec() PluginSpec {
+	return PluginSpec{
+		Name:    pp.Name,
+		Kind:    pp.Kind,
+		Version: pp.Version,
+	}
+}
+
+// PluginSpec provides basic specification for a plugin.
+type PluginSpec struct {
 	Name              string          // the simple name of the plugin.
-	Path              string          // the path that a plugin was loaded from (this will always be a directory)
 	Kind              PluginKind      // the kind of the plugin (language, resource, etc).
 	Version           *semver.Version // the plugin's semantic version, if present.
-	Size              int64           // the size of the plugin, in bytes.
-	InstallTime       time.Time       // the time the plugin was installed.
-	LastUsedTime      time.Time       // the last time the plugin was used.
 	PluginDownloadURL string          // an optional server to use when downloading this plugin.
 	PluginDir         string          // if set, will be used as the root plugin dir instead of ~/.pulumi/plugins.
-	SchemaPath        string          // if set, used as the path for loading and caching the schema
-	SchemaTime        time.Time       // if set and newer than the file at SchemaPath, used to invalidate a cached schema
 }
 
 // Dir gets the expected plugin directory for this plugin.
-func (info PluginInfo) Dir() string {
-	dir := fmt.Sprintf("%s-%s", info.Kind, info.Name)
-	if info.Version != nil {
-		dir = fmt.Sprintf("%s-v%s", dir, info.Version.String())
+func (spec PluginSpec) Dir() string {
+	dir := fmt.Sprintf("%s-%s", spec.Kind, spec.Name)
+	if spec.Version != nil {
+		dir = fmt.Sprintf("%s-v%s", dir, spec.Version.String())
 	}
 	return dir
 }
 
 // File gets the expected filename for this plugin.
-func (info PluginInfo) File() string {
-	return info.FilePrefix() + info.FileSuffix()
+func (spec PluginSpec) File() string {
+	return spec.FilePrefix() + spec.FileSuffix()
 }
 
 // FilePrefix gets the expected default file prefix for the plugin.
-func (info PluginInfo) FilePrefix() string {
-	return fmt.Sprintf("pulumi-%s-%s", info.Kind, info.Name)
+func (spec PluginSpec) FilePrefix() string {
+	return fmt.Sprintf("pulumi-%s-%s", spec.Kind, spec.Name)
 }
 
 // FileSuffix returns the suffix for the plugin (if any).
-func (info PluginInfo) FileSuffix() string {
+func (spec PluginSpec) FileSuffix() string {
 	if runtime.GOOS == windowsGOOS {
 		return ".exe"
 	}
@@ -559,9 +560,9 @@ func (info PluginInfo) FileSuffix() string {
 }
 
 // DirPath returns the directory where this plugin should be installed.
-func (info PluginInfo) DirPath() (string, error) {
+func (spec PluginSpec) DirPath() (string, error) {
 	var err error
-	dir := info.PluginDir
+	dir := spec.PluginDir
 	if dir == "" {
 		dir, err = GetPluginDir()
 		if err != nil {
@@ -569,13 +570,13 @@ func (info PluginInfo) DirPath() (string, error) {
 		}
 	}
 
-	return filepath.Join(dir, info.Dir()), nil
+	return filepath.Join(dir, spec.Dir()), nil
 }
 
 // LockFilePath returns the full path to the plugin's lock file used during installation
 // to prevent concurrent installs.
-func (info PluginInfo) LockFilePath() (string, error) {
-	dir, err := info.DirPath()
+func (spec PluginSpec) LockFilePath() (string, error) {
+	dir, err := spec.DirPath()
 	if err != nil {
 		return "", err
 	}
@@ -584,8 +585,8 @@ func (info PluginInfo) LockFilePath() (string, error) {
 
 // PartialFilePath returns the full path to the plugin's partial file used during installation
 // to indicate installation of the plugin hasn't completed yet.
-func (info PluginInfo) PartialFilePath() (string, error) {
-	dir, err := info.DirPath()
+func (spec PluginSpec) PartialFilePath() (string, error) {
+	dir, err := spec.DirPath()
 	if err != nil {
 		return "", err
 	}
@@ -593,21 +594,59 @@ func (info PluginInfo) PartialFilePath() (string, error) {
 }
 
 // FilePath returns the full path where this plugin's primary executable should be installed.
-func (info PluginInfo) FilePath() (string, error) {
-	dir, err := info.DirPath()
+func (spec PluginSpec) FilePath() (string, error) {
+	dir, err := spec.DirPath()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, info.File()), nil
+	return filepath.Join(dir, spec.File()), nil
+}
+
+func (spec PluginSpec) String() string {
+	var version string
+	if v := spec.Version; v != nil {
+		version = fmt.Sprintf("-%s", v)
+	}
+	return spec.Name + version
+}
+
+// PluginInfo provides basic information about a plugin.  Each plugin gets installed into a system-wide
+// location, by default `~/.pulumi/plugins/<kind>-<name>-<version>/`.  A plugin may contain multiple files,
+// however the primary loadable executable must be named `pulumi-<kind>-<name>`.
+type PluginInfo struct {
+	Name         string          // the simple name of the plugin.
+	Path         string          // the path that a plugin was loaded from (this will always be a directory)
+	Kind         PluginKind      // the kind of the plugin (language, resource, etc).
+	Version      *semver.Version // the plugin's semantic version, if present.
+	Size         int64           // the size of the plugin, in bytes.
+	InstallTime  time.Time       // the time the plugin was installed.
+	LastUsedTime time.Time       // the last time the plugin was used.
+	SchemaPath   string          // if set, used as the path for loading and caching the schema
+	SchemaTime   time.Time       // if set and newer than the file at SchemaPath, used to invalidate a cached schema
+}
+
+// Spec returns the PluginSpec for this PluginInfo
+func (info PluginInfo) Spec() PluginSpec {
+	return PluginSpec{Name: info.Name, Kind: info.Kind, Version: info.Version}
+}
+
+func (info PluginInfo) String() string {
+	var version string
+	if v := info.Version; v != nil {
+		version = fmt.Sprintf("-%s", v)
+	}
+	return info.Name + version
+}
+
+// FilePath returns the full path where this plugin's primary executable should be installed.
+func (info PluginInfo) FilePath() string {
+	return filepath.Join(info.Path, info.Spec().File())
 }
 
 // Delete removes the plugin from the cache.  It also deletes any supporting files in the cache, which includes
 // any files that contain the same prefix as the plugin itself.
 func (info PluginInfo) Delete() error {
-	dir, err := info.DirPath()
-	if err != nil {
-		return err
-	}
+	dir := info.Path
 	if err := os.RemoveAll(dir); err != nil {
 		return err
 	}
@@ -653,21 +692,13 @@ func (info *PluginInfo) SetFileMetadata(path string) error {
 }
 
 func (info *PluginInfo) SetSchemaMetadata() {
-	binpath, err := info.FilePath()
-	if err != nil {
-		return
-	}
+	binpath := info.FilePath()
 	bintime, err := times.Stat(binpath)
 	if err != nil {
 		return
 	}
 
-	dir, err := info.DirPath()
-	if err != nil {
-		return
-	}
-
-	info.SchemaPath = filepath.Join(dir, "schema-"+info.Name+".json")
+	info.SchemaPath = filepath.Join(info.Path, "schema-"+info.Name+".json")
 	info.SchemaTime = bintime.ModTime()
 }
 
@@ -679,35 +710,35 @@ func interpolateURL(serverURL string, version semver.Version, os, arch string) s
 	return replacer.Replace(serverURL)
 }
 
-func (info PluginInfo) GetSource() (PluginSource, error) {
+func (spec PluginSpec) GetSource() (PluginSource, error) {
 	// The plugin has a set URL use that.
-	if info.PluginDownloadURL != "" {
+	if spec.PluginDownloadURL != "" {
 		// Support schematised URLS if the URL has a "schema" part we recognize
-		url, err := url.Parse(info.PluginDownloadURL)
+		url, err := url.Parse(spec.PluginDownloadURL)
 		if err != nil {
 			return nil, err
 		}
 
 		if url.Scheme == "github" {
-			return newGithubSource(url, info.Name, info.Kind)
+			return newGithubSource(url, spec.Name, spec.Kind)
 		}
 
-		return newPluginURLSource(info.Name, info.Kind, info.PluginDownloadURL), nil
+		return newPluginURLSource(spec.Name, spec.Kind, spec.PluginDownloadURL), nil
 	}
 
 	// If the plugin name matches an override, download the plugin from the override URL.
-	if url, ok := pluginDownloadURLOverridesParsed.get(info.Name); ok {
-		return newPluginURLSource(info.Name, info.Kind, url), nil
+	if url, ok := pluginDownloadURLOverridesParsed.get(spec.Name); ok {
+		return newPluginURLSource(spec.Name, spec.Kind, url), nil
 	}
 
 	// Use our default fallback behaviour of github then get.pulumi.com
-	return newFallbackSource(info.Name, info.Kind), nil
+	return newFallbackSource(spec.Name, spec.Kind), nil
 }
 
 // GetLatestVersion tries to find the latest version for this plugin. This is currently only supported for
 // plugins we can get from github releases.
-func (info PluginInfo) GetLatestVersion() (*semver.Version, error) {
-	source, err := info.GetSource()
+func (spec PluginSpec) GetLatestVersion() (*semver.Version, error) {
+	source, err := spec.GetSource()
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +746,7 @@ func (info PluginInfo) GetLatestVersion() (*semver.Version, error) {
 }
 
 // Download fetches an io.ReadCloser for this plugin and also returns the size of the response (if known).
-func (info PluginInfo) Download() (io.ReadCloser, int64, error) {
+func (spec PluginSpec) Download() (io.ReadCloser, int64, error) {
 	// Figure out the OS/ARCH pair for the download URL.
 	var opSy string
 	switch runtime.GOOS {
@@ -733,15 +764,15 @@ func (info PluginInfo) Download() (io.ReadCloser, int64, error) {
 	}
 
 	// The plugin version is necessary for the endpoint. If it's not present, return an error.
-	if info.Version == nil {
-		return nil, -1, errors.Errorf("unknown version for plugin %s", info.Name)
+	if spec.Version == nil {
+		return nil, -1, errors.Errorf("unknown version for plugin %s", spec.Name)
 	}
 
-	source, err := info.GetSource()
+	source, err := spec.GetSource()
 	if err != nil {
 		return nil, -1, err
 	}
-	return source.Download(*info.Version, opSy, arch, getHTTPResponse)
+	return source.Download(*spec.Version, opSy, arch, getHTTPResponse)
 }
 
 func buildHTTPRequest(pluginEndpoint string, token string) (*http.Request, error) {
@@ -792,8 +823,8 @@ func getHTTPResponse(req *http.Request) (io.ReadCloser, int64, error) {
 }
 
 // installLock acquires a file lock used to prevent concurrent installs.
-func (info PluginInfo) installLock() (unlock func(), err error) {
-	finalDir, err := info.DirPath()
+func (spec PluginSpec) installLock() (unlock func(), err error) {
+	finalDir, err := spec.DirPath()
 	if err != nil {
 		return nil, err
 	}
@@ -813,14 +844,14 @@ func (info PluginInfo) installLock() (unlock func(), err error) {
 }
 
 // Install installs a plugin's tarball into the cache. See InstallWithContext for details.
-func (info PluginInfo) Install(tgz io.ReadCloser, reinstall bool) error {
-	return info.InstallWithContext(context.Background(), tarPlugin{tgz}, reinstall)
+func (spec PluginSpec) Install(tgz io.ReadCloser, reinstall bool) error {
+	return spec.InstallWithContext(context.Background(), tarPlugin{tgz}, reinstall)
 }
 
 // DownloadToFile downloads the given PluginInfo to a temporary file and returns that temporary file.
 // This has some retry logic to re-attempt the download if it errors for any reason.
 func DownloadToFile(
-	pkgPlugin PluginInfo,
+	pkgPlugin PluginSpec,
 	wrapper func(stream io.ReadCloser, size int64) io.ReadCloser,
 	retry func(err error, attempt int, limit int, delay time.Duration)) (*os.File, error) {
 
@@ -948,8 +979,8 @@ type PluginContent interface {
 	writeToDir(pathToDir string) error
 }
 
-func SingleFilePlugin(f *os.File, info PluginInfo) PluginContent {
-	return singleFilePlugin{F: f, Kind: info.Kind, Name: info.Name}
+func SingleFilePlugin(f *os.File, spec PluginSpec) PluginContent {
+	return singleFilePlugin{F: f, Kind: spec.Kind, Name: spec.Name}
 }
 
 type singleFilePlugin struct {
@@ -1046,17 +1077,17 @@ func (p dirPlugin) writeToDir(dstRoot string) error {
 // If a failure occurs during installation, the `.partial` file will remain, indicating the plugin wasn't fully
 // installed. The next time the plugin is installed, the old installation directory will be removed and replaced with
 // a fresh install.
-func (info PluginInfo) InstallWithContext(ctx context.Context, content PluginContent, reinstall bool) error {
+func (spec PluginSpec) InstallWithContext(ctx context.Context, content PluginContent, reinstall bool) error {
 	defer contract.IgnoreClose(content)
 
 	// Fetch the directory into which we will expand this tarball.
-	finalDir, err := info.DirPath()
+	finalDir, err := spec.DirPath()
 	if err != nil {
 		return err
 	}
 
 	// Create a file lock file at <pluginsdir>/<kind>-<name>-<version>.lock.
-	unlock, err := info.installLock()
+	unlock, err := spec.installLock()
 	if err != nil {
 		return err
 	}
@@ -1070,7 +1101,7 @@ func (info PluginInfo) InstallWithContext(ctx context.Context, content PluginCon
 	}
 
 	// Get the partial file path (e.g. <pluginsdir>/<kind>-<name>-<version>.partial).
-	partialFilePath, err := info.PartialFilePath()
+	partialFilePath, err := spec.PartialFilePath()
 	if err != nil {
 		return err
 	}
@@ -1171,14 +1202,6 @@ func cleanupTempDirs(finalDir string) error {
 	return nil
 }
 
-func (info PluginInfo) String() string {
-	var version string
-	if v := info.Version; v != nil {
-		version = fmt.Sprintf("-%s", v)
-	}
-	return info.Name + version
-}
-
 // PluginKind represents a kind of a plugin that may be dynamically loaded and used by Pulumi.
 type PluginKind string
 
@@ -1202,12 +1225,12 @@ func IsPluginKind(k string) bool {
 }
 
 // HasPlugin returns true if the given plugin exists.
-func HasPlugin(plug PluginInfo) bool {
-	dir, err := plug.DirPath()
+func HasPlugin(spec PluginSpec) bool {
+	dir, err := spec.DirPath()
 	if err == nil {
 		_, err := os.Stat(dir)
 		if err == nil {
-			partialFilePath, err := plug.PartialFilePath()
+			partialFilePath, err := spec.PartialFilePath()
 			if err == nil {
 				if _, err := os.Stat(partialFilePath); os.IsNotExist(err) {
 					return true
@@ -1219,9 +1242,9 @@ func HasPlugin(plug PluginInfo) bool {
 }
 
 // HasPluginGTE returns true if the given plugin exists at the given version number or greater.
-func HasPluginGTE(plug PluginInfo) (bool, error) {
+func HasPluginGTE(spec PluginSpec) (bool, error) {
 	// If an exact match, return true right away.
-	if HasPlugin(plug) {
+	if HasPlugin(spec) {
 		return true, nil
 	}
 
@@ -1234,16 +1257,16 @@ func HasPluginGTE(plug PluginInfo) (bool, error) {
 	// If we're not doing the legacy plugin behavior and we've been asked for a specific version, do the same plugin
 	// search that we'd do at runtime. This ensures that `pulumi plugin install` works the same way that the runtime
 	// loader does, to minimize confusion when a user has to install new plugins.
-	if !enableLegacyPluginBehavior && plug.Version != nil {
-		requestedVersion := semver.MustParseRange(plug.Version.String())
-		_, err := SelectCompatiblePlugin(plugs, plug.Kind, plug.Name, requestedVersion)
+	if !enableLegacyPluginBehavior && spec.Version != nil {
+		requestedVersion := semver.MustParseRange(spec.Version.String())
+		_, err := SelectCompatiblePlugin(plugs, spec.Kind, spec.Name, requestedVersion)
 		return err == nil, err
 	}
 
 	for _, p := range plugs {
-		if p.Name == plug.Name &&
-			p.Kind == plug.Kind &&
-			(p.Version != nil && plug.Version != nil && p.Version.GTE(*plug.Version)) {
+		if p.Name == spec.Name &&
+			p.Kind == spec.Kind &&
+			(p.Version != nil && spec.Version != nil && p.Version.GTE(*spec.Version)) {
 			return true, nil
 		}
 	}
@@ -1426,13 +1449,21 @@ func getPluginInfoAndPath(
 			}
 		}
 
+		spec := plugin.Spec()
+		path := filepath.Join(plugin.Path, spec.File())
 		info := &PluginInfo{
-			Name:    plugin.Name,
-			Kind:    plugin.Kind,
-			Version: plugin.Version,
+			Name:    spec.Name,
+			Kind:    spec.Kind,
+			Version: spec.Version,
 			Path:    plugin.Path,
 		}
-		return info, filepath.Join(plugin.Path, info.File()), nil
+		// computing plugin sizes can be very expensive (nested node_modules)
+		if !skipMetadata {
+			if err := info.SetFileMetadata(path); err != nil {
+				return nil, "", err
+			}
+		}
+		return info, path, nil
 	}
 
 	// We currently bundle some plugins with "pulumi" and thus expect them to be next to the pulumi binary. We
@@ -1447,7 +1478,7 @@ func getPluginInfoAndPath(
 	optOut, isFound := os.LookupEnv("PULUMI_IGNORE_AMBIENT_PLUGINS")
 	includeAmbient := !(isFound && cmdutil.IsTruthy(optOut)) || isBundled
 	if includeAmbient {
-		filename = (&PluginInfo{Kind: kind, Name: name, Version: version}).FilePrefix()
+		filename = (&PluginSpec{Kind: kind, Name: name, Version: version}).FilePrefix()
 		if path, err := exec.LookPath(filename); err == nil {
 			logging.V(6).Infof("GetPluginPath(%s, %s, %v): found on $PATH %s", kind, name, version, path)
 			return nil, path, nil
@@ -1534,11 +1565,7 @@ func getPluginInfoAndPath(
 	}
 
 	if match != nil {
-		matchPath, err := match.FilePath()
-		if err != nil {
-			return nil, "", err
-		}
-
+		matchPath := match.FilePath()
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v): found in cache at %s", kind, name, version, matchPath)
 		return match, matchPath, nil
 	}
@@ -1571,6 +1598,28 @@ func (sp SortedPluginInfo) Less(i, j int) bool {
 	}
 }
 func (sp SortedPluginInfo) Swap(i, j int) { sp[i], sp[j] = sp[j], sp[i] }
+
+// SortedPluginSpec is a wrapper around PluginSpec that allows for sorting by version.
+type SortedPluginSpec []PluginSpec
+
+func (sp SortedPluginSpec) Len() int { return len(sp) }
+func (sp SortedPluginSpec) Less(i, j int) bool {
+	iVersion := sp[i].Version
+	jVersion := sp[j].Version
+	switch {
+	case iVersion == nil && jVersion == nil:
+		return false
+	case iVersion == nil:
+		return true
+	case jVersion == nil:
+		return false
+	case iVersion.EQ(*jVersion):
+		return iVersion.String() < jVersion.String()
+	default:
+		return iVersion.LT(*jVersion)
+	}
+}
+func (sp SortedPluginSpec) Swap(i, j int) { sp[i], sp[j] = sp[j], sp[i] }
 
 // SelectCompatiblePlugin selects a plugin from the list of plugins with the given kind and name that sastisfies the
 // requested semver range. It returns the highest version plugin that satisfies the requested constraints, or an error

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -79,14 +79,14 @@ func prepareTestPluginTGZ(t *testing.T, files map[string][]byte) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader(tgz))
 }
 
-func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadCloser, PluginInfo) {
+func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadCloser, PluginSpec) {
 	tarball := prepareTestPluginTGZ(t, files)
 
 	dir, err := ioutil.TempDir("", "plugins-test-dir")
 	require.NoError(t, err)
 
 	v1 := semver.MustParse("0.1.0")
-	plugin := PluginInfo{
+	plugin := PluginSpec{
 		Name:      "test",
 		Kind:      ResourcePlugin,
 		Version:   &v1,
@@ -96,7 +96,7 @@ func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadClose
 	return dir, tarball, plugin
 }
 
-func assertPluginInstalled(t *testing.T, dir string, plugin PluginInfo) {
+func assertPluginInstalled(t *testing.T, dir string, plugin PluginSpec) PluginInfo {
 	info, err := os.Stat(filepath.Join(dir, plugin.Dir()))
 	assert.NoError(t, err)
 	assert.True(t, info.IsDir())
@@ -122,6 +122,7 @@ func assertPluginInstalled(t *testing.T, dir string, plugin PluginInfo) {
 	assert.Equal(t, plugin.Name, plugins[0].Name)
 	assert.Equal(t, plugin.Kind, plugins[0].Kind)
 	assert.Equal(t, *plugin.Version, *plugins[0].Version)
+	return plugins[0]
 }
 
 func testDeletePlugin(t *testing.T, dir string, plugin PluginInfo) {
@@ -129,9 +130,9 @@ func testDeletePlugin(t *testing.T, dir string, plugin PluginInfo) {
 	assert.NoError(t, err)
 
 	paths := []string{
-		filepath.Join(dir, plugin.Dir()),
-		filepath.Join(dir, plugin.Dir()+".partial"),
-		filepath.Join(dir, plugin.Dir()+".lock"),
+		filepath.Join(dir, plugin.Path),
+		filepath.Join(dir, plugin.Path+".partial"),
+		filepath.Join(dir, plugin.Path+".lock"),
 	}
 	for _, path := range paths {
 		_, err := os.Stat(path)
@@ -152,13 +153,13 @@ func testPluginInstall(t *testing.T, expectedDir string, files map[string][]byte
 	err := plugin.Install(tarball, false)
 	assert.NoError(t, err)
 
-	assertPluginInstalled(t, dir, plugin)
+	pluginInfo := assertPluginInstalled(t, dir, plugin)
 
 	info, err := os.Stat(filepath.Join(dir, plugin.Dir(), expectedDir))
 	assert.NoError(t, err)
 	assert.True(t, info.IsDir())
 
-	testDeletePlugin(t, dir, plugin)
+	testDeletePlugin(t, dir, pluginInfo)
 }
 
 func TestInstallNoDeps(t *testing.T) {
@@ -175,13 +176,13 @@ func TestInstallNoDeps(t *testing.T) {
 	err := plugin.Install(tarball, false)
 	require.NoError(t, err)
 
-	assertPluginInstalled(t, dir, plugin)
+	pluginInfo := assertPluginInstalled(t, dir, plugin)
 
 	b, err := ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 	require.NoError(t, err)
 	assert.Equal(t, content, b)
 
-	testDeletePlugin(t, dir, plugin)
+	testDeletePlugin(t, dir, pluginInfo)
 }
 
 func TestReinstall(t *testing.T) {
@@ -198,7 +199,7 @@ func TestReinstall(t *testing.T) {
 	err := plugin.Install(tarball, false)
 	require.NoError(t, err)
 
-	assertPluginInstalled(t, dir, plugin)
+	pluginInfo := assertPluginInstalled(t, dir, plugin)
 
 	b, err := ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 	require.NoError(t, err)
@@ -209,13 +210,13 @@ func TestReinstall(t *testing.T) {
 
 	err = plugin.Install(tarball, true)
 
-	assertPluginInstalled(t, dir, plugin)
+	pluginInfo = assertPluginInstalled(t, dir, plugin)
 
 	b, err = ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 	require.NoError(t, err)
 	assert.Equal(t, content, b)
 
-	testDeletePlugin(t, dir, plugin)
+	testDeletePlugin(t, dir, pluginInfo)
 }
 
 func TestConcurrentInstalls(t *testing.T) {
@@ -229,12 +230,14 @@ func TestConcurrentInstalls(t *testing.T) {
 	dir, tarball, plugin := prepareTestDir(t, map[string][]byte{name: content})
 	defer os.RemoveAll(dir)
 
-	assertSuccess := func() {
-		assertPluginInstalled(t, dir, plugin)
+	assertSuccess := func() PluginInfo {
+		pluginInfo := assertPluginInstalled(t, dir, plugin)
 
 		b, err := ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 		assert.NoError(t, err)
 		assert.Equal(t, content, b)
+
+		return pluginInfo
 	}
 
 	// Run several installs concurrently.
@@ -253,9 +256,9 @@ func TestConcurrentInstalls(t *testing.T) {
 	}
 	wg.Wait()
 
-	assertSuccess()
+	pluginInfo := assertSuccess()
 
-	testDeletePlugin(t, dir, plugin)
+	testDeletePlugin(t, dir, pluginInfo)
 }
 
 func TestInstallCleansOldFiles(t *testing.T) {
@@ -278,7 +281,7 @@ func TestInstallCleansOldFiles(t *testing.T) {
 	err = plugin.Install(tarball, false)
 	assert.NoError(t, err)
 
-	assertPluginInstalled(t, dir, plugin)
+	pluginInfo := assertPluginInstalled(t, dir, plugin)
 
 	// Verify leftover files were removed.
 	for _, path := range []string{tempDir1, tempDir2, tempDir3, partialPath} {
@@ -287,7 +290,7 @@ func TestInstallCleansOldFiles(t *testing.T) {
 		assert.True(t, os.IsNotExist(err))
 	}
 
-	testDeletePlugin(t, dir, plugin)
+	testDeletePlugin(t, dir, pluginInfo)
 }
 
 func TestGetPluginsSkipsPartial(t *testing.T) {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -288,13 +288,13 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Test Downloading From Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
 		version := semver.MustParse("4.30.0")
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.30.0" {
@@ -319,7 +319,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -328,13 +328,13 @@ func TestPluginDownload(t *testing.T) {
 	})
 	t.Run("Test Downloading From get.pulumi.com", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "otherdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
@@ -346,7 +346,7 @@ func TestPluginDownload(t *testing.T) {
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -355,13 +355,13 @@ func TestPluginDownload(t *testing.T) {
 	})
 	t.Run("Test Downloading From Custom Server URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
@@ -370,7 +370,7 @@ func TestPluginDownload(t *testing.T) {
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -382,13 +382,13 @@ func TestPluginDownload(t *testing.T) {
 		t.Setenv("GITHUB_REPOSITORY_OWNER", "private")
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("1.22.0")
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "private",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on pulumi github
@@ -420,7 +420,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -430,13 +430,13 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Test Downloading From Private Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.32.0" {
@@ -463,7 +463,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -473,13 +473,13 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Test Downloading From Internal GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
@@ -511,7 +511,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -526,13 +526,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 
 	t.Run("Test GetLatestVersion From Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
@@ -548,12 +548,12 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, expectedVersion, *version)
 	})
 	t.Run("Test GetLatestVersion From Custom Server URL", func(t *testing.T) {
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mock-latest",
 			Kind:              PluginKind("resource"),
 		}
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		version, err := source.GetLatestVersion(getHTTPResponse)
 		assert.Nil(t, version)
@@ -563,13 +563,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		t.Setenv("PULUMI_EXPERIMENTAL", "true")
 		t.Setenv("GITHUB_REPOSITORY_OWNER", "private")
 		t.Setenv("GITHUB_TOKEN", token)
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "private",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("1.0.2")
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
@@ -594,13 +594,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("Test GetLatestVersion From Private Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "",
 			Name:              "mock-private",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mock-private/releases/latest" {
@@ -620,13 +620,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("Test GetLatestVersion From Internal GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
-		info := PluginInfo{
+		spec := PluginSpec{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mock-private",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
-		source, err := info.GetSource()
+		source, err := spec.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.git.org/repos/ourorg/mock/releases/latest" {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

PluginSpec is used to specifiy a plugin, and is what is passed to things like "Install". PluginInfo is used to refer to an installed plugin, and so has extra data like file sizes, and time stamps, but does not include things like plugin download url.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
