### PR TITLE
ci: fix pulumi-watch binaries absent from release binaries

### DIFF
--- a/scripts/get-pulumi-watch.sh
+++ b/scripts/get-pulumi-watch.sh
@@ -24,11 +24,11 @@ fi
 TAG="v0.1.4"
 
 for i in \
-  "darwin-amd64   x86_64-apple-darwin            tar.gz" \
+  "darwin-x64     x86_64-apple-darwin            tar.gz" \
   "darwin-arm64   aarch64-apple-darwin           tar.gz" \
-  "linux-amd64    x86_64-unknown-linux-gnu       tar.gz" \
+  "linux-x64      x86_64-unknown-linux-gnu       tar.gz" \
   "linux-arm64    aarch64-unknown-linux-gnu      tar.gz" \
-  "windows-amd64  x86_64-pc-windows-msvc         zip"; do # Windows is synonymous with ".exe" as well
+  "windows-x64    x86_64-pc-windows-msvc         zip"; do # Windows is synonymous with ".exe" as well
   set -- $i # read loop strings as args
   TARGET="$1"
   FILE="$2"


### PR DESCRIPTION
I looked at the release artifacts of a recent master build and saw these were missing.

Goreleaser expects files in `bin/darwin-x64` and so on, not `bin/darwin-amd64`.