### PR TITLE
Fix "no Pulumi.yaml" error message

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,8 +9,11 @@
 - [codegen/nodejs] Support lazy-loading Node modules.
   [#10538](https://github.com/pulumi/pulumi/pull/10538)
 
-- [cli/backend] Gzip compress HTTPS payloads for `pulumi import` and secret decryption against 
+- [cli/backend] Gzip compress HTTPS payloads for `pulumi import` and secret decryption against
   the Pulumi Service backend.
   [#10558](https://github.com/pulumi/pulumi/pull/10558)
 
 ### Bug Fixes
+
+- [cli] Fix the "no Pulumi.yaml project file found" error message.
+  [#10592](https://github.com/pulumi/pulumi/pull/10592)

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -127,8 +127,8 @@ var ErrProjectNotFound = errors.New("no project file found")
 
 // DetectProjectPathFrom locates the closest project from the given path, searching "upwards" in the directory
 // hierarchy.  If no project is found, an empty path is returned.
-func DetectProjectPathFrom(path string) (string, error) {
-	path, err := fsutil.WalkUp(path, isProject, func(s string) bool {
+func DetectProjectPathFrom(dir string) (string, error) {
+	path, err := fsutil.WalkUp(dir, isProject, func(s string) bool {
 		return true
 	})
 	if err != nil {
@@ -138,7 +138,7 @@ func DetectProjectPathFrom(path string) (string, error) {
 		// Embed/wrap ErrProjectNotFound
 		return "", fmt.Errorf(
 			"no Pulumi.yaml project file found (searching upwards from %s). If you have not "+
-				"created a project yet, use `pulumi new` to do so: %w", path, ErrProjectNotFound)
+				"created a project yet, use `pulumi new` to do so: %w", dir, ErrProjectNotFound)
 	}
 	return path, nil
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The double use of the "path" variable here meant this error message looked like:
```
no Pulumi.yaml project file found (searching upwards from ). If you have not created a project yet, use `pulumi new` to do so: no project file found
```
But we want it to look like:
```
no Pulumi.yaml project file found (searching upwards from /home/fraser/projects). If you have not created a project yet, use `pulumi new` to do so: no project file found
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
