### PR TITLE
[codegen] Implement pcl.AnnotateResourceInputs and apply property overrides for deeply nested objects

### DIFF
--- a/changelog/pending/20221009--programgen-dotnet--pcl-annotate-resource-inputs-apply-property-overrides.yaml
+++ b/changelog/pending/20221009--programgen-dotnet--pcl-annotate-resource-inputs-apply-property-overrides.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/dotnet
+  description: Annotate deeply nested objects with their schema types and apply property name overrides

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -653,6 +653,8 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 		}
 	}
 
+	pcl.AnnotateResourceInputs(r)
+
 	name := r.LogicalName()
 	variableName := makeValidIdentifier(r.Name())
 	argsName := g.resourceArgsTypeName(r)

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1456,6 +1456,10 @@ func (x *ObjectConsExpression) Type() Type {
 	return x.exprType
 }
 
+func (x *ObjectConsExpression) WithType(updateType func(Type) *ObjectConsExpression) *ObjectConsExpression {
+	return updateType(x.exprType)
+}
+
 func (x *ObjectConsExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
@@ -21,6 +21,13 @@ return await Deployment.RunAsync(() =>
                 {
                     Name = "nginx",
                     Image = "nginx:1.14-alpine",
+                    Ports = new[]
+                    {
+                        new Kubernetes.Types.Inputs.Core.V1.ContainerPortArgs
+                        {
+                            ContainerPortValue = 80,
+                        },
+                    },
                     Resources = new Kubernetes.Types.Inputs.Core.V1.ResourceRequirementsArgs
                     {
                         Limits = 

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
@@ -20,6 +20,11 @@ func main() {
 					&corev1.ContainerArgs{
 						Name:  pulumi.String("nginx"),
 						Image: pulumi.String("nginx:1.14-alpine"),
+						Ports: corev1.ContainerPortArray{
+							&corev1.ContainerPortArgs{
+								ContainerPort: pulumi.Int(80),
+							},
+						},
 						Resources: &corev1.ResourceRequirementsArgs{
 							Limits: pulumi.StringMap{
 								"memory": pulumi.String("20Mi"),

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/kubernetes-pod.pp
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/kubernetes-pod.pp
@@ -10,6 +10,7 @@ resource bar "kubernetes:core/v1:Pod" {
             {
                 name = "nginx"
                 image = "nginx:1.14-alpine"
+                ports = [{ containerPort = 80 }]
                 resources = {
                     limits = {
                         memory = "20Mi"

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
@@ -12,6 +12,9 @@ const bar = new kubernetes.core.v1.Pod("bar", {
         containers: [{
             name: "nginx",
             image: "nginx:1.14-alpine",
+            ports: [{
+                containerPort: 80,
+            }],
             resources: {
                 limits: {
                     memory: "20Mi",

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
@@ -12,6 +12,9 @@ bar = kubernetes.core.v1.Pod("bar",
         containers=[kubernetes.core.v1.ContainerArgs(
             name="nginx",
             image="nginx:1.14-alpine",
+            ports=[kubernetes.core.v1.ContainerPortArgs(
+                container_port=80,
+            )],
             resources=kubernetes.core.v1.ResourceRequirementsArgs(
                 limits={
                     "memory": "20Mi",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

For `pcl.GetSchemaForType` to work on `model.ObjectConsExpression`, the type of the expression need to be annotated with its associated schema type. So I've implemented `pcl.AnnotateResourceInputs` which annotates resource inputs but also their deeply nested object properties, making the schema type information available for expressions of type `model.ObjectConsExpression`, then using this information to apply property name overrides in dotnet programgen

> I believe I will use this in java program-gen as well, it will simplify a lot of code 

Fixes #10671 

TODO: requires #10958 to be merged first because I need the `annotateObjectProperties` function implemented there :)  

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
