### PR TITLE
[sdk/python] Prevent set change during iteration errrors

### DIFF
--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -803,7 +803,7 @@ async def _add_dependency(
         # Copy the set before iterating so that any concurrent child additions during
         # the dependency computation (which is async, so can be interleaved with other
         # operations including child resource construction which adds children to this
-        # resource) do not trigger modification during iteration errors.  
+        # resource) do not trigger modification during iteration errors.
         child_resources = res._childResources.copy()
         for child in child_resources:
             await _add_dependency(deps, child, from_resource)

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -800,7 +800,12 @@ async def _add_dependency(
     from .. import ComponentResource  # pylint: disable=import-outside-toplevel
 
     if isinstance(res, ComponentResource) and not res._remote:
-        for child in res._childResources:
+        # Copy the set before iterating so that any concurrent child additions during
+        # the dependency computation (which is async, so can be interleaved with other
+        # operations including child resource construction which adds children to this
+        # resource) do not trigger modification during iteration errors.  
+        child_resources = res._childResources.copy()
+        for child in child_resources:
             await _add_dependency(deps, child, from_resource)
         return
 


### PR DESCRIPTION
Fixes #10885.

I'm not sure how to construct a test that would truly validate this - it would require timing a Child resource construction that occurred in the middle of the dependency resolution, due to the interleaving of async work.