### PR TITLE
Fix orphan register-resource traces

### DIFF
--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,69 +15,23 @@
 package rpcutil
 
 import (
-	"context"
-	"strings"
-
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
-// metadataReaderWriter satisfies both the opentracing.TextMapReader and
-// opentracing.TextMapWriter interfaces.
-type metadataReaderWriter struct {
-	metadata.MD
-}
-
-func (w metadataReaderWriter) Set(key, val string) {
-	// The GRPC HPACK implementation rejects any uppercase keys here.
-	//
-	// As such, since the HTTP_HEADERS format is case-insensitive anyway, we
-	// blindly lowercase the key (which is guaranteed to work in the
-	// Inject/Extract sense per the OpenTracing spec).
-	key = strings.ToLower(key)
-	w.MD[key] = append(w.MD[key], val)
-}
-
-func (w metadataReaderWriter) ForeachKey(handler func(key, val string) error) error {
-	for k, vals := range w.MD {
-		for _, v := range vals {
-			if err := handler(k, v); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// OpenTracingServerInterceptor provides a default gRPC server interceptor for emitting tracing to the global
-// OpenTracing tracer.
+// OpenTracingServerInterceptor provides a default gRPC server
+// interceptor for emitting tracing to the global OpenTracing tracer.
 func OpenTracingServerInterceptor(parentSpan opentracing.Span, options ...otgrpc.Option) grpc.UnaryServerInterceptor {
 	// Log full payloads along with trace spans
 	options = append(options, otgrpc.LogPayloads())
+	tracer := opentracing.GlobalTracer()
 
-	tracingInterceptor := otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer(), options...)
-	if parentSpan == nil {
-		return tracingInterceptor
+	if parentSpan != nil {
+		tracer = &reparentingTracer{parentSpan.Context(), tracer}
 	}
-	spanContext := parentSpan.Context()
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
-		handler grpc.UnaryHandler) (interface{}, error) {
 
-		md, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			md = metadata.New(nil)
-		}
-		carrier := metadataReaderWriter{md}
-		_, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, carrier)
-		if err == opentracing.ErrSpanContextNotFound {
-			contract.IgnoreError(opentracing.GlobalTracer().Inject(spanContext, opentracing.HTTPHeaders, carrier))
-		}
-		return tracingInterceptor(ctx, req, info, handler)
-	}
+	return otgrpc.OpenTracingServerInterceptor(tracer, options...)
 }
 
 // OpenTracingClientInterceptor provides a default gRPC client interceptor for emitting tracing to the global
@@ -92,3 +46,44 @@ func OpenTracingClientInterceptor(options ...otgrpc.Option) grpc.UnaryClientInte
 		}))
 	return otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer(), options...)
 }
+
+// Wraps an opentracing.Tracer to reparent orphan traces with a given
+// default parent span.
+type reparentingTracer struct {
+	parentSpanContext opentracing.SpanContext
+	underlying        opentracing.Tracer
+}
+
+func (t *reparentingTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	if !t.hasChildOf(opts...) {
+		opts = append(opts, opentracing.ChildOf(t.parentSpanContext))
+	}
+	return t.underlying.StartSpan(operationName, opts...)
+}
+
+func (t *reparentingTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	return t.underlying.Inject(sm, format, carrier)
+}
+
+func (t *reparentingTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	return t.underlying.Extract(format, carrier)
+}
+
+func (t *reparentingTracer) packOptions(opts ...opentracing.StartSpanOption) opentracing.StartSpanOptions {
+	sso := opentracing.StartSpanOptions{}
+	for _, o := range opts {
+		o.Apply(&sso)
+	}
+	return sso
+}
+
+func (t *reparentingTracer) hasChildOf(opts ...opentracing.StartSpanOption) bool {
+	for _, ref := range t.packOptions(opts...).References {
+		if ref.Type == opentracing.ChildOfRef {
+			return true
+		}
+	}
+	return false
+}
+
+var _ opentracing.Tracer = &reparentingTracer{}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This is a little fix to the reparenting functionality. 

Before the fix, if I do `pulumi new aws-go` and `pulumi up --yes --tracing file:./up.trace` and view the trace, there is a `pulumi` trace that has most of information, and then there's many orphan traces that did not get parented to spans under `pulumi`, including 4 RegisterResource spans (2x preview/update and 2 resources: Stack and s3.Bucket).

After the fix, the RegisterResource spans are parented to preview or update spans as expected. All the others are too. So for the selected Go example there are therefore no remaining orphan spans.

I'm not sure why the previous impl stopped working as intended, but the new one is more high-level and easier to foolproof.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
