### PR TITLE
Use `dotnet run --no-build`

### DIFF
--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -568,7 +568,7 @@ func (host *dotnetLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		executable = host.binary
 	default:
 		// Run from source.
-		args = append(args, "run")
+		args = append(args, "run", "--no-build")
 
 		if req.GetProgram() != "" {
 			args = append(args, req.GetProgram())

--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -572,6 +572,9 @@ func (host *dotnetLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		// Run from source.
 		args = append(args, "run")
 
+		// If we are certain the project has been built,
+		// passing a --no-build flag to dotnet run results in
+		// up to 1s time savings.
 		if host.dotnetBuildSucceeded {
 			args = append(args, "--no-build")
 		}

--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -129,10 +129,11 @@ func main() {
 // dotnetLanguageHost implements the LanguageRuntimeServer interface
 // for use as an API endpoint.
 type dotnetLanguageHost struct {
-	exec          string
-	engineAddress string
-	tracing       string
-	binary        string
+	exec                 string
+	engineAddress        string
+	tracing              string
+	binary               string
+	dotnetBuildSucceeded bool
 }
 
 func newLanguageHost(exec, engineAddress, tracing string, binary string) pulumirpc.LanguageRuntimeServer {
@@ -433,6 +434,7 @@ func (host *dotnetLanguageHost) DotnetBuild(
 		return err
 	}
 
+	host.dotnetBuildSucceeded = true
 	return nil
 }
 
@@ -568,7 +570,11 @@ func (host *dotnetLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		executable = host.binary
 	default:
 		// Run from source.
-		args = append(args, "run", "--no-build")
+		args = append(args, "run")
+
+		if host.dotnetBuildSucceeded {
+			args = append(args, "--no-build")
+		}
 
 		if req.GetProgram() != "" {
 			args = append(args, req.GetProgram())


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

It seems that `dotnet run --no-build` is a bit faster if the binaries have been built already.

```
time dotnet run .                                                                                                  ~/tmp/how-does-dotnet-do-it-2
Unhandled exception. System.InvalidOperationException: Program run without the Pulumi engine available; re-run using the `pulumi` CLI
   at Pulumi.Deployment..ctor(RunnerOptions runnerOptions)
   at Pulumi.Deployment.<>c.<RunAsync>b__104_0()
   at Pulumi.Deployment.CreateRunnerAndRunAsync(Func`1 deploymentFactory, Func`2 runAsync)
   at Program.<Main>$(String[] args) in /Users/anton/tmp/how-does-dotnet-do-it-2/Program.cs:line 5
   at Program.<Main>(String[] args)
dotnet run .  1.44s user 0.36s system 139% cpu 1.290 total
[134] anton@Antons-MacBook-Pro> time dotnet run .  --no-build                                                                                      ~/tmp/how-does-dotnet-do-it-2
Unhandled exception. System.InvalidOperationException: Program run without the Pulumi engine available; re-run using the `pulumi` CLI
   at Pulumi.Deployment..ctor(RunnerOptions runnerOptions)
   at Pulumi.Deployment.<>c.<RunAsync>b__104_0()
   at Pulumi.Deployment.CreateRunnerAndRunAsync(Func`1 deploymentFactory, Func`2 runAsync)
   at Program.<Main>$(String[] args) in /Users/anton/tmp/how-does-dotnet-do-it-2/Program.cs:line 5
   at Program.<Main>(String[] args)
dotnet run . --no-build  0.41s user 0.19s system 109% cpu 0.553 total
```

It seems that GetRequiredPlugins should always be called before Run, so maybe it's safe to always set --no-build. Perhaps it's safer to cache and have the host remember if it has run Build already or not.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
