### PR TITLE
feat(cli): add --remove flag to pulumi destroy

### DIFF
--- a/changelog/pending/20221006--cli-new--issue-10484.yaml
+++ b/changelog/pending/20221006--cli-new--issue-10484.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/new
+  description: Add --remove flag to`pulumi destroy`

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -35,6 +35,7 @@ import (
 
 func newDestroyCmd() *cobra.Command {
 	var debug bool
+	var remove bool
 	var stack string
 
 	var message string
@@ -69,7 +70,8 @@ func newDestroyCmd() *cobra.Command {
 			"loaded from the associated state file in the workspace.  After running to completion,\n" +
 			"all of this stack's resources and associated state are deleted.\n" +
 			"\n" +
-			"The stack itself is not deleted. Use `pulumi stack rm` to delete the stack.\n" +
+			"The stack itself is not deleted. Use `pulumi stack rm` or the \n" +
+			"`--remove` flag to delete the stack.\n" +
 			"\n" +
 			"Warning: this command is generally irreversible and should be used with great care.",
 		Args: cmdutil.NoArgs,
@@ -221,13 +223,24 @@ func newDestroyCmd() *cobra.Command {
 				SecretsManager:     sm,
 				Scopes:             cancellationScopes,
 			})
+
 			if res == nil && protectedCount > 0 && !jsonDisplay {
 				fmt.Printf("All unprotected resources were destroyed. There are still %d protected resources"+
 					" associated with this stack.\n", protectedCount)
-			} else if res == nil && len(*targets) == 0 && !jsonDisplay {
-				fmt.Printf("The resources in the stack have been deleted, but the history and configuration "+
-					"associated with the stack are still maintained. \nIf you want to remove the stack "+
-					"completely, run `pulumi stack rm %s`.\n", s.Ref())
+			} else if res == nil && len(*targets) == 0 {
+				if !jsonDisplay && !remove {
+					fmt.Printf("The resources in the stack have been deleted, but the history and configuration "+
+						"associated with the stack are still maintained. \nIf you want to remove the stack "+
+						"completely, run `pulumi stack rm %s`.\n", s.Ref())
+				} else if remove {
+					_, err = s.Remove(ctx, false)
+					if err != nil {
+						return result.FromError(err)
+					} else if !jsonDisplay {
+						fmt.Printf("The resources in the stack have been deleted, and the history and " +
+							"configuration removed.\n")
+					}
+				}
 			} else if res != nil && res.Error() == context.Canceled {
 				return result.FromError(errors.New("destroy cancelled"))
 			}
@@ -238,6 +251,9 @@ func newDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,
 		"Print detailed debugging output during resource operations")
+	cmd.PersistentFlags().BoolVar(
+		&remove, "remove", false,
+		"Remove the stack after all resources in the stack have been deleted")
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Addresses issue https://github.com/pulumi/pulumi/issues/10484

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
    - _There does not appear to be a `./pkg/cmd/pulumi/destroy_test_.go` file, and so I did not create one. I sanity-tested that existing commands are not affected, and that the requested use-case(s) work: example `pulumi destroy --remove` and `pulumi destroy --yes --remove`_
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
