### PR TITLE
Update contrib docs with codegen instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,44 @@ We make heavy use of integration level tests that invoke `pulumi` to create and 
 
 The tests in this repository do not create any real cloud resources as part of testing but still uses Pulumi.com to store information about some synthetic resources the tests create. Other repositories may require additional setup before running tests. In most cases, this additional setup consists of setting a few environment variables to configure the provider for the the cloud service we are testing. Please see the `CONTRIBUTING.md` file in the relevant repository, which will explain what additional configuration is needed before running tests.
 
+### Building Providers
+
+When making changes to Pulumi's code generation tooling, you may want to test your changes by regenerating a Pulumi provider. This section describes how to regenerate a provider using a local version of this repository. As an example, we use [`@pulumi/command`](https://github.com/pulumi/pulumi-command).
+
+1. Clone this repository and make local changes to codegen. Assume the absolute path to this repo is `/Users/platypus/pulumi`.
+
+2. Clone @pulumi/command and change into the directory.
+
+```bash
+$ git clone https://github.com/pulumi/pulumi-command /Users/platypus/pulumi-command
+$ cd /Users/platypus/pulumi-command
+```
+
+3. Pulumi providers repos have a top-level directory `provider` which contains a `go.mod` for a Go executable used in provider generation. In this next steps, you will edit the `go.mod` file to point to your local copy of the Pulumi source code.
+First, open the `go.mod` file.
+
+```bash
+$ vim provider/go.mod
+```
+
+4. Add two "replace directives" above the first `require` block redirecting the Go compiler to use your local Pulumi code generator.
+```go.mod
+require github.com/pulumi/pulumi/pkg/v3 => /Users/platypus/pulumi/pkg
+
+require github.com/pulumi/pulumi/sdk/v3 => /Users/platypus/pulumi/sdk
+```
+
+5. Then, you can rebuild the provider following the instructions in the README.md of that provider's repository.
+
+For example:
+
+```bash
+$ cd /Users/platypus/pulumi-command
+$ make ensure
+$ make build
+$ make install
+```
+
 ### Debugging
 
 The Pulumi tools have extensive logging built in.  In fact, we encourage liberal logging in new code, and adding new logging when debugging problems.  This helps to ensure future debugging endeavors benefit from your sleuthing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,14 +89,14 @@ When making changes to Pulumi's code generation tooling, you may want to test yo
 
 1. Clone this repository and make local changes to codegen. Assume the absolute path to this repo is `/Users/platypus/pulumi`.
 
-2. Clone @pulumi/command and change into the directory.
+2. Clone pulumi-command and change into the directory.
 
 ```bash
 $ git clone https://github.com/pulumi/pulumi-command /Users/platypus/pulumi-command
 $ cd /Users/platypus/pulumi-command
 ```
 
-3. Pulumi providers repos have a top-level directory `provider` which contains a `go.mod` for a Go executable used in provider generation. In this next steps, you will edit the `go.mod` file to point to your local copy of the Pulumi source code.
+3. Pulumi provider repos have a top-level directory `provider` which contains a `go.mod` for a Go executable used in provider generation. In this next steps, you will edit the `go.mod` file to point to your local copy of the Pulumi source code.
 First, open the `go.mod` file.
 
 ```bash


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR adds contributor instructions on how to point provider build scripts to a local copy of codegen.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
