### PR TITLE
[go/program-gen] Missing default case handling when generating local variables

### DIFF
--- a/changelog/pending/20221009--programgen-go--go-program-gen-9981.yaml
+++ b/changelog/pending/20221009--programgen-go--go-program-gen-9981.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Missing default case handling when generating local variables

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -857,6 +857,8 @@ func (g *generator) genLocalVariable(w io.Writer, v *pcl.LocalVariable) {
 			g.Fgenf(w, "%s %s string(%s)\n", name, assignment, tmpVar)
 			g.tmpVarCount++
 			g.isErrAssigned = true
+		default:
+			g.Fgenf(w, "%s := %.3v;\n", name, expr)
 		}
 	default:
 		g.Fgenf(w, "%s := %.3v;\n", name, expr)

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -83,6 +83,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		Description: "AWS IAM Policy",
 	},
 	{
+		Directory:   "read-file-func",
+		Description: "ReadFile function translation works",
+	},
+	{
 		Directory:   "aws-optionals",
 		Description: "AWS get invoke with nested object constructor that takes an optional string",
 		// Testing Go behavior exclusively:

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/dotnet/read-file-func.cs
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/dotnet/read-file-func.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.IO;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    var key = File.ReadAllText("key.pub");
+
+    return new Dictionary<string, object?>
+    {
+        ["result"] = key,
+    };
+});
+

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/go/read-file-func.go
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/go/read-file-func.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func readFileOrPanic(path string) pulumi.StringPtrInput {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err.Error())
+	}
+	return pulumi.String(string(data))
+}
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		key := readFileOrPanic("key.pub")
+		ctx.Export("result", key)
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/nodejs/read-file-func.ts
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/nodejs/read-file-func.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as fs from "fs";
+
+const key = fs.readFileSync("key.pub");
+export const result = key;

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/python/read-file-func.py
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/python/read-file-func.py
@@ -1,0 +1,4 @@
+import pulumi
+
+key = (lambda path: open(path).read())("key.pub")
+pulumi.export("result", key)

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/read-file-func.pp
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/read-file-func.pp
@@ -1,0 +1,6 @@
+key = readFile("key.pub")
+
+output result {
+    __logicalName = "result"
+    value = key
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #9981

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
