### PR TITLE
Update automation api secrets provider docstring link

### DIFF
--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
@@ -24,7 +24,7 @@ namespace Pulumi.Automation
         /// <summary>
         /// The secrets provider to user for encryption and decryption of stack secrets.
         /// <para/>
-        /// See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+        /// See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
         /// </summary>
         public string? SecretsProvider { get; set; }
 

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -635,7 +635,7 @@
             <summary>
             The secrets provider to user for encryption and decryption of stack secrets.
             <para/>
-            See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+            See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
             </summary>
         </member>
         <member name="P:Pulumi.Automation.LocalWorkspaceOptions.Program">
@@ -974,7 +974,7 @@
             <summary>
             The secrets provider to use for encryption and decryption of stack secrets.
             <para/>
-            See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+            See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
             </summary>
         </member>
         <member name="P:Pulumi.Automation.Workspace.Program">

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Automation
         /// <summary>
         /// The secrets provider to use for encryption and decryption of stack secrets.
         /// <para/>
-        /// See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+        /// See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
         /// </summary>
         public abstract string? SecretsProvider { get; }
 

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -53,7 +53,7 @@ export class LocalWorkspace implements Workspace {
     readonly pulumiHome?: string;
     /**
      * The secrets provider to use for encryption and decryption of stack secrets.
-     * See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+     * See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
      */
     readonly secretsProvider?: string;
     /**
@@ -660,7 +660,7 @@ export interface LocalWorkspaceOptions {
     envVars?: { [key: string]: string };
     /**
      * The secrets provider to use for encryption and decryption of stack secrets.
-     * See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+     * See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
      */
     secretsProvider?: string;
     /**

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -36,7 +36,7 @@ export interface Workspace {
     readonly pulumiHome?: string;
     /**
      * The secrets provider to use for encryption and decryption of stack secrets.
-     * See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+     * See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
      */
     readonly secretsProvider?: string;
     /**

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -122,7 +122,7 @@ class Workspace(ABC):
     secrets_provider: Optional[str]
     """
     The secrets provider to use for encryption and decryption of stack secrets.
-    See: https://www.pulumi.com/docs/intro/concepts/config/#available-encryption-providers
+    See: https://www.pulumi.com/docs/intro/concepts/secrets/#available-encryption-providers
     """
 
     program: Optional[PulumiFn]


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->
Updates an outdated docstring link I stumbled across while using Pulumi Automation API. 

There is no existing issue.

This is a non-code change and I believe it could be labeled `impact/no-changelog-required`; as such I have not made Changelog updates as per the [updated guidelines](https://github.com/pulumi/pulumi/commit/385d08218a5806c3389dd0a4b565a28b3fecf2a6). If I am mistaken please let me know!

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist


<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
