### PR TITLE
[sdk/dotnet] Use loopback addresses for automation API

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -63,3 +63,9 @@
 
 - [cli] Improve Windows reliability with dependency update to ssh-agent
   [#10486](https://github.com/pulumi/pulumi/pull/10486)
+
+- [sdk/{dotnet,nodejs,python}] Dynamic providers and automation API will not trigger a firewall
+  permission prompt, will only accept network requests via loopback address.
+  [#10498](https://github.com/pulumi/pulumi/pull/10498)
+  [#10502](https://github.com/pulumi/pulumi/pull/10502)
+  [#10503](https://github.com/pulumi/pulumi/pull/10503)

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -643,7 +643,7 @@ namespace Pulumi.Automation
                         webBuilder
                             .ConfigureKestrel(kestrelOptions =>
                             {
-                                kestrelOptions.Listen(IPAddress.Any, 0, listenOptions =>
+                                kestrelOptions.Listen(IPAddress.Loopback, 0, listenOptions =>
                                 {
                                     listenOptions.Protocols = HttpProtocols.Http2;
                                 });


### PR DESCRIPTION
Like #10498, for dotnet. Dotnet uses the same class to provide a language host for Automation API inline & local programs, and lacks a dynamic provider, hence fewer lines changed.