### PR TITLE
Add expectFailure to another case

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1331,8 +1331,8 @@ func (pt *ProgramTester) TestPreviewUpdateAndEdits() error {
 			msg = "(no changes expected)"
 		}
 		pt.t.Logf("Performing empty preview and update%s", msg)
-		if err := pt.PreviewAndUpdate(
-			dir, "empty", pt.opts.ExpectFailure, !pt.opts.AllowEmptyPreviewChanges, !pt.opts.AllowEmptyUpdateChanges); err != nil {
+		if err := pt.PreviewAndUpdate(dir, "empty", pt.opts.ExpectFailure,
+			!pt.opts.AllowEmptyPreviewChanges, !pt.opts.AllowEmptyUpdateChanges); err != nil {
 
 			return fmt.Errorf("empty preview: %w", err)
 		}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1162,7 +1162,7 @@ func (pt *ProgramTester) TestLifeCycleInitAndDestroy() error {
 		}
 
 		if err = pt.TestPreviewUpdateAndEdits(); err != nil {
-			return fmt.Errorf("running test preview, update, and edits: %w", err)
+			return fmt.Errorf("running test preview, update, and edits (updateTest): %w", err)
 		}
 	}
 
@@ -1313,7 +1313,7 @@ func (pt *ProgramTester) TestPreviewUpdateAndEdits() error {
 
 	// If the initial preview/update failed, just exit without trying the rest (but make sure to destroy).
 	if initErr != nil {
-		return initErr
+		return fmt.Errorf("initial failure: %w", initErr)
 	}
 
 	// Perform an empty preview and update; nothing is expected to happen here.
@@ -1321,7 +1321,7 @@ func (pt *ProgramTester) TestPreviewUpdateAndEdits() error {
 		pt.t.Log("Roundtripping checkpoint via stack export and stack import")
 
 		if err := pt.exportImport(dir); err != nil {
-			return err
+			return fmt.Errorf("empty preview + update: %w", err)
 		}
 	}
 
@@ -1332,9 +1332,9 @@ func (pt *ProgramTester) TestPreviewUpdateAndEdits() error {
 		}
 		pt.t.Logf("Performing empty preview and update%s", msg)
 		if err := pt.PreviewAndUpdate(
-			dir, "empty", false, !pt.opts.AllowEmptyPreviewChanges, !pt.opts.AllowEmptyUpdateChanges); err != nil {
+			dir, "empty", pt.opts.ExpectFailure, !pt.opts.AllowEmptyPreviewChanges, !pt.opts.AllowEmptyUpdateChanges); err != nil {
 
-			return err
+			return fmt.Errorf("empty preview: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Expands the scope of `integration.ProgramOptions.ExpectFailures` to enable https://github.com/pulumi/pulumi-yaml/pull/360.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
