### PR TITLE
suggest setting PULUMI_SKIP_UPDATE_CHECK when error fetching latest version #10292

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -382,7 +382,7 @@ func checkForUpdate(ctx context.Context) *diag.Diag {
 
 	latestVer, oldestAllowedVer, err := getCLIVersionInfo(ctx)
 	if err != nil {
-		logging.V(3).Infof("error fetching latest version information: %s", err)
+		logging.V(3).Infof("error fetching latest version information (set `PULUMI_SKIP_UPDATE_CHECK=true` to skip update checks): %s", err)
 	}
 
 	if oldestAllowedVer.GT(curVer) {

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -382,7 +382,8 @@ func checkForUpdate(ctx context.Context) *diag.Diag {
 
 	latestVer, oldestAllowedVer, err := getCLIVersionInfo(ctx)
 	if err != nil {
-		logging.V(3).Infof("error fetching latest version information (set `PULUMI_SKIP_UPDATE_CHECK=true` to skip update checks): %s", err)
+		logging.V(3).Infof("error fetching latest version information "+
+			"(set `PULUMI_SKIP_UPDATE_CHECK=true` to skip update checks): %s", err)
 	}
 
 	if oldestAllowedVer.GT(curVer) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

suggests setting PULUMI_SKIP_UPDATE_CHECK in the log statement.

Fixes #10292 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
