### PR TITLE
ci: fix community contributor workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ on:
         default: false
         required: false
         type: boolean
+    secrets:
+      PULUMI_BOT_TOKEN:
+        required: true
+        description: "GitHub access token, required to mitigate GitHub rate limits"
+      PULUMI_PROD_ACCESS_TOKEN:
+        required: false
+        description: "Pulumi access token, required to run tests against the service"
 
 jobs:
   matrix:

--- a/.github/workflows/on-community-pr.yml
+++ b/.github/workflows/on-community-pr.yml
@@ -41,8 +41,10 @@ jobs:
       pull-requests: write
     uses: pulumi/pulumi/.github/workflows/on-pr-changelog.yml@master
     with:
-      ref: ${{ github.ref }}
+      ref: refs/pull/${{ github.event.pull_request.number }}/merge
       base-ref: origin/${{ github.base_ref }}
       pr-number: ${{ github.event.pull_request.number }}
       changelog-required: ${{ !contains(github.event.pull_request.labels.*.name, 'impact/no-changelog-required') }}
-    secrets: inherit
+    secrets:
+      # Scope secrets to the minimum required:
+      PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/on-pr-changelog.yml
+++ b/.github/workflows/on-pr-changelog.yml
@@ -24,6 +24,10 @@ on:
         required: true
         description: "Whether the changelog is required, used to allow check to pass on empty changelogs"
         type: boolean
+    secrets:
+      PULUMI_BOT_TOKEN:
+        required: true
+        description: "GitHub access token, required to mitigate GitHub rate limits"
 
 defaults:
   run:

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -60,3 +60,7 @@ jobs:
       integration-test-platforms: ubuntu-latest
       smoke-test-platforms: ''
       enable-coverage: true
+    secrets:
+      # Scope secrets to the minimum required:
+      PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      PULUMI_PROD_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}


### PR DESCRIPTION
Fixes a couple issues with our community contribution workflows:
* The ref for calculating changelogs should be the merge ref, the `github.ref` variable is the wrong value, given that it evaluated to `refs/head/master`: https://github.com/pulumi/pulumi/actions/runs/3071146998/jobs/4961576379#step:1:31
* The changelog comment on the dispatch job was redundant
* The CI job needs a GitHub token and Pulumi access token, so those are made explicit. Existing workflow calls to `ci.yml` use `secrets: inherit` to pass these down transparently. For contributor workflows, we prefer to be explicit. This ensures the workflow doesn't have access to, e.g., AWS tokens.