### PR TITLE
test: fix regex used to test Go version output in about command.

### DIFF
--- a/tests/about_test.go
+++ b/tests/about_test.go
@@ -42,7 +42,7 @@ func TestAboutCommands(t *testing.T) {
 		stdout, _ := e.RunCommand("pulumi", "about", "--json")
 		var res interface{}
 		assert.NoError(t, json.Unmarshal([]byte(stdout), &res), "Should be valid json")
-		assert.Regexp(t, `"goVersion": "go(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"`, stdout)
+		assert.Regexp(t, `"goVersion": "go1\..*"`, stdout)
 		assert.Contains(t, stdout, runtime.Compiler)
 		assert.Contains(t, stdout, "Failed to get information about the current stack:")
 	})

--- a/tests/about_test.go
+++ b/tests/about_test.go
@@ -42,7 +42,7 @@ func TestAboutCommands(t *testing.T) {
 		stdout, _ := e.RunCommand("pulumi", "about", "--json")
 		var res interface{}
 		assert.NoError(t, json.Unmarshal([]byte(stdout), &res), "Should be valid json")
-		assert.Regexp(t, `"goVersion": "go\d+.\d+"`, stdout)
+		assert.Regexp(t, `"goVersion": "go(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"`, stdout)
 		assert.Contains(t, stdout, runtime.Compiler)
 		assert.Contains(t, stdout, "Failed to get information about the current stack:")
 	})


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The issue that https://github.com/pulumi/pulumi/pull/10378 was addressing was not fixed by that change. The regex still does not match the expected output, causing the `TestAboutCommands/json` test to fail. This PR updates that regex, so that it's correctly checking that the Go version output is a valid core semver.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
