### PR TITLE
Revert "Install missing plugins when encountering them (#10530)"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,3 +8,6 @@
 
 ### Bug Fixes
 
+- [engine/plugins]: Revert change causing third party provider packages to prevent deployment commands (`up`, `preview`, ...)
+  when used with the nodejs runtime. Reverts #10530.
+  [#10650](https://github.com/pulumi/pulumi/pull/10650)

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -41,7 +41,6 @@ import (
 	"github.com/djherbis/times"
 	"github.com/pkg/errors"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -121,6 +120,39 @@ func parsePluginDownloadURLOverrides(overrides string) (pluginDownloadOverrideAr
 		})
 	}
 	return result, nil
+}
+
+// MissingError is returned by functions that attempt to load plugins if a plugin can't be located.
+type MissingError struct {
+	// Info contains information about the plugin that was not found.
+	Info PluginInfo
+	// includeAmbient is true if we search $PATH for this plugin
+	includeAmbient bool
+}
+
+// NewMissingError allocates a new error indicating the given plugin info was not found.
+func NewMissingError(info PluginInfo, includeAmbient bool) error {
+	return &MissingError{
+		Info:           info,
+		includeAmbient: includeAmbient,
+	}
+}
+
+func (err *MissingError) Error() string {
+	includePath := ""
+	if err.includeAmbient {
+		includePath = " or on your $PATH"
+	}
+
+	if err.Info.Version != nil {
+		return fmt.Sprintf("no %[1]s plugin 'pulumi-%[1]s-%[2]s' found in the workspace at version v%[3]s%[4]s, "+
+			"install the plugin using `pulumi plugin install %[1]s %[2]s v%[3]s`",
+			err.Info.Kind, err.Info.Name, err.Info.Version, includePath)
+	}
+
+	return fmt.Sprintf("no %[1]s plugin 'pulumi-%[1]s-%[2]s' found in the workspace%[3]s, "+
+		"install the plugin using `pulumi plugin install %[1]s %[2]s`",
+		err.Info.Kind, err.Info.Name, includePath)
 }
 
 // PluginSource deals with downloading a specific version of a plugin, or looking up the latest version of it.
@@ -1037,33 +1069,6 @@ func DownloadToFile(
 
 }
 
-// InstallPluginError is returned by functions that are unable to download and install a plugin
-type InstallPluginError struct {
-	// The name of the plugin
-	Name string
-	// The kind of the plugin
-	Kind PluginKind
-	// The requested version of the plugin, if any.
-	Version *semver.Version
-	// the underlying error that occurred during the download or install
-	UnderlyingError error
-}
-
-func (err *InstallPluginError) Error() string {
-	if err.Version != nil {
-		return fmt.Sprintf("Could not automatically download and install %[1]s plugin 'pulumi-%[1]s-%[2]s'"+
-			"at version v%[3]s, "+
-			"install the plugin using `pulumi plugin install %[1]s %[2]s v%[3]s`.\n"+
-			"Underlying error: %[4]s",
-			err.Kind, err.Name, err.Version.String(), err.UnderlyingError.Error())
-	}
-
-	return fmt.Sprintf("Could not automatically download and install %[1]s plugin 'pulumi-%[1]s-%[2]s', "+
-		"install the plugin using `pulumi plugin install %[1]s %[2]s`.\n"+
-		"Underlying error: %[3]s",
-		err.Kind, err.Name, err.UnderlyingError.Error())
-}
-
 type PluginContent interface {
 	io.Closer
 
@@ -1480,62 +1485,6 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version,
 	return path, err
 }
 
