### PR TITLE
Ensure response parsing is included in HTTP client trace spans

### DIFF
--- a/changelog/pending/20220922--cli--fix-tracing-http-resp-parse.yaml
+++ b/changelog/pending/20220922--cli--fix-tracing-http-resp-parse.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fixes --tracing to account for response parsing in HTTP api/* spans.

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -155,7 +155,9 @@ func (c *defaultHTTPClient) Do(req *http.Request, retryAllMethods bool) (*http.R
 }
 
 // pulumiAPICall makes an HTTP request to the Pulumi API.
-func pulumiAPICall(ctx context.Context, requestSpan opentracing.Span, d diag.Sink, client httpClient, cloudAPI, method, path string, body []byte,
+func pulumiAPICall(ctx context.Context,
+	requestSpan opentracing.Span,
+	d diag.Sink, client httpClient, cloudAPI, method, path string, body []byte,
 	tok accessToken, opts httpCallOptions) (string, *http.Response, error) {
 
 	// Normalize URL components

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -155,7 +155,7 @@ func (c *defaultHTTPClient) Do(req *http.Request, retryAllMethods bool) (*http.R
 }
 
 // pulumiAPICall makes an HTTP request to the Pulumi API.
-func pulumiAPICall(ctx context.Context, d diag.Sink, client httpClient, cloudAPI, method, path string, body []byte,
+func pulumiAPICall(ctx context.Context, requestSpan opentracing.Span, d diag.Sink, client httpClient, cloudAPI, method, path string, body []byte,
 	tok accessToken, opts httpCallOptions) (string, *http.Response, error) {
 
 	// Normalize URL components
@@ -196,14 +196,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, client httpClient, cloudAPI
 		return "", nil, fmt.Errorf("creating new HTTP request: %w", err)
 	}
 
-	requestSpan, requestContext := opentracing.StartSpanFromContext(ctx, getEndpointName(method, path),
-		opentracing.Tag{Key: "method", Value: method},
-		opentracing.Tag{Key: "path", Value: path},
-		opentracing.Tag{Key: "api", Value: cloudAPI},
-		opentracing.Tag{Key: "retry", Value: opts.RetryAllMethods})
-	defer requestSpan.Finish()
-
-	req = req.WithContext(requestContext)
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 
 	// Add a User-Agent header to allow for the backend to make breaking API changes while preserving
@@ -218,7 +211,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, client httpClient, cloudAPI
 		req.Header.Set("Authorization", fmt.Sprintf("%s %s", tok.Kind(), tok.String()))
 	}
 
-	tracingOptions := tracing.OptionsFromContext(requestContext)
+	tracingOptions := tracing.OptionsFromContext(ctx)
 	if tracingOptions.PropagateSpans {
 		carrier := opentracing.HTTPHeadersCarrier(req.Header)
 		if err = requestSpan.Tracer().Inject(requestSpan.Context(), opentracing.HTTPHeaders, carrier); err != nil {
@@ -308,6 +301,13 @@ type defaultRESTClient struct {
 func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, method, path string, queryObj, reqObj,
 	respObj interface{}, tok accessToken, opts httpCallOptions) error {
 
+	requestSpan, ctx := opentracing.StartSpanFromContext(ctx, getEndpointName(method, path),
+		opentracing.Tag{Key: "method", Value: method},
+		opentracing.Tag{Key: "path", Value: path},
+		opentracing.Tag{Key: "api", Value: cloudAPI},
+		opentracing.Tag{Key: "retry", Value: opts.RetryAllMethods})
+	defer requestSpan.Finish()
+
 	// Compute query string from query object
 	querystring := ""
 	if queryObj != nil {
@@ -333,7 +333,7 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 
 	// Make API call
 	url, resp, err := pulumiAPICall(
-		ctx, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
+		ctx, requestSpan, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/util/validation"
@@ -471,6 +472,9 @@ func (pc *Client) GetStackUpdates(
 func (pc *Client) ExportStackDeployment(
 	ctx context.Context, stack StackIdentifier, version *int) (apitype.UntypedDeployment, error) {
 
+	tracingSpan, childCtx := opentracing.StartSpanFromContext(ctx, "ExportStackDeployment")
+	defer tracingSpan.Finish()
+
 	path := getStackPath(stack, "export")
 
 	// Tack on a specific version as desired.
@@ -479,7 +483,7 @@ func (pc *Client) ExportStackDeployment(
 	}
 
 	var resp apitype.ExportStackResponse
-	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+	if err := pc.restCall(childCtx, "GET", path, nil, nil, &resp); err != nil {
 		return apitype.UntypedDeployment{}, err
 	}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Pulumi preview seemed to hang for 26s+ on a large stack and a slow network connection, while --tracing was not showing anything to account for these 26s. As it turns out there was a bug that excluded the time it took to transfer the response body over the network and parse it, specifically affecting ExportStack operation in the program. 

This now fixed for all HTTP-related operation spans.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
