### PR TITLE
ci: Enable gh cli in every step of job

### DIFF
--- a/.github/workflows/release-homebrew-tap.yml
+++ b/.github/workflows/release-homebrew-tap.yml
@@ -37,6 +37,7 @@ on:
 
 env:
   PULUMI_VERSION: ${{ inputs.version }}
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 
 jobs:
   update-homebrew-tap:
@@ -79,8 +80,6 @@ jobs:
       - name: Push formula
         working-directory: homebrew-tap
         if: ${{ !inputs.dry-run }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Fixes the issue where the `gh` CLI reported that no token was present: https://github.com/pulumi/pulumi/actions/runs/3145787399/jobs/5113494314