### PR TITLE
Do not call exportStack twice on every update

### DIFF
--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -114,9 +114,10 @@ func newUpCmd() *cobra.Command {
 		targetURNs, replaceURNs := []resource.URN{}, []resource.URN{}
 
 		if len(targets)+len(replaces)+len(targetReplaces) > 0 {
-			// This call to s.Snapshot adds latency s.Update below will call s.Snapshot again, presumably
-			// with the same result. Refactoring this or introducing a cache is a little tricky. For now:
-			// only call Snapshot twice if targets, replaces, or targetReplaces require it.
+			// The s.Snapshot call below adds needless latency as s.Update further below will call
+			// (*cloudBackend).getSnapshot again, presumably re-retrieving the same result over the network.
+			// Although s.Snapshot has a cache, it does not get hit by s.Update as of this writing. For now:
+			// only call s.Snapshot here if targets, replaces, or targetReplaces require it.
 			snap, err := s.Snapshot(ctx)
 			if err != nil {
 				return result.FromError(err)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Looking at detailed performance traces I noticed we call exportStack twice on every update. This can get expensive if stacks are large, and creates extra service traffic. This quick fix makes it only happen if --target like options are specified.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
