### PR TITLE
Don't retry downloads on 403 and 404s responses

### DIFF
--- a/changelog/pending/20220920--cli-plugin--dont-retry-plugin-downloads.yaml
+++ b/changelog/pending/20220920--cli-plugin--dont-retry-plugin-downloads.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: Don't retry plugin downloads in 403 and 404 responses

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -902,18 +902,20 @@ func getHTTPResponse(req *http.Request) (io.ReadCloser, int64, error) {
 type downloadError struct {
 	msg  string
 	code int
-	url  *url.URL
 }
 
 func (e *downloadError) Error() string {
 	return e.msg
 }
 
+func (e *downloadError) Code() int {
+	return e.code
+}
+
 // Create a new downloadError with a message that indicates GITHUB_TOKEN should be set.
 func newGithubPrivateRepoError(statusCode int, url *url.URL) error {
 	return &downloadError{
 		code: statusCode,
-		url:  url,
 		msg: fmt.Sprintf("%d HTTP error fetching plugin from %s. "+
 			"If this is a private GitHub repository, try "+
 			"providing a token via the GITHUB_TOKEN environment variable. "+
@@ -929,13 +931,8 @@ func newDownloadError(statusCode int, url *url.URL) error {
 	}
 	return &downloadError{
 		code: statusCode,
-		url:  url,
 		msg:  fmt.Sprintf("%d HTTP error fetching plugin from %s", statusCode, url),
 	}
-}
-
-func (e *downloadError) Code() int {
-	return e.code
 }
 
 // installLock acquires a file lock used to prevent concurrent installs.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1069,8 +1069,7 @@ func DownloadToFile(
 			}
 
 			// Don't retry, since the request was processed and rejected.
-			if err, ok := readErr.(*downloadError); ok &&
-				err.Code() == 404 || err.Code() == 403 {
+			if err, ok := readErr.(*downloadError); ok && (err.Code() == 404 || err.Code() == 403) {
 				return "", readErr
 			}
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -898,20 +898,20 @@ func getHTTPResponse(req *http.Request) (io.ReadCloser, int64, error) {
 	return resp.Body, resp.ContentLength, nil
 }
 
-// DownloadError is an error that happened during the HTTP download of a plugin.
-type DownloadError struct {
+// downloadError is an error that happened during the HTTP download of a plugin.
+type downloadError struct {
 	msg  string
 	code int
 	url  *url.URL
 }
 
-func (e *DownloadError) Error() string {
+func (e *downloadError) Error() string {
 	return e.msg
 }
 
-// Create a new DownloadError with a message that indicates GITHUB_TOKEN should be set.
+// Create a new downloadError with a message that indicates GITHUB_TOKEN should be set.
 func newGithubPrivateRepoError(statusCode int, url *url.URL) error {
-	return &DownloadError{
+	return &downloadError{
 		code: statusCode,
 		url:  url,
 		msg: fmt.Sprintf("%d HTTP error fetching plugin from %s. "+
@@ -922,19 +922,19 @@ func newGithubPrivateRepoError(statusCode int, url *url.URL) error {
 	}
 }
 
-// Create a new DownloadError.
+// Create a new downloadError.
 func newDownloadError(statusCode int, url *url.URL) error {
 	if url.Host == "api.github.com" && statusCode == 404 {
 		return newGithubPrivateRepoError(statusCode, url)
 	}
-	return &DownloadError{
+	return &downloadError{
 		code: statusCode,
 		url:  url,
 		msg:  fmt.Sprintf("%d HTTP error fetching plugin from %s", statusCode, url),
 	}
 }
 
-func (e *DownloadError) Code() int {
+func (e *downloadError) Code() int {
 	return e.code
 }
 
@@ -1072,7 +1072,7 @@ func DownloadToFile(
 			}
 
 			// Don't retry, since the request was processed and rejected.
-			if err, ok := readErr.(*DownloadError); ok &&
+			if err, ok := readErr.(*downloadError); ok &&
 				err.Code() == 404 || err.Code() == 403 {
 				return "", readErr
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10801

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
