### PR TITLE
Remove experimental github support

### DIFF
--- a/changelog/pending/20221001--cli-about-plugin--rm-github-experimental.yaml
+++ b/changelog/pending/20221001--cli-about-plugin--rm-github-experimental.yaml
@@ -1,0 +1,7 @@
+changes:
+- type: feat
+  scope: cli/about,plugin
+  description: >
+        Remove experimental feature for plugins from private github releases.
+        This is now supported by `github:` plugin urls, see
+        https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author/#support-for-github-releases.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Remove experimental support of github releases for plugin sources. We now have support for this via `github:` download urls.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
