### PR TITLE
ci: Fix env, script cleanup on homebrew tap release action

### DIFF
--- a/.github/workflows/release-homebrew-tap.yml
+++ b/.github/workflows/release-homebrew-tap.yml
@@ -35,6 +35,9 @@ on:
         description: "Whether to run in dry-run mode and skip pushing the commit"
         type: boolean
 
+env:
+  PULUMI_VERSION: ${{ inputs.version }}
+
 jobs:
   update-homebrew-tap:
     name: Update Homebrew Tap
@@ -61,8 +64,6 @@ jobs:
           ./pulumi/.github/scripts/generate-homebrew-tap \
             "${PULUMI_VERSION}" ./pulumi/.github/scripts/pulumi-tap-template.rb \
             > ./homebrew-tap/Formula/pulumi.rb
-
-          git add homebrew-tap/Formula/pulumi.rb
       - name: Commit updated formula
         working-directory: homebrew-tap
         run: |
@@ -71,18 +72,16 @@ jobs:
           git config user.name pulumi-bot
           git config user.email bot@pulumi.com
           git add Formula/pulumi.rb
-          git commit -m "Brew formula update for Pulumi version ${PULUMI_VERSION}"
-          git push -u origin master
           echo "::group::git diff"
-          git diff
+          git  --no-pager diff
           echo "::endgroup::"
+          git commit -m "Brew formula update for Pulumi version ${PULUMI_VERSION}"
       - name: Push formula
         working-directory: homebrew-tap
         if: ${{ !inputs.dry-run }}
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-          PULUMI_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
-          git push
+          git push origin HEAD:master


### PR DESCRIPTION
In #10861, the homebrew tap update failed due to PULUMI_VERSION being undefined. The env var was not declared on all of the steps needed.

Moves the env var declaration up, and makes a few tweaks and removes a `git push` that should not have been run when dry-run is false.

After this is merged, we should be able to trigger it manually [via the GitHub Workflow page]( https://github.com/pulumi/pulumi/actions/workflows/release-homebrew-tap.yml) to verify that the changes work.

Resolves #10861.