### PR TITLE
Fix docs gen heading

### DIFF
--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -13,7 +13,7 @@
 {{- end }}
 
 <!-- Create resource -->
-## Create a {{ .Header.Title }} Resource {#create}
+## Create {{ .Header.Title }} Resource {#create}
 
 {{- if eq .LangChooserLanguages "" }}
 <div>

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -187,7 +187,7 @@ The following arguments are supported:
 
 <!-- Read resource -->
 {{ if ne (len .StateInputs) 0 }}
-## Look up an Existing {{.Header.Title}} Resource {#look-up}
+## Look up Existing {{.Header.Title}} Resource {#look-up}
 
 Get an existing {{.Header.Title}} resource's state with the given name, ID, and optional extra properties used to qualify the lookup.
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -347,7 +347,7 @@ Coming soon!
 
 
 
-## Create a SqlResourceSqlContainer Resource {#create}
+## Create SqlResourceSqlContainer Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a ModuleResource Resource {#create}
+## Create ModuleResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Nursery Resource {#create}
+## Create Nursery Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a RubberTree Resource {#create}
+## Create RubberTree Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -596,7 +596,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 
 
 
-## Look up an Existing RubberTree Resource {#look-up}
+## Look up Existing RubberTree Resource {#look-up}
 
 Get an existing RubberTree resource's state with the given name, ID, and optional extra properties used to qualify the lookup.
 <div>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Nursery Resource {#create}
+## Create Nursery Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a RubberTree Resource {#create}
+## Create RubberTree Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -596,7 +596,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 
 
 
-## Look up an Existing RubberTree Resource {#look-up}
+## Look up Existing RubberTree Resource {#look-up}
 
 Get an existing RubberTree resource's state with the given name, ID, and optional extra properties used to qualify the lookup.
 <div>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a IamResource Resource {#create}
+## Create IamResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Component Resource {#create}
+## Create Component Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Cat Resource {#create}
+## Create Cat Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Component Resource {#create}
+## Create Component Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Workload Resource {#create}
+## Create Workload Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a RegistryGeoReplication Resource {#create}
+## Create RegistryGeoReplication Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Resource Resource {#create}
+## Create Resource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a ResourceInput Resource {#create}
+## Create ResourceInput Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Resource Resource {#create}
+## Create Resource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Resource Resource {#create}
+## Create Resource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a BarResource Resource {#create}
+## Create BarResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a FooResource Resource {#create}
+## Create FooResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a OtherResource Resource {#create}
+## Create OtherResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a OverlayResource Resource {#create}
+## Create OverlayResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Resource Resource {#create}
+## Create Resource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a TypeUses Resource {#create}
+## Create TypeUses Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a ModuleResource Resource {#create}
+## Create ModuleResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
@@ -17,7 +17,7 @@ test new feature with resoruces
 
 
 
-## Create a Foo Resource {#create}
+## Create Foo Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a ModuleTest Resource {#create}
+## Create ModuleTest Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
@@ -17,7 +17,7 @@ The provider type for the kubernetes package.
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
@@ -17,7 +17,7 @@ test new feature with resoruces
 
 
 
-## Create a Foo Resource {#create}
+## Create Foo Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a ModuleTest Resource {#create}
+## Create ModuleTest Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
@@ -17,7 +17,7 @@ The provider type for the kubernetes package.
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a StaticPage Resource {#create}
+## Create StaticPage Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Cat Resource {#create}
+## Create Cat Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Dog Resource {#create}
+## Create Dog Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a God Resource {#create}
+## Create God Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a NoRecursive Resource {#create}
+## Create NoRecursive Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a ToyStore Resource {#create}
+## Create ToyStore Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Person Resource {#create}
+## Create Person Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Pet Resource {#create}
+## Create Pet Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Person Resource {#create}
+## Create Person Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Pet Resource {#create}
+## Create Pet Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Rec Resource {#create}
+## Create Rec Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Nursery Resource {#create}
+## Create Nursery Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a RubberTree Resource {#create}
+## Create RubberTree Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -596,7 +596,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 
 
 
-## Look up an Existing RubberTree Resource {#look-up}
+## Look up Existing RubberTree Resource {#look-up}
 
 Get an existing RubberTree resource's state with the given name, ID, and optional extra properties used to qualify the lookup.
 <div>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Foo Resource {#create}
+## Create Foo Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Foo Resource {#create}
+## Create Foo Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Component Resource {#create}
+## Create Component Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Component Resource {#create}
+## Create Component Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a OtherResource Resource {#create}
+## Create OtherResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Resource Resource {#create}
+## Create Resource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a BarResource Resource {#create}
+## Create BarResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a FooResource Resource {#create}
+## Create FooResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a OtherResource Resource {#create}
+## Create OtherResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a OverlayResource Resource {#create}
+## Create OverlayResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Resource Resource {#create}
+## Create Resource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a TypeUses Resource {#create}
+## Create TypeUses Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a OtherResource Resource {#create}
+## Create OtherResource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Provider Resource {#create}
+## Create Provider Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a Resource Resource {#create}
+## Create Resource Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
@@ -15,7 +15,7 @@ no_edit_this_page: true
 
 
 
-## Create a TypeUses Resource {#create}
+## Create TypeUses Resource {#create}
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>


### PR DESCRIPTION
This should sometimes be a and sometimes an, if we drop it altogether it still reads fine without ever having the chance of being grammatically wrong.

fixes #10777 