### PR TITLE
Remove dependency on `github.com/pkg/errors` in `pkg` module

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -29,7 +29,6 @@ import (
 	_ "gocloud.dev/secrets/hashivault"    // support for hashivault://
 	"google.golang.org/api/cloudkms/v1"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/authhelpers"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -59,19 +58,19 @@ func NewCloudSecretsManagerFromState(state json.RawMessage) (secrets.Manager, er
 func openKeeper(ctx context.Context, url string) (*gosecrets.Keeper, error) {
 	u, err := netUrl.Parse(url)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse the secrets provider URL")
+		return nil, fmt.Errorf("unable to parse the secrets provider URL: %w", err)
 	}
 
 	switch u.Scheme {
 	case gcpkms.Scheme:
 		credentials, err := authhelpers.ResolveGoogleCredentials(ctx, cloudkms.CloudkmsScope)
 		if err != nil {
-			return nil, errors.Wrap(err, "missing google credentials")
+			return nil, fmt.Errorf("missing google credentials: %w", err)
 		}
 
 		kmsClient, _, err := gcpkms.Dial(ctx, credentials.TokenSource)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to connect to gcpkms")
+			return nil, fmt.Errorf("failed to connect to gcpkms: %w", err)
 		}
 		opener := gcpkms.URLOpener{
 			Client: kmsClient,


### PR DESCRIPTION
We'd [previously removed](https://github.com/pulumi/pulumi/pull/6379) the direct dependency on `github.com/pkg/errors` in the `pkg` module, but a [community PR brought it back](https://github.com/pulumi/pulumi/pull/6379). This change removes it once again, as it's not needed for wrapping the errors in these cases.