### PR TITLE
ci: Enable programtests against local backend, improve isolation

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -78,6 +78,8 @@ env:
   PULUMI_TEST_OWNER: "moolumi"
   PULUMI_TEST_ORG: "moolumi"
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  # Release builds use the service, PR checks and snapshots will use the local backend if possible.
+  PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   PYTHON: python
   TESTPARALLELISM: 5
   DOTNET_CLI_TELEMETRY_OPTOUT: "true"

--- a/changelog/pending/20220914--ci--local-programtest.yaml
+++ b/changelog/pending/20220914--ci--local-programtest.yaml
@@ -1,4 +1,7 @@
 changes:
-- type: chore
+- type: feat
   scope: ci
-  description: Enables running program tests against local workspace
+  description: >
+    Improves first-time contributor developer experience and reduces test execution time by
+    defaulting `integration.ProgramTest` to a filestate backend. Tests that require running against
+    a service should set `RequireService` to `true`.

--- a/changelog/pending/20220914--ci--local-programtest.yaml
+++ b/changelog/pending/20220914--ci--local-programtest.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: ci
+  description: Enables running program tests against local workspace

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -745,11 +745,13 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
 		opts.SkipEmptyPreviewUpdate = true
 	}
 	if opts.RequireService {
+		// This token is set in CI jobs, so this escape hatch is here to enable a smooth local dev
+		// experience, i.e.: running "make" and not seeing many failures due to a missing token.
 		if os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
 			t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
 		}
 	} else if opts.CloudURL == "" {
-		opts.CloudURL = NewBackendURL(t)
+		opts.CloudURL = MakeTempBackend(t)
 	}
 
 	return &ProgramTester{
@@ -760,8 +762,8 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *ProgramTester {
 	}
 }
 
