### PR TITLE
Add winget and msi install checks in download cron job

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: winget install pulumi
-        rune: winget install pulumi
+        run: winget install pulumi
       - name: Pulumi Version Details
         id: vars
         shell: bash

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -94,6 +94,23 @@ jobs:
         run: |
           echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
           exit 1
+  windows-winget-install:
+    name: Install Pulumi with WinGet on Windows
+    runs-on: windows-latest
+    steps:
+      - name: winget install pulumi
+        rune: winget install pulumi
+      - name: Pulumi Version Details
+        id: vars
+        shell: bash
+        run: |
+          echo "::set-output name=installed-version::$(pulumi version)"
+          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+      - name: Error if incorrect version found
+        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
+        run: |
+          echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
+          exit 1
   windows-direct-install:
     name: Install Pulumi via script on Windows
     runs-on: windows-latest
@@ -124,6 +141,18 @@ jobs:
           $downloadUrl = "https://get.pulumi.com/releases/sdk/pulumi-v${latestVersion}-windows-x64.zip"
           $tempZip = New-Item -Type File (Join-Path $env:TEMP ([System.IO.Path]::ChangeExtension(([System.IO.Path]::GetRandomFileName()), "zip")))
           Invoke-WebRequest https://get.pulumi.com/releases/sdk/pulumi-v${latestVersion}-windows-x64.zip -OutFile $tempZip
+      - run: ls -la
+        shell: bash
+  windows-verify-msi-download-link:
+    name: Verify Direct MSI Download link on Windows
+    runs-on: windows-latest
+    steps:
+      - name: Direct Download
+        shell: pwsh
+        run: |
+          $latestVersion = (Invoke-WebRequest -UseBasicParsing https://www.pulumi.com/latest-version).Content.Trim()
+          $tempMsi = New-Item -Type File (Join-Path $env:TEMP ([System.IO.Path]::ChangeExtension(([System.IO.Path]::GetRandomFileName()), "msi")))
+          Invoke-WebRequest https://github.com/pulumi/pulumi-winget/releases/download/v${latestVersion}/pulumi-${latestVersion}-windows-x64.msi -OutFile $tempMsi
       - run: ls -la
         shell: bash
   install-via-gha:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10667

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
