### PR TITLE
ci: Enable robust retries on tests

### DIFF
--- a/.github/workflows/ci-integration-test.yml
+++ b/.github/workflows/ci-integration-test.yml
@@ -56,58 +56,58 @@ jobs:
       fail-fast: false
       matrix:
         test-suite:
-          - run: cd sdk/dotnet && make dotnet_test
+          - run: cd sdk/dotnet && ../../scripts/retry make dotnet_test
             eta: 3
-          - run: cd sdk/dotnet && make test_auto
+          - run: cd sdk/dotnet && ../../scripts/retry make test_auto
             eta: 5
-          - run: cd sdk/dotnet && make test_go
+          - run: cd sdk/dotnet && ../../scripts/retry make test_go
             eta: 2
 
-          - run: cd sdk/go && make test_auto
+          - run: cd sdk/go && ../../scripts/retry make test_auto
             eta: 8
-          - run: cd sdk/go && make test_fast
+          - run: cd sdk/go && ../../scripts/retry make test_fast
             eta: 3
 
-          - run: cd sdk/nodejs && make sxs_tests
+          - run: cd sdk/nodejs && ../../scripts/retry make sxs_tests
             eta: 3
-          - run: cd sdk/nodejs && make test_auto
+          - run: cd sdk/nodejs && ../../scripts/retry make test_auto
             eta: 3
-          - run: cd sdk/nodejs && make test_go
+          - run: cd sdk/nodejs && ../../scripts/retry make test_go
             eta: 2
-          - run: cd sdk/nodejs && make unit_tests
+          - run: cd sdk/nodejs && ../../scripts/retry make unit_tests
             eta: 4
 
-          - run: cd sdk/python && make test_auto
+          - run: cd sdk/python && ../../scripts/retry make test_auto
             eta: 6
-          - run: cd sdk/python && make test_fast
+          - run: cd sdk/python && ../../scripts/retry make test_fast
             eta: 3
-          - run: cd sdk/python && make test_go
+          - run: cd sdk/python && ../../scripts/retry make test_go
             eta: 3
 
-          - run: make test_pkg_nodejs
+          - run: ./scripts/retry make test_pkg_nodejs
             eta: 20
 
-          - run: make test_pkg_python
+          - run: ./scripts/retry make test_pkg_python
             eta: 2
-          - run: make test_pkg_rest
+          - run: ./scripts/retry make test_pkg_rest
             eta: 10
 
-          - run: make test_integration_dotnet
+          - run: ./scripts/retry make test_integration_dotnet
             eta: 6
             require-build: true
-          - run: make test_integration_go
+          - run: ./scripts/retry make test_integration_go
             eta: 6
             require-build: true
-          - run: make test_integration_nodejs
+          - run: ./scripts/retry make test_integration_nodejs
             eta: 9
             require-build: true
-          - run: make test_integration_python
+          - run: ./scripts/retry make test_integration_python
             eta: 10
             require-build: true
-          - run: make test_integration_rest
+          - run: ./scripts/retry make test_integration_rest
             eta: 5
             require-build: true
-          - run: make test_integration_subpkgs
+          - run: ./scripts/retry make test_integration_subpkgs
             eta: 15
             require-build: true
     uses: ./.github/workflows/ci-run-test.yml

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -79,7 +79,10 @@ env:
   PULUMI_TEST_ORG: "moolumi"
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   PYTHON: python
-  TESTPARALLELISM: 5
+  GO_TEST_PARALLELISM: 8
+  GO_TEST_PKG_PARALLELISM: 2
+  GO_TEST_SHUFFLE: off
+  PULUMI_TEST_RETRIES: 2
   DOTNET_CLI_TELEMETRY_OPTOUT: "true"
   DOTNET_ROLL_FORWARD: "Major"
   SEGMENT_DOWNLOAD_TIMEOUT_MIN: 10
@@ -110,6 +113,21 @@ jobs:
           echo "$TOOL_BIN" | tee -a "$GITHUB_PATH"
           command -v tar
           tar --version
+      - name: "Windows parallelism reduction"
+        if: ${{ runner.os == 'Windows' }}
+        env:
+          TOOL_BIN: ${{ runner.temp }}/tar-bin
+        run: |
+          echo "GO_TEST_PARALLELISM=5" >> "${GITHUB_ENV}"
+          echo "GO_TEST_PKG_PARALLELISM=1" >> "${GITHUB_ENV}"
+      - name: "macOS use coreutils"
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          set -x
+          brew install coreutils
+          echo "/usr/local/opt/coreutils/libexec/gnubin" | tee -a "$GITHUB_PATH"
+          command -v bash
+          bash --version
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ VERSION         := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ./scripts/pu
 $(info    SHELL           = ${SHELL})
 $(info    VERSION         = ${VERSION})
 
-TESTPARALLELISM ?= 10
-
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running
 # `test_all` without the dependencies.
 TEST_ALL_DEPS ?= build $(SUB_PROJECTS:%=%_install)

--- a/build/common.mk
+++ b/build/common.mk
@@ -104,7 +104,15 @@ PULUMI_NUGET        := $(PULUMI_ROOT)/nuget
 #     make GO_TEST_OPTIONS="-short -test.v" test_fast
 GO_TEST_OPTIONS :=
 
