### PR TITLE
Make getOrganization total, default to 'organization'

### DIFF
--- a/changelog/pending/20220921--sdk-nodejs-python--get-org.yaml
+++ b/changelog/pending/20220921--sdk-nodejs-python--get-org.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs,python
+  description: `getOrganization` now returns "organization" by default.

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.cs
@@ -83,7 +83,7 @@ namespace Pulumi
             Environment.GetEnvironmentVariable("PULUMI_DISABLE_RESOURCE_REFERENCES") == "1" ||
             string.Equals(Environment.GetEnvironmentVariable("PULUMI_DISABLE_RESOURCE_REFERENCES"), "TRUE", StringComparison.OrdinalIgnoreCase);
 
-        private readonly string? _organizationName;
+        private readonly string _organizationName;
         private readonly string _projectName;
         private readonly string _stackName;
         private readonly bool _isDryRun;
@@ -131,7 +131,7 @@ namespace Pulumi
             _isDryRun = dryRunValue;
             _stackName = stack;
             _projectName = project;
-            _organizationName = organization;
+            _organizationName = organization ?? "organization";
 
             var deploymentLogger = CreateDefaultLogger();
 
@@ -160,23 +160,14 @@ namespace Pulumi
             _isDryRun = options?.IsPreview ?? true;
             _stackName = options?.StackName ?? "stack";
             _projectName = options?.ProjectName ?? "project";
-            _organizationName = options?.OrganizationName;
+            _organizationName = options?.OrganizationName ?? "organization";
             this.Engine = engine;
             this.Monitor = monitor;
             _runner = new Runner(this, deploymentLogger);
             _logger = new EngineLogger(this, deploymentLogger, this.Engine);
         }
 
-        string IDeployment.OrganizationName(string? fallback) {
-            if (string.IsNullOrEmpty(_organizationName))
-            {
-                if (fallback == null){
-                    throw new Exception("organization is not available; for test mode, set this in `TestOptions`");
-                }
-                return fallback;
-            }
-            return _organizationName;
-        }
+        string IDeployment.OrganizationName => _organizationName;
         string IDeployment.ProjectName => _projectName;
         string IDeployment.StackName => _stackName;
         bool IDeployment.IsDryRun => _isDryRun;

--- a/sdk/dotnet/Pulumi/Deployment/DeploymentInstance.cs
+++ b/sdk/dotnet/Pulumi/Deployment/DeploymentInstance.cs
@@ -25,10 +25,9 @@ namespace Pulumi
         public string ProjectName => _deployment.ProjectName;
 
         /// <summary>
-        /// Returns the current organization name. If no fallback value is given it throws an exception if
-        /// none is registered.
+        /// Returns the current organization name.
         /// </summary>
-        public string OrganizationName(string? fallback = null) => _deployment.OrganizationName(fallback);
+        public string OrganizationName => _deployment.OrganizationName;
 
         /// <summary>
         /// Whether or not the application is currently being previewed or actually applied.

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Inline.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Inline.cs
@@ -15,7 +15,7 @@ namespace Pulumi
             if (settings is null)
                 throw new ArgumentNullException(nameof(settings));
 
-            _organizationName = settings.Organization;
+            _organizationName = settings.Organization ?? "organization";
             _projectName = settings.Project;
             _stackName = settings.Stack;
             _isDryRun = settings.IsDryRun;

--- a/sdk/dotnet/Pulumi/Deployment/IDeployment.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IDeployment.cs
@@ -17,10 +17,9 @@ namespace Pulumi
         string ProjectName { get; }
 
         /// <summary>
-        /// Returns the current organization name. If no fallback value is given it throws an exception if
-        /// none is registered.
+        /// Returns the current organization name.
         /// </summary>
-        string OrganizationName(string? fallback = null);
+        string OrganizationName { get; }
 
         /// <summary>
         /// Whether or not the application is currently being previewed or actually applied.

--- a/sdk/dotnet/Pulumi/Testing/TestOptions.cs
+++ b/sdk/dotnet/Pulumi/Testing/TestOptions.cs
@@ -21,7 +21,7 @@ namespace Pulumi.Testing
         public bool? IsPreview { get; set; }
 
         /// <summary>
-        /// Organization name. Defaults to nothing if not specified.
+        /// Organization name. Defaults to <b>"organization"</b> if not specified.
         /// </summary>
         public string? OrganizationName { get; set; }
     }

