### PR TITLE
Chunk pulumiTypes.go

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- [codegen/go] Chunk the `pulumiTypes.go` file to reduce max file size.
+  [#10666](https://github.com/pulumi/pulumi/pull/10666)
+
 ### Bug Fixes
 
 - Fix invalid resource type on `pulumi convert` to Go

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3694,10 +3694,10 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 		// Types
 		for types, i := pkg.types, 0; len(types) > 0; i++ {
 			// 500 types corresponds to approximately 5M or 40_000 lines of code.
-			const CHUNK_SIZE = 500
+			const chunkSize = 500
 			chunk := types
-			if len(chunk) > CHUNK_SIZE {
-				chunk = chunk[:CHUNK_SIZE]
+			if len(chunk) > chunkSize {
+				chunk = chunk[:chunkSize]
 			}
 			types = types[len(chunk):]
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10656

This PR prevents more then 500 types + associated types from residing in the same file. This should keep files less then 40,000 LOC. By comparison, the problematic file (`sdk/go/aws/wafv2/pulumiTypes.go`) has 679,162 LOC at 70M.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
