### PR TITLE
ci: Remove a misleading error message on merge queue workflows

### DIFF
--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -94,11 +94,15 @@ jobs:
             echo "::endgroup::"
           fi
 
-          if EXISTING_RELEASE="$(gh release view "v${PULUMI_VERSION}")"; then
-            echo "::error::This version has already been released!"
-            echo "::group::Release ${PULUMI_VERSION}"
-            echo "$EXISTING_RELEASE"
-            echo "::endgroup::"
+          if EXISTING_RELEASE_DRAFT="$(gh release view "v${PULUMI_VERSION}" --json isDraft --jq '.isDraft')"; then
+            if [ "$EXISTING_RELEASE_DRAFT" != "true" ]; then
+              echo "::error::This version has already been released!"
+              echo "::group::Release ${PULUMI_VERSION}"
+              echo "$EXISTING_RELEASE"
+              echo "::endgroup::"
+            else
+              echo "::info Preparing to update draft release ${PULUMI_VERSION}"
+            fi
           fi
 
           if $ERROR; then


### PR DESCRIPTION
When I wrote this check there were no draft releases or my GITHUB_TOKEN token was unauthenticated and so didn't see the draft releases.

Now that we're using merge queues for release processes, and the GITHUB_TOKEN is valid, we need to check if it's published or it's still a draft. This will clear this misleading error on staging workflows:

![An annotation below a GitHub workflow summary with the heading "info / gather" and the error text "This version has already been released!".](https://user-images.githubusercontent.com/788800/191627074-5e22d153-596d-41d5-a9bd-911b90397a9f.png)
