### PR TITLE
ci: Unblock local ProgramTest usage

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -652,10 +652,6 @@ func prepareProgram(t *testing.T, opts *ProgramTestOptions) {
 		t.Parallel()
 	}
 
-	if ciutil.IsCI() && os.Getenv("PULUMI_ACCESS_TOKEN") == "" {
-		t.Skip("Skipping: PULUMI_ACCESS_TOKEN is not set")
-	}
-
 	// If the test panics, recover and log instead of letting the panic escape the test. Even though *this* test will
 	// have run deferred functions and cleaned up, if the panic reaches toplevel it will kill the process and prevent
 	// other tests running in parallel from cleaning up.


### PR DESCRIPTION
The first commit removes a redundant check to skip the test in `prepareProgram`, given the check in `newProgramTester`:

https://github.com/pulumi/pulumi/blob/2b1b4fb0b4d6d2c32cd1303957babc2942703eb4/pkg/testing/integration/program.go#L761-L769

The second refactors the two functions, given that both are private to the test package and `prepareProgram` is called if and only if it's immediately followed by `newProgramTest`. The former is now a side-effecting function that mutates its options, the latter is a pure constructor.