### PR TITLE
Add PatchUpdateUntypedCheckpointRequest API shape

### DIFF
--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -216,6 +216,17 @@ type PatchUpdateCheckpointRequest struct {
 	Deployment json.RawMessage `json:"deployment,omitempty"`
 }
 
+// PatchUpdateUntypedCheckpointRequest defines the body of a request to a patch update checkpoint endpoint of the service
+// API, where `UntypedDeloyment` is an `apitype.UntypedDeployment`. Whereas the PatchUpdateCheckpointRequest API is subject
+// to the service reformatting how a checkpoint is persisted, PatchUpdateUntypedCheckpointRequest enables the CLI to define
+// the exact format.
+// Designed to be compatible with the PatchUpdateCheckpointDeltaRequest API, where formatting is critical in calculating
+// textual diffs.
+type PatchUpdateUntypedCheckpointRequest struct {
+	Version           int             `json:"version"`
+	UntypedDeployment json.RawMessage `json:"untypedDeployment,omitempty"`
+}
+
 // PatchUpdateCheckpointDeltaRequest defines the body of a request to the bandwidth-optimized version of the patch
 // update checkpoint endpoint of the service API. It is semantically equivalent to the PatchUpdateCheckpointRequest, but
 // instead of transferring the entire Deployment as a JSON blob, it encodes it as a textual diff against the last-saved

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -216,13 +216,13 @@ type PatchUpdateCheckpointRequest struct {
 	Deployment json.RawMessage `json:"deployment,omitempty"`
 }
 
-// PatchUpdateUntypedCheckpointRequest defines the body of a request to a patch update checkpoint endpoint of the service
+// PatchUpdateVerbatimCheckpointRequest defines the body of a request to a patch update checkpoint endpoint of the service
 // API, where `UntypedDeloyment` is an `apitype.UntypedDeployment`. Whereas the PatchUpdateCheckpointRequest API is subject
-// to the service reformatting how a checkpoint is persisted, PatchUpdateUntypedCheckpointRequest enables the CLI to define
+// to the service reformatting how a checkpoint is persisted, PatchUpdateVerbatimCheckpointRequest enables the CLI to define
 // the exact format.
 // Designed to be compatible with the PatchUpdateCheckpointDeltaRequest API, where formatting is critical in calculating
 // textual diffs.
-type PatchUpdateUntypedCheckpointRequest struct {
+type PatchUpdateVerbatimCheckpointRequest struct {
 	Version           int             `json:"version"`
 	UntypedDeployment json.RawMessage `json:"untypedDeployment,omitempty"`
 }

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -216,10 +216,10 @@ type PatchUpdateCheckpointRequest struct {
 	Deployment json.RawMessage `json:"deployment,omitempty"`
 }
 
-// PatchUpdateVerbatimCheckpointRequest defines the body of a request to a patch update checkpoint endpoint of the service
-// API, where `UntypedDeloyment` is an `apitype.UntypedDeployment`. Whereas the PatchUpdateCheckpointRequest API is subject
-// to the service reformatting how a checkpoint is persisted, PatchUpdateVerbatimCheckpointRequest enables the CLI to define
-// the exact format.
+// PatchUpdateVerbatimCheckpointRequest defines the body of a request to a patch update checkpoint endpoint of the
+// service API, where `UntypedDeloyment` is an `apitype.UntypedDeployment`. Whereas the PatchUpdateCheckpointRequest
+// API is subject to the service reformatting how a checkpoint is persisted, PatchUpdateVerbatimCheckpointRequest
+// enables the CLI to define the exact format.
 // Designed to be compatible with the PatchUpdateCheckpointDeltaRequest API, where formatting is critical in calculating
 // textual diffs.
 type PatchUpdateVerbatimCheckpointRequest struct {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Expose a new API that accepts an UntypedDeployment not as a struct but as a json.RawMessage, as a part of delta checkpoint work:

If the CLI is able to pass to the service the entire UntypedDeployment in a json.RawMessage that the service can dump directly into S3, then we gain two things:

1. The service doesn’t need to marshal anything before writing to S3 (saving time and also renders the concern about encoding/json compacting input obsolete)
2. We can better guarantee that the UntypedDeployment written in S3 service-side is exactly as the CLI expects it to be formatted, rather than implicitly trust that the service team is marshalling and formatting the checkpoint file into S3 correctly

For full background context: https://github.com/pulumi/pulumi-service/issues/10292
Relevant slack thread: https://pulumi.slack.com/archives/C8A7QG1CZ/p1664916144606579

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