-// NewBackendURL creates a temporary backend directory which will clean up on test exit.
-func NewBackendURL(t *testing.T) string {
+// MakeTempBackend creates a temporary backend directory which will clean up on test exit.
+func MakeTempBackend(t *testing.T) string {
 	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -467,6 +467,9 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 	if overrides.Quick {
 		opts.Quick = overrides.Quick
 	}
+	if overrides.RequireService {
+		opts.RequireService = overrides.RequireService
+	}
 	if overrides.PreviewCommandlineFlags != nil {
 		opts.PreviewCommandlineFlags = append(opts.PreviewCommandlineFlags, overrides.PreviewCommandlineFlags...)
 	}

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -57,7 +57,7 @@ func TestAccMinimal_withLocalState(t *testing.T) {
 				assert.NotNil(t, stackInfo.Deployment)
 			},
 			RunBuild: true,
-			CloudURL: "file://~",
+			CloudURL: integration.NewBackendURL(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -88,7 +88,7 @@ func TestAccDynamicProviderSimple_withLocalState(t *testing.T) {
 				"simple:config:x": "1",
 				"simple:config:y": "1",
 			},
-			CloudURL: "file://~",
+			CloudURL: integration.NewBackendURL(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -109,7 +109,7 @@ func TestAccDynamicProviderClassWithComments_withLocalState(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{
 			Dir:      filepath.Join(getCwd(t), "dynamic-provider/class-with-comments"),
-			CloudURL: "file://~",
+			CloudURL: integration.NewBackendURL(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -146,7 +146,7 @@ func TestAccDynamicProviderMultipleTurns_withLocalState(t *testing.T) {
 					}
 				}
 			},
-			CloudURL: "file://~",
+			CloudURL: integration.NewBackendURL(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -167,7 +167,7 @@ func TestAccDynamicProviderMultipleTurns2_withLocalState(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{
 			Dir:      filepath.Join(getCwd(t), "dynamic-provider/multiple-turns-2"),
-			CloudURL: "file://~",
+			CloudURL: integration.NewBackendURL(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -188,7 +188,7 @@ func TestAccDynamicProviderDerivedInputs_withLocalState(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{
 			Dir:      filepath.Join(getCwd(t), "dynamic-provider/derived-inputs"),
-			CloudURL: "file://~",
+			CloudURL: integration.NewBackendURL(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -225,7 +225,7 @@ func TestAccFormattable_withLocalState(t *testing.T) {
 			},
 			Stdout:   &formattableStdout,
 			Stderr:   &formattableStderr,
-			CloudURL: "file://~",
+			CloudURL: integration.NewBackendURL(t),
 		})
 
 	integration.ProgramTest(t, &test)

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -57,7 +57,7 @@ func TestAccMinimal_withLocalState(t *testing.T) {
 				assert.NotNil(t, stackInfo.Deployment)
 			},
 			RunBuild: true,
-			CloudURL: integration.NewBackendURL(t),
+			CloudURL: integration.MakeTempBackend(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -88,7 +88,7 @@ func TestAccDynamicProviderSimple_withLocalState(t *testing.T) {
 				"simple:config:x": "1",
 				"simple:config:y": "1",
 			},
-			CloudURL: integration.NewBackendURL(t),
+			CloudURL: integration.MakeTempBackend(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -109,7 +109,7 @@ func TestAccDynamicProviderClassWithComments_withLocalState(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{
 			Dir:      filepath.Join(getCwd(t), "dynamic-provider/class-with-comments"),
-			CloudURL: integration.NewBackendURL(t),
+			CloudURL: integration.MakeTempBackend(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -146,7 +146,7 @@ func TestAccDynamicProviderMultipleTurns_withLocalState(t *testing.T) {
 					}
 				}
 			},
-			CloudURL: integration.NewBackendURL(t),
+			CloudURL: integration.MakeTempBackend(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -167,7 +167,7 @@ func TestAccDynamicProviderMultipleTurns2_withLocalState(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{
 			Dir:      filepath.Join(getCwd(t), "dynamic-provider/multiple-turns-2"),
-			CloudURL: integration.NewBackendURL(t),
+			CloudURL: integration.MakeTempBackend(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -188,7 +188,7 @@ func TestAccDynamicProviderDerivedInputs_withLocalState(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{
 			Dir:      filepath.Join(getCwd(t), "dynamic-provider/derived-inputs"),
-			CloudURL: integration.NewBackendURL(t),
+			CloudURL: integration.MakeTempBackend(t),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -225,7 +225,7 @@ func TestAccFormattable_withLocalState(t *testing.T) {
 			},
 			Stdout:   &formattableStdout,
 			Stderr:   &formattableStderr,
-			CloudURL: integration.NewBackendURL(t),
+			CloudURL: integration.MakeTempBackend(t),
 		})
 
 	integration.ProgramTest(t, &test)

--- a/tests/integration/integration_dotnet_test.go
+++ b/tests/integration/integration_dotnet_test.go
@@ -265,6 +265,8 @@ func TestStackReferenceDotnet(t *testing.T) {
 	}
 
 	opts := &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir:          filepath.Join("stack_reference", "dotnet"),
 		Dependencies: []string{"Pulumi"},
 		Quick:        true,
@@ -297,6 +299,8 @@ func TestStackReferenceSecretsDotnet(t *testing.T) {
 	d := "stack_reference_secrets"
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir:          filepath.Join(d, "dotnet", "step1"),
 		Dependencies: []string{"Pulumi"},
 		Config: map[string]string{

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -448,6 +448,8 @@ func TestStackReferenceGo(t *testing.T) {
 	}
 
 	opts := &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir: filepath.Join("stack_reference", "go"),
 		Dependencies: []string{
 			"github.com/pulumi/pulumi/sdk/v3",

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -725,7 +725,7 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 		Secrets: map[string]string{
 			"mysecret": "THISISASECRET",
 		},
-		CloudURL:   integration.NewBackendURL(t),
+		CloudURL:   integration.MakeTempBackend(t),
 		NoParallel: true, // mutates environment variables
 	}
 
@@ -810,7 +810,7 @@ func TestCloudSecretProvider(t *testing.T) {
 	}
 
 	localTestOptions := testOptions.With(integration.ProgramTestOptions{
-		CloudURL: integration.NewBackendURL(t),
+		CloudURL: integration.MakeTempBackend(t),
 	})
 
 	azureTestOptions := testOptions.With(integration.ProgramTestOptions{

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -160,6 +160,8 @@ func TestProjectMain(t *testing.T) {
 // TestStackProjectName ensures we can read the Pulumi stack and project name from within the program.
 func TestStackProjectName(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir:          "stack_project_name",
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
@@ -603,6 +605,8 @@ func TestStackReferenceNodeJS(t *testing.T) {
 	}
 
 	opts := &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir:          filepath.Join("stack_reference", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
@@ -688,6 +692,8 @@ func TestStackReferenceSecretsNodejs(t *testing.T) {
 	d := "stack_reference_secrets"
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir:          filepath.Join(d, "nodejs", "step1"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
@@ -719,7 +725,7 @@ func TestPasswordlessPassphraseSecretsProvider(t *testing.T) {
 		Secrets: map[string]string{
 			"mysecret": "THISISASECRET",
 		},
-		CloudURL:   "file://~",
+		CloudURL:   integration.NewBackendURL(t),
 		NoParallel: true, // mutates environment variables
 	}
 
@@ -804,7 +810,7 @@ func TestCloudSecretProvider(t *testing.T) {
 	}
 
 	localTestOptions := testOptions.With(integration.ProgramTestOptions{
-		CloudURL: "file://~",
+		CloudURL: integration.NewBackendURL(t),
 	})
 
 	azureTestOptions := testOptions.With(integration.ProgramTestOptions{

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -267,6 +267,8 @@ func TestStackReferencePython(t *testing.T) {
 	}
 
 	opts := &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir: filepath.Join("stack_reference", "python"),
 		Dependencies: []string{
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
@@ -297,6 +299,8 @@ func TestMultiStackReferencePython(t *testing.T) {
 
 	// build a stack with an export
 	exporterOpts := &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir: filepath.Join("stack_reference_multi", "python", "exporter"),
 		Dependencies: []string{
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
@@ -311,6 +315,8 @@ func TestMultiStackReferencePython(t *testing.T) {
 	integration.ProgramTest(t, exporterOpts)
 
 	importerOpts := &integration.ProgramTestOptions{
+		RequireService: true,
+
 		Dir: filepath.Join("stack_reference_multi", "python", "importer"),
 		Dependencies: []string{
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),

--- a/tests/integration/query/query_test.go
+++ b/tests/integration/query/query_test.go
@@ -16,7 +16,7 @@ func TestQuery(t *testing.T) {
 		Dir:          "step1",
 		StackName:    "query-stack-781a480a-fcac-4e5a-ab08-a73bc8cbcdd2",
 		Dependencies: []string{"@pulumi/pulumi"},
-		CloudURL:     "file://~", // Required; we hard-code the stack name
+		CloudURL:     integration.NewBackendURL(t), // Required; we hard-code the stack name
 		EditDirs: []integration.EditDir{
 			// Try to create resources during `pulumi query`. This should fail.
 			{

--- a/tests/integration/query/query_test.go
+++ b/tests/integration/query/query_test.go
@@ -16,7 +16,7 @@ func TestQuery(t *testing.T) {
 		Dir:          "step1",
 		StackName:    "query-stack-781a480a-fcac-4e5a-ab08-a73bc8cbcdd2",
 		Dependencies: []string{"@pulumi/pulumi"},
-		CloudURL:     integration.NewBackendURL(t), // Required; we hard-code the stack name
+		CloudURL:     integration.MakeTempBackend(t), // Required; we hard-code the stack name
 		EditDirs: []integration.EditDir{
 			// Try to create resources during `pulumi query`. This should fail.
 			{


### PR DESCRIPTION
These changes make integration tests run much more quickly on a local dev loop, for easily parallelized program tests like in the `integration_go_test.go` file the improvement was on the order of minutes across all tests.

The changes rely on setting `PULUMI_BACKEND_URL` to override the backend during particular tests. The backend is set to a temporary directory which is cleaned up on exit. 

A helper function `NewBackendUrl(t *testing.T)` is added to enable

When `PULUMI_TEST_USE_SERVICE=true`, the `RequireService` option is set to true.

When `RequireService == true`, the test is skipped if an access token is not present, improving local dev experience by skipping tests which would error very loudly.

When `RequireService == false and CloudURL == ""`, then we use the helper function to create a temporary directory and point the filestate backend to it. 

The CloudURL check allows tests which, even in the presence of `PULUMI_TEST_USE_SERVICE=true`, to still run against a local backend. E.g.: 

```go
	localTestOptions := testOptions.With(integration.ProgramTestOptions{
		CloudURL: integration.NewBackendURL(t),
	})
```