### PR TITLE
Compress `/import` API calls to the Pulumi REST API

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -59,6 +59,10 @@
 - [sdk/{nodejs/python}] Added `getOrganization()` to return the current organization if available.
   [#10504](https://github.com/pulumi/pulumi/pull/10504)
 
+- [cli/backend] Gzip compress HTTPS payloads for `pulumi import` and secret decryption against 
+  the Pulumi Service backend.
+  [#10558](https://github.com/pulumi/pulumi/pull/10558)
+
 ### Bug Fixes
 
 - [codegen/go] Fix StackReference codegen.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -437,7 +437,8 @@ func (pc *Client) BulkDecryptValue(ctx context.Context, stack StackIdentifier,
 	ciphertexts [][]byte) (map[string][]byte, error) {
 	req := apitype.BulkDecryptValueRequest{Ciphertexts: ciphertexts}
 	var resp apitype.BulkDecryptValueResponse
-	if err := pc.restCall(ctx, "POST", getStackPath(stack, "batch-decrypt"), nil, &req, &resp); err != nil {
+	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "batch-decrypt"), nil, &req, &resp,
+		httpCallOptions{GzipCompress: true}); err != nil {
 		return nil, err
 	}
 
@@ -490,7 +491,8 @@ func (pc *Client) ImportStackDeployment(ctx context.Context, stack StackIdentifi
 	deployment *apitype.UntypedDeployment) (UpdateIdentifier, error) {
 
 	var resp apitype.ImportStackResponse
-	if err := pc.restCall(ctx, "POST", getStackPath(stack, "import"), nil, deployment, &resp); err != nil {
+	if err := pc.restCallWithOptions(ctx, "POST", getStackPath(stack, "import"), nil, deployment, &resp,
+		httpCallOptions{GzipCompress: true}); err != nil {
 		return UpdateIdentifier{}, err
 	}
 


### PR DESCRIPTION
The Pulumi REST API supports GZIP compressed payloads, and we use this for `PATCH /checkpoints` and `POST /events/batch`.

We were not using it for `POST /import` or `POST /batch-decrypt`, even though both can in common cases need to upload multi-MB payloads.

We now GZIP these two payloads.

Fixes #9266.