### PR TITLE
Add --checksum to `pulumi plugin install`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,7 +34,7 @@
 
 - [sdk/go] Improve error messages for `StackReference`s
   [#10477](https://github.com/pulumi/pulumi/pull/10477)
-  
+
 - [sdk/dotnet] Added `Output.CreateSecret<T>(Output<T> value)` to set the secret bit on an output value.
   [#10467](https://github.com/pulumi/pulumi/pull/10467)
 
@@ -43,6 +43,9 @@
 
 - [sdk/go] enable direct compilation via `go build`(set `PULUMI_GO_USE_RUN=true` to opt out)
   [#10375](https://github.com/pulumi/pulumi/pull/10375)
+
+- [cli/plugin] `plugin install` now supports a `--checksum` option.
+  [#10528](https://github.com/pulumi/pulumi/pull/10528)
 
 ### Bug Fixes
 
@@ -70,13 +73,13 @@
 - [cli] Fixes `survey.v1` panics in Terminal UI introduced in
   [#10130](https://github.com/pulumi/pulumi/issues/10130) in v3.38.0.
   [#10475](https://github.com/pulumi/pulumi/pull/10475)
-  
+
 - [codegen/ts] Fix non-pulumi owned provider import alias.
   [#10447](https://github.com/pulumi/pulumi/pull/10447)
 
 - [codegen/go] Fix import path for non-pulumi owner providers
   [#10485](https://github.com/pulumi/pulumi/pull/10485)
-  
+
 - [cli] Fixes panics on repeat Ctrl+C invocation during long-running updates
   [#10489](https://github.com/pulumi/pulumi/pull/10489)
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -553,17 +553,7 @@ func (reader *checksumReader) Read(p []byte) (int, error) {
 }
 
 func (reader *checksumReader) Close() error {
-	err := reader.io.Close()
-	if err != nil {
-		return err
-	}
-
-	actualChecksum := reader.hasher.Sum(nil)
-	if !bytes.Equal(reader.checksum, actualChecksum) {
-		return fmt.Errorf("invalid checksum, expected %x, actual %x", reader.checksum, actualChecksum)
-	}
-
-	return nil
+	return reader.io.Close()
 }
 
 func (source *checksumSource) Download(

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -553,7 +553,7 @@ func (reader *checksumReader) Read(p []byte) (int, error) {
 }
 
 func (reader *checksumReader) Close() error {
-	err := reader.Close()
+	err := reader.io.Close()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

With non-hex string:
```
$ pulumi plugin install resource gcp 6.35.0 --checksum boom
error: --checksum was not a valid hex string: encoding/hex: invalid byte: U+006F 'o'
```

With the wrong checksum:
```
$ pulumi plugin install resource gcp 6.35.0 --checksum c58ade076e5b84aaeef154950e6b9b907341f0747163e3f299d3fc21594baa9d
[resource plugin gcp-6.35.0] installing
Downloading plugin: 44.08 MiB / 44.08 MiB [=========================] 100.00% 7s
error: [resource plugin gcp-6.35.0] downloading from : failed to download plugin: gcp-6.35.0: invalid checksum, expected c58ade076e5b84aaeef154950e6b9b907341f0747163e3f299d3fc21594baa9d, actual c58ade076e5b84aaeef154950e6b9b907341f0747163e3f299d3fc21594baa9c
```

Made the retry logic a bit smarter to not retry checksum failures (yes it _could_ be a network bit got flipped, but I think the UX is probably better here to not retry automatically)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
