### PR TITLE
sdk/go: Move unsafe API to internals package

### DIFF
--- a/sdk/go/pulumi/internals.go
+++ b/sdk/go/pulumi/internals.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pulumi
 
 import "context"

--- a/sdk/go/pulumi/internals.go
+++ b/sdk/go/pulumi/internals.go
@@ -1,0 +1,10 @@
+package pulumi
+
+import "golang.org/x/net/context"
+
+// Functions in this file are exposed in pulumi/internals via go:linkname
+func awaitWithContext(ctx context.Context, o Output) (interface{}, bool, bool, []Resource, error) {
+	value, known, secret, deps, err := o.getState().await(ctx)
+
+	return value, known, secret, deps, err
+}

--- a/sdk/go/pulumi/internals.go
+++ b/sdk/go/pulumi/internals.go
@@ -1,6 +1,6 @@
 package pulumi
 
-import "golang.org/x/net/context"
+import "context"
 
 // Functions in this file are exposed in pulumi/internals via go:linkname
 func awaitWithContext(ctx context.Context, o Output) (interface{}, bool, bool, []Resource, error) {

--- a/sdk/go/pulumi/internals/outputs.go
+++ b/sdk/go/pulumi/internals/outputs.go
@@ -1,0 +1,36 @@
+package internals
+
+import (
+	"context"
+	_ "unsafe" // unsafe is needed to use go:linkname
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+//go:linkname awaitWithContext github.com/pulumi/pulumi/sdk/v3/go/pulumi.awaitWithContext
+func awaitWithContext(ctx context.Context, o pulumi.Output) (interface{}, bool, bool, []pulumi.Resource, error)
+
+// UnsafeAwaitOutputResult is an output from a Pulumi function or resource that has been resolved.
+//
+// This is a low level API and should be used with care.
+type UnsafeAwaitOutputResult struct {
+	Value        interface{}       // The value of the output. If unknown (in a dry-run), the value will be nil.
+	Known        bool              // True if the value is known.
+	Secret       bool              // True if the value is a secret.
+	Dependencies []pulumi.Resource // The resources that this output depends on.
+}
+
+// UnsafeAwaitOutput blocks until the output is resolved and returns the resolved value and
+// metadata.
+//
+// This is a low level API and should be used with care.
+func UnsafeAwaitOutput(ctx context.Context, o pulumi.Output) (UnsafeAwaitOutputResult, error) {
+	value, known, secret, deps, err := awaitWithContext(ctx, o)
+
+	return UnsafeAwaitOutputResult{
+		Value:        value,
+		Known:        known,
+		Secret:       secret,
+		Dependencies: deps,
+	}, err
+}

--- a/sdk/go/pulumi/internals/outputs.go
+++ b/sdk/go/pulumi/internals/outputs.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internals
 
 import (

--- a/sdk/go/pulumi/internals/outputs_test.go
+++ b/sdk/go/pulumi/internals/outputs_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internals
 
 import (

--- a/sdk/go/pulumi/internals/outputs_test.go
+++ b/sdk/go/pulumi/internals/outputs_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func await(out pulumi.Output) (interface{}, bool, bool, []pulumi.Resource, error) {
-	return awaitWithContext(context.Background(), out)
+	result, err := UnsafeAwaitOutput(context.Background(), out)
+
+	return result.Value, result.Known, result.Secret, result.Dependencies, err
 }
 
 func TestBasicOutputs(t *testing.T) {

--- a/sdk/go/pulumi/internals/outputs_test.go
+++ b/sdk/go/pulumi/internals/outputs_test.go
@@ -1,0 +1,42 @@
+package internals
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+func await(out pulumi.Output) (interface{}, bool, bool, []pulumi.Resource, error) {
+	return awaitWithContext(context.Background(), out)
+}
+
+func TestBasicOutputs(t *testing.T) {
+	t.Parallel()
+
+	// Just test basic resolve and reject functionality.
+	{
+		out, resolve, _ := pulumi.NewOutput()
+		go func() {
+			resolve(42)
+		}()
+		v, known, secret, deps, err := await(out)
+		assert.Nil(t, err)
+		assert.True(t, known)
+		assert.False(t, secret)
+		assert.Nil(t, deps)
+		assert.NotNil(t, v)
+		assert.Equal(t, 42, v.(int))
+	}
+	{
+		out, _, reject := pulumi.NewOutput()
+		go func() {
+			reject(errors.New("boom"))
+		}()
+		v, _, _, _, err := await(out)
+		assert.NotNil(t, err)
+		assert.Nil(t, v)
+	}
+}

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -551,31 +551,6 @@ func UnsafeUnknownOutput(deps []Resource) Output {
 	return output
 }
 
-// UnsafeAwaitOutputResult is an output from a Pulumi function or resource that has been resolved.
-//
-// This is a low level API and should be used with care.
-type UnsafeAwaitOutputResult struct {
-	Value        interface{} // The value of the output. If unknown (in a dry-run), the value will be nil.
-	Known        bool        // True if the value is known.
-	Secret       bool        // True if the value is a secret.
-	Dependencies []Resource  // The resources that this output depends on.
-}
-
-// UnsafeAwaitOutput blocks until the output is resolved and returns the resolved value and
-// metadata.
-//
-// This is a low level API and should be used with care.
-func UnsafeAwaitOutput(ctx context.Context, o Output) (UnsafeAwaitOutputResult, error) {
-	value, known, secret, deps, err := o.getState().await(ctx)
-
-	return UnsafeAwaitOutputResult{
-		Value:        value,
-		Known:        known,
-		Secret:       secret,
-		Dependencies: deps,
-	}, err
-}
-
 // ToSecretWithContext wraps the input in an Output marked as secret
 // that will resolve when all Inputs contained in the given value have resolved.
 func ToSecretWithContext(ctx context.Context, input interface{}) Output {

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -26,9 +26,7 @@ import (
 )
 
 func await(out Output) (interface{}, bool, bool, []Resource, error) {
-	result, err := UnsafeAwaitOutput(context.Background(), out)
-
-	return result.Value, result.Known, result.Secret, result.Dependencies, err
+	return awaitWithContext(context.Background(), out)
 }
 
 func assertApplied(t *testing.T, out Output) {


### PR DESCRIPTION
Following internal discussion, expose this function on a separate package: `sdk/v3/go/pulumi/internals`.