-func attemptToDownloadAndInstallPlugin(kind PluginKind, name string, version *semver.Version) error {
-	pluginSpec := PluginSpec{
-		Kind: kind,
-		Name: name,
-	}
-
-	if version == nil {
-		latestVersion, err := pluginSpec.GetLatestVersion()
-		if err != nil {
-			return &InstallPluginError{
-				Name:            name,
-				Kind:            kind,
-				UnderlyingError: err,
-			}
-		}
-
-		version = latestVersion
-	}
-
-	pluginSpec.Version = version
-
-	withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
-		header := fmt.Sprintf("Downloading plugin %s v%s", pluginSpec.Name, version.String())
-		return ReadCloserProgressBar(stream, size, header, colors.Always)
-	}
-
-	retry := func(err error, attempt int, limit int, delay time.Duration) {
-		cmdutil.Diag().Warningf(
-			diag.Message("", "Error downloading plugin: %s\nWill retry in %v [%d/%d]"), err, delay, attempt, limit)
-	}
-
-	downloadedFile, err := DownloadToFile(pluginSpec, withProgress, retry)
-	if err != nil {
-		downloadError := fmt.Errorf("error downloading plugin %s to file: %w", pluginSpec.Name, err)
-		return &InstallPluginError{
-			Name:            name,
-			Kind:            kind,
-			Version:         version,
-			UnderlyingError: downloadError,
-		}
-	}
-
-	logging.V(1).Infof("installing plugin %s", pluginSpec.Name)
-	pluginInstallError := pluginSpec.Install(downloadedFile, false)
-	if pluginInstallError != nil {
-		return &InstallPluginError{
-			Name:            name,
-			Kind:            kind,
-			Version:         version,
-			UnderlyingError: pluginInstallError,
-		}
-	}
-
-	return nil
-}
-
 func GetPluginInfo(kind PluginKind, name string, version *semver.Version,
 	projectPlugins []ProjectPlugin) (*PluginInfo, error) {
 	info, path, err := getPluginInfoAndPath(kind, name, version, false, projectPlugins)
@@ -1677,17 +1626,11 @@ func getPluginInfoAndPath(
 		logging.V(6).Infof("GetPluginPath(%s, %s, %s): enabling new plugin behavior", kind, name, version)
 		candidate, err := SelectCompatiblePlugin(plugins, kind, name, semver.MustParseRange(version.String()))
 		if err != nil {
-			// could not find a compatible plugin
-			// this could be due to the fact that a transitive version of a plugin is required
-			// which are not picked up by initial pass of required plugin installations
-			// so instead of reporting an error, we just install that required plugin
-			if err = attemptToDownloadAndInstallPlugin(kind, name, version); err != nil {
-				return nil, "", err
-			}
-
-			// downloaded the missing plugin successfully
-			// restart the plugin retrieval
-			return getPluginInfoAndPath(kind, name, version, skipMetadata, projectPlugins)
+			return nil, "", NewMissingError(PluginInfo{
+				Name:    name,
+				Kind:    kind,
+				Version: version,
+			}, includeAmbient)
 		}
 		match = &candidate
 	} else {
@@ -1723,13 +1666,11 @@ func getPluginInfoAndPath(
 		return match, matchPath, nil
 	}
 
-	if err := attemptToDownloadAndInstallPlugin(kind, name, version); err != nil {
-		return nil, "", err
-	}
-
-	// downloaded the missing plugin successfully
-	// restart the plugin retrieval
-	return getPluginInfoAndPath(kind, name, version, skipMetadata, projectPlugins)
+	return nil, "", NewMissingError(PluginInfo{
+		Name:    name,
+		Kind:    kind,
+		Version: version,
+	}, includeAmbient)
 }
 
 // SortedPluginInfo is a wrapper around PluginInfo that allows for sorting by version.

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -892,6 +892,83 @@ func TestParsePluginDownloadURLOverride(t *testing.T) {
 	}
 }
 
+func TestMissingErrorText(t *testing.T) {
+	t.Parallel()
+
+	v1 := semver.MustParse("0.1.0")
+	tests := []struct {
+		Name           string
+		Plugin         PluginInfo
+		IncludeAmbient bool
+		ExpectedError  string
+	}{
+		{
+			Name: "ResourceWithVersion",
+			Plugin: PluginInfo{
+				Name:    "myplugin",
+				Kind:    ResourcePlugin,
+				Version: &v1,
+			},
+			IncludeAmbient: true,
+			ExpectedError: "no resource plugin 'pulumi-resource-myplugin' found in the workspace " +
+				"at version v0.1.0 or on your $PATH, install the plugin using `pulumi plugin install resource myplugin v0.1.0`",
+		},
+		{
+			Name: "ResourceWithVersion_ExcludeAmbient",
+			Plugin: PluginInfo{
+				Name:    "myplugin",
+				Kind:    ResourcePlugin,
+				Version: &v1,
+			},
+			IncludeAmbient: false,
+			ExpectedError: "no resource plugin 'pulumi-resource-myplugin' found in the workspace " +
+				"at version v0.1.0, install the plugin using `pulumi plugin install resource myplugin v0.1.0`",
+		},
+		{
+			Name: "ResourceWithoutVersion",
+			Plugin: PluginInfo{
+				Name:    "myplugin",
+				Kind:    ResourcePlugin,
+				Version: nil,
+			},
+			IncludeAmbient: true,
+			ExpectedError: "no resource plugin 'pulumi-resource-myplugin' found in the workspace " +
+				"or on your $PATH, install the plugin using `pulumi plugin install resource myplugin`",
+		},
+		{
+			Name: "ResourceWithoutVersion_ExcludeAmbient",
+			Plugin: PluginInfo{
+				Name:    "myplugin",
+				Kind:    ResourcePlugin,
+				Version: nil,
+			},
+			IncludeAmbient: false,
+			ExpectedError: "no resource plugin 'pulumi-resource-myplugin' found in the workspace" +
+				", install the plugin using `pulumi plugin install resource myplugin`",
+		},
+		{
+			Name: "LanguageWithoutVersion",
+			Plugin: PluginInfo{
+				Name:    "dotnet",
+				Kind:    LanguagePlugin,
+				Version: nil,
+			},
+			IncludeAmbient: true,
+			ExpectedError: "no language plugin 'pulumi-language-dotnet' found in the workspace " +
+				"or on your $PATH, install the plugin using `pulumi plugin install language dotnet`",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+			err := NewMissingError(tt.Plugin, tt.IncludeAmbient)
+			assert.Equal(t, tt.ExpectedError, err.Error())
+		})
+	}
+}
+
 //nolint:paralleltest // changes directory for process
 func TestUnmarshalProjectWithProviderList(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Debugging into the engine showed that execution appeared to query for the resource plugin `checkly/pulumi`, which is close to the NPM package name (`@checkly/pulumi`), however the resource plugin is named `checkly`. This caused Pulumi to attempt to acquire and download the plugin and fail.

This bug is specific to the nodejs language host - other languages are unaffected, as verified by converting an example program to YAML and converting to each and running a `pulumi preview`.

```yaml
name: tmp.k4AiLfczOQ
runtime: go
description: A minimal AWS Pulumi YAML program
resources:
  my-bucket:
    properties:
      activated: true
      frequency: 10
      request:
        method: GET
        url: https://checklyhq.com
      type: API
    type: checkly:Check
```

Fixes #10648.