-GO_TEST_FLAGS = -count=1 -cover -tags=all -timeout 1h -parallel ${TESTPARALLELISM} ${GO_TEST_OPTIONS}
+GO_TEST_PARALLELISM     ?= 10   # -parallel, number of parallel tests to run within a package
+GO_TEST_PKG_PARALLELISM ?= 2    # -p flag, number of parallel packages to test
+GO_TEST_SHUFFLE         ?= off  # -shuffle flag, randomizes order of tests within a package
+
+GO_TEST_FLAGS = -count=1 -cover -tags=all -timeout 1h \
+	-parallel ${GO_TEST_PARALLELISM} \
+	-shuffle ${GO_TEST_SHUFFLE} \
+	-p ${GO_TEST_PKG_PARALLELISM} \
+	${GO_TEST_OPTIONS}
 GO_TEST_FAST_FLAGS = -short ${GO_TEST_FLAGS}
 GOPROXY = 'https://proxy.golang.org'
 

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -31,6 +31,13 @@ cov = os.environ.get('PULUMI_TEST_COVERAGE_PATH', None)
 if cov is not None:
     args = args + [f'-coverprofile={cov}/go-test-{os.urandom(4).hex()}.cov', '-coverpkg=github.com/pulumi/pulumi/pkg/v3/...,github.com/pulumi/pulumi/sdk/v3/...']
 
+test_parallelism = int(os.environ.get("GO_TEST_PARALLELISM", "8"))
+pkg_parallelism = int(os.environ.get("GO_TEST_PKG_PARALLELISM", "2"))
+# TODO: https://github.com/pulumi/pulumi/issues/10699
+# Enable running tests with -shuffle on.
+shuffle = os.environ.get("GO_TEST_SHUFFLE", "off")
+args = ['-parallel', str(test_parallelism), '-p', str(pkg_parallelism), "-shuffle", shuffle] + args
+
 if integration_test_subset:
     print(f"Using test subset: {integration_test_subset}")
     args += ['-run', INTEGRATION_TESTS[integration_test_subset]]

--- a/scripts/retry
+++ b/scripts/retry
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script implements a general retry mechanism for a command. On each iteration, parallelism
+# flags are halved and the command is retried.
+
+retries="${PULUMI_TEST_RETRIES:-"0"}"
+attempts=1
+success=false
+retried=false
+
+run_tests() {
+    export GO_TEST_PARALLELISM="${GO_TEST_PARALLELISM:-"8"}"
+    export GO_TEST_PKG_PARALLELISM="${GO_TEST_PKG_PARALLELISM:-"2"}"
+    # TODO: https://github.com/pulumi/pulumi/issues/10699
+    # Enable running tests with -shuffle on.
+    export GO_TEST_SHUFFLE=${GO_TEST_SHUFFLE:-"off"}
+
+    echo "COMMAND     = " "${@}"
+
+    until "${@}"; do
+        retried=true
+        if [ "${attempts}" -gt "${retries}" ]; then
+            echo "::warning Failed after ${attempts} attempts"
+            return
+        else
+            echo "::warning Retrying command"
+        fi
+        attempts=$((attempts + 1))
+
+        export GO_TEST_PARALLELISM=$((GO_TEST_PARALLELISM <= 2 ? 1 : GO_TEST_PARALLELISM / 2))
+        export GO_TEST_PKG_PARALLELISM=$((GO_TEST_PARALLELISM <= 2 ? 1 : GO_TEST_PKG_PARALLELISM / 2))
+        export GO_TEST_SHUFFLE="off"
+    done
+
+    success=true
+}
+
+run_tests "${@}"
+
+echo "::set-output name=TEST_SUCCESS::${success}"
+echo "::set-output name=TEST_RETRIED::${retried}"
+
+if ! "${success}"; then
+    exit 1
+fi

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -7,8 +7,6 @@ DOTNET_VERSION  := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ../../script
 
 $(info    DOTNET_VERSION  = $(DOTNET_VERSION))
 
-TESTPARALLELISM ?= 10
-
 include ../../build/common.mk
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -3,7 +3,6 @@ LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/go/pulumi-language-go
 VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ../../scripts/pulumi-version.sh go))
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
-TESTPARALLELISM  ?= 10
 
 $(info    VERSION         = $(VERSION))
 

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -5,7 +5,6 @@ VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ../../scrip
 LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-nodejs
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
-TESTPARALLELISM ?= 10
 TEST_FAST_TIMEOUT := 2m
 
 $(info    VERSION         = $(VERSION))

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -12,7 +12,6 @@ PYENVSRC := $(PYENV)/src
 BLACK_FLAGS := ./lib/pulumi --exclude lib/pulumi/runtime/proto
 
 PROJECT_PKGS    := $(shell go list ./cmd/...)
-TESTPARALLELISM ?= 10
 
 include ../../build/common.mk
 


### PR DESCRIPTION
This adds a retry script to `./scripts/retry` which takes any shell command and retries it up to `PULUMI_TEST_RETRIES` times. On each iteration of the script, parallelism and variation is reduced.
