### PR TITLE
add `CHANGELOG.md` link to the version warning message

### DIFF
--- a/changelog/pending/20220915--cli-display--link-changelog.yaml
+++ b/changelog/pending/20220915--cli-display--link-changelog.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Adds link to master CHANGELOG.md in the version upgrade message.

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -498,7 +498,9 @@ func getUpgradeMessage(latest semver.Version, current semver.Version) string {
 		msg += "run \n   " + cmd + "\nor "
 	}
 
-	msg += "visit https://pulumi.com/docs/reference/install/ for manual instructions and release notes."
+	msg += "visit https://pulumi.com/docs/reference/install/ for manual instructions\n\n"
+	msg += "Release Notes:\n"
+	msg += "https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md"
 	return msg
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10090 

Adds a link to the `CHANGELOG.md` for users to be able to see new features in the version we're asking them to upgrade to.

example uses `pulumi version`
[![asciicast](https://asciinema.org/a/NIqQD6e7Ma49FiMt0hGWjEuUz.svg)](https://asciinema.org/a/NIqQD6e7Ma49FiMt0hGWjEuUz)


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
