### PR TITLE
chore(sdk/nodejs): Adds tests for resource alias combinations

### DIFF
--- a/sdk/nodejs/tests/runtime/langhost/cases/070.unusual_alias_names/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/070.unusual_alias_names/index.js
@@ -1,0 +1,27 @@
+// This test checks for unusually named pulumi resources with aliases
+
+
+let pulumi = require("../../../../..");
+let assert = require("assert");
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, aliases) {
+        super(
+            "test:index:MyResource",
+            name,
+            {},
+            {
+                aliases: aliases
+            }
+        );
+    }
+}
+
+const resource1 = new MyResource("testResource1", []);
+assert.equal(resource1.__aliases[0], undefined);
+const resource2 = new MyResource("some-random-resource-name", ["test-alias-name"]);
+resource2.__aliases[0].apply(alias => assert.equal(alias, ["test-alias-name"]))
+const resource3 = new MyResource("other:random:resource:name", ["other:test:alias:name"]);
+resource3.__aliases[0].apply(alias => assert.equal(alias, ["other:test:alias:name"]))
+const resource4 = new MyResource("-other@random:resource!name", ["other!test@alias+name"]);
+resource4.__aliases[0].apply(alias => assert.equal(alias, ["other!test@alias+name"]))

--- a/sdk/nodejs/tests/runtime/langhost/cases/071.large_alias_counts/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/071.large_alias_counts/index.js
@@ -1,0 +1,23 @@
+// This test creates a resource with many aliases
+
+
+let pulumi = require("../../../../..");
+let assert = require("assert");
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, aliases, parent) {
+        super(
+            "test:index:MyResource",
+            name,
+            {},
+            {
+                aliases: aliases,
+                parent
+            }
+        );
+    }
+}
+
+const resource1Aliases = Array.from(new Array(10000).keys()).map(key => `my-alias-name-${key}`);
+const resource1 = new MyResource("testResource1", resource1Aliases);
+resource1.__aliases.map(alias => alias.apply(aliasName => assert(resource1Aliases.includes(aliasName))));

--- a/sdk/nodejs/tests/runtime/langhost/cases/072.large_alias_lineage_chains/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/072.large_alias_lineage_chains/index.js
@@ -1,0 +1,27 @@
+// This test creates two resources - the first a parent of the second, both of which have many aliases
+
+
+let pulumi = require("../../../../..");
+let assert = require("assert");
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, aliases, parent) {
+        super(
+            "test:index:MyResource",
+            name,
+            {},
+            {
+                aliases: aliases,
+                parent
+            }
+        );
+    }
+}
+
+const resource1Aliases = Array.from(new Array(1000).keys()).map(key => `my-alias-name-${key}`);
+const resource1 = new MyResource("testResource1", resource1Aliases);
+resource1.__aliases.map(alias => alias.apply(aliasName => assert(resource1Aliases.includes(aliasName))));
+
+const resource2Aliases = Array.from(new Array(1000).keys()).map(key => `my-other-alias-name-${key}`);
+const resource2 = new MyResource("testResource2", resource2Aliases, resource1)
+resource2.__aliases.map(alias => alias.apply(aliasName => assert(resource2Aliases.includes(aliasName))));

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1235,6 +1235,28 @@ describe("rpc", () => {
                 );
             },
         },
+        "unusual_alias_names": {
+            program: path.join(base, "070.unusual_alias_names"),
+            expectResourceCount: 4,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, ...args: any) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
+        "large_alias_counts": {
+            program: path.join(base, "071.large_alias_counts"),
+            expectResourceCount: 1,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, ...args: any) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
+    /** Skipping this test case as it requires limiting the alias multiplication which occurs */
+    // "large_alias_lineage_chains": {
+        // program: path.join(base, "072.large_alias_lineage_chains"),
+        // expectResourceCount: 1,
+        // registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, ...args: any) => {
+        // return { urn: makeUrn(t, name), id: undefined, props: undefined };
+        // },
+    // }
     };
 
     for (const casename of Object.keys(cases)) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10053 

Adds a few tests (one skipped) to replicate some issues we've been seeing in aliasing.  The skipped test (and the slow unskipped test) should be resolved by #9734 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
