### PR TITLE
Revert "Split PluginInfo in Info and Spec"

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -223,13 +223,15 @@ type pluginAbout struct {
 }
 
 func getPluginsAbout() ([]pluginAbout, error) {
-	pluginSpec, err := getProjectPluginsSilently()
+	var pluginInfo []workspace.PluginInfo
+	var err error
+	pluginInfo, err = getProjectPluginsSilently()
 
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(pluginSpec, func(i, j int) bool {
-		pi, pj := pluginSpec[i], pluginSpec[j]
+	sort.Slice(pluginInfo, func(i, j int) bool {
+		pi, pj := pluginInfo[i], pluginInfo[j]
 		if pi.Name < pj.Name {
 			return true
 		} else if pi.Name == pj.Name && pi.Kind == pj.Kind &&
@@ -239,8 +241,8 @@ func getPluginsAbout() ([]pluginAbout, error) {
 		return false
 	})
 
-	var plugins = make([]pluginAbout, len(pluginSpec))
-	for i, p := range pluginSpec {
+	var plugins = make([]pluginAbout, len(pluginInfo))
+	for i, p := range pluginInfo {
 		plugins[i] = pluginAbout{
 			Name:    p.Name,
 			Version: p.Version,
@@ -548,7 +550,7 @@ func (runtime projectRuntimeAbout) String() string {
 
 // This is necessary because dotnet invokes build during the call to
 // getProjectPlugins.
-func getProjectPluginsSilently() ([]workspace.PluginSpec, error) {
+func getProjectPluginsSilently() ([]workspace.PluginInfo, error) {
 	_, w, err := os.Pipe()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/plugin.go
+++ b/pkg/cmd/pulumi/plugin.go
@@ -51,7 +51,7 @@ func newPluginCmd() *cobra.Command {
 }
 
 // getProjectPlugins fetches a list of plugins used by this project.
-func getProjectPlugins() ([]workspace.PluginSpec, error) {
+func getProjectPlugins() ([]workspace.PluginInfo, error) {
 	proj, root, err := readProject()
 	if err != nil {
 		return nil, err
@@ -67,6 +67,7 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 
 	// Get the required plugins and then ensure they have metadata populated about them.  Because it's possible
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
+	var results []workspace.PluginInfo
 	plugins, err := plugin.GetRequiredPlugins(ctx.Host, plugin.ProgInfo{
 		Proj:    proj,
 		Pwd:     pwd,
@@ -75,38 +76,16 @@ func getProjectPlugins() ([]workspace.PluginSpec, error) {
 	if err != nil {
 		return nil, err
 	}
-	return plugins, nil
-}
-
-func resolvePlugins(plugins []workspace.PluginSpec) ([]workspace.PluginInfo, error) {
-	proj, root, err := readProject()
-	if err != nil {
-		return nil, err
-	}
-
-	projinfo := &engine.Projinfo{Proj: proj, Root: root}
-	_, _, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	defer ctx.Close()
-
-	// Get the required plugins and then ensure they have metadata populated about them.  Because it's possible
-	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
-	var results []workspace.PluginInfo
 	for _, plugin := range plugins {
-		info, err := workspace.GetPluginInfo(plugin.Kind, plugin.Name, plugin.Version, ctx.Host.GetProjectPlugins())
-		if err != nil {
-			err = info.SetFileMetadata(info.Path)
+		if path, _ := workspace.GetPluginPath(plugin.Kind, plugin.Name,
+			plugin.Version, ctx.Host.GetProjectPlugins()); path != "" {
+			err = plugin.SetFileMetadata(path)
 			if err != nil {
 				return nil, err
 			}
 			contract.IgnoreError(err)
 		}
-		if info != nil {
-			results = append(results, *info)
-		}
+		results = append(results, plugin)
 	}
 	return results, nil
 }

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -60,7 +60,7 @@ func newPluginInstallCmd() *cobra.Command {
 			}
 
 			// Parse the kind, name, and version, if specified.
-			var installs []workspace.PluginSpec
+			var installs []workspace.PluginInfo
 			if len(args) > 0 {
 				if !workspace.IsPluginKind(args[0]) {
 					return fmt.Errorf("unrecognized plugin kind: %s", args[0])
@@ -80,7 +80,7 @@ func newPluginInstallCmd() *cobra.Command {
 					return errors.New("missing plugin version argument, this is required if installing from a file")
 				}
 
-				pluginSpec := workspace.PluginSpec{
+				pluginInfo := workspace.PluginInfo{
 					Kind:              workspace.PluginKind(args[0]),
 					Name:              args[1],
 					Version:           version,
@@ -89,14 +89,14 @@ func newPluginInstallCmd() *cobra.Command {
 
 				// If we don't have a version try to look one up
 				if version == nil {
-					latestVersion, err := pluginSpec.GetLatestVersion()
+					latestVersion, err := pluginInfo.GetLatestVersion()
 					if err != nil {
 						return err
 					}
-					pluginSpec.Version = latestVersion
+					pluginInfo.Version = latestVersion
 				}
 
-				installs = append(installs, pluginSpec)
+				installs = append(installs, pluginInfo)
 			} else {
 				if file != "" {
 					return errors.New("--file (-f) is only valid if a specific package is being installed")
@@ -188,7 +188,7 @@ func newPluginInstallCmd() *cobra.Command {
 	return cmd
 }
 
-func getFilePayload(file string, spec workspace.PluginSpec) (workspace.PluginContent, error) {
+func getFilePayload(file string, info workspace.PluginInfo) (workspace.PluginContent, error) {
 	source := file
 	stat, err := os.Stat(file)
 	if err != nil {
@@ -216,7 +216,7 @@ func getFilePayload(file string, spec workspace.PluginSpec) (workspace.PluginCon
 		if (stat.Mode() & 0100) == 0 {
 			return nil, fmt.Errorf("%s is not executable", source)
 		}
-		return workspace.SingleFilePlugin(f, spec), nil
+		return workspace.SingleFilePlugin(f, info), nil
 	}
 	return workspace.TarPlugin(f), nil
 }

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -38,12 +38,7 @@ func newPluginLsCmd() *cobra.Command {
 			var plugins []workspace.PluginInfo
 			var err error
 			if projectOnly {
-				var pluginSpecs []workspace.PluginSpec
-				if pluginSpecs, err = getProjectPlugins(); err != nil {
-					return fmt.Errorf("loading project plugins: %w", err)
-				}
-				plugins, err = resolvePlugins(pluginSpecs)
-				if err != nil {
+				if plugins, err = getProjectPlugins(); err != nil {
 					return fmt.Errorf("loading project plugins: %w", err)
 				}
 			} else {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -97,7 +97,7 @@ func (l *pluginLoader) ensurePlugin(pkg string, version *semver.Version) error {
 		return nil
 	}
 
-	pkgPlugin := workspace.PluginSpec{
+	pkgPlugin := workspace.PluginInfo{
 		Kind:    workspace.ResourcePlugin,
 		Name:    pkg,
 		Version: version,

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -1358,7 +1358,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		plugins  []workspace.PluginSpec
+		plugins  []workspace.PluginInfo
 		snapshot *deploy.Snapshot
 		validate func(t *testing.T, r *resource.State)
 		versions []string
@@ -1373,7 +1373,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 		{
 			name:     "default-version",
 			versions: []string{"1.0.0", "1.1.0"},
-			plugins: []workspace.PluginSpec{{
+			plugins: []workspace.PluginInfo{{
 				Name:              "pkgA",
 				Version:           &semver.Version{Major: 1, Minor: 1},
 				PluginDownloadURL: "example.com/default",
@@ -1390,7 +1390,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 		{
 			name:     "specified-provider",
 			versions: []string{"1.0.0", "1.1.0"},
-			plugins: []workspace.PluginSpec{{
+			plugins: []workspace.PluginInfo{{
 				Name:    "pkgA",
 				Version: &semver.Version{Major: 1, Minor: 1},
 				Kind:    workspace.ResourcePlugin,
@@ -1408,7 +1408,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 			name:     "higher-in-snapshot",
 			versions: []string{"1.3.0", "1.1.0"},
 			prog:     prog(),
-			plugins: []workspace.PluginSpec{{
+			plugins: []workspace.PluginInfo{{
 				Name:    "pkgA",
 				Version: &semver.Version{Major: 1, Minor: 1},
 				Kind:    workspace.ResourcePlugin,

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -4823,7 +4823,7 @@ func TestPluginsAreDownloaded(t *testing.T) {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{})
 		assert.NoError(t, err)
 		return nil
-	}, workspace.PluginSpec{Name: "pkgA"}, workspace.PluginSpec{Name: "pkgB", Version: &semver10})
+	}, workspace.PluginInfo{Name: "pkgA"}, workspace.PluginInfo{Name: "pkgB", Version: &semver10})
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -40,10 +40,10 @@ const (
 )
 
 // pluginSet represents a set of plugins.
-type pluginSet map[string]workspace.PluginSpec
+type pluginSet map[string]workspace.PluginInfo
 
 // Add adds a plugin to this plugin set.
-func (p pluginSet) Add(plug workspace.PluginSpec) {
+func (p pluginSet) Add(plug workspace.PluginInfo) {
 	p[plug.String()] = plug
 }
 
@@ -64,9 +64,9 @@ func (p pluginSet) Union(other pluginSet) pluginSet {
 // For example, the plugin aws would be removed if there was an already existing plugin
 // aws-5.4.0.
 func (p pluginSet) Deduplicate() pluginSet {
-	existing := map[string]workspace.PluginSpec{}
+	existing := map[string]workspace.PluginInfo{}
 	newSet := newPluginSet()
-	add := func(p workspace.PluginSpec) {
+	add := func(p workspace.PluginInfo) {
 		prev, ok := existing[p.Name]
 		if ok {
 			// If either `pluginDownloadURL`, `Version` or both are set we consider the
@@ -97,8 +97,8 @@ func (p pluginSet) Deduplicate() pluginSet {
 }
 
 // Values returns a slice of all of the plugins contained within this set.
-func (p pluginSet) Values() []workspace.PluginSpec {
-	var plugins []workspace.PluginSpec
+func (p pluginSet) Values() []workspace.PluginInfo {
+	var plugins []workspace.PluginInfo
 	for _, value := range p {
 		plugins = append(plugins, value)
 	}
@@ -106,8 +106,8 @@ func (p pluginSet) Values() []workspace.PluginSpec {
 }
 
 // newPluginSet creates a new empty pluginSet.
-func newPluginSet(plugins ...workspace.PluginSpec) pluginSet {
-	var s pluginSet = make(map[string]workspace.PluginSpec, len(plugins))
+func newPluginSet(plugins ...workspace.PluginInfo) pluginSet {
+	var s pluginSet = make(map[string]workspace.PluginInfo, len(plugins))
 	for _, p := range plugins {
 		s.Add(p)
 	}
@@ -164,7 +164,7 @@ func gatherPluginsFromSnapshot(plugctx *plugin.Context, target *deploy.Target) (
 		}
 		logging.V(preparePluginLog).Infof(
 			"gatherPluginsFromSnapshot(): plugin %s %s is required by first-class provider %q", pkg, version, urn)
-		set.Add(workspace.PluginSpec{
+		set.Add(workspace.PluginInfo{
 			Name:              pkg.String(),
 			Kind:              workspace.ResourcePlugin,
 			Version:           version,
@@ -209,7 +209,7 @@ func ensurePluginsAreLoaded(plugctx *plugin.Context, plugins pluginSet, kinds pl
 }
 
 // installPlugin installs a plugin from the given backend client.
-func installPlugin(ctx context.Context, plugin workspace.PluginSpec) error {
+func installPlugin(ctx context.Context, plugin workspace.PluginInfo) error {
 	logging.V(preparePluginLog).Infof("installPlugin(%s, %s): beginning install", plugin.Name, plugin.Version)
 	if plugin.Kind == workspace.LanguagePlugin {
 		logging.V(preparePluginLog).Infof(
@@ -276,7 +276,7 @@ func installPlugin(ctx context.Context, plugin workspace.PluginSpec) error {
 // that the engine uses to determine which version of a particular provider to load.
 //
 // it is critical that this function be 100% deterministic.
-func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[tokens.Package]workspace.PluginSpec {
+func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[tokens.Package]workspace.PluginInfo {
 	// Language hosts are not required to specify the full set of plugins they depend on. If the set of plugins received
 	// from the language host does not include any resource providers, fall back to the full set of plugins.
 	languageReportedProviderPlugins := false
@@ -293,7 +293,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 		sourceSet = allPlugins
 	}
 
-	defaultProviderPlugins := make(map[tokens.Package]workspace.PluginSpec)
+	defaultProviderPlugins := make(map[tokens.Package]workspace.PluginInfo)
 
 	// Sort the set of source plugins by version, so that we iterate over the set of plugins in a deterministic order.
 	// Sorting by version gets us two properties:
@@ -305,7 +305,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 	// Despite these properties, the below loop explicitly handles those cases to preserve correct behavior even if the
 	// sort is not functioning properly.
 	sourcePlugins := sourceSet.Values()
-	sort.Sort(workspace.SortedPluginSpec(sourcePlugins))
+	sort.Sort(workspace.SortedPluginInfo(sourcePlugins))
 	for _, p := range sourcePlugins {
 		logging.V(preparePluginLog).Infof("computeDefaultProviderPlugins(): considering %s", p)
 		if p.Kind != workspace.ResourcePlugin {
@@ -333,9 +333,9 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 				continue
 			}
 
-			contract.Failf("Should not have seen an older plugin if sorting is correct!\n  %s-%s\n  %s-%s",
-				p.Name, p.Version.String(),
-				seenPlugin.Name, seenPlugin.Version.String())
+			contract.Failf("Should not have seen an older plugin if sorting is correct!\n  %s-%s %s\n  %s-%s - %s",
+				p.Name, p.Version.String(), p.Path,
+				seenPlugin.Name, seenPlugin.Version.String(), seenPlugin.Path)
 		}
 
 		logging.V(preparePluginLog).Infof(
@@ -350,7 +350,7 @@ func computeDefaultProviderPlugins(languagePlugins, allPlugins pluginSet) map[to
 		}
 	}
 
-	defaultProviderInfo := make(map[tokens.Package]workspace.PluginSpec)
+	defaultProviderInfo := make(map[tokens.Package]workspace.PluginInfo)
 	for name, plugin := range defaultProviderPlugins {
 		defaultProviderInfo[name] = plugin
 	}

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -34,12 +34,12 @@ func TestDefaultProvidersSingle(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name:              "kubernetes",
 		Version:           mustMakeVersion("0.22.0"),
 		Kind:              workspace.ResourcePlugin,
@@ -68,12 +68,12 @@ func TestDefaultProvidersOverrideNoVersion(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name:    "aws",
 		Version: nil,
 		Kind:    workspace.ResourcePlugin,
@@ -92,17 +92,17 @@ func TestDefaultProvidersOverrideNewerVersion(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.0"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.1"),
 		Kind:    workspace.ResourcePlugin,
 	})
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.2-dev.1553126336"),
 		Kind:    workspace.ResourcePlugin,
@@ -121,12 +121,12 @@ func TestDefaultProvidersSnapshotOverrides(t *testing.T) {
 	t.Parallel()
 
 	languagePlugins := newPluginSet()
-	languagePlugins.Add(workspace.PluginSpec{
+	languagePlugins.Add(workspace.PluginInfo{
 		Name: "python",
 		Kind: workspace.LanguagePlugin,
 	})
 	snapshotPlugins := newPluginSet()
-	snapshotPlugins.Add(workspace.PluginSpec{
+	snapshotPlugins.Add(workspace.PluginInfo{
 		Name:    "aws",
 		Version: mustMakeVersion("0.17.0"),
 		Kind:    workspace.ResourcePlugin,
@@ -147,41 +147,41 @@ func TestPluginSetDeduplicate(t *testing.T) {
 		input    pluginSet
 		expected pluginSet
 	}{{
-		input: newPluginSet(workspace.PluginSpec{
+		input: newPluginSet(workspace.PluginInfo{
 			Name:    "foo",
 			Version: &semver.Version{Major: 1},
-		}, workspace.PluginSpec{
+		}, workspace.PluginInfo{
 			Name: "foo",
 		}),
-		expected: newPluginSet(workspace.PluginSpec{
+		expected: newPluginSet(workspace.PluginInfo{
 			Name:    "foo",
 			Version: &semver.Version{Major: 1},
 		}),
 	}, {
-		input: newPluginSet(workspace.PluginSpec{
+		input: newPluginSet(workspace.PluginInfo{
 			Name:    "bar",
 			Version: &semver.Version{Minor: 3},
-		}, workspace.PluginSpec{
+		}, workspace.PluginInfo{
 			Name:              "bar",
 			PluginDownloadURL: "example.com/bar",
-		}, workspace.PluginSpec{
+		}, workspace.PluginInfo{
 			Name:              "bar",
 			Version:           &semver.Version{Patch: 3},
 			PluginDownloadURL: "example.com",
-		}, workspace.PluginSpec{
+		}, workspace.PluginInfo{
 			Name: "foo",
 		}),
-		expected: newPluginSet(workspace.PluginSpec{
+		expected: newPluginSet(workspace.PluginInfo{
 			Name:    "bar",
 			Version: &semver.Version{Minor: 3},
-		}, workspace.PluginSpec{
+		}, workspace.PluginInfo{
 			Name:              "bar",
 			PluginDownloadURL: "example.com/bar",
-		}, workspace.PluginSpec{
+		}, workspace.PluginInfo{
 			Name:              "bar",
 			Version:           &semver.Version{Patch: 3},
 			PluginDownloadURL: "example.com",
-		}, workspace.PluginSpec{
+		}, workspace.PluginInfo{
 			Name: "foo",
 		}),
 	}}
@@ -198,20 +198,20 @@ func TestPluginSetDeduplicate(t *testing.T) {
 func TestDefaultProviderPluginsSorting(t *testing.T) {
 	t.Parallel()
 	v1 := semver.MustParse("0.0.1-alpha.10")
-	p1 := workspace.PluginSpec{
+	p1 := workspace.PluginInfo{
 		Name:    "foo",
 		Version: &v1,
 		Kind:    workspace.ResourcePlugin,
 	}
 	v2 := semver.MustParse("0.0.1-alpha.10+dirty")
-	p2 := workspace.PluginSpec{
+	p2 := workspace.PluginInfo{
 		Name:    "foo",
 		Version: &v2,
 		Kind:    workspace.ResourcePlugin,
 	}
 	plugins := newPluginSet(p1, p2)
 	result := computeDefaultProviderPlugins(plugins, plugins)
-	assert.Equal(t, map[tokens.Package]workspace.PluginSpec{
+	assert.Equal(t, map[tokens.Package]workspace.PluginInfo{
 		"foo": p2,
 	}, result)
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -208,7 +208,7 @@ func RunInstallPlugins(
 
 func installPlugins(
 	proj *workspace.Project, pwd, main string, target *deploy.Target,
-	plugctx *plugin.Context, returnInstallErrors bool) (pluginSet, map[tokens.Package]workspace.PluginSpec, error) {
+	plugctx *plugin.Context, returnInstallErrors bool) (pluginSet, map[tokens.Package]workspace.PluginInfo, error) {
 
 	// Before launching the source, ensure that we have all of the plugins that we need in order to proceed.
 	//

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -197,9 +197,9 @@ func addDefaultProviders(target *Target, source Source, prev *Snapshot) error {
 	}
 
 	// Pull the versions we'll use for default providers from the snapshot's manifest.
-	defaultProviderInfo := make(map[tokens.Package]workspace.PluginSpec)
+	defaultProviderInfo := make(map[tokens.Package]workspace.PluginInfo)
 	for _, p := range prev.Manifest.Plugins {
-		defaultProviderInfo[tokens.Package(p.Name)] = p.Spec()
+		defaultProviderInfo[tokens.Package(p.Name)] = p
 	}
 
 	// Determine the necessary set of default providers and inject references to default providers as appropriate.

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -24,7 +24,7 @@ import (
 
 type ProgramFunc func(runInfo plugin.RunInfo, monitor *ResourceMonitor) error
 
-func NewLanguageRuntime(program ProgramFunc, requiredPlugins ...workspace.PluginSpec) plugin.LanguageRuntime {
+func NewLanguageRuntime(program ProgramFunc, requiredPlugins ...workspace.PluginInfo) plugin.LanguageRuntime {
 	return &languageRuntime{
 		requiredPlugins: requiredPlugins,
 		program:         program,
@@ -32,7 +32,7 @@ func NewLanguageRuntime(program ProgramFunc, requiredPlugins ...workspace.Plugin
 }
 
 type languageRuntime struct {
-	requiredPlugins []workspace.PluginSpec
+	requiredPlugins []workspace.PluginInfo
 	program         ProgramFunc
 }
 
@@ -40,7 +40,7 @@ func (p *languageRuntime) Close() error {
 	return nil
 }
 
-func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginSpec, error) {
+func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginInfo, error) {
 	return p.requiredPlugins, nil
 }
 

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -393,7 +393,7 @@ func (host *pluginHost) CloseProvider(provider plugin.Provider) error {
 	delete(host.plugins, provider)
 	return nil
 }
-func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
+func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
 	return nil
 }
 func (host *pluginHost) ResolvePlugin(
@@ -416,7 +416,7 @@ func (host *pluginHost) ResolvePlugin(
 	return nil, nil
 }
 func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
-	kinds plugin.Flags) ([]workspace.PluginSpec, error) {
+	kinds plugin.Flags) ([]workspace.PluginInfo, error) {
 	return host.languageRuntime.GetRequiredPlugins(info)
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -71,7 +71,7 @@ func (host *testPluginHost) CloseProvider(provider plugin.Provider) error {
 func (host *testPluginHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
 	return nil, errors.New("unsupported")
 }
-func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {
+func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
 	return nil
 }
 func (host *testPluginHost) ResolvePlugin(

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -58,7 +58,7 @@ type EvalRunInfo struct {
 // a confgiuration map.  This evaluation is performed using the given plugin context and may optionally use the
 // given plugin host (or the default, if this is nil).  Note that closing the eval source also closes the host.
 func NewEvalSource(plugctx *plugin.Context, runinfo *EvalRunInfo,
-	defaultProviderInfo map[tokens.Package]workspace.PluginSpec, dryRun bool) Source {
+	defaultProviderInfo map[tokens.Package]workspace.PluginInfo, dryRun bool) Source {
 
 	return &evalSource{
 		plugctx:             plugctx,
@@ -71,7 +71,7 @@ func NewEvalSource(plugctx *plugin.Context, runinfo *EvalRunInfo,
 type evalSource struct {
 	plugctx             *plugin.Context                         // the plugin context.
 	runinfo             *EvalRunInfo                            // the directives to use when running the program.
-	defaultProviderInfo map[tokens.Package]workspace.PluginSpec // the default provider versions for this source.
+	defaultProviderInfo map[tokens.Package]workspace.PluginInfo // the default provider versions for this source.
 	dryRun              bool                                    // true if this is a dry-run operation only.
 }
 
@@ -246,7 +246,7 @@ func (iter *evalSourceIterator) forkRun(opts Options, config map[config.Key]stri
 type defaultProviders struct {
 	// A map of package identifiers to versions, used to disambiguate which plugin to load if no version is provided
 	// by the language host.
-	defaultProviderInfo map[tokens.Package]workspace.PluginSpec
+	defaultProviderInfo map[tokens.Package]workspace.PluginInfo
 
 	// A map of ProviderRequest strings to provider references, used to keep track of the set of default providers that
 	// have already been loaded.

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -45,7 +45,7 @@ type QuerySource interface {
 // NewQuerySource creates a `QuerySource` for some target runtime environment specified by
 // `runinfo`, and supported by language plugins provided in `plugctx`.
 func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client BackendClient,
-	runinfo *EvalRunInfo, defaultProviderVersions map[tokens.Package]workspace.PluginSpec,
+	runinfo *EvalRunInfo, defaultProviderVersions map[tokens.Package]workspace.PluginInfo,
 	provs ProviderSource) (QuerySource, error) {
 
 	// Create a new builtin provider. This provider implements features such as `getStack`.
@@ -195,7 +195,7 @@ func runLangPlugin(src *querySource) result.Result {
 // newQueryResourceMonitor creates a new resource monitor RPC server intended to be used in Pulumi's
 // "query mode".
 func newQueryResourceMonitor(
-	builtins *builtinProvider, defaultProviderInfo map[tokens.Package]workspace.PluginSpec,
+	builtins *builtinProvider, defaultProviderInfo map[tokens.Package]workspace.PluginInfo,
 	provs ProviderSource, reg *providers.Registry, plugctx *plugin.Context,
 	providerRegErrChan chan<- result.Result, tracingSpan opentracing.Span, runinfo *EvalRunInfo) (*queryResmon, error) {
 

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -73,7 +73,7 @@ type Host interface {
 
 	// EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
 	// and/or there are errors loading one or more plugins, a non-nil error is returned.
-	EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) error
+	EnsurePlugins(plugins []workspace.PluginInfo, kinds Flags) error
 	// ResolvePlugin resolves a plugin kind, name, and optional semver to a candidate plugin to load.
 	ResolvePlugin(kind workspace.PluginKind, name string, version *semver.Version) (*workspace.PluginInfo, error)
 
@@ -398,7 +398,7 @@ func (host *defaultHost) LanguageRuntime(runtime string) (LanguageRuntime, error
 
 // EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
 // and/or there are errors loading one or more plugins, a non-nil error is returned.
-func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds Flags) error {
+func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds Flags) error {
 	// Use a multieerror to track failures so we can return one big list of all failures at the end.
 	var result error
 	for _, plugin := range plugins {
@@ -518,8 +518,8 @@ const (
 var AllPlugins = AnalyzerPlugins | LanguagePlugins | ResourcePlugins
 
 // GetRequiredPlugins lists a full set of plugins that will be required by the given program.
-func GetRequiredPlugins(host Host, info ProgInfo, kinds Flags) ([]workspace.PluginSpec, error) {
-	var plugins []workspace.PluginSpec
+func GetRequiredPlugins(host Host, info ProgInfo, kinds Flags) ([]workspace.PluginInfo, error) {
+	var plugins []workspace.PluginInfo
 
 	if kinds&LanguagePlugins != 0 {
 		// First make sure the language plugin is present.  We need this to load the required resource plugins.
@@ -528,7 +528,7 @@ func GetRequiredPlugins(host Host, info ProgInfo, kinds Flags) ([]workspace.Plug
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load language plugin %s", info.Proj.Runtime.Name())
 		}
-		plugins = append(plugins, workspace.PluginSpec{
+		plugins = append(plugins, workspace.PluginInfo{
 			Name: info.Proj.Runtime.Name(),
 			Kind: workspace.LanguagePlugin,
 		})

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -28,7 +28,7 @@ type LanguageRuntime interface {
 	// Closer closes any underlying OS resources associated with this plugin (like processes, RPC channels, etc).
 	io.Closer
 	// GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
-	GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, error)
+	GetRequiredPlugins(info ProgInfo) ([]workspace.PluginInfo, error)
 	// Run executes a program in the language runtime for planning or deployment purposes.  If
 	// info.DryRun is true, the code must not assume that side-effects or final values resulting
 	// from resource deployments are actually available.  If it is false, on the other hand, a real

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -106,7 +106,7 @@ func NewLanguageRuntimeClient(ctx *Context, runtime string, client pulumirpc.Lan
 func (h *langhost) Runtime() string { return h.runtime }
 
 // GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
-func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, error) {
+func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginInfo, error) {
 	proj := string(info.Proj.Name)
 	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(proj=%s,pwd=%s,program=%s) executing",
 		h.runtime, proj, info.Pwd, info.Program)
@@ -129,7 +129,7 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, er
 		return nil, rpcError
 	}
 
-	var results []workspace.PluginSpec
+	var results []workspace.PluginInfo
 	for _, info := range resp.GetPlugins() {
 		var version *semver.Version
 		if v := info.GetVersion(); v != "" {
@@ -142,7 +142,7 @@ func (h *langhost) GetRequiredPlugins(info ProgInfo) ([]workspace.PluginSpec, er
 		if !workspace.IsPluginKind(info.GetKind()) {
 			return nil, errors.Errorf("unrecognized plugin kind: %s", info.GetKind())
 		}
-		results = append(results, workspace.PluginSpec{
+		results = append(results, workspace.PluginInfo{
 			Name:              info.GetName(),
 			Kind:              workspace.PluginKind(info.GetKind()),
 			Version:           version,

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -288,13 +288,13 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Test Downloading From Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
 		version := semver.MustParse("4.30.0")
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.30.0" {
@@ -319,7 +319,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -328,13 +328,13 @@ func TestPluginDownload(t *testing.T) {
 	})
 	t.Run("Test Downloading From get.pulumi.com", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "otherdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
@@ -346,7 +346,7 @@ func TestPluginDownload(t *testing.T) {
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -355,13 +355,13 @@ func TestPluginDownload(t *testing.T) {
 	})
 	t.Run("Test Downloading From Custom Server URL", func(t *testing.T) {
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
@@ -370,7 +370,7 @@ func TestPluginDownload(t *testing.T) {
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -382,13 +382,13 @@ func TestPluginDownload(t *testing.T) {
 		t.Setenv("GITHUB_REPOSITORY_OWNER", "private")
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("1.22.0")
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "private",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on pulumi github
@@ -420,7 +420,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -430,13 +430,13 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Test Downloading From Private Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/tags/v4.32.0" {
@@ -463,7 +463,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -473,13 +473,13 @@ func TestPluginDownload(t *testing.T) {
 	t.Run("Test Downloading From Internal GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
 		version := semver.MustParse("4.32.0")
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mockdl",
 			Version:           &version,
 			Kind:              PluginKind("resource"),
 		}
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
@@ -511,7 +511,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.Equal(t, "application/octet-stream", req.Header.Get("Accept"))
 			return newMockReadCloser(expectedBytes)
 		}
-		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
+		r, l, err := source.Download(*info.Version, "darwin", "amd64", getHTTPResponse)
 		assert.Nil(t, err)
 		readBytes, err := ioutil.ReadAll(r)
 		assert.Nil(t, err)
@@ -526,13 +526,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 
 	t.Run("Test GetLatestVersion From Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "mock-latest",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t,
@@ -548,12 +548,12 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		assert.Equal(t, expectedVersion, *version)
 	})
 	t.Run("Test GetLatestVersion From Custom Server URL", func(t *testing.T) {
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
 			Name:              "mock-latest",
 			Kind:              PluginKind("resource"),
 		}
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		version, err := source.GetLatestVersion(getHTTPResponse)
 		assert.Nil(t, version)
@@ -563,13 +563,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 		t.Setenv("PULUMI_EXPERIMENTAL", "true")
 		t.Setenv("GITHUB_REPOSITORY_OWNER", "private")
 		t.Setenv("GITHUB_TOKEN", token)
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "private",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("1.0.2")
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			// Test that the asset isn't on github
@@ -594,13 +594,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("Test GetLatestVersion From Private Pulumi GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "",
 			Name:              "mock-private",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.github.com/repos/pulumi/pulumi-mock-private/releases/latest" {
@@ -620,13 +620,13 @@ func TestPluginGetLatestVersion(t *testing.T) {
 	})
 	t.Run("Test GetLatestVersion From Internal GitHub Releases", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", token)
-		spec := PluginSpec{
+		info := PluginInfo{
 			PluginDownloadURL: "github://api.git.org/ourorg/mock",
 			Name:              "mock-private",
 			Kind:              PluginKind("resource"),
 		}
 		expectedVersion := semver.MustParse("4.37.5")
-		source, err := spec.GetSource()
+		source, err := info.GetSource()
 		assert.NoError(t, err)
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.String() == "https://api.git.org/repos/ourorg/mock/releases/latest" {


### PR DESCRIPTION
Reverts pulumi/pulumi#10492

This change seems to be causing TestInstallCleansOldFiles test failure on Windows, which is only qualifying master builds. Reverting temporarily.