### PR TITLE
fix(automation): runPulumiCommand failed to call onOutput when provided

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,5 @@
 
 ### Bug Fixes
 
+- [sdk/nodejs] Calls onOutput in runPulumiCmd
+  [#10631](https://github.com/pulumi/pulumi/pull/10631)

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -61,6 +61,9 @@ export async function runPulumiCmd(
         if (exitCode !== 0) {
             throw createCommandError(commandResult);
         }
+        if (onOutput) {
+            onOutput(stdout);
+        }
         return commandResult;
     } catch (err) {
         const error = err as Error;

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -35,6 +35,7 @@
         "@types/normalize-package-data": "^2.4.0",
         "@types/read-package-tree": "^5.2.0",
         "@types/semver": "^5.5.0",
+        "@types/sinon": "^10.0.13",
         "@types/split2": "^2.1.6",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
@@ -43,7 +44,8 @@
         "eslint-plugin-import": "^2.23.4",
         "mocha": "^9.0.0",
         "mockpackage": "file:tests/mockpackage",
-        "nyc": "^15.1.0"
+        "nyc": "^15.1.0",
+        "sinon": "^14.0.0"
     },
     "pulumi": {
         "comment": "Do not remove. Marks this as as a deployment-time-only package"

--- a/sdk/nodejs/tests/automation/cmd.spec.ts
+++ b/sdk/nodejs/tests/automation/cmd.spec.ts
@@ -1,0 +1,29 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { runPulumiCmd } from "../../automation";
+import { asyncTest } from "../util";
+
+describe("automation/cmd", () => {
+    it("calls onOutput when provided to runPulumiCmd", asyncTest(async () => {
+        const spy = sinon.spy();
+        await runPulumiCmd(["version"], ".", {}, spy);
+
+        assert.ok(spy.calledOnce);
+        assert.strictEqual(spy.firstCall.firstArg, spy.lastCall.lastArg);
+    }));
+});
+

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -100,6 +100,7 @@
         "tests/runtime/langhost/run.spec.ts",
         "tests/runtime/langhost/cases/069.ambiguous_entrypoints/index.ts",
 
+        "tests/automation/cmd.spec.ts",
         "tests/automation/localWorkspace.spec.ts",
 
         "tests_with_mocks/mocks.spec.ts"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10611
When modifying `runPulumiCmd`, we failed to continue calling `onOutput` on the new API's stdout return.  This resolves that issue.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
