### PR TITLE
Couple of 'about' improvments

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -547,7 +547,8 @@ func (runtime projectRuntimeAbout) String() string {
 
 // This is necessary because dotnet invokes build during the call to
 // getProjectPlugins.
-func getProjectPluginsSilently(ctx *plugin.Context, proj *workspace.Project, pwd, main string) ([]workspace.PluginSpec, error) {
+func getProjectPluginsSilently(
+	ctx *plugin.Context, proj *workspace.Project, pwd, main string) ([]workspace.PluginSpec, error) {
 	_, w, err := os.Pipe()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -174,10 +173,10 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 	}
 
 	var backend backend.Backend
-	backend, err = currentBackend(ctx, display.Options{Color: cmdutil.GetGlobalColorization()})
+	backend, err = nonInteractiveCurrentBackend(ctx)
 	if err != nil {
 		addError(err, "Could not access the backend")
-	} else {
+	} else if backend != nil {
 		var stack currentStackAbout
 		if stack, err = getCurrentStackAbout(ctx, backend, selectedStack); err != nil {
 			addError(err, "Failed to get information about the current stack")

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -133,7 +133,8 @@ func newDestroyCmd() *cobra.Command {
 
 			proj, root, err := readProject()
 			if err != nil && errors.Is(err, workspace.ErrProjectNotFound) {
-				logging.Warningf("failed to find current Pulumi project, continuing with an empty project using stack %v from backend %v",
+				logging.Warningf("failed to find current Pulumi project, "+
+					"continuing with an empty project using stack %v from backend %v",
 					s.Ref().Name(), s.Backend().Name())
 				proj = &workspace.Project{}
 				root = ""

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -108,6 +108,22 @@ func isFilestateBackend(opts display.Options) (bool, error) {
 	return filestate.IsFileStateBackendURL(url), nil
 }
 
+func nonInteractiveCurrentBackend(ctx context.Context) (backend.Backend, error) {
+	if backendInstance != nil {
+		return backendInstance, nil
+	}
+
+	url, err := workspace.GetCurrentCloudURL()
+	if err != nil {
+		return nil, fmt.Errorf("could not get cloud url: %w", err)
+	}
+
+	if filestate.IsFileStateBackendURL(url) {
+		return filestate.New(cmdutil.Diag(), url)
+	}
+	return httpstate.Current(ctx, cmdutil.Diag(), url)
+}
+
 func currentBackend(ctx context.Context, opts display.Options) (backend.Backend, error) {
 	if backendInstance != nil {
 		return backendInstance, nil


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Don't try to log into a backend for 'about', pointed out in  https://github.com/pulumi/pulumi/issues/10439#issuecomment-1219933307

Also fix about to not try and get project plugins unless we have a project. Reduces two errors to one.

Before (with 3.34.1):
```
warning: Failed to get information about the plugin: no Pulumi.yaml project file found (searching upwards from /home/fraser/projects). If you have not created a project yet, use `pulumi new` to do so
warning: Failed to read project: no Pulumi.yaml project file found (searching upwards from /home/fraser/projects). If you have not created a project yet, use `pulumi new` to do so
warning: Failed to get information about the current stack: no Pulumi.yaml project file found (searching upwards from /home/fraser/projects). If you have not created a project yet, use `pulumi new` to do so
```

After:
```
warning: Failed to read project: no Pulumi.yaml project file found (searching upwards from ). If you have not created a project yet, use `pulumi new` to do so: no project file found
warning: Failed to get information about the current stack: no Pulumi.yaml project file found (searching upwards from ). If you have not created a project yet, use `pulumi new` to do so: no project file found
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
