### PR TITLE
Improve the error message for Pulumi.yaml with wrong type of data

### DIFF
--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -182,7 +182,7 @@ func ValidateProject(raw interface{}) error {
 	var ok bool
 	var obj map[string]interface{}
 	if obj, ok = result.(map[string]interface{}); !ok {
-		return fmt.Errorf("expected an object")
+		return fmt.Errorf("expected project to be an object, was '%T'", result)
 	}
 
 	// Couple of manual errors to match Validate

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -76,7 +76,7 @@ func TestProjectLoadJSON(t *testing.T) {
 
 	// Test wrong type
 	_, err := writeAndLoad("\"hello  \"")
-	assert.Equal(t, "expected an object", err.Error())
+	assert.Equal(t, "expected project to be an object, was 'string'", err.Error())
 
 	// Test lack of name
 	_, err = writeAndLoad("{}")
@@ -139,7 +139,7 @@ func TestProjectLoadYAML(t *testing.T) {
 
 	// Test wrong type
 	_, err := writeAndLoad("\"hello\"")
-	assert.Equal(t, "expected an object", err.Error())
+	assert.Equal(t, "expected project to be an object, was 'string'", err.Error())
 
 	// Test bad key
 	_, err = writeAndLoad("4: hello")


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

"expected an object" isn't very informative, "expected project to be an object, was 'string'" is much better.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
