### PR TITLE
Use set-all

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1193,16 +1193,17 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 		return err
 	}
 
-	for key, value := range pt.opts.Config {
-		if err := pt.runPulumiCommand("pulumi-config",
-			[]string{"config", "set", key, value}, dir, false); err != nil {
-			return err
-		}
-	}
+	if len(pt.opts.Config)+len(pt.opts.Secrets) > 0 {
+		setAllArgs := []string{"config", "set-all"}
 
-	for key, value := range pt.opts.Secrets {
-		if err := pt.runPulumiCommand("pulumi-config",
-			[]string{"config", "set", "--secret", key, value}, dir, false); err != nil {
+		for key, value := range pt.opts.Config {
+			setAllArgs = append(setAllArgs, "--plaintext", fmt.Sprintf("%s=%s", key, value))
+		}
+		for key, value := range pt.opts.Secrets {
+			setAllArgs = append(setAllArgs, "--secret", fmt.Sprintf("%s=%s", key, value))
+		}
+
+		if err := pt.runPulumiCommand("pulumi-config", setAllArgs, dir, false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Similar to what Automation API does. It does not look like Automation API does any escaping so perhaps this is OK. The change saves lots of precious seconds on CI when a lot of examples and config values are involved, like in pulumi/templates.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
