### PR TITLE
Introduce an efficient text-diff based patch protocol

### DIFF
--- a/changelog/pending/20221011--backend-service--httpstate-backend-patch-protocol.yaml
+++ b/changelog/pending/20221011--backend-service--httpstate-backend-patch-protocol.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/service
+  description: Implements diff-based snapshot saving protocol that reduces bandwidth on large stacks. To opt into this feature, set the environment variable and value `PULUMI_OPTIMIZED_CHECKPOINT_PATCH=true`.

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -327,9 +327,15 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 	var reqBody []byte
 	var err error
 	if reqObj != nil {
-		reqBody, err = json.Marshal(reqObj)
-		if err != nil {
-			return fmt.Errorf("marshalling request object as JSON: %w", err)
+		// Send verbatim if already marshalled. This is
+		// important when sending indented JSON is needed.
+		if raw, ok := reqObj.(json.RawMessage); ok {
+			reqBody = []byte(raw)
+		} else {
+			reqBody, err = json.Marshal(reqObj)
+			if err != nil {
+				return fmt.Errorf("marshalling request object as JSON: %w", err)
+			}
 		}
 	}
 

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -104,6 +104,8 @@ func init() {
 	addEndpoint("GET", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}", "getUpdateStatus")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}", "startUpdate")
 	addEndpoint("PATCH", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}/checkpoint", "patchCheckpoint")
+	addEndpoint("PATCH", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}/checkpointdelta", "patchCheckpointDelta")
+	addEndpoint("PATCH", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}/checkpointverbatim", "patchCheckpointVerbatim")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}/complete", "completeUpdate")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}/events", "postEngineEvent")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/{updateKind}/{updateID}/events/batch", "postEngineEventBatch")

--- a/pkg/backend/httpstate/client/marshal.go
+++ b/pkg/backend/httpstate/client/marshal.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// Unlike json.Marshal preserves possible indentation in req.Deployment.
+func marshalVerbatimCheckpointRequest(req apitype.PatchUpdateVerbatimCheckpointRequest) (json.RawMessage, error) {
+	sentinel := []byte(`"*"`)
+	cp := req
+	cp.UntypedDeployment = sentinel
+	pattern, err := json.Marshal(cp)
+	if err != nil {
+		return nil, err
+	}
+	f := bytes.ReplaceAll(pattern, sentinel, req.UntypedDeployment)
+	return f, nil
+}

