### PR TITLE
Wrap project load errors with the path that failed

### DIFF
--- a/changelog/pending/20221009--cli--project-path-error.yaml
+++ b/changelog/pending/20221009--cli--project-path-error.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Project path is included in error messages when a project can't be loaded.

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -15,6 +15,7 @@
 package workspace
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"sync"
@@ -85,29 +86,29 @@ func (singleton *projectLoader) load(path string) (*Project, error) {
 
 	marshaller, err := marshallerForPath(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can not read '%s': %w", path, err)
 	}
 
 	b, err := readFileStripUTF8BOM(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not read '%s': %w", path, err)
 	}
 
 	var raw interface{}
 	err = marshaller.Unmarshal(b, &raw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not unmarshal '%s': %w", path, err)
 	}
 
 	err = ValidateProject(raw)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not validate '%s': %w", path, err)
 	}
 
 	var project Project
 	err = marshaller.Unmarshal(b, &project)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not unmarshal '%s': %w", path, err)
 	}
 
 	singleton.internal[path] = &project

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -76,19 +76,19 @@ func TestProjectLoadJSON(t *testing.T) {
 
 	// Test wrong type
 	_, err := writeAndLoad("\"hello  \"")
-	assert.Equal(t, "expected project to be an object, was 'string'", err.Error())
+	assert.Contains(t, err.Error(), "expected project to be an object, was 'string'")
 
 	// Test lack of name
 	_, err = writeAndLoad("{}")
-	assert.Equal(t, "project is missing a 'name' attribute", err.Error())
+	assert.Contains(t, err.Error(), "project is missing a 'name' attribute")
 
 	// Test bad name
 	_, err = writeAndLoad("{\"name\": \"\"}")
-	assert.Equal(t, "project is missing a non-empty string 'name' attribute", err.Error())
+	assert.Contains(t, err.Error(), "project is missing a non-empty string 'name' attribute")
 
 	// Test missing runtime
 	_, err = writeAndLoad("{\"name\": \"project\"}")
-	assert.Equal(t, "project is missing a 'runtime' attribute", err.Error())
+	assert.Contains(t, err.Error(), "project is missing a 'runtime' attribute")
 
 	// Test other schema errors
 	_, err = writeAndLoad("{\"name\": \"project\", \"runtime\": 4}")
@@ -139,27 +139,27 @@ func TestProjectLoadYAML(t *testing.T) {
 
 	// Test wrong type
 	_, err := writeAndLoad("\"hello\"")
-	assert.Equal(t, "expected project to be an object, was 'string'", err.Error())
+	assert.Contains(t, err.Error(), "expected project to be an object, was 'string'")
 
 	// Test bad key
 	_, err = writeAndLoad("4: hello")
-	assert.Equal(t, "expected only string keys, got '%!s(int=4)'", err.Error())
+	assert.Contains(t, err.Error(), "expected only string keys, got '%!s(int=4)'")
 
 	// Test nested bad key
 	_, err = writeAndLoad("hello:\n    6: bad")
-	assert.Equal(t, "expected only string keys, got '%!s(int=6)'", err.Error())
+	assert.Contains(t, err.Error(), "expected only string keys, got '%!s(int=6)'")
 
 	// Test lack of name
 	_, err = writeAndLoad("{}")
-	assert.Equal(t, "project is missing a 'name' attribute", err.Error())
+	assert.Contains(t, err.Error(), "project is missing a 'name' attribute")
 
 	// Test bad name
 	_, err = writeAndLoad("name:")
-	assert.Equal(t, "project is missing a non-empty string 'name' attribute", err.Error())
+	assert.Contains(t, err.Error(), "project is missing a non-empty string 'name' attribute")
 
 	// Test missing runtime
 	_, err = writeAndLoad("name: project")
-	assert.Equal(t, "project is missing a 'runtime' attribute", err.Error())
+	assert.Contains(t, err.Error(), "project is missing a 'runtime' attribute")
 
 	// Test other schema errors
 	_, err = writeAndLoad("name: project\nruntime: 4")

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -16,6 +16,7 @@ package workspace
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -104,7 +105,7 @@ func (repo TemplateRepository) Templates() ([]Template, error) {
 
 	// See if there's a Pulumi.yaml in the directory.
 	template, err := LoadTemplate(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	} else if err == nil {
 		return []Template{template}, nil
@@ -128,7 +129,7 @@ func (repo TemplateRepository) Templates() ([]Template, error) {
 			}
 
 			template, err := LoadTemplate(filepath.Join(path, name))
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return nil, err
 			} else if err == nil {
 				result = append(result, template)
@@ -154,7 +155,7 @@ func (repo TemplateRepository) PolicyTemplates() ([]PolicyPackTemplate, error) {
 
 	// See if there's a PulumiPolicy.yaml in the directory.
 	template, err := LoadPolicyPackTemplate(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	} else if err == nil {
 		return []PolicyPackTemplate{template}, nil
@@ -178,7 +179,7 @@ func (repo TemplateRepository) PolicyTemplates() ([]PolicyPackTemplate, error) {
 			}
 
 			template, err := LoadPolicyPackTemplate(filepath.Join(path, name))
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return nil, err
 			} else if err == nil {
 				result = append(result, template)
@@ -349,7 +350,7 @@ func retrievePulumiTemplates(templateName string, offline bool, templateKind Tem
 		// Provide a nicer error message when the template can't be found (dir doesn't exist).
 		_, err := os.Stat(subDir)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return TemplateRepository{}, newTemplateNotFoundError(templateDir, templateName)
 			}
 			contract.IgnoreError(err)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -146,9 +146,10 @@ func TestStackInitValidation(t *testing.T) {
 
 		stdout, stderr := e.RunCommandExpectError("pulumi", "stack", "init", "valid-name")
 		assert.Equal(t, "", stdout)
-		assert.Contains(t, stderr,
-			"error: could not get cloud url: could not load current project: "+
-				"invalid YAML file: yaml: line 1: did not find expected key")
+		assert.Contains(t, stderr, "error: could not get cloud url: could not load current project: could not unmarshal '")
+		// Project path is printed between these two 's, but due to macos having multiple paths for temporary
+		// files we don't try to check the path in the test.
+		assert.Contains(t, stderr, "': invalid YAML file: yaml: line 1: did not find expected key")
 	})
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

It's not always clear _which_ project we're loading (especially when iterating template directories), so this adds the project path to the error message and also clarifies which part of project loading failed (e.g. no marshaller, failed validation, etc).

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
