### PR TITLE
Add install winget cli step to download cron job before using winget to download pulumi

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -98,7 +98,13 @@ jobs:
     name: Install Pulumi with WinGet on Windows
     runs-on: windows-latest
     steps:
-      - name: winget install pulumi
+      - name: Install WinGet CLI
+        shell: powershell
+        run:
+          Add-AppxPackage -Path 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
+          $wingetAlreadyInstalled = Get-AppPackage -name 'Microsoft.DesktopAppInstaller'
+          if (!$wingetAlreadyInstalled) Add-AppxPackage -Path https://aka.ms/getwinget
+      - name: Install Pulumi Using Winget
         run: winget install pulumi
       - name: Pulumi Version Details
         id: vars


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Not exactly sure if this will work but only one way to find out. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
