### PR TITLE
[sdk/nodejs] Use loopback addresses for providers & automation API

### DIFF
--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -211,7 +211,7 @@ Event: ${line}\n${e.toString()}`);
             const languageServer = new LanguageServer(program);
             server.addService(langrpc.LanguageRuntimeService, languageServer);
             const port: number = await new Promise<number>((resolve, reject) => {
-                server.bindAsync(`0.0.0.0:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
+                server.bindAsync(`127.0.0.1:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
                     if (err) {
                         reject(err);
                     } else {
@@ -334,7 +334,7 @@ Event: ${line}\n${e.toString()}`);
             const languageServer = new LanguageServer(program);
             server.addService(langrpc.LanguageRuntimeService, languageServer);
             const port: number = await new Promise<number>((resolve, reject) => {
-                server.bindAsync(`0.0.0.0:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
+                server.bindAsync(`127.0.0.1:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
                     if (err) {
                         reject(err);
                     } else {

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -385,7 +385,7 @@ export async function main(args: string[]) {
         construct: constructRPC,
     });
     const port: number = await new Promise<number>((resolve, reject) => {
-        server.bindAsync(`0.0.0.0:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
+        server.bindAsync(`127.0.0.1:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
             if (err) {
                 reject(err);
             } else {

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -641,7 +641,7 @@ export async function main(provider: Provider, args: string[]) {
     const engineAddr = parsedArgs?.engineAddress;
     server.addService(provrpc.ResourceProviderService, new Server(engineAddr, provider, uncaughtErrors));
     const port: number = await new Promise<number>((resolve, reject) => {
-        server.bindAsync(`0.0.0.0:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
+        server.bindAsync(`127.0.0.1:0`, grpc.ServerCredentials.createInsecure(), (err, p) => {
             if (err) {
                 reject(err);
             } else {

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1570,7 +1570,7 @@ async function createMockEngineAsync(
     server.addService(enginerpc.EngineService, engineImpl);
 
     const port = await new Promise<number>((resolve, reject) => {
-        server.bindAsync("0.0.0.0:0", grpc.ServerCredentials.createInsecure(), (err, p) => {
+        server.bindAsync("127.0.0.1:0", grpc.ServerCredentials.createInsecure(), (err, p) => {
             if (err) {
                 reject(err);
             } else {
@@ -1583,7 +1583,7 @@ async function createMockEngineAsync(
 
     cleanup(async () => server.forceShutdown());
 
-    return { server: server, addr: `0.0.0.0:${port}` };
+    return { server: server, addr: `127.0.0.1:${port}` };
 }
 
 function serveLanguageHostProcess(engineAddr: string): { proc: childProcess.ChildProcess; addr: Promise<string> } {
@@ -1608,7 +1608,7 @@ function serveLanguageHostProcess(engineAddr: string): { proc: childProcess.Chil
         const dataString: string = stripEOL(data);
         if (addrResolve) {
             // The first line is the address; strip off the newline and resolve the promise.
-            addrResolve(`0.0.0.0:${dataString}`);
+            addrResolve(`127.0.0.1:${dataString}`);
             addrResolve = undefined;
         } else {
             console.log(`langhost.stdout: ${dataString}`);


### PR DESCRIPTION
Improves security and should avoid tripping Windows & macOS firewall to allow `pulumi-resource-*` to accept network connections.