### PR TITLE
Serde `<Resource><nil>` pointers correctly

### DIFF
--- a/changelog/pending/20220915--sdk-go--serde-for-nil-resource-refs.yaml
+++ b/changelog/pending/20220915--sdk-go--serde-for-nil-resource-refs.yaml
@@ -1,0 +1,5 @@
+changes:
+  - type: fix
+    scope: sdk/go
+    description: >
+      Correctly handle nil resource references in the RPC layer.

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -429,13 +429,16 @@ func copyInputTo(ctx *Context, v resource.PropertyValue, dest reflect.Value) err
 		return nil
 	}
 
-	switch dest.Type().Kind() {
-	case reflect.Map:
-		return copyToMap(ctx, v, dest.Type(), dest)
-	case reflect.Slice:
-		return copyToSlice(ctx, v, dest.Type(), dest)
-	case reflect.Struct:
-		return copyToStruct(ctx, v, dest.Type(), dest)
+	// A resource reference looks like a struct, but must be deserialzed differently.
+	if !v.IsResourceReference() {
+		switch dest.Type().Kind() {
+		case reflect.Map:
+			return copyToMap(ctx, v, dest.Type(), dest)
+		case reflect.Slice:
+			return copyToSlice(ctx, v, dest.Type(), dest)
+		case reflect.Struct:
+			return copyToStruct(ctx, v, dest.Type(), dest)
+		}
 	}
 
 	_, err := unmarshalOutput(ctx, v, dest)

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -1715,3 +1715,24 @@ func TestConstructResult(t *testing.T) {
 		"someValue": resource.NewStringProperty("something"),
 	}, resolvedProps)
 }
+
+type MyComponentWithResource struct {
+	ResourceState
+
+	// This is not realistic, but it replicates what you get when you send a `nil` pointer
+	// over RPC for a resource.
+	Component Resource `pulumi:"component"`
+}
+
+func TestSerdeNilNestedResource(t *testing.T) {
+	t.Parallel()
+
+	component := &MyComponentWithResource{
+		Component: (*MyComponent)(nil),
+	}
+	_, state, err := newConstructResult(component)
+	assert.NoError(t, err)
+
+	_, _, _, err = marshalInputs(state)
+	assert.NoError(t, err)
+}

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -359,8 +359,8 @@ func marshalInputImpl(v interface{},
 			if err != nil {
 				return resource.PropertyValue{}, nil, err
 			}
-			contract.Assert(known)
-			contract.Assert(!secretURN)
+			contract.Assertf(known, "URN must be known")
+			contract.Assertf(!secretURN, "URN must not be secret")
 
 			if custom, ok := v.(CustomResource); ok {
 				id, _, secretID, err := custom.ID().awaitID(context.Background())

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -309,7 +309,7 @@ func marshalInputImpl(v interface{},
 		// If v is nil, just return that.
 		if v == nil {
 			return resource.PropertyValue{}, nil, nil
-		} else if val := reflect.ValueOf(v); val.Kind() == reflect.Pointer && val.IsNil() {
+		} else if val := reflect.ValueOf(v); val.Kind() == reflect.Ptr && val.IsNil() {
 			// Here we round trip through a reflect.Value to catch fat pointers of the
 			// form
 			//

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -309,6 +309,15 @@ func marshalInputImpl(v interface{},
 		// If v is nil, just return that.
 		if v == nil {
 			return resource.PropertyValue{}, nil, nil
+		} else if val := reflect.ValueOf(v); val.Kind() == reflect.Pointer && val.IsNil() {
+			// Here we round trip through a reflect.Value to catch fat pointers of the
+			// form
+			//
+			// 	<SomeType><nil value>
+			//
+			// This prevents calling methods on nil pointers when we cast to an interface
+			// (like `Resource`)
+			return resource.PropertyValue{}, nil, nil
 		}
 
 		// Look for some well known types.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This fixes the `pulumi-go-provider/examples/random-login` example. Previously, it panicked on the RPC layer. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
