### PR TITLE
Rename ExperimentalPlans to GeneratePlan

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -258,8 +258,8 @@ type UpdateOptions struct {
 	AutoApprove bool
 	// SkipPreview, when true, causes the preview step to be skipped.
 	SkipPreview bool
-	// Experimental plan support, when true cause plans to be generated.
-	ExperimentalPlans bool
+	// GeneratePlan when true cause plans to be generated.
+	GeneratePlan bool
 }
 
 // QueryOptions configures a query to operate against a backend and the engine.

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -186,7 +186,9 @@ func newPreviewCmd() *cobra.Command {
 					DisableOutputValues:       disableOutputValues(),
 					UpdateTargets:             targetURNs,
 					TargetDependents:          targetDependents,
-					ExperimentalPlans:         hasExperimentalCommands() || planFilePath != "",
+					// If we're trying to save a plan then we _need_ to generate it. We also turn this on in
+					// experimental mode to just get more testing of it.
+					GeneratePlan: hasExperimentalCommands() || planFilePath != "",
 				},
 				Display: displayOpts,
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -164,7 +164,9 @@ func newUpCmd() *cobra.Command {
 			DisableOutputValues:       disableOutputValues(),
 			UpdateTargets:             targetURNs,
 			TargetDependents:          targetDependents,
-			ExperimentalPlans:         hasExperimentalCommands() || planFilePath != "",
+			// If we're in experimental mode then we trigger a plan to be generated during the preview phase
+			// which will be constrained to during the update phase.
+			GeneratePlan: hasExperimentalCommands(),
 		}
 
 		if planFilePath != "" {
@@ -349,11 +351,13 @@ func newUpCmd() *cobra.Command {
 		}
 
 		opts.Engine = engine.UpdateOptions{
-			LocalPolicyPacks:  engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
-			Parallel:          parallel,
-			Debug:             debug,
-			Refresh:           refreshOption,
-			ExperimentalPlans: hasExperimentalCommands() || planFilePath != "",
+			LocalPolicyPacks: engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
+			Parallel:         parallel,
+			Debug:            debug,
+			Refresh:          refreshOption,
+			// If we're in experimental mode then we trigger a plan to be generated during the preview phase
+			// which will be constrained to during the update phase.
+			GeneratePlan: hasExperimentalCommands(),
 		}
 
 		// TODO for the URL case:

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -266,7 +266,7 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions, policy
 			UseLegacyDiff:             deployment.Options.UseLegacyDiff,
 			DisableResourceReferences: deployment.Options.DisableResourceReferences,
 			DisableOutputValues:       deployment.Options.DisableOutputValues,
-			ExperimentalPlans:         deployment.Options.UpdateOptions.ExperimentalPlans,
+			GeneratePlan:              deployment.Options.UpdateOptions.GeneratePlan,
 		}
 		newPlan, walkResult = deployment.Deployment.Execute(ctx, opts, preview)
 		close(done)

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -3248,7 +3248,7 @@ func TestPlannedUpdate(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3360,7 +3360,7 @@ func TestUnplannedCreate(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3427,7 +3427,7 @@ func TestUnplannedDelete(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3499,7 +3499,7 @@ func TestExpectedDelete(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3568,7 +3568,7 @@ func TestExpectedCreate(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3630,7 +3630,7 @@ func TestPropertySetChange(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3681,7 +3681,7 @@ func TestExpectedUnneededCreate(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3746,7 +3746,7 @@ func TestExpectedUnneededDelete(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3823,7 +3823,7 @@ func TestResoucesWithSames(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3914,7 +3914,7 @@ func TestPlannedPreviews(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -3999,7 +3999,7 @@ func TestPlannedUpdateChangedStack(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -4082,7 +4082,7 @@ func TestPlannedOutputChanges(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -4149,7 +4149,7 @@ func TestPlannedInputOutputDifferences(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -4233,7 +4233,7 @@ func TestAliasWithPlans(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -4298,7 +4298,7 @@ func TestComputedCanBeDropped(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -4450,7 +4450,7 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -4643,7 +4643,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -4802,7 +4802,7 @@ func TestPluginsAreDownloaded(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()
@@ -5095,7 +5095,7 @@ func TestProviderDeterministicPreview(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, ExperimentalPlans: true},
+		Options: UpdateOptions{Host: host, GeneratePlan: true},
 	}
 
 	project := p.GetProject()

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -149,8 +149,8 @@ type UpdateOptions struct {
 	// The plan to use for the update, if any.
 	Plan *deploy.Plan
 
-	// true if experimental plans should be generated.
-	ExperimentalPlans bool
+	// true if plans should be generated.
+	GeneratePlan bool
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -63,7 +63,7 @@ type Options struct {
 	UseLegacyDiff             bool           // whether or not to use legacy diffing behavior.
 	DisableResourceReferences bool           // true to disable resource reference support.
 	DisableOutputValues       bool           // true to disable output value support.
-	ExperimentalPlans         bool           // true to enable experimental plan support.
+	GeneratePlan              bool           // true to enable plan generation.
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -181,8 +181,8 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 		}
 	}
 
-	// If we're in experimental mode save these new outputs to the plan
-	if se.opts.ExperimentalPlans {
+	// If we're generating plans save these new outputs to the plan
+	if se.opts.GeneratePlan {
 		if resourcePlan, ok := se.deployment.newPlans.get(urn); ok {
 			resourcePlan.Goal.OutputDiff = NewPlanDiff(oldOuts.Diff(outs))
 			resourcePlan.Outputs = outs
@@ -352,8 +352,8 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 			se.deployment.news.set(newState.URN, newState)
 		}
 
-		// If we're in experimental mode update the resource's outputs in the generated plan.
-		if se.opts.ExperimentalPlans {
+		// If we're generating plans update the resource's outputs in the generated plan.
+		if se.opts.GeneratePlan {
 			if resourcePlan, ok := se.deployment.newPlans.get(newState.URN); ok {
 				resourcePlan.Outputs = newState.Outputs
 			}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -268,8 +268,8 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, res
 			}
 		}
 
-		// If we're in experimental mode add the operation to the plan being generated
-		if sg.opts.ExperimentalPlans {
+		// If we're generating plans add the operation to the plan being generated
+		if sg.opts.GeneratePlan {
 			// Resource plan might be aliased
 			urn, isAliased := sg.aliased[s.URN()]
 			if !isAliased {
@@ -450,8 +450,8 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 		new.ID = goal.ID
 		new.ImportID = goal.ID
 
-		// If we're in experimental mode create a plan, Imports have no diff, just a goal state
-		if sg.opts.ExperimentalPlans {
+		// If we're generating plans create a plan, Imports have no diff, just a goal state
+		if sg.opts.GeneratePlan {
 			newResourcePlan := &ResourcePlan{
 				Seed: randomSeed,
 				Goal: NewGoalPlan(nil, goal)}
@@ -490,8 +490,8 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 		new.Inputs = inputs
 	}
 
-	// If the resource is valid and we're in experimental mode generate a plan
-	if !invalid && sg.opts.ExperimentalPlans {
+	// If the resource is valid and we're generating plans then generate a plan
+	if !invalid && sg.opts.GeneratePlan {
 		if recreating || wasExternal || sg.isTargetedReplace(urn) || !hasOld {
 			oldInputs = nil
 		}
@@ -832,8 +832,8 @@ func (sg *stepGenerator) generateStepsFromDiff(
 							continue
 						}
 
-						// If we're in experimental mode create a plan for this delete
-						if sg.opts.ExperimentalPlans {
+						// If we're generating plans create a plan for this delete
+						if sg.opts.GeneratePlan {
 							if _, ok := sg.deployment.newPlans.get(dependentResource.URN); !ok {
 								// We haven't see this resource before, create a new
 								// resource plan for it with no goal (because it's going to be a delete)
@@ -971,8 +971,8 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt map[resource.URN]bool) ([]St
 			}
 		}
 
-		// If we're in experimental mode add a delete op to the plan for this resource
-		if sg.opts.ExperimentalPlans {
+		// If we're generating plans add a delete op to the plan for this resource
+		if sg.opts.GeneratePlan {
 			resourcePlan, ok := sg.deployment.newPlans.get(s.URN())
 			if !ok {
 				// TODO(pdg-plan): using the program inputs means that non-determinism could sneak in as part of default


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This option is just used to control if a plan is generated or not, we'll continue to use it even after plans are no longer experimental. No need to generate a plan if it's not being used at all (e.g. during `up`).