### PR TITLE
Set pulumi organization for tests via environment variables

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -606,6 +606,7 @@ func TestStackReferenceNodeJS(t *testing.T) {
 		Dir:          filepath.Join("stack_reference", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
+		Env:          []string{"PULUMI_ORGANIZATION=test-org"},
 		EditDirs: []integration.EditDir{
 			{
 				Dir:      "step1",
@@ -694,6 +695,7 @@ func TestStackReferenceSecretsNodejs(t *testing.T) {
 			"org": owner,
 		},
 		Quick: true,
+		Env:   []string{fmt.Sprintf("PULUMI_ORGANIZATION=%s", owner)},
 		EditDirs: []integration.EditDir{
 			{
 				Dir:             filepath.Join(d, "nodejs", "step2"),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

Fixes master build due to a failing integration test from #10504 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
