### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -542,7 +541,7 @@ func newNewCmd() *cobra.Command {
 
 // errorIfNotEmptyDirectory returns an error if path is not empty.
 func errorIfNotEmptyDirectory(path string) error {
-	infos, err := ioutil.ReadDir(path)
+	infos, err := os.ReadDir(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -763,7 +763,7 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 			g.isErrAssigned = true
 		case *readDirTemp:
 			tmpSuffix := strings.Split(t.Name, "files")[1]
-			g.Fgenf(w, "%s, err := ioutil.ReadDir(%.v)\n", t.Name, t.Value.Args[0])
+			g.Fgenf(w, "%s, err := os.ReadDir(%.v)\n", t.Name, t.Value.Args[0])
 			g.Fgenf(w, "if err != nil {\n")
 			if genZeroValueDecl {
 				g.Fgenf(w, "return _zero, err\n")

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1119,7 +1119,7 @@ func (g *generator) functionName(tokenArg model.Expression) (string, string, str
 var functionPackages = map[string][]string{
 	"join":             {"strings"},
 	"mimeType":         {"mime", "path"},
-	"readDir":          {"io/ioutil"},
+	"readDir":          {"os"},
 	"readFile":         {"io/ioutil"},
 	"filebase64":       {"io/ioutil", "encoding/base64"},
 	"toBase64":         {"encoding/base64"},

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -3,6 +3,7 @@ package pcl
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,7 +22,7 @@ var fileToMockPlugins = map[string]map[string]string{
 func TestBindProgram(t *testing.T) {
 	t.Parallel()
 
-	testdata, err := ioutil.ReadDir(testdataPath)
+	testdata, err := os.ReadDir(testdataPath)
 	if err != nil {
 		t.Fatalf("could not read test data: %v", err)
 	}
@@ -33,7 +34,7 @@ func TestBindProgram(t *testing.T) {
 			continue
 		}
 		folderPath := filepath.Join(testdataPath, v.Name())
-		files, err := ioutil.ReadDir(folderPath)
+		files, err := os.ReadDir(folderPath)
 		if err != nil {
 			t.Fatalf("could not read test data: %v", err)
 		}

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -117,7 +118,7 @@ func getDocsForPackage(pkg *Package) []doc {
 func TestParseAndRenderDocs(t *testing.T) {
 	t.Parallel()
 
-	files, err := ioutil.ReadDir(testdataPath)
+	files, err := os.ReadDir(testdataPath)
 	if err != nil {
 		t.Fatalf("could not read test data: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestParseAndRenderDocs(t *testing.T) {
 func TestReferenceRenderer(t *testing.T) {
 	t.Parallel()
 
-	files, err := ioutil.ReadDir(testdataPath)
+	files, err := os.ReadDir(testdataPath)
 	if err != nil {
 		t.Fatalf("could not read test data: %v", err)
 	}

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/go/aws-s3-folder.go
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/go/aws-s3-folder.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/s3"
@@ -21,7 +21,7 @@ func main() {
 			return err
 		}
 		siteDir := "www"
-		files0, err := ioutil.ReadDir(siteDir)
+		files0, err := os.ReadDir(siteDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -15,7 +15,6 @@
 package codegen
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -123,7 +122,7 @@ func SortedKeys(m interface{}) []string {
 // in a subdirectory, only entire subdirectories. This function will need improvements to be able to
 // target that use-case.
 func CleanDir(dirPath string, exclusions StringSet) error {
-	subPaths, err := ioutil.ReadDir(dirPath)
+	subPaths, err := os.ReadDir(dirPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -142,7 +142,7 @@ func CopyFile(src, dst string) error {
 // From https://blog.depado.eu/post/copy-files-and-directories-in-go
 func CopyDir(src, dst string) error {
 	var err error
-	var fds []os.FileInfo
+	var fds []os.DirEntry
 	var srcinfo os.FileInfo
 
 	if srcinfo, err = os.Stat(src); err != nil {
@@ -153,7 +153,7 @@ func CopyDir(src, dst string) error {
 		return err
 	}
 
-	if fds, err = ioutil.ReadDir(src); err != nil {
+	if fds, err = os.ReadDir(src); err != nil {
 		return err
 	}
 	for _, fd := range fds {

--- a/sdk/go/common/util/fsutil/copy.go
+++ b/sdk/go/common/util/fsutil/copy.go
@@ -35,7 +35,7 @@ func CopyFile(dst string, src string, excl map[string]bool) error {
 
 	if info.IsDir() {
 		// Recursively copy all files in a directory.
-		files, err := ioutil.ReadDir(src)
+		files, err := os.ReadDir(src)
 		if err != nil {
 			return err
 		}

--- a/sdk/go/common/util/fsutil/walkup.go
+++ b/sdk/go/common/util/fsutil/walkup.go
@@ -15,7 +15,6 @@
 package fsutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -32,7 +31,7 @@ func WalkUp(path string, walkFn func(string) bool, visitParentFn func(string) bo
 
 	for {
 		// visit each file
-		files, err := ioutil.ReadDir(curr)
+		files, err := os.ReadDir(curr)
 		if err != nil {
 			return "", err
 		}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1272,7 +1272,7 @@ func (spec PluginSpec) InstallWithContext(ctx context.Context, content PluginCon
 func cleanupTempDirs(finalDir string) error {
 	dir := filepath.Dir(finalDir)
 
-	infos, err := ioutil.ReadDir(dir)
+	infos, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
@@ -1422,7 +1422,7 @@ func GetPluginsWithMetadata() ([]PluginInfo, error) {
 }
 
 func getPlugins(dir string, skipMetadata bool) ([]PluginInfo, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -1890,7 +1890,7 @@ var pluginRegexp = regexp.MustCompile(
 var installingPluginRegexp = regexp.MustCompile(`\.tmp[0-9]+$`)
 
 // tryPlugin returns true if a file is a plugin, and extracts information about it.
-func tryPlugin(file os.FileInfo) (PluginKind, string, semver.Version, bool) {
+func tryPlugin(file os.DirEntry) (PluginKind, string, semver.Version, bool) {
 	// Only directories contain plugins.
 	if !file.IsDir() {
 		logging.V(11).Infof("skipping file in plugin directory: %s", file.Name())
@@ -1955,7 +1955,7 @@ func getPluginSize(path string) (int64, error) {
 
 	size := int64(0)
 	if file.IsDir() {
-		subs, err := ioutil.ReadDir(path)
+		subs, err := os.ReadDir(path)
 		if err != nil {
 			return 0, err
 		}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -262,7 +262,7 @@ func getPluginsFromDir(
 	dir string, pulumiPackagePathToVersionMap map[string]semver.Version,
 	inNodeModules bool) ([]*pulumirpc.PluginDependency, error) {
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading plugin dir %s", dir)
 	}
@@ -274,12 +274,12 @@ func getPluginsFromDir(
 		curr := filepath.Join(dir, name)
 
 		// Re-stat the directory, in case it is a symlink.
-		file, err = os.Stat(curr)
+		fi, err := os.Stat(curr)
 		if err != nil {
 			allErrors = multierror.Append(allErrors, err)
 			continue
 		}
-		if file.IsDir() {
+		if fi.IsDir() {
 			// if a directory, recurse.
 			more, err := getPluginsFromDir(
 				curr, pulumiPackagePathToVersionMap, inNodeModules || filepath.Base(dir) == "node_modules")


### PR DESCRIPTION
# Description

This PR replaces all `ioutil.ReadDir` to `os.ReadDir`. `ioutil.ReadDir` has been deprecated in Go 1.16. The new `os.ReadDir` is a more efficient implementation than `ioutil.ReadDir`. 

The full proposal can be read here: https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467

Reference: https://pkg.go.dev/io/ioutil#ReadDir

## Checklist

- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~: Refactoring only, no new features added.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] ~~I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change~~: This PR is a non user-facing change.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] ~~Yes, there are changes in this PR that warrants bumping the Pulumi Service API version~~: N/A
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
