### PR TITLE
refactor: create a LoginManager interface for encapsulating backend logins

### DIFF
--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -141,7 +141,7 @@ func newLoginCmd() *cobra.Command {
 					return fmt.Errorf("unable to set default org for this type of backend")
 				}
 			} else {
-				be, err = httpstate.Login(ctx, cmdutil.Diag(), cloudURL, displayOptions)
+				be, err = httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, displayOptions)
 				// if the user has specified a default org to associate with the backend
 				if defaultOrg != "" {
 					cloudURL, err := workspace.GetCurrentCloudURL()

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -120,7 +120,7 @@ func requirePolicyPack(ctx context.Context, policyPack string) (backend.PolicyPa
 		Color: cmdutil.GetGlobalColorization(),
 	}
 
-	b, err := httpstate.Login(ctx, cmdutil.Diag(), cloudURL, displayOptions)
+	b, err := httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, displayOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -121,7 +121,7 @@ func nonInteractiveCurrentBackend(ctx context.Context) (backend.Backend, error) 
 	if filestate.IsFileStateBackendURL(url) {
 		return filestate.New(cmdutil.Diag(), url)
 	}
-	return httpstate.Current(ctx, cmdutil.Diag(), url)
+	return httpstate.NewLoginManager().Current(ctx, cmdutil.Diag(), url)
 }
 
 func currentBackend(ctx context.Context, opts display.Options) (backend.Backend, error) {
@@ -137,7 +137,7 @@ func currentBackend(ctx context.Context, opts display.Options) (backend.Backend,
 	if filestate.IsFileStateBackendURL(url) {
 		return filestate.New(cmdutil.Diag(), url)
 	}
-	return httpstate.Login(ctx, cmdutil.Diag(), url, opts)
+	return httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), url, opts)
 }
 
 // This is used to control the contents of the tracing header.


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Do for the login functions (`Login` and `Current`) what https://github.com/pulumi/pulumi/pull/9310 did for the backend client. This provides a way to customize the login behavior. This adds a `LoginManager` interface, with `Login` and `Current` methods. The `NewLoginManager` function returns a `defaultLoginManager` instance, and to modify which `LoginManager` implementation is returned, the `newLoginManager` function can be reassigned in an init function within the `httpstate` package. 

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
