### PR TITLE
Use loadPackageSchema instead of accessing entries

### DIFF
--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -63,13 +63,11 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	}
 	var pkgSchema *packageSchema
 
-	var ok bool
-	pkgInfo := PackageInfo{
-		name: pkg,
-	}
-	pkgSchema, ok = b.options.packageCache.entries[pkgInfo]
-	if !ok {
-		return hcl.Diagnostics{unknownPackage(pkg, tokenRange)}
+	pkgSchema, err := b.options.packageCache.loadPackageSchema(b.options.loader, pkg, "")
+	if err != nil {
+		e := unknownPackage(pkg, tokenRange)
+		e.Detail = err.Error()
+		return hcl.Diagnostics{e}
 	}
 
 	var res *schema.Resource


### PR DESCRIPTION
Direct access to entries is both not threadsafe and failes without version support.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This allows Pulumi YAML to depend on 3.41.1. Without this change tests fail.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
