### PR TITLE
Prep for real 3.40.0 release

### DIFF
--- a/.github/scripts/get-next-version
+++ b/.github/scripts/get-next-version
@@ -14,7 +14,7 @@ if [[ "${PREVIOUS_VERSION}" = *-*.* ]]; then
   VERSION="${PREVIOUS_VERSION%.*}.$((${PREVIOUS_VERSION##*.} + 1))"
 else
   IFS=. read -r major minor rest <<< "${PREVIOUS_VERSION}"
-  VERSION="TAG=${major}.$((minor + 1)).0"
+  VERSION="${major}.$((minor + 1)).0"
 fi
 
 echo -n "$VERSION"

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -42,4 +42,5 @@ jobs:
       version: ${{ needs.info.outputs.version }}
       next-version: ${{ needs.info.outputs.next-version }}
       release-notes: ${{ github.event.release.body }}
+      run-dispatch-commands: true
     secrets: inherit


### PR DESCRIPTION
This turns the "safeties off" after validating the bors workflow and ensuring everything up to the dispatch commands succeeds.

It also fixes an error in `get-next-version` that resulted in the "vNext" PR #10701 to calculate the wrong "next version", which was corrected by hand. (The branch name and commit history is evidence of the error.)