### PR TITLE
ci: Reenable Brew publishing after GH runners removed brew from path

### DIFF
--- a/.github/workflows/trigger-homebrew-event.yml
+++ b/.github/workflows/trigger-homebrew-event.yml
@@ -13,6 +13,9 @@ jobs:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     steps:
+      - name: Add Homebrew to the PATH
+        run: |
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "${GITHUB_PATH}"
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           token: ${{secrets.PULUMI_BOT_TOKEN}}


### PR DESCRIPTION
GitHub removed `brew` from the path:
- https://github.com/actions/runner-images/issues/6283

This change should be reviewed and after it merges, we should be able to run the following command with an appropriate access token to trigger the workflow and publish 3.40.2:

```shell
pulumictl create homebrew-bump "3.40.2" "$(git rev-parse v3.40.2)"
```

Resolves #10860 