### PR TITLE
ci: Skip refresh on tests that should fail fast

### DIFF
--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -32,6 +32,7 @@ func TestNoEmitExitStatus(t *testing.T) {
 		Stderr:        stderr,
 		ExpectFailure: true,
 		Quick:         true,
+		SkipRefresh:   true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// ensure exit status is not emitted by the program
 			assert.NotContains(t, stderr.String(), "exit status")
@@ -75,6 +76,7 @@ func TestGoRunEnvFlag(t *testing.T) {
 		Stderr:        stderr,
 		ExpectFailure: true,
 		Quick:         true,
+		SkipRefresh:   true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// ensure exit status IS emitted by the program as it indicates `go run` was used
 			assert.Contains(t, stderr.String(), "exit status")


### PR DESCRIPTION
These tests performed unnecessary refresh steps. Happened to catch these while optimizing build times. The impact on execution times was negligible.