### PR TITLE
[sdk/python] Allow editable installs without build step

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -2,7 +2,7 @@
 .mypy_cache/
 *.pyc
 /env/
-/*.egg-info
+*.egg-info/
 .venv/
 venv/
 .coverage

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -34,7 +34,7 @@ ensure:: $(PYTHON).ensure .ensure.phony
 
 build_package:: ensure
 	rm -rf $(PYENVSRC) && cp -R ./lib/. $(PYENVSRC)/
-	sed -i.bak "s/\$${VERSION}/$(PYPI_VERSION)/g" $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
+	sed -i.bak 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
 	cp ../../README.md $(PYENVSRC)
 	. venv/*/activate && cd $(PYENVSRC) && \
 		python setup.py build bdist_wheel --universal

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -17,13 +17,19 @@
 from setuptools import setup, find_packages
 
 
+VERSION = "3.0.0"
+
+
 def readme():
-    with open('README.md', encoding='utf-8') as f:
-        return f.read()
+    try:
+        with open('README.md', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        return "Pulumi's Python SDK - Development Version"
 
 
 setup(name='pulumi',
-      version='${VERSION}',
+      version=VERSION,
       description='Pulumi\'s Python SDK',
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
This commit modifies `setup.py` to use a Python variable as the source of the package version instead of a placeholder string and adds a fallback for the README definition. This makes the package installable via the `-e` flag directly from its source directory (`sdk/python/lib`), rather than having a build step and having to `-e` install the built directory (`sdk/python/env/src`).

This is equivalent to some changes we've made in our generated Python provider SDKs (#7097 and #7479), making the core SDK consistent with those.