### PR TITLE
Require a config path to be passed to NewSecret methods

### DIFF
--- a/pkg/backend/filestate/crypto.go
+++ b/pkg/backend/filestate/crypto.go
@@ -26,14 +26,6 @@ func NewPassphraseSecretsManager(stackName tokens.Name, configFile string,
 	rotatePassphraseSecretsProvider bool) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
-	if configFile == "" {
-		f, err := workspace.DetectProjectStackPath(stackName.Q())
-		if err != nil {
-			return nil, err
-		}
-		configFile = f
-	}
-
 	info, err := workspace.LoadProjectStack(configFile)
 	if err != nil {
 		return nil, err

--- a/pkg/backend/httpstate/crypto.go
+++ b/pkg/backend/httpstate/crypto.go
@@ -25,14 +25,6 @@ import (
 func NewServiceSecretsManager(s Stack, stackName tokens.Name, configFile string) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
-	if configFile == "" {
-		f, err := workspace.DetectProjectStackPath(stackName.Q())
-		if err != nil {
-			return nil, err
-		}
-		configFile = f
-	}
-
 	info, err := workspace.LoadProjectStack(configFile)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -51,16 +51,20 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 	}
 
 	sm, err := func() (secrets.Manager, error) {
+		configFile, err := getProjectStackPath(s)
+		if err != nil {
+			return nil, err
+		}
+
 		if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
-			return newCloudSecretsManager(s.Ref().Name(), stackConfigFile, ps.SecretsProvider)
+			return newCloudSecretsManager(s.Ref().Name(), configFile, ps.SecretsProvider)
 		}
 
 		if ps.EncryptionSalt != "" {
-			return filestate.NewPassphraseSecretsManager(s.Ref().Name(), stackConfigFile,
-				false /* rotatePassphraseSecretsProvider */)
+			return filestate.NewPassphraseSecretsManager(s.Ref().Name(), configFile, false /* rotatePassphraseSecretsProvider */)
 		}
 
-		return s.DefaultSecretManager(stackConfigFile)
+		return s.DefaultSecretManager(configFile)
 	}()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/crypto_cloud.go
+++ b/pkg/cmd/pulumi/crypto_cloud.go
@@ -28,14 +28,6 @@ import (
 func newCloudSecretsManager(stackName tokens.Name, configFile, secretsProvider string) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
-	if configFile == "" {
-		f, err := workspace.DetectProjectStackPath(stackName.Q())
-		if err != nil {
-			return nil, err
-		}
-		configFile = f
-	}
-
 	info, err := workspace.LoadProjectStack(configFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Don't do config path resolution deep in the secret managers, expect paths to be resolved higher up.