### PR TITLE
ci: Re-enable checksums

### DIFF
--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -40,7 +40,6 @@ env:
 jobs:
   sign:
     name: sign
-    if: false # TODO: Enable this job after signing key is configured.
     runs-on: ubuntu-latest
 
     steps:
@@ -80,9 +79,11 @@ jobs:
 
       - name: Sign checksums
         working-directory: artifacts
+        # Requires a signing key to be configured.
+        if: false
         shell: bash
         env:
-          RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
+          # RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
           version: ${{ inputs.version }}
         run: |
           set -u
@@ -110,7 +111,7 @@ jobs:
 
   publish:
     name: release
-    # needs: [sign]
+    needs: [sign]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
In the absence of key distribution or attestation of a "proper" signing key for now, this enables the "sign" job which adds checksum artifacts, sans signatures.

This leaves open the possibility of using sigstore.dev & tooling, or some other tooling to sign artifacts.

Fixes #10707.