### PR TITLE
ci: Fix make brew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ install_all:: install
 dist:: build
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
 
-# NOTE: the brew target intentionally avoids the dependency on `build`, as it does not require the language SDKs.
+.PHONY: brew
+# NOTE: the brew target intentionally avoids the dependency on `build`, as each language SDK has its own brew target
 brew::
 	./scripts/brew.sh "${PROJECT}"
 

--- a/scripts/brew.sh
+++ b/scripts/brew.sh
@@ -12,7 +12,7 @@ BREW_VERSION=$(./scripts/get-version HEAD)
               ${PROJECT})
 
 # Fetch extra language binaries like YAML and Java from GitHub releases.
-./scripts/get-language-providers.sh
+./scripts/prep-for-goreleaser.sh "local"
 
 # Install these extra binaries into $GOPATH/bin
 GOOS=$(go env GOOS)
@@ -21,4 +21,5 @@ GOPATH=$(go env GOPATH)
 # goreleaser in pulumi/pulumi renames amd64 to x64
 RENAMED_ARCH="${GOARCH/amd64/x64}"
 mkdir -p "$GOPATH/bin"
-cp goreleaser-lang/*/${GOOS}-${RENAMED_ARCH}/pulumi-language-* "$GOPATH/bin/"
+cp bin/${GOOS}-${RENAMED_ARCH}/* "$GOPATH/bin/"
+cp bin/${GOOS}/* "$GOPATH/bin/"

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -3,6 +3,8 @@
 set -eo pipefail
 set -x
 
+LOCAL="${1:-"false"}"
+
 get_version() {
   local repo="$1"
   (
@@ -60,6 +62,11 @@ for i in "github.com/pulumi/pulumi-java java" "github.com/pulumi/pulumi-yaml yam
         set -- $k # treat strings in loop as args
         DIST_ARCH="$1"
         RENAMED_ARCH="$2" # goreleaser in pulumi/pulumi renames amd64 to x64
+
+        # if TARGET is set and DIST_OS-DIST_ARCH does not match, skip
+        if [ "${LOCAL}" = "local" ] && [ "$(go env GOOS)-$(go env GOARCH)" != "${DIST_OS}-${DIST_ARCH}" ]; then
+            continue
+        fi
 
         ARCHIVE="pulumi-language-${PULUMI_LANG}-${TAG}-${DIST_OS}-${DIST_ARCH}"
 

--- a/scripts/get-pulumi-watch.sh
+++ b/scripts/get-pulumi-watch.sh
@@ -5,21 +5,14 @@ set -x
 
 # When run by goreleaser, the arguments are absent, so files are installed in:
 #
-# * ./bin/darwin-amd64
+# * ./bin/darwin-x64
 # * ./bin/darwin-arm64
-# * ./bin/linux-amd64
+# * ./bin/linux-x64
 # * ./bin/linux-arm64
-# * ./bin/windows-amd64
+# * ./bin/windows-x64
 #
 # Allowing us to customize the archives for each.
-#
-# When run by GitHub Actions in tests, we set the args so that we install only the current OS's
-# binaries and in the shared "local path" dir, ./bin
-FILTER_TARGET="${1}"
-
-if [ "${FILTER_TARGET}" = "local" ]; then
-  FILTER_TARGET="$(go env GOOS)-$(go env GOARCH)"
-fi
+LOCAL="${1:-"false"}"
 
 TAG="v0.1.4"
 
@@ -34,13 +27,11 @@ for i in \
   FILE="$2"
   EXT="$3"
 
+  GO_TARGET="${TARGET/x64/amd64}"
+
   DIST_DIR="./bin/${TARGET}"
-  if [ -n "${FILTER_TARGET}" ]; then
-    if [ "${TARGET}" != "${FILTER_TARGET}" ]; then
-      continue
-    else
-      DIST_DIR="./bin"
-    fi
+  if [ "${LOCAL}" = "local" ] && [ "$(go env GOOS)-$(go env GOARCH)" != "${GO_TARGET}" ]; then
+    continue
   fi
 
   mkdir -p "${DIST_DIR}"

--- a/scripts/prep-for-goreleaser.sh
+++ b/scripts/prep-for-goreleaser.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Populates ./bin directories for use by goreleaser.
 rm -rf ./bin
+
+LOCAL="${1:-"false"}"
 
 COMMIT_TIME=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d%H%M')
 
@@ -10,6 +14,10 @@ install_file () {
     shift
 
     for OS in "$@"; do # for each argument after the first:
+        # if LOCAL == "true" and `go env goos` is not equal to the OS, skip it
+        if [ "${LOCAL}" = "local" ] && [ "$(go env GOOS)" != "${OS}" ]; then
+            continue
+        fi
         DESTDIR="bin/${OS}"
         mkdir -p "${DESTDIR}"
         dest=$(basename "${src}")
@@ -36,5 +44,5 @@ install_file sdk/python/dist/pulumi-python3-shim.cmd                        wind
 install_file sdk/python/cmd/pulumi-language-python-exec          linux darwin windows
 
 # Get pulumi-watch binaries
-./scripts/get-pulumi-watch.sh
-./scripts/get-language-providers.sh
+./scripts/get-pulumi-watch.sh "${LOCAL}"
+./scripts/get-language-providers.sh "${LOCAL}"


### PR DESCRIPTION
This enables `make brew` to run as before, accounting for directory changes. The prep-for-goreleaser script places artifacts in `./bin/` now.

`make brew` now succeeds.

Fixes #10735 