### PR TITLE
Fix downstream checks by using master terraform-bridge

### DIFF
--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -79,16 +79,21 @@ jobs:
           tag: v0.0.32
           cache: enable
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.PR_COMMIT_SHA }}
+      - uses: actions/checkout@v3
+        with:
+          repository: pulumi/pulumi-terraform-bridge
+          ref: master
+          path: ./pulumi-terraform-bridge
       - name: Test Downstream
         uses: pulumi/action-test-provider-downstream@v1.0.0
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-          replacements: github.com/pulumi/pulumi/pkg/v3=pulumi/pkg,github.com/pulumi/pulumi/sdk/v3=pulumi/sdk
+          replacements: github.com/pulumi/pulumi/pkg/v3=pulumi/pkg,github.com/pulumi/pulumi/sdk/v3=pulumi/sdk,github.com/pulumi/pulumi-terraform-bridge/v3=pulumi/pulumi-terraform-bridge
           downstream-name: pulumi-${{ matrix.provider }}
           downstream-url: https://github.com/pulumi/pulumi-${{ matrix.provider }}
           use-provider-dir: true


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Currently downstream checks are broken because terraform-bridge used in providers has not caught up with sdk/ changes from this repo. But terraform-bridge master has caught up. This change links against terraform-bridge master and does the checks.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
