### PR TITLE
Resolve discriminated unions when the discriminator is a string pointer

### DIFF
--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -183,6 +183,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		// We have special testing for this case because lambda is a python keyword.
 		Skip: codegen.NewStringSet("go", "nodejs", "dotnet"),
 	},
+	{
+		Directory:   "discriminated-union",
+		Description: "Discriminated Unions for choosing an input type",
+		Skip:        codegen.NewStringSet("go"),
+		// Blocked on go: TODO[pulumi/pulumi#10834]
+	},
 }
 
 // Checks that a generated program is correct

--- a/pkg/codegen/testing/test/testdata/discriminated-union-pp/discriminated-union.pp
+++ b/pkg/codegen/testing/test/testdata/discriminated-union-pp/discriminated-union.pp
@@ -1,0 +1,19 @@
+resource server "azure-native:dbforpostgresql:Server" {
+    location = "brazilsouth"
+    properties = {
+        createMode = "PointInTimeRestore",
+        restorePointInTime = "2017-12-14T00:00:37.467Z",
+        sourceServerId = "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforPostgreSQL/servers/sourceserver"
+    }
+    resourceGroupName = "TargetResourceGroup"
+    serverName = "targetserver"
+    sku = {
+        capacity = 2,
+        family = "Gen5",
+        name = "B_Gen5_2",
+        tier = "Basic"
+    }
+    tags = {
+        ElasticServer = "1"
+    }
+}

--- a/pkg/codegen/testing/test/testdata/discriminated-union-pp/dotnet/discriminated-union.cs
+++ b/pkg/codegen/testing/test/testdata/discriminated-union-pp/dotnet/discriminated-union.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Pulumi;
+using AzureNative = Pulumi.AzureNative;
+
+return await Deployment.RunAsync(() => 
+{
+    var server = new AzureNative.DBforPostgreSQL.Server("server", new()
+    {
+        Location = "brazilsouth",
+        Properties = new AzureNative.DBforPostgreSQL.Inputs.ServerPropertiesForRestoreArgs
+        {
+            CreateMode = "PointInTimeRestore",
+            RestorePointInTime = "2017-12-14T00:00:37.467Z",
+            SourceServerId = "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforPostgreSQL/servers/sourceserver",
+        },
+        ResourceGroupName = "TargetResourceGroup",
+        ServerName = "targetserver",
+        Sku = new AzureNative.DBforPostgreSQL.Inputs.SkuArgs
+        {
+            Capacity = 2,
+            Family = "Gen5",
+            Name = "B_Gen5_2",
+            Tier = "Basic",
+        },
+        Tags = 
+        {
+            { "ElasticServer", "1" },
+        },
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/discriminated-union-pp/nodejs/discriminated-union.ts
+++ b/pkg/codegen/testing/test/testdata/discriminated-union-pp/nodejs/discriminated-union.ts
@@ -1,0 +1,22 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as azure_native from "@pulumi/azure-native";
+
+const server = new azure_native.dbforpostgresql.Server("server", {
+    location: "brazilsouth",
+    properties: {
+        createMode: "PointInTimeRestore",
+        restorePointInTime: "2017-12-14T00:00:37.467Z",
+        sourceServerId: "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforPostgreSQL/servers/sourceserver",
+    },
+    resourceGroupName: "TargetResourceGroup",
+    serverName: "targetserver",
+    sku: {
+        capacity: 2,
+        family: "Gen5",
+        name: "B_Gen5_2",
+        tier: "Basic",
+    },
+    tags: {
+        ElasticServer: "1",
+    },
+});

--- a/pkg/codegen/testing/test/testdata/discriminated-union-pp/python/discriminated-union.py
+++ b/pkg/codegen/testing/test/testdata/discriminated-union-pp/python/discriminated-union.py
@@ -1,0 +1,21 @@
+import pulumi
+import pulumi_azure_native as azure_native
+
+server = azure_native.dbforpostgresql.Server("server",
+    location="brazilsouth",
+    properties=azure_native.dbforpostgresql.ServerPropertiesForRestoreArgs(
+        create_mode="PointInTimeRestore",
+        restore_point_in_time="2017-12-14T00:00:37.467Z",
+        source_server_id="/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/SourceResourceGroup/providers/Microsoft.DBforPostgreSQL/servers/sourceserver",
+    ),
+    resource_group_name="TargetResourceGroup",
+    server_name="targetserver",
+    sku=azure_native.dbforpostgresql.SkuArgs(
+        capacity=2,
+        family="Gen5",
+        name="B_Gen5_2",
+        tier="Basic",
+    ),
+    tags={
+        "ElasticServer": "1",
+    })


### PR DESCRIPTION
Examples in our docs that use discriminated unions to determine `...Input` types are broken, e.g., pulumi/pulumi-azure-native#1960.

Debugging this, I found that the discriminator is expected to be a string, but it is (in this case) a *string wrapped in a __convert call. This patch simply tries both cases.

Submitting this as a speculative draft PR because I'm new to this area and don't know if this is the best approach to fix the issue. Maybe the `__convert(*string)` should be resolved to a plain string before the lookup?

Apologies for the whitespace changes, gofmt 1.19 will do that.