### PR TITLE
ci: Improve test parallelism, enabled by #10263

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -908,8 +908,9 @@ func TestDestroyStackRef(t *testing.T) {
 	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes", "-s", "dev")
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestRotatePassphrase(t *testing.T) {
+	t.Parallel()
+
 	e := ptesting.NewEnvironment(t)
 	defer func() {
 		if !t.Failed() {
@@ -1134,8 +1135,9 @@ func printfTestValidation(t *testing.T, stack integration.RuntimeValidationStack
 	assert.Equal(t, 11, foundStderr)
 }
 
-//nolint:paralleltest // mutates environment variables
 func TestPassphrasePrompting(t *testing.T) {
+	t.Parallel()
+
 	e := ptesting.NewEnvironment(t)
 	defer func() {
 		if !t.Failed() {


### PR DESCRIPTION
These tests no longer mutate environment variables, instead using `e.SetEnvVars` to only set env vars on child processes since #10263.