### PR TITLE
ci: Fix Windows flake with longer timeout

### DIFF
--- a/sdk/python/lib/test/runtime/test_resource_dep_cycle.py
+++ b/sdk/python/lib/test/runtime/test_resource_dep_cycle.py
@@ -19,7 +19,7 @@ from pulumi.runtime import settings, mocks
 import pulumi
 
 
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(10)
 @pulumi.runtime.test
 def test_pulumi_does_not_hang_on_dependency_cycle(my_mocks):
     c = MockComponentResource(name='c')

--- a/sdk/python/lib/test/test_broken_dynamic_provider.py
+++ b/sdk/python/lib/test/test_broken_dynamic_provider.py
@@ -80,7 +80,7 @@ class X(dyn.Resource):
 
 
 @raises(AssertionError)
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(10)
 @pulumi.runtime.test
 def test_pulumi_broken_dynamic_provider(my_mocks):
     x = X(name='my_x', args=XInputs({'my_key_1': 'my_value_1'}))

--- a/sdk/python/lib/test/test_monitor_termination.py
+++ b/sdk/python/lib/test/test_monitor_termination.py
@@ -27,7 +27,7 @@ from .helpers import raises
 # Verify that when the monitor becomes unavailable (via
 # unavailable_mocks), programs fail with a `RunError` and do not hang.
 @raises(pulumi.RunError)
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(10)
 @pulumi.runtime.test
 def test_resource_registration_does_not_hang_when_monitor_unavailable(unavailable_mocks):
     MyCustom('mycustom', {'inprop': 'hello'})


### PR DESCRIPTION
This fixes Windows tests failing like this due to very short (1 second) timeouts.

https://github.com/pulumi/pulumi/actions/runs/3054396239/jobs/4926314390
