### PR TITLE
[cli] fix `pulumi console` command

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -78,3 +78,6 @@
   [#10498](https://github.com/pulumi/pulumi/pull/10498)
   [#10502](https://github.com/pulumi/pulumi/pull/10502)
   [#10503](https://github.com/pulumi/pulumi/pull/10503)
+
+- [cli] Fix `pulumi console` command to follow documented behavior in help message/docs.
+  [#10509](https://github.com/pulumi/pulumi/pull/10509)

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -73,13 +73,13 @@ func newConsoleCmd() *cobra.Command {
 				// Open the stack specific URL (e.g. app.pulumi.com/{org}/{project}/{stack}) for this
 				// stack if a stack is selected and is a cloud stack, else open the cloud backend URL
 				// home page, e.g. app.pulumi.com.
-				if consoleURL, err := cloudBackend.StackConsoleURL(stack.Ref()); err != nil {
-					launchConsole(consoleURL)
-				} else {
+				url, err := cloudBackend.StackConsoleURL(stack.Ref())
+				if err != nil {
 					// Open the cloud backend home page if retrieving the stack
 					// console URL fails.
-					launchConsole(cloudBackend.URL())
+					url = cloudBackend.URL()
 				}
+				launchConsole(url)
 				return nil
 			}
 			fmt.Println("This command is not available for your backend. " +


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
This PR fixes the `pulumi console` command to redirect the user to the stack's page in the pulumi service UI as documented.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10508 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
