### PR TITLE
Fix invalid resource type on `pulumi convert` to Go

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,5 @@
 
 ### Bug Fixes
 
+- Fix invalid resource type on `pulumi convert` to Go
+  [#10670](https://github.com/pulumi/pulumi/pull/10670)

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -924,7 +924,6 @@ func (g *generator) useLookupInvokeForm(token string) bool {
 // is aliased, returning that alias if available.
 func (g *generator) getModOrAlias(pkg, mod, originalMod string) string {
 	info, ok := g.getGoPackageInfo(pkg)
-	mod = strings.Split(mod, "/")[0]
 	if !ok {
 		return mod
 	}
@@ -940,6 +939,7 @@ func (g *generator) getModOrAlias(pkg, mod, originalMod string) string {
 			return path.Base(info.ImportBasePath)
 		}
 	}
+	mod = strings.Split(mod, "/")[0]
 	return mod
 }
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -924,6 +924,7 @@ func (g *generator) useLookupInvokeForm(token string) bool {
 // is aliased, returning that alias if available.
 func (g *generator) getModOrAlias(pkg, mod, originalMod string) string {
 	info, ok := g.getGoPackageInfo(pkg)
+	mod = strings.Split(mod, "/")[0]
 	if !ok {
 		return mod
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -184,8 +184,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 					"Unsafe enum conversions from type %s not implemented yet: %s => %s",
 					from.Type(), from, to))
 			}
-			enumTag := fmt.Sprintf("%s.%s",
-				tokenToModule(to.Token), tokenToName(to.Token))
+			pkg, mod, typ, _ := pcl.DecomposeToken(to.Token, to.SyntaxNode().Range())
+			mod = g.getModOrAlias(pkg, mod, mod)
+			enumTag := fmt.Sprintf("%s.%s", mod, typ)
 			if isOutput {
 				g.Fgenf(w,
 					"%.v.ApplyT(func(x *%[3]s) %[2]s { return %[2]s(*x) }).(%[2]sOutput)",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10664 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
