### PR TITLE
[dotnet/tests] Update unit test adapter for mypkg schema

### DIFF
--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/schema.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/schema.json
@@ -215,7 +215,7 @@
         "Microsoft.NET.Test.Sdk": "16.5.0",
         "Moq": "4.13.1",
         "NUnit": "3.12.0",
-        "NUnit3TestAdapter": "3.16.1"
+        "NUnit3TestAdapter": "4.2.1"
       }
     },
     "go": {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs/schema.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs/schema.json
@@ -662,7 +662,7 @@
         "Microsoft.NET.Test.Sdk": "16.5.0",
         "Moq": "4.13.1",
         "NUnit": "3.12.0",
-        "NUnit3TestAdapter": "3.16.1"
+        "NUnit3TestAdapter": "4.2.1"
       }
     }
   }


### PR DESCRIPTION
Update NUnit3TestAdapter used in tests to be able to test with latest SDK (M1) cc @RobbieMcKinstry to confirm the fix

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
