### PR TITLE
Support .cmd executables for plugins on Windows

### DIFF
--- a/changelog/pending/20220922--engine--fix-cmd.yaml
+++ b/changelog/pending/20220922--engine--fix-cmd.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix node and python MLCs on Windows.

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -69,8 +69,11 @@ func prepareTestPluginTGZ(t *testing.T, files map[string][]byte) io.ReadCloser {
 	}
 
 	// Add plugin binary to included files.
-	files["pulumi-resource-test"] = nil
-	files["pulumi-resource-test.exe"] = nil
+	if runtime.GOOS == "windows" {
+		files["pulumi-resource-test.exe"] = nil
+	} else {
+		files["pulumi-resource-test"] = nil
+	}
 
 	tgz, err := createTGZ(files)
 	require.NoError(t, err)
@@ -99,7 +102,11 @@ func assertPluginInstalled(t *testing.T, dir string, plugin PluginSpec) PluginIn
 	assert.NoError(t, err)
 	assert.True(t, info.IsDir())
 
-	info, err = os.Stat(filepath.Join(dir, plugin.Dir(), plugin.File()))
+	file := filepath.Join(dir, plugin.Dir(), plugin.File())
+	if runtime.GOOS == "windows" {
+		file += ".exe"
+	}
+	info, err = os.Stat(file)
 	assert.NoError(t, err)
 	assert.False(t, info.IsDir())
 


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Always return a PluginInfo with a path.

Merge SetSchemaMetadata into SetFileMetadata.

Specifically check for .exe in windows test.

Try to find an existing file for the reported plugin path. Fallback to plugin.exe if we can't find one.

Should allow https://github.com/pulumi/pulumi/pull/10805 to merge without test failures.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