--- a/pkg/backend/httpstate/diffs.go
+++ b/pkg/backend/httpstate/diffs.go
@@ -1,0 +1,163 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+type deploymentDiffState struct {
+	lastSavedDeployment json.RawMessage
+	sequenceNumber      int
+	noChecksums         bool
+	strictMode          bool
+	minimalDiffSize     int
+}
+
+type deploymentDiff struct {
+	sequenceNumber  int
+	checkpointHash  string
+	deploymentDelta json.RawMessage
+}
+
+func newDeploymentDiffState() *deploymentDiffState {
+	return &deploymentDiffState{sequenceNumber: 1}
+}
+
+func (dds *deploymentDiffState) SequenceNumber() int {
+	return dds.sequenceNumber
+}
+
+func (dds *deploymentDiffState) CanDiff() bool {
+	return dds.lastSavedDeployment != nil
+}
+
+// Size-based heuristics trying to estimate if the diff method will be
+// worth it and take less time than sending the entire deployment.
+func (dds *deploymentDiffState) ShouldDiff(new *apitype.UntypedDeployment) bool {
+	if !dds.CanDiff() {
+		return false
+	}
+	small := dds.minimalDiffSize
+	if small == 0 {
+		small = 1024 * 32
+	}
+	if len(dds.lastSavedDeployment) < small {
+		return false
+	}
+	if len(new.Deployment) < small {
+		return false
+	}
+	return true
+}
+
+func (dds *deploymentDiffState) Diff(ctx context.Context,
+	deployment *apitype.UntypedDeployment) (deploymentDiff, error) {
+
+	if !dds.CanDiff() {
+		return deploymentDiff{}, fmt.Errorf("Diff() cannot be called before Saved()")
+	}
+
+	if deployment.Version == 0 {
+		return deploymentDiff{}, fmt.Errorf("deployment.Version should be set")
+	}
+
+	tracingSpan, childCtx := opentracing.StartSpanFromContext(ctx, "Diff")
+	defer tracingSpan.Finish()
+
+	before := dds.lastSavedDeployment
+
+	after, err := marshalUntypedDeployment(deployment)
+	if err != nil {
+		return deploymentDiff{}, fmt.Errorf("marshalUntypedDeployment failed: %v", err)
+	}
+
+	var checkpointHash string
+	checkpointHashReady := &sync.WaitGroup{}
+
+	if !dds.noChecksums {
+		checkpointHashReady.Add(1)
+		go func() {
+			defer checkpointHashReady.Done()
+			checkpointHash = dds.computeHash(childCtx, after)
+		}()
+	}
+
+	delta, err := dds.computeEdits(childCtx, string(before), string(after))
+	if err != nil {
+		return deploymentDiff{}, fmt.Errorf("Cannot marshal the edits: %v", err)
+	}
+
+	checkpointHashReady.Wait()
+
+	tracingSpan.SetTag("before", len(before))
+	tracingSpan.SetTag("after", len(after))
+	tracingSpan.SetTag("diff", len(delta))
+	tracingSpan.SetTag("compression", 100.0*float64(len(delta))/float64(len(after)))
+	tracingSpan.SetTag("hash", checkpointHash)
+
+	diff := deploymentDiff{
+		checkpointHash:  checkpointHash,
+		deploymentDelta: delta,
+		sequenceNumber:  dds.sequenceNumber,
+	}
+
+	return diff, nil
+}
+
+// Indicates that a deployment was just saved to the service.
+func (dds *deploymentDiffState) Saved(ctx context.Context, deployment *apitype.UntypedDeployment) error {
+	d, err := marshalUntypedDeployment(deployment)
+	if err != nil {
+		return err
+	}
+	dds.lastSavedDeployment = d
+	dds.sequenceNumber++
+
+	return nil
+}
+
+func (*deploymentDiffState) computeHash(ctx context.Context, deployment json.RawMessage) string {
+	tracingSpan, _ := opentracing.StartSpanFromContext(ctx, "computeHash")
+	defer tracingSpan.Finish()
+	hash := sha256.Sum256(deployment)
+	return hex.EncodeToString(hash[:])
+}
+
+func (*deploymentDiffState) computeEdits(ctx context.Context, before, after string) (json.RawMessage, error) {
+	tracingSpan, _ := opentracing.StartSpanFromContext(ctx, "computeEdits")
+	defer tracingSpan.Finish()
+
+	edits := myers.ComputeEdits(span.URIFromURI(""), before, after)
+
+	delta, err := json.Marshal(edits)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot marshal the edits: %v", err)
+	}
+
+	return delta, nil
+}

