### PR TITLE
fix(ci): Disable setup-dotnet action, rely on globally installed dotnet

### DIFF
--- a/.github/workflows/ci-build-sdks.yml
+++ b/.github/workflows/ci-build-sdks.yml
@@ -137,10 +137,11 @@ jobs:
           version: ${{ inputs.version }}
         run: |
           ./scripts/versions.sh | tee -a "${GITHUB_ENV}"
-      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
+      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+      #   uses: actions/setup-dotnet@v2
+      #   with:
+      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
       - name: Build the .NET SDK package
         run: |
           cd sdk/dotnet

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -66,10 +66,11 @@ jobs:
           python-version: ${{ fromJson(inputs.version-set).python }}
           cache: pip
           cache-dependency-path: sdk/python/requirements.txt
-      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
+      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+      #   uses: actions/setup-dotnet@v2
+      #   with:
+      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
       - run: mkdir -p "${{ runner.temp }}/opt/pulumi/nuget"
       - name: Add NuGet packages as a local NuGet source
         run: |

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -148,10 +148,11 @@ jobs:
           python-version: ${{ fromJson(inputs.version-set).python }}
           cache: pip
           cache-dependency-path: sdk/python/requirements.txt
-      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
+      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+      #   uses: actions/setup-dotnet@v2
+      #   with:
+      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
       - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -46,10 +46,11 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9.x # TODO(friel) use version_set
-      - name: Set up DotNet
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 6.0.x # TODO(friel) use version_set
+      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
+      # - name: Set up DotNet
+      #   uses: actions/setup-dotnet@v2
+      #   with:
+      #     dotnet-version: 6.0.x # TODO(friel) use version_set
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Check out source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,11 +87,12 @@ jobs:
         if: ${{ matrix.language == 'python' }}
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
-      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-        if: ${{ matrix.language == 'dotnet' }}
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
+      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+      #   if: ${{ matrix.language == 'dotnet' }}
+      #   uses: actions/setup-dotnet@v1
+      #   with:
+      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
       - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
         if: ${{ matrix.language == 'nodejs' }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
Resolves #10997 

Disables this step and leaves a pointer to #11000 to implement in November when .NET 7 is released.