### PR TITLE
Improve error message about stack name validation

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -291,7 +291,7 @@ func (b *localBackend) ValidateStackName(stackName string) error {
 
 	validNameRegex := regexp.MustCompile("^[A-Za-z0-9_.-]{1,100}$")
 	if !validNameRegex.MatchString(stackName) {
-		return errors.New("stack names may only contain alphanumeric, hyphens, underscores, or periods")
+		return errors.New("stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
 	}
 
 	return nil

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -291,7 +291,8 @@ func (b *localBackend) ValidateStackName(stackName string) error {
 
 	validNameRegex := regexp.MustCompile("^[A-Za-z0-9_.-]{1,100}$")
 	if !validNameRegex.MatchString(stackName) {
-		return errors.New("stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
+		return errors.New(
+			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
 	}
 
 	return nil

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -82,7 +82,8 @@ func TestStackTagValidation(t *testing.T) {
 
 		stdout, stderr := e.RunCommandExpectError("pulumi", "stack", "init", "invalid name (spaces, parens, etc.)")
 		assert.Equal(t, "", stdout)
-		assert.Contains(t, stderr, "stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
+		assert.Contains(t, stderr,
+			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
 	})
 
 	t.Run("Error_DescriptionLength", func(t *testing.T) {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -82,7 +82,7 @@ func TestStackTagValidation(t *testing.T) {
 
 		stdout, stderr := e.RunCommandExpectError("pulumi", "stack", "init", "invalid name (spaces, parens, etc.)")
 		assert.Equal(t, "", stdout)
-		assert.Contains(t, stderr, "stack names may only contain alphanumeric, hyphens, underscores, or periods")
+		assert.Contains(t, stderr, "stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
 	})
 
 	t.Run("Error_DescriptionLength", func(t *testing.T) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Hello pulumers. I spent some hours trying to discover why my stack name was invalid, because the error message didn't mention the 100 characters limit imposed by the CLI. I had no problem in shortening the stack name, but what do you think about improving the error message?

Thanks 🙏 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works **(changed the error message in the test too)**
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change **(not applicable)**
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version **(not applicable)**
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
