### PR TITLE
Add tracing to `npm install` and fix orphan tracing

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -344,12 +344,12 @@ options:
 		span := opentracing.SpanFromContext(ctx)
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		pwd, _, pluginCtx, err := engine.ProjectInfoContext(
-			projinfo, 
-			nil, 
-			cmdutil.Diag(), 
-			cmdutil.Diag(), 
-			false, 
-			span
+			projinfo,
+			nil,
+			cmdutil.Diag(),
+			cmdutil.Diag(),
+			false,
+			span,
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -344,7 +344,13 @@ options:
 		span := opentracing.SpanFromContext(ctx)
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		pwd, _, pluginCtx, err := engine.ProjectInfoContext(
-			projinfo, nil, cmdutil.Diag(), cmdutil.Diag(), false, span)
+			projinfo, 
+			nil, 
+			cmdutil.Diag(), 
+			cmdutil.Diag(), 
+			false, 
+			span
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -33,7 +33,9 @@ type clientLanguageRuntimeHost struct {
 func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host, error) {
 	// Dial the language runtime.
 	conn, err := grpc.Dial(address, grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()), rpcutil.GrpcChannelOptions())
+		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()),
+		grpc.WithStreamInterceptor(rpcutil.OpenTracingStreamClientInterceptor()),
+		rpcutil.GrpcChannelOptions())
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to language host: %w", err)
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -169,6 +169,7 @@ func wrapProviderWithGrpc(provider plugin.Provider) (plugin.Provider, io.Closer,
 		fmt.Sprintf("127.0.0.1:%v", port),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()),
