### PR TITLE
ci: Use yarn link before install, ensure Pulumi latest is used

### DIFF
--- a/sdk/go/common/workspace/plugins_install_nodejs_test.go
+++ b/sdk/go/common/workspace/plugins_install_nodejs_test.go
@@ -23,7 +23,7 @@ import (
 
 var tarball = map[string][]byte{
 	"PulumiPlugin.yaml": []byte("runtime: nodejs\n"),
-	"package.json":      []byte(`{"name":"test","dependencies":{"@pulumi/pulumi":"^2.0.0"}}`),
+	"package.json":      []byte(`{"name":"test","dependencies":{"@pulumi/pulumi":"latest"}}`),
 }
 
 func TestNodeNPMInstall(t *testing.T) {

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -86,8 +86,8 @@ func TestHistoryCommand(t *testing.T) {
 		e.ImportDirectory("integration/stack_outputs")
 		e.RunCommand("pulumi", "stack", "init", "stack-without-updates")
 		e.RunCommand("pulumi", "stack", "init", "history-test")
-		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
+		e.RunCommand("yarn", "install")
 		// Update the history-test stack.
 		e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview", "-m", "this is an updated stack")
 		// Confirm we see the update message in thie history output.

--- a/tests/integration/targets/targets_test.go
+++ b/tests/integration/targets/targets_test.go
@@ -36,8 +36,8 @@ func TestUntargetedCreateDuringTargetedUpdate(t *testing.T) {
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 
 	e.ImportDirectory("untargeted_create")
-	e.RunCommand("pulumi", "stack", "init", stackName)
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
+	e.RunCommand("pulumi", "stack", "init", stackName)
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
 	urn, _ := e.RunCommand("pulumi", "stack", "output", "urn")
 
@@ -75,8 +75,8 @@ func TestDeleteManyTargets(t *testing.T) {
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 	e.ImportDirectory(projName)
 	e.RunCommand("pulumi", "stack", "init", stackName)
-	e.RunCommand("yarn", "install")
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
+	e.RunCommand("yarn", "install")
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
 
 	// Create a handy mkURN func to create URNs for dynamic resources in this project/stack.

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -255,8 +255,8 @@ func TestStackCommands(t *testing.T) {
 		e.ImportDirectory("integration/stack_dependencies")
 		e.SetBackend(e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", stackName)
-		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
+		e.RunCommand("yarn", "install")
 		e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
 		// We're going to futz with the stack a little so that one of the resources we just created
 		// becomes invalid.
@@ -348,8 +348,8 @@ func TestStackBackups(t *testing.T) {
 		e.RunCommand("pulumi", "stack", "init", stackName)
 
 		// Build the project.
-		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
+		e.RunCommand("yarn", "install")
 
 		// Now run pulumi up.
 		before := time.Now().UnixNano()
@@ -469,8 +469,8 @@ func TestLocalStateLocking(t *testing.T) {
 	e.ImportDirectory("integration/single_resource")
 	e.SetBackend(e.LocalURL())
 	e.RunCommand("pulumi", "stack", "init", "foo")
-	e.RunCommand("yarn", "install")
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
+	e.RunCommand("yarn", "install")
 
 	count := 10
 	stderrs := make(chan string, count)
@@ -582,8 +582,8 @@ func TestLocalStateGzip(t *testing.T) { //nolint:paralleltest
 	e.ImportDirectory("integration/stack_dependencies")
 	e.SetBackend(e.LocalURL())
 	e.RunCommand("pulumi", "stack", "init", stackName)
-	e.RunCommand("yarn", "install")
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
+	e.RunCommand("yarn", "install")
 	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
 
 	assertGzipFileFormat, assertPlainFileFormat := stackFileFormatAsserters(t, e, stackName)


### PR DESCRIPTION
These cut execution time on myriad node tests by 5 to 30 seconds each. Linking `@pulumi/pulumi` first, before `yarn install`, enables yarn to skip downloading and extracting the node SDK before replacing it with a symlink.