### PR TITLE
Re-enable prior release process's checksums

### DIFF
--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -67,18 +67,26 @@ jobs:
       - name: Flatten artifact directories
         run: |
           mkdir -p ./artifacts
+          mkdir -p ./sums.tmp
           mv ./artifacts-tmp/artifacts-*/* ./artifacts
+
+        # Each of these commands strips the ./ prefix to match existing (<=3.39) formatting.
+      - name: Checksums with SHA256
+        working-directory: artifacts
+        env:
+          version: ${{ inputs.version }}
+        run: sha256sum ./* | sed 's/.\///' | tee "../sums.tmp/pulumi-${version}-checksums.txt"
 
       - name: Checksums with BLAKE3
         working-directory: artifacts
-        run: b3sum ./* | tee B3SUMS
+        run: b3sum ./* | sed 's/.\///' | tee ../sums.tmp/B3SUMS
 
       - name: Checksums with SHA512
         working-directory: artifacts
-        run: sha512sum ./* | tee SHA512SUMS
+        run: sha512sum ./* | sed 's/.\///' | tee ../sums.tmp/SHA512SUMS
 
       - name: Sign checksums
-        working-directory: artifacts
+        working-directory: sums.tmp
         # Requires a signing key to be configured.
         if: false
         shell: bash
@@ -87,26 +95,27 @@ jobs:
           version: ${{ inputs.version }}
         run: |
           set -u
-          echo "$RELEASE_KEY" > release.key
+          releaseKey="$(mktemp -d)/release.key"
+          echo "$RELEASE_KEY" > "${releaseKey}"
           set -x
-          for algo in B3 SHA512; do
+          for file in *; do
             echo | rsign sign \
               -p "${GITHUB_WORKSPACE}/.github/workflows/release.pub" \
-              -s release.key \
+              -s "${releaseKey}" \
               -t "${{ inputs.project }} v$version signed with automated key" \
               -c 'see website for signing information' \
-              -x "${algo}SUMS.auto.minisig" \
-              "${algo}SUMS"
+              -x "${file}.auto.minisig" \
+              "${file}"
           done
-          rm release.key
-          cat {B3,SHA512}SUMS.auto.minisig
+          rm "${releaseKey}"
+          cat ./*.auto.minisig
 
       - uses: actions/upload-artifact@v2
         with:
           name: artifacts-signatures
           retention-days: 1
           path: |
-            artifacts/*SUMS*
+            sums.tmp/*
           if-no-files-found: error
 
   publish:

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: artifacts
         env:
           version: ${{ inputs.version }}
-        run: sha256sum ./* | sed 's/.\///' | tee "../sums.tmp/pulumi-${version}-checksums.txt"
+        run: sha256sum ./pulumi-*.{tar.gz,zip} | sed 's/.\///' | tee "../sums.tmp/pulumi-${version}-checksums.txt"
 
       - name: Checksums with BLAKE3
         working-directory: artifacts

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -62,13 +62,13 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v2
         with:
-          path: artifacts-tmp
+          path: artifacts.tmp
 
       - name: Flatten artifact directories
         run: |
           mkdir -p ./artifacts
           mkdir -p ./sums.tmp
-          mv ./artifacts-tmp/artifacts-*/* ./artifacts
+          mv ./artifacts.tmp/artifacts-*/* ./artifacts
 
         # Each of these commands strips the ./ prefix to match existing (<=3.39) formatting.
       - name: Checksums with SHA256
@@ -134,23 +134,23 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v2
         with:
-          path: artifacts-tmp
+          path: artifacts.tmp
       - name: Rename SDKs
         run: |
           (
-            cd artifacts-tmp/artifacts-dotnet-sdk
+            cd artifacts.tmp/artifacts-dotnet-sdk
             for file in *.nupkg ; do
               mv -vT "$file" "sdk-dotnet-$file"
             done
           )
           (
-            cd artifacts-tmp/artifacts-python-sdk
+            cd artifacts.tmp/artifacts-python-sdk
             for file in *.whl ; do
               mv -vT "$file" "sdk-python-$file"
             done
           )
           (
-            cd artifacts-tmp/artifacts-nodejs-sdk
+            cd artifacts.tmp/artifacts-nodejs-sdk
             for file in *.tgz ; do
               mv -vT "$file" "sdk-nodejs-$file"
             done
@@ -158,7 +158,7 @@ jobs:
       - name: Flatten artifact directories
         run: |
           mkdir -p ./artifacts
-          mv ./artifacts-tmp/artifacts-*/* ./artifacts
+          mv ./artifacts.tmp/artifacts-*/* ./artifacts
       - uses: ncipollo/release-action@3d2de22e3d0beab188d8129c27f103d8e91bf13a
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
Re-enables creating a `pulumi-${version}-checksum.txt` on release.

The s3 blob upload will upload this to S3 as it's configured to upload any artifact in the release prefixed with `pulumi-`:

https://github.com/pulumi/pulumi/blob/bce637624e00b610c213f4f60fe1dd17aa8513b2/.github/workflows/release.yml#L130-L137

Resolves #10807