--- a/pkg/backend/httpstate/marshal.go
+++ b/pkg/backend/httpstate/marshal.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// Unlike json.Marshal preserves possible indentation in the Deployment field.
+func marshalUntypedDeployment(deployment *apitype.UntypedDeployment) (json.RawMessage, error) {
+	sentinel := []byte(`"*"`)
+	cp := *deployment
+	cp.Deployment = sentinel
+	pattern, err := json.Marshal(cp)
+	if err != nil {
+		return nil, err
+	}
+	fixed := bytes.ReplaceAll(pattern, sentinel, deployment.Deployment)
+	return fixed, nil
+}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -1,0 +1,223 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+)
+
+// Check that cloudSnapshotPersister can talk the diff-based
+// "checkpointverbatim" and "checkpointdelta" protocol when saving
+// snapshots.
+func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	stackID := client.StackIdentifier{
+		Owner:   "owner",
+		Project: "project",
+		Stack:   "stack",
+	}
+	updateID := "update-id"
+
+	var persistedState json.RawMessage
+
+	var lastRequest *http.Request
+
+	lastRequestAsVerbatim := func() (ret apitype.PatchUpdateVerbatimCheckpointRequest) {
+		err := json.NewDecoder(lastRequest.Body).Decode(&ret)
+		assert.Equal(t, "/api/stacks/owner/project/stack/update/update-id/checkpointverbatim", lastRequest.URL.Path)
+		assert.NoError(t, err)
+		return
+	}
+
+	lastRequestAsDelta := func() (ret apitype.PatchUpdateCheckpointDeltaRequest) {
+		err := json.NewDecoder(lastRequest.Body).Decode(&ret)
+		assert.Equal(t, "/api/stacks/owner/project/stack/update/update-id/checkpointdelta", lastRequest.URL.Path)
+		assert.NoError(t, err)
+		return
+	}
+
+	handleVerbatim := func(req apitype.PatchUpdateVerbatimCheckpointRequest) {
+		persistedState = req.UntypedDeployment
+	}
+
+	handleDelta := func(req apitype.PatchUpdateCheckpointDeltaRequest) {
+		edits := []gotextdiff.TextEdit{}
+		if err := json.Unmarshal(req.DeploymentDelta, &edits); err != nil {
+			assert.NoError(t, err)
+		}
+		persistedState = json.RawMessage([]byte(gotextdiff.ApplyEdits(string(persistedState), edits)))
+		assert.Equal(t, req.CheckpointHash, fmt.Sprintf("%x", sha256.Sum256(persistedState)))
+	}
+
+	typedPersistedState := func() apitype.DeploymentV3 {
+		var ud apitype.UntypedDeployment
+		err := json.Unmarshal(persistedState, &ud)
+		assert.NoError(t, err)
+		var d3 apitype.DeploymentV3
+		err = json.Unmarshal(ud.Deployment, &d3)
+		assert.NoError(t, err)
+		return d3
+	}
+
+	newMockServer := func() *httptest.Server {
+		return httptest.NewServer(
+			http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				lastRequest = req
+				rw.WriteHeader(200)
+				message := `{}`
+				reader, err := gzip.NewReader(req.Body)
+				assert.NoError(t, err)
+				defer reader.Close()
+				rbytes, err := ioutil.ReadAll(reader)
+				assert.NoError(t, err)
+				_, err = rw.Write([]byte(message))
+				assert.NoError(t, err)
+				req.Body = io.NopCloser(bytes.NewBuffer(rbytes))
+			}))
+	}
+
+	newMockTokenSource := func() tokenSourceCapability {
+		return tokenSourceFn(func() (string, error) {
+			return "token", nil
+		})
+	}
+
+	initPersister := func() *cloudSnapshotPersister {
+		server := newMockServer()
+		backendGeneric, err := New(nil, server.URL)
+		assert.NoError(t, err)
+		backend := backendGeneric.(*cloudBackend)
+		persister := backend.newSnapshotPersister(ctx, client.UpdateIdentifier{
+			StackIdentifier: stackID,
+			UpdateKind:      apitype.UpdateUpdate,
+			UpdateID:        updateID,
+		}, newMockTokenSource(), nil)
+		persister.deploymentDiffState = newDeploymentDiffState()
+		persister.deploymentDiffState.minimalDiffSize = 1
+		return persister
+	}
+
+	persister := initPersister()
+
+	// Req 1: the first request sends indented data verbatim to establish a good baseline state for further diffs.
+
+	err := persister.Save(&deploy.Snapshot{
+		Resources: []*resource.State{
+			{URN: resource.URN("urn-1")},
+		},
+	})
+	assert.NoError(t, err)
+
+	req1 := lastRequestAsVerbatim()
+	assert.Equal(t, 1, req1.SequenceNumber)
+	assert.Equal(t, 3, req1.Version)
+	assert.Equal(t, "{\"version\":3,\"deployment\":{\n\"manifest\": {\n\"time\": \"0001-01-01T00:00:00Z\""+
+		",\n\"magic\": \"\",\n\"version\": \"\"\n},\n\"resources\": [\n{\n\"urn\": \"urn-1\",\n\"custom\":"+
+		" false,\n\"type\": \"\"\n}\n]\n}}", string(req1.UntypedDeployment))
+
+	handleVerbatim(req1)
+	assert.Equal(t, []apitype.ResourceV3{
+		{URN: resource.URN("urn-1")},
+	}, typedPersistedState().Resources)
+
+	// Req 2: then it switches to sending deltas as text diffs together with SHA-256 checksum of the expected
+	// resulting text representation of state.
+
+	err = persister.Save(&deploy.Snapshot{
+		Resources: []*resource.State{
+			{URN: resource.URN("urn-1")},
+			{URN: resource.URN("urn-2")},
+		},
+	})
+	assert.NoError(t, err)
+
+	req2 := lastRequestAsDelta()
+	assert.Equal(t, 2, req2.SequenceNumber)
+	assert.Equal(t, "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":12,\"column\":1,\"offset\":-1},\"end\""+
+		":{\"line\":12,\"column\":1,\"offset\":-1}},\"NewText\":\"},\\n\"},{\"Span\":{\"uri\":\"\","+
+		"\"start\":{\"line\":12,\"column\":1,\"offset\":-1},\"end\":{\"line\":12,"+
+		"\"column\":1,\"offset\":-1}},\"NewText\":\"{\\n\"},{\"Span\":{\"uri\":\"\",\"start\":"+
+		"{\"line\":12,\"column\":1,\"offset\":-1},\"end\":{\"line\":12,\"column\":1,\"offset\":-1}}"+
+		",\"NewText\":\"\\\"urn\\\": \\\"urn-2\\\",\\n\"},{\"Span\":{\"uri\":\"\",\"start\":"+
+		"{\"line\":12,\"column\":1,\"offset\":-1},\"end\":{\"line\":12,\"column\":1,\"offset\":-1}}"+
+		",\"NewText\":\"\\\"custom\\\": false,\\n\"},{\"Span\":{\"uri\":\"\",\"start\":{\"line\":12,"+
+		"\"column\":1,\"offset\":-1},\"end\":{\"line\":12,\"column\":1,\"offset\":-1}},\"NewText\":\""+
+		"\\\"type\\\": \\\"\\\"\\n\"}]", string(req2.DeploymentDelta))
+	assert.Equal(t, "75e2f82ca2735650366fba27b53ec97f310abd457aca27266fb29c4377ee00e7", req2.CheckpointHash)
+
+	handleDelta(req2)
+	assert.Equal(t, []apitype.ResourceV3{
+		{URN: resource.URN("urn-1")},
+		{URN: resource.URN("urn-2")},
+	}, typedPersistedState().Resources)
+
+	// Req 3: and continues using the diff protocol.
+
+	err = persister.Save(&deploy.Snapshot{
+		Resources: []*resource.State{
+			{URN: resource.URN("urn-1")},
+		},
+	})
+	assert.NoError(t, err)
+
+	req3 := lastRequestAsDelta()
+	assert.Equal(t, 3, req3.SequenceNumber)
+	assert.Equal(t, "[{\"Span\":{\"uri\":\"\",\"start\":{\"line\":12,\"column\":1,\"offset\":-1"+
+		"},\"end\":{\"line\":13,\"column\":1,\"offset\":-1}},\"NewText\":\"\"},{\"Span\":{"+
+		"\"uri\":\"\",\"start\":{\"line\":13,\"column\":1,\"offset\":-1},\"end\":{\"line\":14,"+
+		"\"column\":1,\"offset\":-1}},\"NewText\":\"\"},{\"Span\":{\"uri\":\"\",\"start\":"+
+		"{\"line\":14,\"column\":1,\"offset\":-1},\"end\":{\"line\":15,\"column\":1,"+
+		"\"offset\":-1}},\"NewText\":\"\"},{\"Span\":{\"uri\":\"\",\"start\":{\"line\":15,"+
+		"\"column\":1,\"offset\":-1},\"end\":{\"line\":16,\"column\":1,\"offset\":-1}},"+
+		"\"NewText\":\"\"},{\"Span\":{\"uri\":\"\",\"start\":{\"line\":16,\"column\":1,"+
+		"\"offset\":-1},\"end\":{\"line\":17,\"column\":1,\"offset\":-1}},\"NewText\":\"\"}]",
+		string(req3.DeploymentDelta))
+	assert.Equal(t, "5f2fd84a225e7c1895528b4b9394607d6b39aefa4ee74f57e018dadcb16bf2e2", req3.CheckpointHash)
+
+	handleDelta(req3)
+	assert.Equal(t, []apitype.ResourceV3{
+		{URN: resource.URN("urn-1")},
+	}, typedPersistedState().Resources)
+}
+
+type tokenSourceFn func() (string, error)
+
+var _ tokenSourceCapability = tokenSourceFn(nil)
+
+func (tsf tokenSourceFn) GetToken() (string, error) {
+	return tsf()
+}

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -22,11 +22,17 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
+type tokenSourceCapability interface {
+	GetToken() (string, error)
+}
+
 // tokenSource is a helper type that manages the renewal of the lease token for a managed update.
 type tokenSource struct {
 	requests chan tokenRequest
 	done     chan bool
 }
