### PR TITLE
Fix .github/scripts/generate-homebrew-tap to export PULUMI_VERSION

### DIFF
--- a/.github/scripts/generate-homebrew-tap
+++ b/.github/scripts/generate-homebrew-tap
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PULUMI_VERSION="${1}"
+export PULUMI_VERSION="${1}"
 TAP_FILE="${2:-"./.github/scripts/homebrew-tap.rb}"}"
 TAP_FILE="$(realpath "${TAP_FILE}")"
 


### PR DESCRIPTION
To prevent bad commits like https://github.com/pulumi/homebrew-tap/commit/cf74ca655dfa00411779c16862633e65ba0e3672 when running locally.