### PR TITLE
fix(sdk/nodejs): resolves issue with multiple parallel shell processes

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -84,3 +84,6 @@
 
 - [cli] Fix `pulumi console` command to follow documented behavior in help message/docs.
   [#10509](https://github.com/pulumi/pulumi/pull/10509)
+
+- [sdk/nodejs] Fixes an issue which would occur when multiple processes were spawned and some would receive no stdout/stderr
+  [10522](https://github.com/pulumi/pulumi/pull/10522)

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as childProcess from "child_process";
+import * as execa from "execa";
 
 import { createCommandError } from "./errors";
 
@@ -40,7 +40,7 @@ export class CommandResult {
 const unknownErrCode = -2;
 
 /** @internal */
-export function runPulumiCmd(
+export async function runPulumiCmd(
     args: string[],
     cwd: string,
     additionalEnv: { [key: string]: string },
@@ -55,35 +55,15 @@ export function runPulumiCmd(
 
     const env = { ...process.env, ...additionalEnv };
 
-    return new Promise<CommandResult>((resolve, reject) => {
-        const proc = childProcess.spawn("pulumi", args, { env, cwd });
-
-        // TODO: write to buffers and avoid concatenation
-        let stdout = "";
-        let stderr = "";
-        proc.stdout.on("data", (data) => {
-            if (data && data.toString) {
-                data = data.toString();
-            }
-            if (onOutput) {
-                onOutput(data);
-            }
-            stdout += data;
-        });
-        proc.stderr.on("data", (data) => {
-            stderr += data;
-        });
-        proc.on("exit", (code, signal) => {
-            const resCode = code !== null ? code : unknownErrCode;
-            const result = new CommandResult(stdout, stderr, resCode);
-            if (code !== 0) {
-                return reject(createCommandError(result));
-            }
-            return resolve(result);
-        });
-        proc.on("error", (err) => {
-            const result = new CommandResult(stdout, stderr, unknownErrCode, err);
-            return reject(createCommandError(result));
-        });
-    });
+    try {
+        const { stdout, stderr, exitCode } = await execa("pulumi", args, { env, cwd });
+        const commandResult = new CommandResult(stdout, stderr, exitCode);
+        if (exitCode !== 0) {
+            throw createCommandError(commandResult);
+        }
+        return commandResult;
+    } catch (err) {
+        const error = err as Error;
+        throw createCommandError(new CommandResult("", error.message, unknownErrCode, error));
+    }
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -12,6 +12,7 @@
         "@grpc/grpc-js": "~1.3.8",
         "@logdna/tail-file": "^2.0.6",
         "@pulumi/query": "^0.3.0",
+        "execa": "^5.1.0",
         "google-protobuf": "^3.5.0",
         "ini": "^2.0.0",
         "js-yaml": "^3.14.0",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10523 

Currently, there is an issue when spawning multiple child_processes at once - it's not entirely clear what's causing the issues but whatever it is, subprocesses being spawned are closing with successful exit codes and our runner / those processes' parent receives no data back from the pipes attached to them.  This replaces the `child_process` implementation with [execa](https://www.npmjs.com/package/execa) which appears to be very well supported.  It simplifies how these commands are processed and eliminates the null-stdout errors.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works (these tests already exist)
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