+		grpc.WithStreamInterceptor(rpcutil.OpenTracingStreamClientInterceptor()),
 		rpcutil.GrpcChannelOptions(),
 	)
 	if err != nil {

--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -44,6 +44,7 @@ func NewHostClient(addr string) (*HostClient, error) {
 		addr,
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()),
+		grpc.WithStreamInterceptor(rpcutil.OpenTracingStreamClientInterceptor()),
 		rpcutil.GrpcChannelOptions(),
 	)
 	if err != nil {

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -121,6 +121,7 @@ func dialPlugin(port, bin, prefix string) (*grpc.ClientConn, error) {
 		"127.0.0.1:"+port,
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()),
+		grpc.WithStreamInterceptor(rpcutil.OpenTracingStreamClientInterceptor()),
 		rpcutil.GrpcChannelOptions(),
 	)
 	if err != nil {

--- a/sdk/go/common/util/rpcutil/health.go
+++ b/sdk/go/common/util/rpcutil/health.go
@@ -30,6 +30,7 @@ func Healthcheck(context context.Context, addr string, duration time.Duration, c
 		addr,
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(OpenTracingClientInterceptor()),
+		grpc.WithStreamInterceptor(OpenTracingStreamClientInterceptor()),
 		GrpcChannelOptions(),
 	)
 	if err != nil {

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -34,6 +34,19 @@ func OpenTracingServerInterceptor(parentSpan opentracing.Span, options ...otgrpc
 	return otgrpc.OpenTracingServerInterceptor(tracer, options...)
 }
 
+// Like OpenTracingServerInterceptor but for instrumenting streaming gRPC calls.
+func OpenTracingStreamServerInterceptor(parentSpan opentracing.Span, options ...otgrpc.Option) grpc.StreamServerInterceptor {
+	// Log full payloads along with trace spans
+	options = append(options, otgrpc.LogPayloads())
+	tracer := opentracing.GlobalTracer()
+
+	if parentSpan != nil {
+		tracer = &reparentingTracer{parentSpan.Context(), tracer}
+	}
+
+	return otgrpc.OpenTracingStreamServerInterceptor(tracer, options...)
+}
+
 // OpenTracingClientInterceptor provides a default gRPC client interceptor for emitting tracing to the global
 // OpenTracing tracer.
 func OpenTracingClientInterceptor(options ...otgrpc.Option) grpc.UnaryClientInterceptor {

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -35,7 +35,9 @@ func OpenTracingServerInterceptor(parentSpan opentracing.Span, options ...otgrpc
 }
 
 // Like OpenTracingServerInterceptor but for instrumenting streaming gRPC calls.
-func OpenTracingStreamServerInterceptor(parentSpan opentracing.Span, options ...otgrpc.Option) grpc.StreamServerInterceptor {
+func OpenTracingStreamServerInterceptor(parentSpan opentracing.Span,
+	options ...otgrpc.Option) grpc.StreamServerInterceptor {
+
 	// Log full payloads along with trace spans
 	options = append(options, otgrpc.LogPayloads())
 	tracer := opentracing.GlobalTracer()

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -60,6 +60,18 @@ func OpenTracingClientInterceptor(options ...otgrpc.Option) grpc.UnaryClientInte
 	return otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer(), options...)
 }
 
+// Like OpenTracingClientInterceptor but for streaming gRPC calls.
+func OpenTracingStreamClientInterceptor(options ...otgrpc.Option) grpc.StreamClientInterceptor {
+	options = append(options,
+		// Log full payloads along with trace spans
+		otgrpc.LogPayloads(),
+		// Do not trace calls to the empty method
+		otgrpc.IncludingSpans(func(_ opentracing.SpanContext, method string, _, _ interface{}) bool {
+			return method != ""
+		}))
+	return otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer(), options...)
+}
+
 // Wraps an opentracing.Tracer to reparent orphan traces with a given
 // default parent span.
 type reparentingTracer struct {

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -63,6 +63,7 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 	// Now new up a gRPC server and register any RPC interfaces the caller wants.
 	srv := grpc.NewServer(
 		grpc.UnaryInterceptor(OpenTracingServerInterceptor(parentSpan, options...)),
+		grpc.StreamInterceptor(OpenTracingStreamServerInterceptor(parentSpan, options...)),
 		grpc.MaxRecvMsgSize(maxRPCMessageSize),
 	)
 	for _, register := range registers {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -713,9 +713,7 @@ func (host *nodeLanguageHost) InstallDependencies(
 	// best effort close, but we try an explicit close and error check at the end as well
 	defer closer.Close()
 
-	ctx := server.Context()
-
-	tracingSpan, _ := opentracing.StartSpanFromContext(ctx, "npm-install")
+	tracingSpan, ctx := opentracing.StartSpanFromContext(server.Context(), "npm-install")
 	defer tracingSpan.Finish()
 
 	stdout.Write([]byte("Installing dependencies...\n\n"))

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -713,9 +713,14 @@ func (host *nodeLanguageHost) InstallDependencies(
 	// best effort close, but we try an explicit close and error check at the end as well
 	defer closer.Close()
 
+	ctx := server.Context()
+
+	tracingSpan, _ := opentracing.StartSpanFromContext(ctx, "npm-install")
+	defer tracingSpan.Finish()
+
 	stdout.Write([]byte("Installing dependencies...\n\n"))
 
-	_, err = npm.Install(server.Context(), req.Directory, false /*production*/, stdout, stderr)
+	_, err = npm.Install(ctx, req.Directory, false /*production*/, stdout, stderr)
 	if err != nil {
 		return fmt.Errorf("npm install failed: %w", err)
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR adds an `npm-install` span to the trace as created by `pulumi new typescript --tracing file:./new.trace`, and makes sure this trace has no orphan spans.

The no-orphan-traces part includes fixes to some of our infrastructure that are riding in the same PR.

1. In the case of streaming gRPC calls like ```    rpc  InstallDependencies(InstallDependenciesRequest) returns (stream  InstallDependenciesResponse) {}```, add missing interceptors so that tracing "sees" those calls just as normal calls

2. In the case of pulumi new command, a plugin.Context was created that "forgot" about tracing setup in InitTracing, and therefore client calls to the language plugin were forgetting the parent

## Rationale

We're finding that `npm i` takes a long time (40s locally, 5-20 min in CI) in some cases such as azure-native templates, and wanted to add a opentracing span for it. With the changes here the span shows up but it is not parented.


## Not fixing

There are some complications in pulumi-language-nodejs because plugin.Close always does it via SIgkill, finalizers are not guaranteed to run (defer does not work, etc), so it's impossible to Close tracing at the right moment, so the root span of the provider does not work. We need to separately track switching plugins to graceful termination (not SigKILL). But this works for now.


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes [2294](https://github.com/pulumi/home/issues/2294)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
