### PR TITLE
ci: Skip Python service tests when access token is absent

### DIFF
--- a/sdk/python/lib/test/automation/test_errors.py
+++ b/sdk/python/lib/test/automation/test_errors.py
@@ -28,7 +28,7 @@ from .test_local_workspace import stack_namer, test_path
 compilation_error_project = "compilation_error"
 runtime_error_project = "runtime_error"
 
-
+@pytest.mark.skipif("PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set")
 class TestErrors(unittest.TestCase):
     def test_inline_runtime_error_python(self):
         project_name = "inline_runtime_error_python"

--- a/sdk/python/lib/test/automation/test_isolation.py
+++ b/sdk/python/lib/test/automation/test_isolation.py
@@ -18,6 +18,7 @@
 # operations.
 
 import asyncio
+import os
 import pytest
 import sys
 import typing
@@ -77,7 +78,7 @@ async def async_stack_up(stack):
 async def async_stack_destroy(stack):
     return stack.destroy()
 
-
+@pytest.mark.skipif("PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set")
 @pytest.mark.asyncio
 async def test_parallel_updates():
     first_stack_name = f"stack-{uuid.uuid4()}"
@@ -88,7 +89,7 @@ async def test_parallel_updates():
     stack_destroy_responses = await asyncio.gather(*[async_stack_destroy(stack) for stack in stacks])
     assert all({stack_response.summary.result == "succeeded" for stack_response in stack_destroy_responses})
 
-
+@pytest.mark.skipif("PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set")
 @pytest.mark.skipif(
     sys.platform == 'win32',
     reason="TODO[pulumi/pulumi#8716] fails on Windows")

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -109,6 +109,7 @@ def get_stack(stack_list: List[StackSummary], name: str) -> Optional[StackSummar
     return None
 
 
+@pytest.mark.skipif("PULUMI_ACCESS_TOKEN" not in os.environ, reason="PULUMI_ACCESS_TOKEN not set")
 class TestLocalWorkspace(unittest.TestCase):
     def test_project_settings(self):
         for ext in extensions:


### PR DESCRIPTION
These tests fail loudly and hard when `PULUMI_ACCESS_TOKEN` is not set, making local dev experience more brittle. Along with changes made in a future PR to enable easier local dev testing without a Pulumi service account, this will improve developer experience when running `make` in the repo.