### PR TITLE
sdk/go: Enable unsafe await of Output values in Go SDK

### DIFF
--- a/changelog/pending/20220928--sdk-go--unsafe-await.yaml
+++ b/changelog/pending/20220928--sdk-go--unsafe-await.yaml
@@ -1,0 +1,6 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: >
+    Adds an `UnsafeAwaitOutput` function to the Go SDK. This permits a workaround for component
+    providers and other advanced scenarios where resources created are conditional on an output.

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -551,6 +551,31 @@ func UnsafeUnknownOutput(deps []Resource) Output {
 	return output
 }
 
+// UnsafeAwaitOutputResult is an output from a Pulumi function or resource that has been resolved.
+//
+// This is a low level API and should be used with care.
+type UnsafeAwaitOutputResult struct {
+	Value        interface{} // The value of the output. If unknown (in a dry-run), the value will be nil.
+	Known        bool        // True if the value is known.
+	Secret       bool        // True if the value is a secret.
+	Dependencies []Resource  // The resources that this output depends on.
+}
+
+// UnsafeAwaitOutput blocks until the output is resolved and returns the resolved value and
+// metadata.
+//
+// This is a low level API and should be used with care.
+func UnsafeAwaitOutput(ctx context.Context, o Output) (UnsafeAwaitOutputResult, error) {
+	value, known, secret, deps, err := o.getState().await(ctx)
+
+	return UnsafeAwaitOutputResult{
+		Value:        value,
+		Known:        known,
+		Secret:       secret,
+		Dependencies: deps,
+	}, err
+}
+
 // ToSecretWithContext wraps the input in an Output marked as secret
 // that will resolve when all Inputs contained in the given value have resolved.
 func ToSecretWithContext(ctx context.Context, input interface{}) Output {

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func await(out Output) (interface{}, bool, bool, []Resource, error) {
-	return out.getState().await(context.Background())
+	result, err := UnsafeAwaitOutput(context.Background(), out)
+
+	return result.Value, result.Known, result.Secret, result.Dependencies, err
 }
 
 func assertApplied(t *testing.T, out Output) {


### PR DESCRIPTION
Barring implementation of #4834 or this PR, conditionally creating resources in a component provider requires creating resources inside of an Apply, which we strongly recommend against. While both provide workarounds, this new API may be more ergonomic to use - when used correctly - to conditionally create child resources.

A struct return type is used to avoid confusion of the adjacent boolean return values `known` and `secret`.