### PR TITLE
[nodejs/auto] Fix incremental behavior of onStdout

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,9 @@
 
 - Fix invalid resource type on `pulumi convert` to Go
   [#10670](https://github.com/pulumi/pulumi/pull/10670)
+
+- [auto/nodejs] `onOutput` is now called incrementally as the
+  underyling Pulumi process produces data, instead of being called
+  once at the end of the process execution. This restores behavior
+  that regressed since 3.39.0.
+  [#10678](https://github.com/pulumi/pulumi/pull/10678)

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -56,14 +56,23 @@ export async function runPulumiCmd(
     const env = { ...process.env, ...additionalEnv };
 
     try {
-        const { stdout, stderr, exitCode } = await execa("pulumi", args, { env, cwd });
+        const proc = execa("pulumi", args, { env, cwd });
+
+        if (onOutput && proc.stdout) {
+            proc.stdout!.on("data", (data: any) => {
+                if (data && data.toString) {
+                    data = data.toString();
+                }
+                onOutput(data);
+            });
+        }
+
+        const { stdout, stderr, exitCode } = await proc;
         const commandResult = new CommandResult(stdout, stderr, exitCode);
         if (exitCode !== 0) {
             throw createCommandError(commandResult);
         }
-        if (onOutput) {
-            onOutput(stdout);
-        }
+
         return commandResult;
     } catch (err) {
         const error = err as Error;

--- a/sdk/nodejs/tests/automation/cmd.spec.ts
+++ b/sdk/nodejs/tests/automation/cmd.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,17 +13,19 @@
 // limitations under the License.
 
 import * as assert from "assert";
-import * as sinon from "sinon";
 import { runPulumiCmd } from "../../automation";
 import { asyncTest } from "../util";
 
 describe("automation/cmd", () => {
     it("calls onOutput when provided to runPulumiCmd", asyncTest(async () => {
-        const spy = sinon.spy();
-        await runPulumiCmd(["version"], ".", {}, spy);
-
-        assert.ok(spy.calledOnce);
-        assert.strictEqual(spy.firstCall.firstArg, spy.lastCall.lastArg);
+        let output = "";
+        let numCalls = 0;
+        await runPulumiCmd(["--help"], ".", {}, (data: string) => {
+            output += data;
+            numCalls += 1;
+        });
+        assert.ok(numCalls > 1, `expected numCalls > 1, got ${numCalls}`);
+        assert.match(output, new RegExp("Usage[:]"));
+        assert.match(output, new RegExp("[-][-]verbose"));
     }));
 });
-


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10611 

Originally the issue was introduced in https://github.com/pulumi/pulumi/commit/26549ab52d9ce02b7461d87dc7789524a4e8f8c4 that switched from child_process to execa library.  This accidentally dropped onOutput support. 

The fix in 10631 reintroduced onOutput support as one-shot call at the end of the process.

https://github.com/pulumi/pulumi/pull/10631/files#diff-b35ce5a8458abde54622e6fcc6d9b47f30c1cbb88c12d0e22986ca7b97e20a84R64

This PR is trying to go back to the behavior where onOutput is called with data chunks from the pulumi output stream as they arrive.




## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
