### PR TITLE
ci: Increase bors timeout

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,8 @@
 delete_merged_branches = true
 update_base_for_deletes = true
 
+timeout-sec = 7200 # two hours, in seconds
+
 status = [
 	'bors-ok',
 ]


### PR DESCRIPTION
The default timeout is one hour, which our CI runs can exceed. This should give us a buffer while work is done to reduce execution time to a reasonable threshold.