### PR TITLE
Add Organization to go sdk

### DIFF
--- a/changelog/pending/20220921--sdk-go--org-name.yaml
+++ b/changelog/pending/20220921--sdk-go--org-name.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Added `Context.Organization` to return the current organization if available.

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -482,6 +482,7 @@ func (host *goLanguageHost) constructEnv(req *pulumirpc.RunRequest) ([]string, e
 		}
 	}
 
+	maybeAppendEnv(pulumi.EnvOrganization, req.GetOrganization())
 	maybeAppendEnv(pulumi.EnvProject, req.GetProject())
 	maybeAppendEnv(pulumi.EnvStack, req.GetStack())
 	maybeAppendEnv(pulumi.EnvConfig, config)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -191,6 +191,15 @@ func (ctx *Context) wait() error {
 	return nil
 }
 
+// Organization returns the current organization name.
+func (ctx *Context) Organization() string {
+	org := ctx.info.Organization
+	if org == "" {
+		org = "organization"
+	}
+	return org
+}
+
 // Project returns the current project name.
 func (ctx *Context) Project() string { return ctx.info.Project }
 

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -26,6 +26,12 @@ func WithMocks(project, stack string, mocks MockResourceMonitor) RunOption {
 	}
 }
 
+func WithMocksWithOrganization(organization, project, stack string, mocks MockResourceMonitor) RunOption {
+	return func(info *RunInfo) {
+		info.Project, info.Stack, info.Mocks, info.Organization = project, stack, mocks, organization
+	}
+}
+
 // MockResourceArgs is used to construct call Mock
 type MockCallArgs struct {
 	// Token indicates which function is being called. This token is of the form "package:module:function".

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -172,6 +172,7 @@ func getEnvInfo() RunInfo {
 	}
 
 	return RunInfo{
+		Organization:     os.Getenv(EnvOrganization),
 		Project:          os.Getenv(EnvProject),
 		Stack:            os.Getenv(EnvStack),
 		Config:           config,
@@ -185,6 +186,8 @@ func getEnvInfo() RunInfo {
 }
 
 const (
+	// EnvOrganization is the envvar used to read the current Pulumi organization name.
+	EnvOrganization = "PULUMI_ORGANIZATION"
 	// EnvProject is the envvar used to read the current Pulumi project name.
 	EnvProject = "PULUMI_PROJECT"
 	// EnvStack is the envvar used to read the current Pulumi stack name.

--- a/tests/integration/integration_go_smoke_test.go
+++ b/tests/integration/integration_go_smoke_test.go
@@ -39,9 +39,6 @@ func TestStackReferenceGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		Quick: true,
-		Config: map[string]string{
-			"org": os.Getenv("PULUMI_TEST_OWNER"),
-		},
 		EditDirs: []integration.EditDir{
 			{
 				Dir:      "step1",

--- a/tests/integration/stack_reference/go/main.go
+++ b/tests/integration/stack_reference/go/main.go
@@ -8,15 +8,11 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		cfg := config.New(ctx, ctx.Project())
-
-		org := cfg.Require("org")
-		slug := fmt.Sprintf("%v/%v/%v", org, ctx.Project(), ctx.Stack())
+		slug := fmt.Sprintf("%v/%v/%v", ctx.Organization(), ctx.Project(), ctx.Stack())
 		_, err := pulumi.NewStackReference(ctx, slug, nil)
 
 		if err != nil {

--- a/tests/integration/stack_reference/go/step1/main.go
+++ b/tests/integration/stack_reference/go/step1/main.go
@@ -8,16 +8,12 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
-		cfg := config.New(ctx, ctx.Project())
-
-		org := cfg.Require("org")
-		slug := fmt.Sprintf("%v/%v/%v", org, ctx.Project(), ctx.Stack())
+		slug := fmt.Sprintf("%v/%v/%v", ctx.Organization(), ctx.Project(), ctx.Stack())
 		stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
 
 		if err != nil {

--- a/tests/integration/stack_reference/go/step2/main.go
+++ b/tests/integration/stack_reference/go/step2/main.go
@@ -8,17 +8,13 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 // Tests that the stack export that included secrets in step1 is read into a secret output.
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
-		cfg := config.New(ctx, ctx.Project())
-
-		org := cfg.Require("org")
-		slug := fmt.Sprintf("%v/%v/%v", org, ctx.Project(), ctx.Stack())
+		slug := fmt.Sprintf("%v/%v/%v", ctx.Organization(), ctx.Project(), ctx.Stack())
 		stackRef, err := pulumi.NewStackReference(ctx, slug, nil)
 
 		if err != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds organization name to the gosdk.
Part of https://github.com/pulumi/pulumi/issues/2800.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
