### PR TITLE
fix: Best effort support for Go versions below 1.18

### DIFF
--- a/changelog/pending/20220927--sdk-go--install-deps-1-18.yaml
+++ b/changelog/pending/20220927--sdk-go--install-deps-1-18.yaml
@@ -1,0 +1,6 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: >
+    Go programs run with Go 1.17 or below failed due to go mod tidy being run with -compat=1.18. The
+    change is reverted.

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -553,7 +553,7 @@ func (host *goLanguageHost) InstallDependencies(
 		return err
 	}
 
-	cmd := exec.Command(gobin, "mod", "tidy", "-compat=1.18")
+	cmd := exec.Command(gobin, "mod", "tidy")
 	cmd.Dir = req.Directory
 	cmd.Env = os.Environ()
 	cmd.Stdout, cmd.Stderr = stdout, stderr


### PR DESCRIPTION
As go 1.17 is out of support, it falls outside our support window. However, we may still want to remove the `-compat=1.18` flag passed to `go mod tidy` to allow best effort support for whichever the current Go version is.