### PR TITLE
Change GO_TEST_PARALLELISM to improve Windows CI

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           TOOL_BIN: ${{ runner.temp }}/tar-bin
         run: |
-          echo "GO_TEST_PARALLELISM=4" >> "${GITHUB_ENV}"
+          echo "GO_TEST_PARALLELISM=2" >> "${GITHUB_ENV}"
           echo "GO_TEST_PKG_PARALLELISM=1" >> "${GITHUB_ENV}"
       - name: "macOS use coreutils"
         if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION
Hopefully this will improve our merge queue success rates on Windows