+
+var _ tokenSourceCapability = &tokenSource{}
 
 type tokenRequest chan<- tokenResponse
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -64,6 +64,7 @@ require (
 require (
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/natefinch/atomic v1.0.1
 	github.com/pulumi/pulumi-java/pkg v0.6.0
 	github.com/pulumi/pulumi-yaml v0.5.9

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1027,6 +1027,7 @@ github.com/hetznercloud/hcloud-go v1.33.1/go.mod h1:XX/TQub3ge0yWR2yHWmnDVIrB+MQ
 github.com/hetznercloud/hcloud-go v1.35.0/go.mod h1:mepQwR6va27S3UQthaEPGS86jtzSY9xWL1e9dyxXpgA=
 github.com/hexops/autogold v1.3.0 h1:IEtGNPxBeBu8RMn8eKWh/Ll9dVNgSnJ7bp/qHgMQ14o=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hexops/valast v1.4.0 h1:sFzyxPDP0riFQUzSBXTCCrAbbIndHPWMndxuEjXdZlc=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -225,6 +225,9 @@ type PatchUpdateCheckpointRequest struct {
 type PatchUpdateVerbatimCheckpointRequest struct {
 	Version           int             `json:"version"`
 	UntypedDeployment json.RawMessage `json:"untypedDeployment,omitempty"`
+
+	// Idempotency key incremented by the client on every PATCH call within the same update.
+	SequenceNumber int `json:"sequenceNumber"`
 }
 
 // PatchUpdateCheckpointDeltaRequest defines the body of a request to the bandwidth-optimized version of the patch


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #3930 (the client side updates)

Introduces a protocol for saving state that uses text diffs over slightly-indented JSON. The client changes are currently behind a feature flag PULUMI_OPTIMIZED_CHECKPOINT_PATCH=true. When Pulumi service deploys the corresponding endpoints, this functionality will start to be available for the users opting into the flag.

Besides tests added in the PR we have ran some end-to-end tests manually against an experimental service deployment with @caseyyh to make sure the client and the server are aligned on the protocol.


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
