### PR TITLE
ci: Re-enable Windows tests with temp dir

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -150,13 +150,16 @@ def run_list_tests(pkg_dir: str, tags: List[str]) -> List[str]:
     # $ go test -tags all --list ./tests/integration
     # no Go files in /home/friel/c/github.com/pulumi/pulumi
     # ```
-    cmd = sp.run(
-        ["go", "test", "-tags", " ".join(tags), "--list", "."],
-        check=True,
-        cwd=pkg_dir,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        cmd = sp.run(
+            ["go", "test", "-tags", " ".join(tags), "--list", "."],
+            check=True,
+            cwd=pkg_dir,
+            capture_output=True,
+            text=True,
+        )
+    except sp.CalledProcessError as err:
+        raise Exception("Failed to list packages in module, usually this implies a Go compilation error. Check that `make lint` succeeds.") from err
 
     tests: List[str] = []
 

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"testing"
 
@@ -171,10 +170,6 @@ func testPluginInstall(t *testing.T, expectedDir string, files map[string][]byte
 }
 
 func TestInstallNoDeps(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO[pulumi/pulumi#8649] Skipped on Windows: issues with TEMP dir")
-	}
-
 	name := "foo.txt"
 	content := []byte("hello\n")
 
@@ -194,10 +189,6 @@ func TestInstallNoDeps(t *testing.T) {
 }
 
 func TestReinstall(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO[pulumi/pulumi#8649] Skipped on Windows: issues with TEMP dir")
-	}
-
 	name := "foo.txt"
 	content := []byte("hello\n")
 
@@ -228,10 +219,6 @@ func TestReinstall(t *testing.T) {
 }
 
 func TestConcurrentInstalls(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO[pulumi/pulumi#8649] Skipped on Windows: issues with TEMP dir")
-	}
-
 	name := "foo.txt"
 	content := []byte("hello\n")
 


### PR DESCRIPTION
These tests pass on my Windows device, perhaps due to some more systemic fix with path handling.

Resume running these tests.

Resolves #8649