### PR TITLE
Bump TSC version to 3.8.3

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,7 @@
 ### Improvements
 
+- [sdk/nodejs] Updated the vendored version of TypeScript in the NodeJS SDK and runtime from v3.7.3 to v3.8.3
+  [#10618](https://github.com/pulumi/pulumi/pull/10618)
+
 ### Bug Fixes
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -23,7 +23,7 @@
         "semver": "^6.1.0",
         "source-map-support": "^0.5.6",
         "ts-node": "^7.0.1",
-        "typescript": "~3.7.3",
+        "typescript": "~3.8.3",
         "upath": "^1.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR bumps the version of TypeScript used by the NodeJS runtime (and the NodeJS SDK (`@pulumi/pulumi`)) to v3.8.3 from v3.73. 

v3.8 introduces the `import type` and `export type` syntax, which is required to use OpenTelemetry.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
