### PR TITLE
[WIP] Allows for Pulumi.prompts.yaml files in templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage.cov
 **/obj/
 coverage/
 venv/
+.envrc
 
 **/.idea/
 *.iml

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -319,7 +319,7 @@ func completeNodeJSInstall(ctx context.Context, finalDir string) error {
 
 func completePythonInstall(ctx context.Context, finalDir, projPath string, proj *workspace.PolicyPackProject) error {
 	const venvDir = "venv"
-	if err := python.InstallDependencies(ctx, finalDir, venvDir, false /*showOutput*/); err != nil {
+	if err := python.InstallDependencies(ctx, finalDir, venvDir, false /*showOutput*/, python.Venv); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -140,7 +140,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 				result.Plugins = plugins
 			}
 
-			lang, err := pluginContext.Host.LanguageRuntime(proj.Runtime.Name())
+			lang, err := pluginContext.Host.LanguageRuntime(proj.Runtime.Name(), make(map[string]string))
 			if err != nil {
 				addError(err, fmt.Sprintf("Failed to load language plugin %s", proj.Runtime.Name()))
 			} else {

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -110,7 +110,7 @@ func newConvertCmd() *cobra.Command {
 			defer ctx.Close()
 
 			if !generateOnly {
-				if err := installDependencies(ctx, &proj.Runtime, pwd); err != nil {
+				if err := installDependencies(ctx, &proj.Runtime, pwd, map[string]string{}); err != nil {
 					return result.FromError(err)
 				}
 			}

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -255,7 +255,7 @@ func installPolicyPackDependencies(ctx *plugin.Context,
 	proj *workspace.PolicyPackProject, projPath, root string) error {
 	// First make sure the language plugin is present.  We need this to load the required resource plugins.
 	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-	lang, err := ctx.Host.LanguageRuntime(proj.Runtime.Name())
+	lang, err := ctx.Host.LanguageRuntime(proj.Runtime.Name(), make(map[string]string))
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -324,7 +324,7 @@ func newUpCmd() *cobra.Command {
 
 		defer pctx.Close()
 
-		if err = installDependencies(pctx, &proj.Runtime, pwd); err != nil {
+		if err = installDependencies(pctx, &proj.Runtime, pwd, make(map[string]string)); err != nil {
 			return result.FromError(err)
 		}
 

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -147,7 +147,7 @@ func buildVirtualEnv(ctx context.Context) error {
 		}
 	}
 
-	err = python.InstallDependencies(ctx, hereDir, venvDir, false /*showOutput*/)
+	err = python.InstallDependencies(ctx, hereDir, venvDir, false /*showOutput*/, "venv")
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -47,6 +47,6 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 	}, nil
 }
 
-func (host *clientLanguageRuntimeHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
+func (host *clientLanguageRuntimeHost) LanguageRuntime(runtime string, promptArgs map[string]string) (plugin.LanguageRuntime, error) {
 	return host.languageRuntime, nil
 }

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -340,7 +340,7 @@ func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (p
 	return plug.(plugin.Provider), nil
 }
 
-func (host *pluginHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
+func (host *pluginHost) LanguageRuntime(runtime string, promptArgs map[string]string) (plugin.LanguageRuntime, error) {
 	return host.languageRuntime, nil
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -68,7 +68,7 @@ func (host *testPluginHost) Provider(pkg tokens.Package, version *semver.Version
 func (host *testPluginHost) CloseProvider(provider plugin.Provider) error {
 	return host.closeProvider(provider)
 }
-func (host *testPluginHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
+func (host *testPluginHost) LanguageRuntime(runtime string, promptArgs map[string]string) (plugin.LanguageRuntime, error) {
 	return nil, errors.New("unsupported")
 }
 func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginSpec, kinds plugin.Flags) error {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -199,7 +199,7 @@ func (iter *evalSourceIterator) forkRun(opts Options, config map[config.Key]stri
 		// Next, launch the language plugin.
 		run := func() result.Result {
 			rt := iter.src.runinfo.Proj.Runtime.Name()
-			langhost, err := iter.src.plugctx.Host.LanguageRuntime(rt)
+			langhost, err := iter.src.plugctx.Host.LanguageRuntime(rt, make(map[string]string))
 			if err != nil {
 				return result.FromError(fmt.Errorf("failed to launch language host %s: %w", rt, err))
 			}

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -142,7 +142,7 @@ func (src *querySource) forkRun() {
 
 func runLangPlugin(src *querySource) result.Result {
 	rt := src.runinfo.Proj.Runtime.Name()
-	langhost, err := src.plugctx.Host.LanguageRuntime(rt)
+	langhost, err := src.plugctx.Host.LanguageRuntime(rt, make(map[string]string))
 	if err != nil {
 		return result.FromError(fmt.Errorf("failed to launch language host %s: %w", rt, err))
 	}

--- a/pkg/util/yamlutil/node_tools.go
+++ b/pkg/util/yamlutil/node_tools.go
@@ -22,6 +22,15 @@ func YamlErrorf(node *yaml.Node, format string, a ...interface{}) error {
 // Get attempts to obtain the value at an index in a sequence or in a mapping. Returns the node and true if successful;
 // nil and false if out of bounds or not found; and nil, false, and an error if any error occurs.
 func Get(l *yaml.Node, key interface{}) (*yaml.Node, bool, error) {
+	contains := func(s []string, str string) bool {
+		for _, v := range s {
+			if v == str {
+				return true
+			}
+		}
+	
+		return false
+	}
 	switch l.Kind {
 	case yaml.DocumentNode:
 		// Automatically recurse as documents contain a single element
@@ -40,9 +49,9 @@ func Get(l *yaml.Node, key interface{}) (*yaml.Node, bool, error) {
 				continue
 			}
 
-			switch k := key.(type) {
+			switch key.(type) {
 			case string:
-				if v.Tag == "str" && v.Value == k {
+				if contains([]string{"str", "!!str"}, v.Tag) && v.Value == key {
 					return l.Content[i+1], true, nil
 				}
 			default:

--- a/proto/.checksum.txt
+++ b/proto/.checksum.txt
@@ -8,7 +8,7 @@
 1949619858 9233 proto/pulumi/analyzer.proto
 2889436496 3240 proto/pulumi/engine.proto
 3421371250 793 proto/pulumi/errors.proto
-3300935796 5024 proto/pulumi/language.proto
+2209961833 5023 proto/pulumi/language.proto
 2700626499 1743 proto/pulumi/plugin.proto
 1451439690 19667 proto/pulumi/provider.proto
 3448262075 10699 proto/pulumi/resource.proto

--- a/proto/pulumi/language.proto
+++ b/proto/pulumi/language.proto
@@ -32,7 +32,7 @@ service LanguageRuntime {
     rpc GetPluginInfo(google.protobuf.Empty) returns (PluginInfo) {}
 
     // InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
-    rpc  InstallDependencies(InstallDependenciesRequest) returns (stream  InstallDependenciesResponse) {}
+    rpc InstallDependencies(InstallDependenciesRequest) returns (stream  InstallDependenciesResponse) {}
 
     // About returns information about the runtime for this language.
     rpc About(google.protobuf.Empty) returns (AboutResponse) {}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1258,7 +1258,7 @@ func (spec PluginSpec) InstallWithContext(ctx context.Context, content PluginCon
 				return errors.Wrap(err, "installing plugin dependencies")
 			}
 		case "python":
-			if err := python.InstallDependencies(ctx, finalDir, "venv", false /*showOutput*/); err != nil {
+			if err := python.InstallDependencies(ctx, finalDir, "venv", false /*showOutput*/, python.Venv); err != nil {
 				return errors.Wrap(err, "installing plugin dependencies")
 			}
 		}


### PR DESCRIPTION
passes additional prompt args along to runtime hosts

adds a toolchain argument with venv default to the python runtime

allows for beginnings of interactions with poetry

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

A lot of this was done pretty quickly to get `new` to work - I haven't ironed out the other places dependencies are installed, nor automated `poetry` usage within things like `pulumi up`.  This is _extremely_ WIP.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
