### PR TITLE
Fix 'Extract release notes'

### DIFF
--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -42,6 +42,7 @@ jobs:
       release-notes: "${{ fromJSON(steps.notes.outputs.release-notes) }}"
     env:
       GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
See an example failure here: https://github.com/pulumi/pulumi/actions/runs/3193706020/jobs/5212536658

Looks like we need to sett GH_TOKEN for the `gh` cli, not sure if we need GITHUB_TOKEN as well, but probably doesn't hurt to have it set.