--- a/sdk/nodejs/metadata.ts
+++ b/sdk/nodejs/metadata.ts
@@ -17,11 +17,10 @@
 import * as settings from "./runtime/settings";
 
 /**
- * getOrganization returns the current organization name. If no fallback value is given it throws an exception
- * if none is registered.
+ * getOrganization returns the current organization name.
  */
-export function getOrganization(fallback?: string): string {
-    return settings.getOrganization(fallback);
+export function getOrganization(): string {
+    return settings.getOrganization();
 }
 /**
  * getProject returns the current project name. It throws an exception if none is registered.

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -47,7 +47,7 @@ export interface Options {
     readonly queryMode?: boolean; // true if we're in query mode (does not allow resource registration).
     readonly legacyApply?: boolean; // true if we will resolve missing outputs to inputs during preview.
     readonly cacheDynamicProviders?: boolean; // true if we will cache serialized dynamic providers on the program side.
-    readonly organization?: string; // the name of the current organization (if available).
+    readonly organization?: string; // the name of the current organization.
 
     /**
      * Directory containing the send/receive files for making synchronous invokes to the engine.
@@ -92,7 +92,7 @@ export function resetOptions(
     process.env[nodeEnvKeys.parallel] = parallel.toString();
     process.env[nodeEnvKeys.monitorAddr] = monitorAddr;
     process.env[nodeEnvKeys.engineAddr] = engineAddr;
-    process.env[nodeEnvKeys.organization] = organization;
+    process.env[nodeEnvKeys.organization] = organization === "" ? "organization" : organization;
 }
 
 export function setMockOptions(mockMonitor: any, project?: string, stack?: string, preview?: boolean, organization?: string) {
@@ -163,14 +163,10 @@ export function cacheDynamicProviders(): boolean {
 /**
  * Get the organization being run by the current update.
  */
-export function getOrganization(fallback?: string): string {
+export function getOrganization(): string {
     const organization = options().organization;
     if (organization) {
         return organization;
-    }
-
-    if (fallback !== undefined){
-        return fallback;
     }
 
     // If the organization is missing, specialize the error.

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -48,6 +48,7 @@ class LanguageServer(LanguageRuntimeServicer):
 
         # Configure the runtime so that the user program hooks up to Pulumi as appropriate.
         engine_address = request.args[0] if request.args else ""
+        organization = request.organization if request.organization else "organization"
         reset_options(
             project=request.project,
             monitor_address=request.monitor_address,
@@ -55,7 +56,7 @@ class LanguageServer(LanguageRuntimeServicer):
             stack=request.stack,
             parallel=request.parallel,
             preview=request.dryRun,
-            organization=request.organization,
+            organization=organization,
         )
 
         if request.config:

--- a/sdk/python/lib/pulumi/metadata.py
+++ b/sdk/python/lib/pulumi/metadata.py
@@ -18,12 +18,11 @@ from .runtime.settings import get_project as runtime_gp
 from .runtime.settings import get_stack as runtime_gs
 
 
-def get_organization(fallback: Optional[str] = None) -> str:
+def get_organization() -> str:
     """
-    Returns the current organization name. If no fallback value is given it throws an exception if none is
-    registered.
+    Returns the current organization name.
     """
-    return runtime_go(fallback)
+    return runtime_go()
 
 
 def get_project() -> str:

--- a/sdk/python/lib/pulumi/policy/__main__.py
+++ b/sdk/python/lib/pulumi/policy/__main__.py
@@ -51,7 +51,7 @@ def main():
                 stack=os.environ["PULUMI_STACK"],
                 dry_run=os.environ["PULUMI_DRY_RUN"] == "true",
                 # PULUMI_ORGANIZATION might not be set for filestate backends
-                organization=os.environ.get("PULUMI_ORGANIZATION", None),
+                organization=os.environ.get("PULUMI_ORGANIZATION", "organization"),
             )
         )
 

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -82,7 +82,9 @@ class ProviderServicer(ResourceProviderServicer):
             request, proto.ConstructRequest
         ), f"request is not ConstructRequest but is {type(request)} instead"
 
