### PR TITLE
ci: fix on-release script typo, clean up goreleaser.yml

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: "${{ fromJSON(steps.version.outputs.version) }}"
-      next_version: "${{ fromJSON(steps.version.outputs.next_version) }}"
+      next-version: "${{ fromJSON(steps.version.outputs.next-version) }}"
     steps:
       - uses: actions/checkout@v3
         # Uses release ref (tag)
@@ -31,7 +31,7 @@ jobs:
           ./.github/scripts/set-output version "${PULUMI_VERSION}"
 
           NEXT_VERSION="$(.github/scripts/get-next-version "${PULUMI_VERSION}")"
-          ./.github/scripts/set-output next_version "${NEXT_VERSION}"
+          ./.github/scripts/set-output next-version "${NEXT_VERSION}"
 
   release:
     name: release
@@ -40,6 +40,6 @@ jobs:
     with:
       ref: ${{ github.event.release.tag_name }}
       version: ${{ needs.info.outputs.version }}
-      next_version: ${{ needs.info.outputs.next_version }}
+      next-version: ${{ needs.info.outputs.next-version }}
       release-notes: ${{ github.event.release.body }}
     secrets: inherit

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,14 +2,6 @@ dist: goreleaser
 
 project_name: pulumi
 
-blobs:
-- bucket: get.pulumi.com
-  folder: releases/sdk/
-  ids:
-    - pulumi
-  provider: s3
-  region: us-west-2
-
 builds:
 - &pulumibin
   id: pulumi
@@ -96,6 +88,3 @@ brews:
       (bash_completion/"pulumi.bash").write Utils.safe_popen_read("#{bin}/pulumi gen-completion bash")
       (zsh_completion/"_pulumi").write Utils.safe_popen_read("#{bin}/pulumi gen-completion zsh")
       (fish_completion/"pulumi.fish").write Utils.safe_popen_read("#{bin}/pulumi gen-completion fish")
-
-release:
-  discussion_category_name: Releases


### PR DESCRIPTION
The "on-release.yml" workflow for the v3.39.4 job failed due to a typo. Workflow here: https://github.com/pulumi/pulumi/actions/runs/3049276939

Error:

> The workflow is not valid. .github/workflows/on-release.yml (Line: 39, Col: 11): Input next-version is required, but not provided while calling. .github/workflows/on-release.yml (Line: 43, Col: 21): Invalid input, next_version is not defined in the referenced workflow.

The input parameter for `release.yml` is `next-version`, with a hyphen, not `next_version`.

