### PR TITLE
Add api type for PatchUpdateCheckpointDeltaRequest

### DIFF
--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -216,6 +216,24 @@ type PatchUpdateCheckpointRequest struct {
 	Deployment json.RawMessage `json:"deployment,omitempty"`
 }
 
+// PatchUpdateCheckpointDeltaRequest defines the body of a request to the bandwidth-optimized version of the patch
+// update checkpoint endpoint of the service API. It is semantically equivalent to the PatchUpdateCheckpointRequest, but
+// instead of transferring the entire Deployment as a JSON blob, it encodes it as a textual diff against the last-saved
+// deployment. This conserves bandwidth on large resources.
+type PatchUpdateCheckpointDeltaRequest struct {
+	// Protocol version.
+	Version int `json:"version"`
+
+	// SHA256 hash of the result of aplying the DeploymentDelta to the previously saved deployment.
+	CheckpointHash string `json:"checkpointHash"`
+
+	// Idempotency key incremented by the client on every PATCH call within the same update.
+	SequenceNumber int `json:"sequenceNumber"`
+
+	// Textual diff that recovers the desired deployment JSON when applied to the previously saved deployment JSON.
+	DeploymentDelta json.RawMessage `json:"deploymentDelta,omitempty"`
+}
+
 // AppendUpdateLogEntryRequest defines the body of a request to the append update log entry endpoint of the service API.
 // No longer sent from the CLI, but the type definition is still required for backwards compat with older clients.
 type AppendUpdateLogEntryRequest struct {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Add API shape for PatchUpdateCheckpointDeltaRequest for the service to ingest. Pulled from prototyped branch https://github.com/pulumi/pulumi/compare/t0yv0/efficient-patch-protocol

Parent story: https://github.com/pulumi/home/issues/1768

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
