### PR TITLE
Fix cloning from ADO repos

### DIFF
--- a/changelog/pending/20221006--cli-new--fix-ado-repos.yaml
+++ b/changelog/pending/20221006--cli-new--fix-ado-repos.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Fix cloning templates from Azure DevOps repos.

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 // VCSKind represents the hostname of a specific type of VCS.
@@ -280,6 +281,7 @@ func GitCloneAndCheckoutCommit(url string, commit plumbing.Hash, path string) er
 }
 
 func GitCloneOrPull(rawurl string, referenceName plumbing.ReferenceName, path string, shallow bool) error {
+	logging.V(10).Infof("Attempting to clone from %s at ref %s", rawurl, referenceName)
 	if u, err := url.Parse(rawurl); err == nil && u.Hostname() == AzureDevOpsHostName {
 		// system-installed git is used to clone Azure DevOps repositories
 		// due to https://github.com/go-git/go-git/issues/64
@@ -346,7 +348,7 @@ func gitCloneOrPullSystemGit(url string, referenceName plumbing.ReferenceName, p
 	if _, err := os.Stat(filepath.Join(path, ".git")); os.IsNotExist(err) {
 		// Repo does not exist, clone it.
 		gitArgs = []string{
-			"clone", url,
+			"clone", url, ".",
 		}
 		// For shallow clones, use a depth of 1.
 		if shallow {

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 const (
@@ -373,8 +374,11 @@ func RetrieveGitFolder(rawurl string, path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get git ref: %w", err)
 	}
-	if ref != "" {
+	logging.V(10).Infof(
+		"Attempting to fetch from %s at commit %s@%s for subdirectory '%s'",
+		url, ref, commit, subDirectory)
 
+	if ref != "" {
 		// Different reference attempts to cycle through
 		// We default to master then main in that order. We need to order them to avoid breaking
 		// already existing processes for repos that already have a master and main branch.
@@ -405,6 +409,7 @@ func RetrieveGitFolder(rawurl string, path string) (string, error) {
 
 	// Verify the sub directory exists.
 	fullPath := filepath.Join(path, filepath.FromSlash(subDirectory))
+	logging.V(10).Infof("Cloned %s at commit %s@%s to %s", url, ref, commit, fullPath)
 	info, err := os.Stat(fullPath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Small path bug, "git clone" by default clones to a new folder based on the last part of the repo name. So running something like `pulumi new https://fraser0275@dev.azure.com/fraser0275/fraser/_git/fraser` resulted in us making a folder like /tmp/pulumi-templates-1234/fraser with all the templates in it. That last part of the path was unexpected, because when we use gogit it clones directly into the target directory we give it.

Simple fix to just add `.` to the git clone command. I also added some logging while I was about here, given it helped me work out this issue.

Fixes https://github.com/pulumi/pulumi/issues/10886

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works. **No but I did manually check I could download templates from azure devops.**
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
