### PR TITLE
Add Output.format to python SDK

### DIFF
--- a/changelog/pending/20221004--sdk-python--python-format.yaml
+++ b/changelog/pending/20221004--sdk-python--python-format.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add Output.format to the python SDK.

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -256,3 +256,42 @@ class OutputApplyTests(unittest.TestCase):
         test_output = Output.from_input('anything').apply(lambda _: bad_output)
         self.assertEqual(await test_output.is_secret(), False)
         self.assertEqual(await test_output.is_known(), False)
+
+class OutputAllTests(unittest.TestCase):
+    @pulumi_test
+    async def test_args(self):
+        o1 = Output.from_input(1)
+        o2 = Output.from_input("hi")
+        x = Output.all(o1, o2)
+        x_val = await x.future()
+        self.assertEqual(x_val, [1, "hi"])
+
+    @pulumi_test
+    async def test_kwargs(self):
+        o1 = Output.from_input(1)
+        o2 = Output.from_input("hi")
+        x = Output.all(x=o1, y=o2)
+        x_val = await x.future()
+        self.assertEqual(x_val, {"x": 1, "y": "hi"})
+
+class OutputFormatTests(unittest.TestCase):
+    @pulumi_test
+    async def test_nothing(self):
+        x = Output.format("blank format")
+        x_val = await x.future()
+        self.assertEqual(x_val, "blank format")
+
+    @pulumi_test
+    async def test_simple(self):
+        i = Output.from_input(1)
+        x = Output.format("{0}", i)
+        x_val = await x.future()
+        self.assertEqual(x_val, "1")
+
+    @pulumi_test
+    async def test_args_and_kwags(self):
+        i = Output.from_input(1)
+        s = Output.from_input("hi")
+        x = Output.format("{0}, {s}", i, s=s)
+        x_val = await x.future()
+        self.assertEqual(x_val, "1, hi")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Add Output.format to python SDK

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