+        organization = request.organization if request.organization else "organization"
         pulumi.runtime.settings.reset_options(
+            organization=organization,
             project=_empty_as_none(request.project),
             stack=_empty_as_none(request.stack),
             parallel=_zero_as_none(request.parallel),
@@ -211,7 +213,9 @@ class ProviderServicer(ResourceProviderServicer):
             request, proto.CallRequest
         ), f"request is not CallRequest but is {type(request)} instead"
 
+        organization = request.organization if request.organization else "organization"
         pulumi.runtime.settings.reset_options(
+            organization=organization,
             project=_empty_as_none(request.project),
             stack=_empty_as_none(request.stack),
             parallel=_zero_as_none(request.parallel),

--- a/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/provider_pb2.pyi
@@ -23,6 +23,7 @@ from google.protobuf.struct_pb2 import Struct
 class ConstructRequest:
     class PropertyDependencies:
         urns: List[str]
+    organization: str
     project: str
     stack: str
     config: Dict[str, str]
@@ -66,6 +67,7 @@ class CallRequest:
     argDependencies: Dict[str, ArgumentDependencies]
     provider: str
     version: str
+    organization: str
     project: str
     stack: str
     config: Dict[str, str]

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -130,7 +130,7 @@ class Settings:
 
 
 # default to "empty" settings.
-SETTINGS = Settings(stack="stack", project="project")
+SETTINGS = Settings(stack="stack", project="project", organization="organization")
 
 
 def configure(settings: Settings):
@@ -157,21 +157,13 @@ def is_legacy_apply_enabled():
     return bool(SETTINGS.legacy_apply_enabled)
 
 
-def get_organization(fallback: Optional[str] = None) -> str:
+def get_organization() -> str:
     """
-    Returns the current organization name. If no fallback value is given it throws an exception if none is
-    registered.
+    Returns the current organization name.
 
     When writing unit tests, you can set this flag via `pulumi.runtime.set_mocks` by supplying a value
     for the argument `organization`.
     """
-    if SETTINGS.organization is None:
-        if fallback is not None:
-            return fallback
-
-        raise Exception(
-            "Missing organization name; for test mode, please call `pulumi.runtime.setMocks"
-        )
     return SETTINGS.organization
 
 

--- a/tests/integration/stack_reference/dotnet/Program.cs
+++ b/tests/integration/stack_reference/dotnet/Program.cs
@@ -11,7 +11,7 @@ class Program
     {
         return Deployment.RunAsync(async () =>
         {
-            var slug = $"{Deployment.Instance.OrganizationName()}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
+            var slug = $"{Deployment.Instance.OrganizationName}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
             var a = new StackReference(slug);
 
             return new Dictionary<string, object>

--- a/tests/integration/stack_reference/dotnet/step1/Program.cs
+++ b/tests/integration/stack_reference/dotnet/step1/Program.cs
@@ -11,7 +11,7 @@ class Program
     {
         return Deployment.RunAsync(async () =>
         {
-            var slug = $"{Deployment.Instance.OrganizationName()}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
+            var slug = $"{Deployment.Instance.OrganizationName}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
             var a = new StackReference(slug);
 
             var oldVal = (string[])await a.GetValueAsync("val");

--- a/tests/integration/stack_reference/dotnet/step2/Program.cs
+++ b/tests/integration/stack_reference/dotnet/step2/Program.cs
@@ -10,7 +10,7 @@ class Program
     {
         return Deployment.RunAsync(async () =>
         {
-            var slug = $"{Deployment.Instance.OrganizationName()}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
+            var slug = $"{Deployment.Instance.OrganizationName}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
             var a = new StackReference(slug);
 
             var gotError = false;

--- a/tests/integration/stack_reference_secrets/dotnet/step2/Program.cs
+++ b/tests/integration/stack_reference_secrets/dotnet/step2/Program.cs
@@ -13,7 +13,7 @@ class Program
             // Kinda strange, but we are getting a stack reference to ourselves, and referencing
             // the result of the previous deployment.
 
-            var slug = $"{Deployment.Instance.OrganizationName()}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
+            var slug = $"{Deployment.Instance.OrganizationName}/{Deployment.Instance.ProjectName}/{Deployment.Instance.StackName}";
             var sr = new StackReference(slug);
 
             return new Dictionary<string, object>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Changes `getOrganization` to return "organization" by default. This will apply when using filestate, or by default in unit tests (unless explicitly set as part of test setup).

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
