### PR TITLE
Reimplement #10984

### DIFF
--- a/changelog/pending/20221010--sdk-go--update-deprecated-things.yaml
+++ b/changelog/pending/20221010--sdk-go--update-deprecated-things.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Update notes, update the deprecated functions, make some lint.

--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -372,7 +372,7 @@ func DeterminePluginDependency(packageDir, packageName, packageVersion string) (
 	case os.IsNotExist(err):
 		break
 	case err != nil:
-		return nil, fmt.Errorf("Failed to read version file: %w", err)
+		return nil, fmt.Errorf("failed to read version file: %w", err)
 	}
 
 	defaultName := strings.ToLower(strings.TrimPrefix(packageName, "Pulumi."))
@@ -403,7 +403,7 @@ func DeterminePluginDependency(packageDir, packageName, packageVersion string) (
 
 	_, err = semver.ParseTolerant(version)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid package version: %w", err)
+		return nil, fmt.Errorf("invalid package version: %w", err)
 	}
 
 	result := &pulumirpc.PluginDependency{
@@ -545,7 +545,7 @@ func (w *logWriter) LogToUser(val string) (int, error) {
 	return len(val), nil
 }
 
-// RPC endpoint for LanguageRuntimeServer::Run
+// Run is the RPC endpoint for LanguageRuntimeServer::Run
 func (host *dotnetLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
 	config, err := host.constructConfig(req)
 	if err != nil {
@@ -769,7 +769,7 @@ func (host *dotnetLanguageHost) GetProgramDependencies(
 	}
 	cmd := exec.Command(ex, cmdArgs...)
 	if out, err = cmd.Output(); err != nil {
-		return nil, fmt.Errorf("Failed to call \"%s\": %w", ex, err)
+		return nil, fmt.Errorf("failed to call \"%s\": %w", ex, err)
 	}
 	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
 	var packages []*pulumirpc.DependencyInfo
@@ -793,7 +793,7 @@ func (host *dotnetLanguageHost) GetProgramDependencies(
 				// Transitive package => name version
 				version = 1
 			} else {
-				return nil, fmt.Errorf("Failed to parse \"%s\"", p)
+				return nil, fmt.Errorf("failed to parse \"%s\"", p)
 			}
 			packages = append(packages, &pulumirpc.DependencyInfo{
 				Name:    nameRequiredVersion[0],

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -462,7 +462,7 @@ func (l *LocalWorkspace) ImportStack(ctx context.Context, stackName string, stat
 	return nil
 }
 
-// Outputs get the current set of Stack outputs from the last Stack.Up().
+// StackOutputs gets the current set of Stack outputs from the last Stack.Up().
 func (l *LocalWorkspace) StackOutputs(ctx context.Context, stackName string) (OutputMap, error) {
 	// standard outputs
 	outStdout, outStderr, code, err := l.runPulumiCmdSync(ctx, "stack", "output", "--json", "--stack", stackName)

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -87,7 +87,7 @@ func UserAgent(agent string) Option {
 	})
 }
 
-// Show config secrets when they appear.
+// ShowSecrets configures whether to show config secrets when they appear.
 func ShowSecrets(show bool) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ShowSecrets = &show

--- a/sdk/go/auto/opthistory/opthistory.go
+++ b/sdk/go/auto/opthistory/opthistory.go
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package optup contains functional options to be used with stack history operations
+// Package opthistory contains functional options to be used with stack history operations
 // github.com/sdk/v3/go/x/auto Stack.History(ctx, pageSize, page, ...opthistory.Option)
 package opthistory
 
-// Show config secrets when they appear.
+// ShowSecrets configures whether to show config secrets when they appear.
 func ShowSecrets(show bool) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ShowSecrets = &show

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -87,7 +87,7 @@ func UserAgent(agent string) Option {
 	})
 }
 
-// Show config secrets when they appear in the config.
+// ShowSecrets configures whether to show config secrets when they appear in the config.
 func ShowSecrets(show bool) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ShowSecrets = &show

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -115,7 +115,7 @@ func Plan(path string) Option {
 	})
 }
 
-// Show config secrets when they appear.
+// ShowSecrets configures whether to show config secrets when they appear.
 func ShowSecrets(show bool) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ShowSecrets = &show

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -107,7 +107,7 @@ type Workspace interface {
 	// ImportStack imports the specified deployment state into a pre-existing stack.
 	// This can be combined with ExportStack to edit a stack's state (such as recovery from failed deployments).
 	ImportStack(context.Context, string, apitype.UntypedDeployment) error
-	// Outputs get the current set of Stack outputs from the last Stack.Up().
+	// StackOutputs gets the current set of Stack outputs from the last Stack.Up().
 	StackOutputs(context.Context, string) (OutputMap, error)
 }
 

--- a/sdk/go/common/diag/sink.go
+++ b/sdk/go/common/diag/sink.go
@@ -17,12 +17,10 @@ package diag
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"io"
 )
 
 // Sink facilitates pluggable diagnostics messages.
@@ -67,7 +65,7 @@ func DefaultSink(stdout io.Writer, stderr io.Writer, opts FormatOptions) Sink {
 	contract.Require(stdout != nil, "stdout")
 	contract.Require(stderr != nil, "stderr")
 	// Discard debug output by default unless requested.
-	debug := ioutil.Discard
+	debug := io.Discard
 	if opts.Debug {
 		debug = stdout
 	}

--- a/sdk/go/common/diag/sink_test.go
+++ b/sdk/go/common/diag/sink_test.go
@@ -16,7 +16,6 @@ package diag
 
 import (
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,11 +26,11 @@ import (
 func discardSink() Sink {
 	// Create a new default sink with /dev/null writers to avoid spamming the test log.
 	return newDefaultSink(FormatOptions{Color: colors.Never}, map[Severity]io.Writer{
-		Debug:   ioutil.Discard,
-		Info:    ioutil.Discard,
-		Infoerr: ioutil.Discard,
-		Error:   ioutil.Discard,
-		Warning: ioutil.Discard,
+		Debug:   io.Discard,
+		Info:    io.Discard,
+		Infoerr: io.Discard,
+		Error:   io.Discard,
+		Warning: io.Discard,
 	})
 }
 

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -351,11 +351,11 @@ func (a *Asset) readPath() (*Blob, error) {
 }
 
 func (a *Asset) readURI() (*Blob, error) {
-	url, isUrl, err := a.GetURIURL()
+	url, isURL, err := a.GetURIURL()
 	if err != nil {
 		return nil, err
 	}
-	contract.Assertf(isUrl, "Expected a URI-based asset")
+	contract.Assertf(isURL, "Expected a URI-based asset")
 	switch s := url.Scheme; s {
 	case "http", "https":
 		resp, err := httputil.GetWithRetry(url.String(), http.DefaultClient)
@@ -885,11 +885,11 @@ func (a *Archive) readPath() (ArchiveReader, error) {
 
 func (a *Archive) readURI() (ArchiveReader, error) {
 	// To read a URI-based archive, fetch the contents remotely and use the extension to pick the format to use.
-	url, isurl, err := a.GetURIURL()
+	url, isURL, err := a.GetURIURL()
 	if err != nil {
 		return nil, err
 	}
-	contract.Assertf(isurl, "Expected a URI-based asset")
+	contract.Assertf(isURL, "Expected a URI-based asset")
 
 	format := detectArchiveFormat(url.Path)
 	if format == NotArchive {

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -303,7 +302,7 @@ func (a *Asset) Bytes() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(blob)
+	return io.ReadAll(blob)
 }
 
 // Read begins reading an asset.
@@ -352,11 +351,11 @@ func (a *Asset) readPath() (*Blob, error) {
 }
 
 func (a *Asset) readURI() (*Blob, error) {
-	url, isurl, err := a.GetURIURL()
+	url, isUrl, err := a.GetURIURL()
 	if err != nil {
 		return nil, err
 	}
-	contract.Assertf(isurl, "Expected a URI-based asset")
+	contract.Assertf(isUrl, "Expected a URI-based asset")
 	switch s := url.Scheme; s {
 	case "http", "https":
 		resp, err := httputil.GetWithRetry(url.String(), http.DefaultClient)
@@ -416,7 +415,7 @@ func (blob *Blob) Size() int64                { return blob.sz }
 // NewByteBlob creates a new byte blob.
 func NewByteBlob(data []byte) *Blob {
 	return &Blob{
-		rd: ioutil.NopCloser(bytes.NewReader(data)),
+		rd: io.NopCloser(bytes.NewReader(data)),
 		sz: int64(len(data)),
 	}
 }
@@ -441,7 +440,7 @@ func NewReadCloserBlob(r io.ReadCloser) (*Blob, error) {
 	}
 	// Otherwise, read it all in, and create a blob out of that.
 	defer contract.IgnoreClose(r)
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -1052,7 +1051,7 @@ func addNextFileToZIP(r ArchiveReader, zw *zip.Writer, seenFiles map[string]bool
 	// the ZIP format includes a date representation that starts at 1980. Use `SetModTime` to
 	// remain compatible with Go 1.9.
 	// nolint: megacheck
-	fh.SetModTime(time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC))
+	fh.Modified = time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC)
 
 	fw, err := zw.CreateHeader(fh)
 	if err != nil {
@@ -1188,7 +1187,7 @@ func readArchive(ar io.ReadCloser, format ArchiveFormat) (ArchiveReader, error) 
 			}
 			ra = f
 			sz = stat.Size()
-		} else if data, err := ioutil.ReadAll(ar); err != nil {
+		} else if data, err := io.ReadAll(ar); err != nil {
 			return nil, err
 		} else {
 			ra = bytes.NewReader(data)
@@ -1220,7 +1219,7 @@ func (r *tarArchiveReader) Next() (string, *Blob, error) {
 		case tar.TypeReg:
 			// Return the tar reader for this file's contents.
 			data := &Blob{
-				rd: ioutil.NopCloser(r.tr),
+				rd: io.NopCloser(r.tr),
 				sz: file.Size,
 			}
 			name := filepath.Clean(file.Name)

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -120,7 +119,7 @@ func TestAssetSerialize(t *testing.T) {
 	t.Run("path asset", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		assert.Nil(t, err)
 		file := f.Name()
 		asset, err := NewPathAsset(file)
@@ -422,7 +421,7 @@ func TestArchiveTarFiles(t *testing.T) {
 	arch, err := NewPathArchive(repoRoot)
 	assert.Nil(t, err)
 
-	err = arch.Archive(TarArchive, ioutil.Discard)
+	err = arch.Archive(TarArchive, io.Discard)
 	assert.Nil(t, err)
 }
 
@@ -436,7 +435,7 @@ func TestArchiveZipFiles(t *testing.T) {
 	arch, err := NewPathArchive(repoRoot)
 	assert.Nil(t, err)
 
-	err = arch.Archive(ZIPArchive, ioutil.Discard)
+	err = arch.Archive(ZIPArchive, io.Discard)
 	assert.Nil(t, err)
 }
 
@@ -445,12 +444,12 @@ func TestNestedArchive(t *testing.T) {
 	t.Parallel()
 
 	// Create temp dir and place some files.
-	dirName, err := ioutil.TempDir("", "")
+	dirName, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 	assert.NoError(t, os.MkdirAll(filepath.Join(dirName, "foo", "bar"), 0777))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(dirName, "foo", "a.txt"), []byte("a"), 0777))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(dirName, "foo", "bar", "b.txt"), []byte("b"), 0777))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(dirName, "c.txt"), []byte("c"), 0777))
+	assert.NoError(t, os.WriteFile(filepath.Join(dirName, "foo", "a.txt"), []byte("a"), 0777))
+	assert.NoError(t, os.WriteFile(filepath.Join(dirName, "foo", "bar", "b.txt"), []byte("b"), 0777))
+	assert.NoError(t, os.WriteFile(filepath.Join(dirName, "c.txt"), []byte("c"), 0777))
 
 	// Construct an AssetArchive with a nested PathArchive.
 	innerArch, err := NewPathArchive(filepath.Join(dirName, "./foo"))
@@ -464,7 +463,7 @@ func TestNestedArchive(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Write a ZIP of the AssetArchive to disk.
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	fileName := tmpFile.Name()
 	assert.Nil(t, err)
 	err = arch.Archive(ZIPArchive, tmpFile)
@@ -488,10 +487,10 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	t.Parallel()
 
 	// Create temp dir and place some files.
-	dirName, err := ioutil.TempDir("", "")
+	dirName, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 	assert.NoError(t, os.MkdirAll(filepath.Join(dirName, "foo", "bar"), 0777))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(dirName, "foo", "bar", "b.txt"), []byte("b"), 0777))
+	assert.NoError(t, os.WriteFile(filepath.Join(dirName, "foo", "bar", "b.txt"), []byte("b"), 0777))
 
 	// Construct an AssetArchive with a nested PathArchive.
 	outerArch, err := NewPathArchive(filepath.Join(dirName, "./foo"))
@@ -505,7 +504,7 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Write a ZIP of the AssetArchive to disk.
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	fileName := tmpFile.Name()
 	assert.Nil(t, err)
 	err = arch.Archive(ZIPArchive, tmpFile)
@@ -545,7 +544,7 @@ func TestInvalidPathArchive(t *testing.T) {
 	t.Parallel()
 
 	// Create a temp file that is not an asset.
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	fileName := tmpFile.Name()
 	assert.NoError(t, err)
 	fmt.Fprintf(tmpFile, "foo\n")

--- a/sdk/go/common/resource/config/key.go
+++ b/sdk/go/common/resource/config/key.go
@@ -70,7 +70,7 @@ func (k *Key) Name() string {
 	return k.name
 }
 
-func (k *Key) MarshalJSON() ([]byte, error) {
+func (k Key) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.String())
 }
 
@@ -90,7 +90,7 @@ func (k *Key) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (k *Key) MarshalYAML() (interface{}, error) {
+func (k Key) MarshalYAML() (interface{}, error) {
 	return k.String(), nil
 }
 
@@ -110,7 +110,7 @@ func (k *Key) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (k *Key) String() string {
+func (k Key) String() string {
 	return k.namespace + ":" + k.name
 }
 

--- a/sdk/go/common/resource/config/key.go
+++ b/sdk/go/common/resource/config/key.go
@@ -49,7 +49,7 @@ func ParseKey(s string) (Key, error) {
 		return Key{namespace: s[:idx], name: s[idx+1:]}, nil
 	case 2:
 		if mm, err := tokens.ParseModuleMember(s); err == nil {
-			if mm.Module().Name() == tokens.ModuleName("config") {
+			if mm.Module().Name() == "config" {
 				return Key{
 					namespace: mm.Module().Package().String(),
 					name:      mm.Name().String(),
@@ -62,15 +62,15 @@ func ParseKey(s string) (Key, error) {
 		"(configuration keys should be of the form `<namespace>:<name>`)", s)
 }
 
-func (k Key) Namespace() string {
+func (k *Key) Namespace() string {
 	return k.namespace
 }
 
-func (k Key) Name() string {
+func (k *Key) Name() string {
 	return k.name
 }
 
-func (k Key) MarshalJSON() ([]byte, error) {
+func (k *Key) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.String())
 }
 
@@ -90,7 +90,7 @@ func (k *Key) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (k Key) MarshalYAML() (interface{}, error) {
+func (k *Key) MarshalYAML() (interface{}, error) {
 	return k.String(), nil
 }
 
@@ -110,7 +110,7 @@ func (k *Key) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (k Key) String() string {
+func (k *Key) String() string {
 	return k.namespace + ":" + k.name
 }
 

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -222,7 +222,7 @@ func (a *analyzer) AnalyzeStack(resources []AnalyzerStackResource) ([]AnalyzeDia
 				continue
 			}
 
-			pdeps := []string{}
+			pdeps := make([]string, 0, 1)
 			for _, d := range pd {
 				pdeps = append(pdeps, string(d))
 			}
@@ -604,7 +604,7 @@ func convertEnforcementLevel(el pulumirpc.EnforcementLevel) (apitype.Enforcement
 		return apitype.Disabled, nil
 
 	default:
-		return "", fmt.Errorf("Invalid enforcement level %d", el)
+		return "", fmt.Errorf("invalid enforcement level %d", el)
 	}
 }
 
@@ -615,8 +615,7 @@ func convertConfigSchema(schema *pulumirpc.PolicyConfigSchema) *AnalyzerPolicyCo
 
 	props := make(map[string]JSONSchema)
 	for k, v := range unmarshalMap(schema.GetProperties()) {
-		s := v.(map[string]interface{})
-		props[k] = JSONSchema(s)
+		props[k] = v.(JSONSchema)
 	}
 
 	return &AnalyzerPolicyConfigSchema{

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -16,7 +16,7 @@ package plugin
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 
 	"github.com/opentracing/opentracing-go"
 
@@ -67,16 +67,16 @@ func NewContext(d, statusD diag.Sink, host Host, _ ConfigSource,
 		disableProviderPreview, parentSpan, plugins)
 }
 
-// Variation of NewContext that also sets known project Root. Additionally accepts Plugins
+// NewContextWithRoot is a variation of NewContext that also sets known project Root. Additionally accepts Plugins
 func NewContextWithRoot(d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]interface{}, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins) (*Context, error) {
 
 	if d == nil {
-		d = diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{Color: colors.Never})
+		d = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
 	}
 	if statusD == nil {
-		statusD = diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{Color: colors.Never})
+		statusD = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
 	}
 
 	ctx := &Context{

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -112,7 +112,7 @@ func (eng *hostServer) GetRootResource(ctx context.Context,
 	return &response, nil
 }
 
-// SetRootResources sets the current root resource's URN. Generally only called on startup when the Stack resource is
+// SetRootResource sets the current root resource's URN. Generally only called on startup when the Stack resource is
 // registered.
 func (eng *hostServer) SetRootResource(ctx context.Context,
 	req *lumirpc.SetRootResourceRequest) (*lumirpc.SetRootResourceResponse, error) {

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -227,7 +227,7 @@ type DiffResult struct {
 	DeleteBeforeReplace bool                    // if true, this resource must be deleted before recreating it.
 }
 
-// Computes the detailed diff of Updated, Added and Deleted keys.
+// NewDetailedDiffFromObjectDiff computes the detailed diff of Updated, Added and Deleted keys.
 func NewDetailedDiffFromObjectDiff(diff *resource.ObjectDiff) map[string]PropertyDiff {
 	if diff == nil {
 		return map[string]PropertyDiff{}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -154,7 +154,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 	return p, nil
 }
 
-// Create a new provider by loading the plugin binary located at `path`.
+// NewProviderFromPath creates a new provider by loading the plugin binary located at `path`.
 func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error) {
 	env := os.Environ()
 	plug, err := newPlugin(ctx, ctx.Pwd, path, "",

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -1656,7 +1656,7 @@ func walkValueSelfWithDescendants(
 	visit func(path string, v *structpb.Value) error) error {
 
 	if v == nil {
-		return fmt.Errorf("Bad *structpb.Value nil at %s", path)
+		return fmt.Errorf("bad *structpb.Value nil at %s", path)
 	}
 	err := visit(path, v)
 	if err != nil {
@@ -1688,7 +1688,7 @@ func walkValueSelfWithDescendants(
 	case *structpb.Value_NullValue:
 		return nil
 	default:
-		return fmt.Errorf("Bad *structpb.Value of unknown type at %s: %v", path, v)
+		return fmt.Errorf("bad *structpb.Value of unknown type at %s: %v", path, v)
 	}
 	return nil
 }

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -142,14 +142,14 @@ func (err *ReqError) Error() string {
 // HasValue returns true if the slot associated with the given property key contains a real value.  It returns false
 // if a value is null or an output property that is awaiting a value to be assigned.  That is to say, HasValue indicates
 // a semantically meaningful value is present (even if it's a computed one whose concrete value isn't yet evaluated).
-func (m PropertyMap) HasValue(k PropertyKey) bool {
-	v, has := m[k]
+func (props PropertyMap) HasValue(k PropertyKey) bool {
+	v, has := props[k]
 	return has && v.HasValue()
 }
 
 // ContainsUnknowns returns true if the property map contains at least one unknown value.
-func (m PropertyMap) ContainsUnknowns() bool {
-	for _, v := range m {
+func (props PropertyMap) ContainsUnknowns() bool {
+	for _, v := range props {
 		if v.ContainsUnknowns() {
 			return true
 		}
@@ -158,8 +158,8 @@ func (m PropertyMap) ContainsUnknowns() bool {
 }
 
 // ContainsSecrets returns true if the property map contains at least one secret value.
-func (m PropertyMap) ContainsSecrets() bool {
-	for _, v := range m {
+func (props PropertyMap) ContainsSecrets() bool {
+	for _, v := range props {
 		if v.ContainsSecrets() {
 			return true
 		}
@@ -168,40 +168,40 @@ func (m PropertyMap) ContainsSecrets() bool {
 }
 
 // Mappable returns a mapper-compatible object map, suitable for deserialization into structures.
-func (m PropertyMap) Mappable() map[string]interface{} {
-	return m.MapRepl(nil, nil)
+func (props PropertyMap) Mappable() map[string]interface{} {
+	return props.MapRepl(nil, nil)
 }
 
 // MapRepl returns a mapper-compatible object map, suitable for deserialization into structures.  A key and/or value
 // replace function, replk/replv, may be passed that will replace elements using custom logic if appropriate.
-func (m PropertyMap) MapRepl(replk func(string) (string, bool),
+func (props PropertyMap) MapRepl(replk func(string) (string, bool),
 	replv func(PropertyValue) (interface{}, bool)) map[string]interface{} {
 	obj := make(map[string]interface{})
-	for _, k := range m.StableKeys() {
+	for _, k := range props.StableKeys() {
 		key := string(k)
 		if replk != nil {
 			if rk, repk := replk(key); repk {
 				key = rk
 			}
 		}
-		obj[key] = m[k].MapRepl(replk, replv)
+		obj[key] = props[k].MapRepl(replk, replv)
 	}
 	return obj
 }
 
 // Copy makes a shallow copy of the map.
-func (m PropertyMap) Copy() PropertyMap {
+func (props PropertyMap) Copy() PropertyMap {
 	new := make(PropertyMap)
-	for k, v := range m {
+	for k, v := range props {
 		new[k] = v
 	}
 	return new
 }
 
 // StableKeys returns all of the map's keys in a stable order.
-func (m PropertyMap) StableKeys() []PropertyKey {
-	sorted := make([]PropertyKey, 0, len(m))
-	for k := range m {
+func (props PropertyMap) StableKeys() []PropertyKey {
+	sorted := make([]PropertyKey, 0, len(props))
+	for k := range props {
 		sorted = append(sorted, k)
 	}
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })

--- a/sdk/go/common/resource/properties_diff.go
+++ b/sdk/go/common/resource/properties_diff.go
@@ -55,7 +55,7 @@ func (diff *ObjectDiff) Same(k PropertyKey) bool {
 	return !diff.Changed(k)
 }
 
-// Returns true if there are no changes (adds, deletes, updates) in the diff. Also returns true if
+// AnyChanges returns true if there are no changes (adds, deletes, updates) in the diff. Also returns true if
 // diff is nil. Otherwise returns false.
 func (diff *ObjectDiff) AnyChanges() bool {
 	return diff != nil && len(diff.Adds)+len(diff.Deletes)+len(diff.Updates) > 0
@@ -393,7 +393,7 @@ func (v PropertyValue) DeepEquals(other PropertyValue) bool {
 	return v.V == other.V
 }
 
-// Diff returns a diffset by comparing the property map to another; it returns nil if there are no diffs.
+// DiffIncludeUnknowns returns a diffset by comparing the property map to another; it returns nil if there are no diffs.
 func (props PropertyMap) DiffIncludeUnknowns(other PropertyMap, ignoreKeys ...IgnoreKeyFunc) *ObjectDiff {
 	adds := make(PropertyMap)
 	deletes := make(PropertyMap)

--- a/sdk/go/common/resource/resource_id.go
+++ b/sdk/go/common/resource/resource_id.go
@@ -30,8 +30,8 @@ import (
 type ID string
 
 // String converts a resource ID into a string.
-func (id ID) String() string {
-	return string(id)
+func (id *ID) String() string {
+	return string(*id)
 }
 
 // StringPtr converts an optional ID into an optional string.
@@ -90,27 +90,27 @@ func NewUniqueHexID(prefix string, randlen, maxlen int) (ID, error) {
 	return ID(u), err
 }
 
-// NewFixedUniqueHex generates a new "random" hex string for use by resource providers. It will take the optional prefix
-// and append randlen random characters (defaulting to 8 if not > 0).  The result must not exceed maxlen total
-// characterss (if > 0).  Note that capping to maxlen necessarily increases the risk of collisions.
+// NewUniqueHexV2 generates a new "random" hex string for use by resource providers. It will take the optional prefix
+// and append randLen random characters (defaulting to 8 if not > 0).  The result must not exceed maxLen total
+// characters (if > 0).  Note that capping to maxLen necessarily increases the risk of collisions.
 // The randomness for this method is a function of urn and sequenceNumber iff sequenceNUmber > 0, else it falls back to
 // a non-deterministic source of randomness.
-func NewUniqueHexV2(urn URN, sequenceNumber int, prefix string, randlen, maxlen int) (string, error) {
-	if randlen <= 0 {
-		randlen = 8
+func NewUniqueHexV2(urn URN, sequenceNumber int, prefix string, randLen, maxLen int) (string, error) {
+	if randLen <= 0 {
+		randLen = 8
 	}
-	if maxlen > 0 && len(prefix)+randlen > maxlen {
+	if maxLen > 0 && len(prefix)+randLen > maxLen {
 		return "", errors.Errorf(
-			"name '%s' plus %d random chars is longer than maximum length %d", prefix, randlen, maxlen)
+			"name '%s' plus %d random chars is longer than maximum length %d", prefix, randLen, maxLen)
 	}
 
 	if sequenceNumber == 0 {
 		// No sequence number fallback to old logic
-		return NewUniqueHex(prefix, randlen, maxlen)
+		return NewUniqueHex(prefix, randLen, maxLen)
 	}
 
-	if randlen > 32 {
-		return "", errors.Errorf("randLen is longer than 32, %d", randlen)
+	if randLen > 32 {
+		return "", errors.Errorf("randLen is longer than 32, %d", randLen)
 	}
 
 	// TODO(seqnum) This is seeded by urn and sequence number, and urn has the stack and project names in it.
@@ -127,7 +127,7 @@ func NewUniqueHexV2(urn URN, sequenceNumber int, prefix string, randlen, maxlen 
 	bs := hasher.Sum(nil)
 	contract.Assert(len(bs) == 64)
 
-	return prefix + hex.EncodeToString(bs)[:randlen], nil
+	return prefix + hex.EncodeToString(bs)[:randLen], nil
 }
 
 // NewUniqueName generates a new "random" string primarily intended for use by resource providers for

--- a/sdk/go/common/resource/resource_id.go
+++ b/sdk/go/common/resource/resource_id.go
@@ -30,8 +30,8 @@ import (
 type ID string
 
 // String converts a resource ID into a string.
-func (id *ID) String() string {
-	return string(*id)
+func (id ID) String() string {
+	return string(id)
 }
 
 // StringPtr converts an optional ID into an optional string.

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -245,7 +245,7 @@ func (e *Environment) WriteTestFile(filename string, contents string) {
 		e.T.Fatalf("error making directories for test file (%v): %v", filename, err)
 	}
 
-	if err := ioutil.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
+	if err := os.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
 		e.T.Fatalf("writing test file (%v): %v", filename, err)
 	}
 }

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -138,7 +138,7 @@ func doArchiveTest(t *testing.T, path string, files ...fileContents) {
 }
 
 func archiveContents(prefixPathInsideTar, path string, files ...fileContents) ([]byte, error) {
-	dir, err := ioutil.TempDir("", "archive-test")
+	dir, err := os.MkdirTemp("", "archive-test")
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -17,7 +17,6 @@ package ciutil
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 )
@@ -74,7 +73,7 @@ func (t githubActionsCI) DetectVars() Vars {
 	return v
 }
 
-// TryGetEvent returns the GitHub webhook payload found in the GitHub Actions environment.
+// GetPREvent returns the GitHub webhook payload found in the GitHub Actions environment.
 // GitHub stores the JSON payload of the webhook that triggered the workflow in a path.
 // The path is set as the value of the env var GITHUB_EVENT_PATH. Returns nil if an error
 // is encountered or the GITHUB_EVENT_PATH is not set.
@@ -84,7 +83,7 @@ func (t githubActionsCI) GetPREvent() *githubActionsPullRequestEvent {
 		return nil
 	}
 
-	b, err := ioutil.ReadFile(eventPath)
+	b, err := os.ReadFile(eventPath)
 	if err != nil {
 		return nil
 	}

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -152,7 +152,7 @@ func MeasureText(text string) int {
 	return uniseg.GraphemeClusterCount(clean)
 }
 
-func (table Table) ToStringWithGap(columnGap string) string {
+func (table *Table) ToStringWithGap(columnGap string) string {
 	columnCount := len(table.Headers)
 
 	// Figure out the preferred column width for each column.  It will be set to the max length of

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -152,7 +152,7 @@ func MeasureText(text string) int {
 	return uniseg.GraphemeClusterCount(clean)
 }
 
-func (table *Table) ToStringWithGap(columnGap string) string {
+func (table Table) ToStringWithGap(columnGap string) string {
 	columnCount := len(table.Headers)
 
 	// Figure out the preferred column width for each column.  It will be set to the max length of

--- a/sdk/go/common/util/cmdutil/spinner.go
+++ b/sdk/go/common/util/cmdutil/spinner.go
@@ -54,11 +54,11 @@ func NewSpinnerAndTicker(prefix string, ttyFrames []string,
 
 // Spinner represents a very simple progress reporter.
 type Spinner interface {
-	// Print the next frame of the spinner. After Tick() has been called, there should be no writes to Stdout before
+	// Tick prints the next frame of the spinner. After Tick() has been called, there should be no writes to Stdout before
 	// calling Reset().
 	Tick()
 
-	// Called to release ownership of stdout, so others may write to it.
+	// Reset is called to release ownership of stdout, so others may write to it.
 	Reset()
 }
 

--- a/sdk/go/common/util/cmdutil/trace.go
+++ b/sdk/go/common/util/cmdutil/trace.go
@@ -17,7 +17,6 @@ package cmdutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/url"
@@ -37,11 +36,11 @@ import (
 // TracingEndpoint is the Zipkin-compatible tracing endpoint where tracing data will be sent.
 var TracingEndpoint string
 
-// Deprecated. TracingToFile=true if pulumi was called with a file://
-// scheme URL (--tracing=file:///...). Even in this case
-// TracingEndpoint will now have the tcp:// scheme and will point to a
-// proxy server that will append traces to the user-specified file.
-// Plugins should respect TracingEndpoint and ignore TracingToFile.
+// TracingToFile indicates if pulumi was called with a file:// scheme URL (--tracing=file:///...).
+//
+// Deprecated: Even in this case TracingEndpoint will now have the tcp:// scheme and will point to a
+// proxy server that will append traces to the user-specified file. Plugins should respect
+// TracingEndpoint and ignore TracingToFile.
 var TracingToFile bool
 
 var TracingRootSpan opentracing.Span
@@ -195,7 +194,7 @@ func startProxyAppDashServer(collector appdash.Collector) (string, error) {
 
 	// The default sends to stderr, which is unfortunate for
 	// end-users. Discard for now.
-	cs.Log = log.New(ioutil.Discard, "appdash", 0)
+	cs.Log = log.New(io.Discard, "appdash", 0)
 
 	return fmt.Sprintf("tcp://127.0.0.1:%d", collectorPort), nil
 }

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -43,13 +43,13 @@ type VCSKind = string
 const (
 	defaultGitCloudRepositorySuffix = ".git"
 
-	// The host name for GitLab.
+	// GitLabHostName The host name for GitLab.
 	GitLabHostName VCSKind = "gitlab.com"
-	// The host name for GitHub.
+	// GitHubHostName The host name for GitHub.
 	GitHubHostName VCSKind = "github.com"
-	// The host name for Azure DevOps
+	// AzureDevOpsHostName The host name for Azure DevOps
 	AzureDevOpsHostName VCSKind = "dev.azure.com"
-	// The host name for Bitbucket
+	// BitbucketHostName The host name for Bitbucket
 	BitbucketHostName VCSKind = "bitbucket.org"
 )
 

--- a/sdk/go/common/util/httputil/http.go
+++ b/sdk/go/common/util/httputil/http.go
@@ -41,7 +41,7 @@ func DoWithRetry(req *http.Request, client *http.Client) (*http.Response, error)
 	return doWithRetry(req, client, opts)
 }
 
-// DoWithRetry calls client.Do, but retrying 500s (even for POSTs). Using the provided delays.
+// DoWithRetryOpts calls client.Do, but retrying 500s (even for POSTs). Using the provided delays.
 func DoWithRetryOpts(req *http.Request, client *http.Client, opts RetryOpts) (*http.Response, error) {
 	return doWithRetry(req, client, opts)
 }

--- a/sdk/go/common/util/mapper/mapper.go
+++ b/sdk/go/common/util/mapper/mapper.go
@@ -25,7 +25,7 @@ import (
 type Mapper interface {
 	// Decode decodes a JSON-like object into the target pointer to a structure.
 	Decode(obj map[string]interface{}, target interface{}) MappingError
-	// DecodeField decodes a single JSON-like value (with a given type and name) into a target pointer to a structure.
+	// DecodeValue decodes a single JSON-like value (with a given type and name) into a target pointer to a structure.
 	DecodeValue(obj map[string]interface{}, ty reflect.Type, key string, target interface{}, optional bool) FieldError
 	// Encode encodes an object into a JSON-like in-memory object.
 	Encode(source interface{}) (map[string]interface{}, MappingError)

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -36,7 +36,7 @@ func OpenTracingServerInterceptor(parentSpan opentracing.Span, options ...otgrpc
 	return otgrpc.OpenTracingServerInterceptor(tracer, options...)
 }
 
-// Like OpenTracingServerInterceptor but for instrumenting streaming gRPC calls.
+// OpenTracingStreamServerInterceptor is OpenTracingServerInterceptor for instrumenting streaming gRPC calls.
 func OpenTracingStreamServerInterceptor(parentSpan opentracing.Span,
 	options ...otgrpc.Option) grpc.StreamServerInterceptor {
 
@@ -61,7 +61,7 @@ func OpenTracingClientInterceptor(options ...otgrpc.Option) grpc.UnaryClientInte
 	return otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer(), options...)
 }
 
-// Like OpenTracingClientInterceptor but for streaming gRPC calls.
+// OpenTracingStreamClientInterceptor is OpenTracingClientInterceptor for streaming gRPC calls.
 func OpenTracingStreamClientInterceptor(options ...otgrpc.Option) grpc.StreamClientInterceptor {
 	options = append(append(options,
 		// Do not trace calls to the empty method

--- a/sdk/go/common/util/rpcutil/writer.go
+++ b/sdk/go/common/util/rpcutil/writer.go
@@ -88,7 +88,7 @@ func (w *pipeWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Returns a pair of streams for use with the language runtimes InstallDependencies method
+// MakeStreams returns a pair of streams for use with the language runtimes InstallDependencies method
 func MakeStreams(
 	server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 	isTerminal bool) (io.Closer, io.Writer, io.Writer, error) {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -622,7 +622,7 @@ func (info *PluginInfo) Spec() PluginSpec {
 	return PluginSpec{Name: info.Name, Kind: info.Kind, Version: info.Version}
 }
 
-func (info *PluginInfo) String() string {
+func (info PluginInfo) String() string {
 	var version string
 	if v := info.Version; v != nil {
 		version = fmt.Sprintf("-%s", v)
@@ -1094,11 +1094,12 @@ func (p dirPlugin) writeToDir(dstRoot string) error {
 	})
 }
 
-// InstallWithContext installs a plugin's tarball into the cache. It validates that plugin names are in the expected format.
-// Previous versions of Pulumi extracted the tarball to a temp directory first, and then renamed the temp directory
-// to the final directory. The rename operation fails often enough on Windows due to aggressive virus scanners opening
-// files in the temp directory. To address this, we now extract the tarball directly into the final directory, and use
-// file locks to prevent concurrent installs.
+// InstallWithContext installs a plugin's tarball into the cache. It validates that plugin names are in the expected
+// format. Previous versions of Pulumi extracted the tarball to a temp directory first, and then renamed the temp
+// directory to the final directory. The rename operation fails often enough on Windows due to aggressive virus scanners
+// opening files in the temp directory. To address this, we now extract the tarball directly into the final directory,
+// and use file locks to prevent concurrent installs.
+//
 // Each plugin has its own file lock, with the same name as the plugin directory, with a `.lock` suffix.
 // During installation an empty file with a `.partial` suffix is created, indicating that installation is in-progress.
 // The `.partial` file is deleted when installation is complete, indicating that the plugin has finished installing.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -516,7 +516,7 @@ func (source *checksumSource) Download(
 	}, length, nil
 }
 
-// Information about a locally installed plugin specified by the project.
+// ProjectPlugin Information about a locally installed plugin specified by the project.
 type ProjectPlugin struct {
 	Name    string          // the simple name of the plugin.
 	Kind    PluginKind      // the kind of the plugin (language, resource, etc).
@@ -524,7 +524,7 @@ type ProjectPlugin struct {
 	Path    string          // the path that a plugin is to be loaded from (this will always be a directory)
 }
 
-// Return a PluginSpec object for this project plugin.
+// Spec Return a PluginSpec object for this project plugin.
 func (pp ProjectPlugin) Spec() PluginSpec {
 	return PluginSpec{
 		Name:    pp.Name,
@@ -618,11 +618,11 @@ type PluginInfo struct {
 }
 
 // Spec returns the PluginSpec for this PluginInfo
-func (info PluginInfo) Spec() PluginSpec {
+func (info *PluginInfo) Spec() PluginSpec {
 	return PluginSpec{Name: info.Name, Kind: info.Kind, Version: info.Version}
 }
 
-func (info PluginInfo) String() string {
+func (info *PluginInfo) String() string {
 	var version string
 	if v := info.Version; v != nil {
 		version = fmt.Sprintf("-%s", v)
@@ -632,7 +632,7 @@ func (info PluginInfo) String() string {
 
 // Delete removes the plugin from the cache.  It also deletes any supporting files in the cache, which includes
 // any files that contain the same prefix as the plugin itself.
-func (info PluginInfo) Delete() error {
+func (info *PluginInfo) Delete() error {
 	dir := info.Path
 	if err := os.RemoveAll(dir); err != nil {
 		return err
@@ -1094,7 +1094,7 @@ func (p dirPlugin) writeToDir(dstRoot string) error {
 	})
 }
 
-// Install installs a plugin's tarball into the cache. It validates that plugin names are in the expected format.
+// InstallWithContext installs a plugin's tarball into the cache. It validates that plugin names are in the expected format.
 // Previous versions of Pulumi extracted the tarball to a temp directory first, and then renamed the temp directory
 // to the final directory. The rename operation fails often enough on Windows due to aggressive virus scanners opening
 // files in the temp directory. To address this, we now extract the tarball directly into the final directory, and use
@@ -1104,7 +1104,7 @@ func (p dirPlugin) writeToDir(dstRoot string) error {
 // The `.partial` file is deleted when installation is complete, indicating that the plugin has finished installing.
 // If a failure occurs during installation, the `.partial` file will remain, indicating the plugin wasn't fully
 // installed. The next time the plugin is installed, the old installation directory will be removed and replaced with
-// a fresh install.
+// a fresh installation.
 func (spec PluginSpec) InstallWithContext(ctx context.Context, content PluginContent, reinstall bool) error {
 	defer contract.IgnoreClose(content)
 

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -348,7 +348,7 @@ func (info *ProjectRuntimeInfo) SetOption(key string, value interface{}) {
 	info.options[key] = value
 }
 
-func (info *ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
+func (info ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
 	if info.options == nil || len(info.options) == 0 {
 		return info.name, nil
 	}
@@ -359,7 +359,7 @@ func (info *ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
 	}, nil
 }
 
-func (info *ProjectRuntimeInfo) MarshalJSON() ([]byte, error) {
+func (info ProjectRuntimeInfo) MarshalJSON() ([]byte, error) {
 	if info.options == nil || len(info.options) == 0 {
 		return json.Marshal(info.name)
 	}

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -237,7 +236,7 @@ func (proj *Project) Validate() error {
 	return nil
 }
 
-// TrustResourceDependencies returns whether or not this project's runtime can be trusted to accurately report
+// TrustResourceDependencies returns whether this project's runtime can be trusted to accurately report
 // dependencies. All languages supported by Pulumi today do this correctly. This option remains useful when bringing
 // up new Pulumi languages.
 func (proj *Project) TrustResourceDependencies() bool {
@@ -349,7 +348,7 @@ func (info *ProjectRuntimeInfo) SetOption(key string, value interface{}) {
 	info.options[key] = value
 }
 
-func (info ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
+func (info *ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
 	if info.options == nil || len(info.options) == 0 {
 		return info.name, nil
 	}
@@ -360,7 +359,7 @@ func (info ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
 	}, nil
 }
 
-func (info ProjectRuntimeInfo) MarshalJSON() ([]byte, error) {
+func (info *ProjectRuntimeInfo) MarshalJSON() ([]byte, error) {
 	if info.options == nil || len(info.options) == 0 {
 		return json.Marshal(info.name)
 	}
@@ -440,5 +439,5 @@ func save(path string, value interface{}, mkDirAll bool) error {
 	}
 
 	//nolint: gosec
-	return ioutil.WriteFile(path, b, 0644)
+	return os.WriteFile(path, b, 0644)
 }

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -288,7 +288,7 @@ func retrieveURLTemplates(rawurl string, offline bool, templateKind TemplateKind
 
 	var fullPath string
 	if fullPath, err = RetrieveGitFolder(rawurl, temp); err != nil {
-		return TemplateRepository{}, fmt.Errorf("Failed to retrieve git folder: %w", err)
+		return TemplateRepository{}, fmt.Errorf("failed to retrieve git folder: %w", err)
 	}
 
 	return TemplateRepository{

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -232,7 +232,7 @@ func normalizeVersion(version string) (string, error) {
 func (m *modInfo) getPlugin() (*pulumirpc.PluginDependency, error) {
 	pulumiPlugin, err := m.readPulumiPluginJSON()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load pulumi-plugin.json: %w", err)
+		return nil, fmt.Errorf("failed to load pulumi-plugin.json: %w", err)
 	}
 
 	if (!strings.HasPrefix(m.Path, "github.com/pulumi/pulumi-") && pulumiPlugin == nil) ||
@@ -396,7 +396,7 @@ func runProgram(bin string, env []string) *pulumirpc.RunResponse {
 	}
 }
 
-// RPC endpoint for LanguageRuntimeServer::Run
+// Run is RPC endpoint for LanguageRuntimeServer::Run
 func (host *goLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
 	// Create the environment we'll use to run the process.  This is how we pass the RunInfo to the actual
 	// Go program runtime, to avoid needing any sort of program interface other than just a main entrypoint.
@@ -628,7 +628,7 @@ func (host *goLanguageHost) GetProgramDependencies(
 	cmd := exec.Command(ex, cmdArgs...)
 	var out []byte
 	if out, err = cmd.Output(); err != nil {
-		return nil, fmt.Errorf("Failed to get modules: %w", err)
+		return nil, fmt.Errorf("failed to get modules: %w", err)
 	}
 
 	dec := json.NewDecoder(bytes.NewReader(out))
@@ -639,7 +639,7 @@ func (host *goLanguageHost) GetProgramDependencies(
 			if err == io.EOF {
 				break
 			}
-			return nil, fmt.Errorf("Failed to parse \"%s %s\" output: %w", ex, strings.Join(cmdArgs, " "), err)
+			return nil, fmt.Errorf("failed to parse \"%s %s\" output: %w", ex, strings.Join(cmdArgs, " "), err)
 		}
 		parsed = append(parsed, m)
 

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -211,7 +211,7 @@ func TestGetPlugin(t *testing.T) {
 				}
 				path := filepath.Join(cwd, c.JSONPath)
 				err := os.MkdirAll(path, 0700)
-				assert.NoErrorf(t, err, "Failed to setup test folder", path)
+				assert.NoErrorf(t, err, "Failed to setup test folder %s", path)
 				bytes, err := c.JSON.JSON()
 				assert.NoError(t, err, "Failed to setup test pulumi-plugin.json")
 				err = os.WriteFile(filepath.Join(path, "pulumi-plugin.json"), bytes, 0600)

--- a/sdk/go/pulumi/config/config_test.go
+++ b/sdk/go/pulumi/config/config_test.go
@@ -214,7 +214,7 @@ func TestSecretConfig(t *testing.T) {
 			if val == "a string value" {
 				result <- val.(string)
 			} else {
-				errChan <- fmt.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("invalid result: %v", val)
 
 			}
 		}
@@ -251,7 +251,7 @@ func TestSecretConfig(t *testing.T) {
 			if reflect.DeepEqual(expectedTestStruct, *ts) {
 				objResult <- *ts
 			} else {
-				errChan <- fmt.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("invalid result: %v", val)
 			}
 		}
 		return v, nil
@@ -281,7 +281,7 @@ func TestSecretConfig(t *testing.T) {
 			if val == true {
 				resultBool <- val.(bool)
 			} else {
-				errChan <- fmt.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("invalid result: %v", val)
 
 			}
 		}
@@ -312,7 +312,7 @@ func TestSecretConfig(t *testing.T) {
 			if val == 42 {
 				resultInt <- val.(int)
 			} else {
-				errChan <- fmt.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("invalid result: %v", val)
 
 			}
 		}

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -716,7 +716,7 @@ func (ctx *Context) getResource(urn string) (*pulumirpc.RegisterResourceResponse
 		Args: rpcArgs,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Invoke(%s, ...): error: %v", tok, err)
+		return nil, fmt.Errorf("invoke(%s, ...): error: %v", tok, err)
 	}
 
 	// If there were any failures from the provider, return them.

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -60,12 +60,12 @@ func (log *logState) Debug(msg string, args *LogArgs) error {
 	return log._log(pulumirpc.LogSeverity_DEBUG, msg, args)
 }
 
-// Logs an informational message that is generally printed to stdout during resource
+// Info logs an informational message that is generally printed to stdout during resource
 func (log *logState) Info(msg string, args *LogArgs) error {
 	return log._log(pulumirpc.LogSeverity_INFO, msg, args)
 }
 
-// Logs a warning to indicate that something went wrong, but not catastrophically so.
+// Warn logs a warning to indicate that something went wrong, but not catastrophically so.
 func (log *logState) Warn(msg string, args *LogArgs) error {
 	return log._log(pulumirpc.LogSeverity_WARNING, msg, args)
 }

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -32,7 +32,7 @@ func WithMocksWithOrganization(organization, project, stack string, mocks MockRe
 	}
 }
 
-// MockResourceArgs is used to construct call Mock
+// MockCallArgs is used to construct a call Mock
 type MockCallArgs struct {
 	// Token indicates which function is being called. This token is of the form "package:module:function".
 	Token string

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -543,7 +543,7 @@ func ToSecret(input interface{}) Output {
 	return ToSecretWithContext(context.Background(), input)
 }
 
-// Creates an unknown output. This is a low level API and should not be used in programs as this
+// UnsafeUnknownOutput Creates an unknown output. This is a low level API and should not be used in programs as this
 // will cause "pulumi up" to fail if called and used during a non-dryrun deployment.
 func UnsafeUnknownOutput(deps []Resource) Output {
 	output, _, _ := NewOutput()
@@ -1096,8 +1096,8 @@ func convert(v interface{}, to reflect.Type) interface{} {
 	return rv.Convert(to).Interface()
 }
 
-// TODO: ResourceOutput and the init() should probably be code generated.
 // ResourceOutput is an Output that returns Resource values.
+// TODO: ResourceOutput and the init() should probably be code generated.
 type ResourceOutput struct{ *OutputState }
 
 // ElementType returns the element type of this Output (Resource).
@@ -1113,7 +1113,7 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
-// An Input type carrying Resource values.
+// ResourceInput is an Input type carrying Resource values.
 //
 // Unfortunately `Resource` values do not implement `ResourceInput` in
 // the current version. Use `NewResourceInput` instead.

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -514,7 +514,7 @@ func TestUnsecret(t *testing.T) {
 			// validate the value
 			resultChan <- val
 		} else {
-			errChan <- fmt.Errorf("Invalid result: %v", val)
+			errChan <- fmt.Errorf("invalid result: %v", val)
 		}
 		return val, nil
 	})
@@ -554,7 +554,7 @@ func TestSecrets(t *testing.T) {
 			// validate the value
 			resultChan <- val
 		} else {
-			errChan <- fmt.Errorf("Invalid result: %v", val)
+			errChan <- fmt.Errorf("invalid result: %v", val)
 		}
 		return val, nil
 	})
@@ -600,7 +600,7 @@ func TestSecretApply(t *testing.T) {
 			// validate the value
 			resultChan <- val
 		} else {
-			errChan <- fmt.Errorf("Invalid result: %v", val)
+			errChan <- fmt.Errorf("invalid result: %v", val)
 		}
 		return val, nil
 	})

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -434,7 +434,7 @@ func getPluginVersion(info packageJSON) (string, error) {
 // nodejs, we have no problem calling this synchronously, and can block until we get the
 // response which we can then synchronously send to nodejs.
 
-// RPC endpoint for LanguageRuntimeServer::Run
+// Run is the RPC endpoint for LanguageRuntimeServer::Run
 func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
 	tracingSpan := opentracing.SpanFromContext(ctx)
 
@@ -789,18 +789,18 @@ type yarnLockTree struct {
 func parseYarnLockFile(path string) ([]*pulumirpc.DependencyInfo, error) {
 	ex, err := executable.FindExecutable("yarn")
 	if err != nil {
-		return nil, fmt.Errorf("Found %s but no yarn executable: %w", path, err)
+		return nil, fmt.Errorf("found %s but no yarn executable: %w", path, err)
 	}
 	cmdArgs := []string{"list", "--json"}
 	cmd := exec.Command(ex, cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to run \"%s %s\": %w", ex, strings.Join(cmdArgs, " "), err)
+		return nil, fmt.Errorf("failed to run \"%s %s\": %w", ex, strings.Join(cmdArgs, " "), err)
 	}
 
 	var lock yarnLock
 	if err = json.Unmarshal(out, &lock); err != nil {
-		return nil, fmt.Errorf("Failed to parse\"%s %s\": %w", ex, strings.Join(cmdArgs, " "), err)
+		return nil, fmt.Errorf("failed to parse\"%s %s\": %w", ex, strings.Join(cmdArgs, " "), err)
 	}
 	leafs := lock.Data.Trees
 
@@ -809,11 +809,11 @@ func parseYarnLockFile(path string) ([]*pulumirpc.DependencyInfo, error) {
 	// Has the form name@version
 	splitName := func(index int, nameVersion string) (string, string, error) {
 		if nameVersion == "" {
-			return "", "", fmt.Errorf("Expected \"name\" in dependency %d", index)
+			return "", "", fmt.Errorf("expected \"name\" in dependency %d", index)
 		}
 		split := strings.LastIndex(nameVersion, "@")
 		if split == -1 {
-			return "", "", fmt.Errorf("Failed to parse name and version from %s", nameVersion)
+			return "", "", fmt.Errorf("failed to parse name and version from %s", nameVersion)
 		}
 		return nameVersion[:split], nameVersion[split+1:], nil
 	}
@@ -849,17 +849,17 @@ type npmPackage struct {
 func parseNpmLockFile(path string) ([]*pulumirpc.DependencyInfo, error) {
 	ex, err := executable.FindExecutable("npm")
 	if err != nil {
-		return nil, fmt.Errorf("Found %s but not npm: %w", path, err)
+		return nil, fmt.Errorf("found %s but not npm: %w", path, err)
 	}
 	cmdArgs := []string{"ls", "--json", "--depth=0"}
 	cmd := exec.Command(ex, cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf(`Failed to run "%s %s": %w`, ex, strings.Join(cmdArgs, " "), err)
+		return nil, fmt.Errorf(`failed to run "%s %s": %w`, ex, strings.Join(cmdArgs, " "), err)
 	}
 	file := npmFile{}
 	if err = json.Unmarshal(out, &file); err != nil {
-		return nil, fmt.Errorf(`Failed to parse \"%s %s": %w`, ex, strings.Join(cmdArgs, " "), err)
+		return nil, fmt.Errorf(`failed to parse \"%s %s": %w`, ex, strings.Join(cmdArgs, " "), err)
 	}
 	result := make([]*pulumirpc.DependencyInfo, len(file.Dependencies))
 	var i int
@@ -880,7 +880,7 @@ func crossCheckPackageJSONFile(path string, file []byte,
 
 	var body packageJSON
 	if err := json.Unmarshal(file, &body); err != nil {
-		return nil, fmt.Errorf("Could not parse %s: %w", path, err)
+		return nil, fmt.Errorf("could not parse %s: %w", path, err)
 	}
 	dependencies := make(map[string]string)
 	for k, v := range body.Dependencies {
@@ -939,19 +939,19 @@ func (host *nodeLanguageHost) GetProgramDependencies(
 			return nil, err
 		}
 	} else if os.IsNotExist(err) {
-		return nil, fmt.Errorf("Could not find either %s or %s", yarnFile, npmFile)
+		return nil, fmt.Errorf("could not find either %s or %s", yarnFile, npmFile)
 	} else {
-		return nil, fmt.Errorf("Could not get node dependency data: %w", err)
+		return nil, fmt.Errorf("could not get node dependency data: %w", err)
 	}
 	if !req.TransitiveDependencies {
 		file, err := ioutil.ReadFile(packageFile)
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("Could not find %s. "+
+			return nil, fmt.Errorf("could not find %s. "+
 				"Please include this in your report and run "+
 				`pulumi about --transitive" to get a list of used packages`,
 				packageFile)
 		} else if err != nil {
-			return nil, fmt.Errorf("Could not read %s: %w", packageFile, err)
+			return nil, fmt.Errorf("could not read %s: %w", packageFile, err)
 		}
 		result, err = crossCheckPackageJSONFile(packageFile, file, result)
 		if err != nil {

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -348,10 +348,10 @@ var packagesWithoutPlugins = map[string]struct{}{
 }
 
 type pythonPackage struct {
-	Name     string                   `json:"name"`
-	Version  string                   `json:"version"`
-	Location string                   `json:"location"`
-	plugin   *plugin.PulumiPluginJSON `json:"-"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Location string `json:"location"`
+	plugin   *plugin.PulumiPluginJSON
 }
 
 // Returns if pkg is a pulumi package.
@@ -513,7 +513,7 @@ func determinePluginDependency(
 // Reference on PEP440: https://www.python.org/dev/peps/pep-0440/
 func determinePluginVersion(packageVersion string) (string, error) {
 	if len(packageVersion) == 0 {
-		return "", fmt.Errorf("Cannot parse empty string")
+		return "", fmt.Errorf("cannot parse empty string")
 	}
 	// Verify ASCII
 	for i := 0; i < len(packageVersion); i++ {
@@ -536,7 +536,7 @@ func determinePluginVersion(packageVersion string) (string, error) {
 
 	// Explicitly err on epochs
 	if num, maybeEpoch := parseNumber(packageVersion); num != "" && strings.HasPrefix(maybeEpoch, "!") {
-		return "", fmt.Errorf("Epochs are not supported")
+		return "", fmt.Errorf("epochs are not supported")
 	}
 
 	segments := []string{}
@@ -644,7 +644,7 @@ func runPythonCommand(ctx context.Context, virtualenv, cwd string, arg ...string
 	return output, err
 }
 
-// RPC endpoint for LanguageRuntimeServer::Run
+// Run is RPC endpoint for LanguageRuntimeServer::Run
 func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
 	args := []string{host.exec}
 	args = append(args, host.constructArguments(req)...)
@@ -937,7 +937,7 @@ func (host *pythonLanguageHost) GetProgramDependencies(
 	var result []pipDependency
 	err = json.Unmarshal([]byte(out), &result)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse \"python %s\" result: %w", strings.Join(cmdArgs, " "), err)
+		return nil, fmt.Errorf("failed to parse \"python %s\" result: %w", strings.Join(cmdArgs, " "), err)
 	}
 
 	dependencies := make([]*pulumirpc.DependencyInfo, len(result))

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -48,7 +48,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 		},
 		{
 			input: "",
-			err:   fmt.Errorf("Cannot parse empty string"),
+			err:   fmt.Errorf("cannot parse empty string"),
 		},
 		{
 			input:    "4.3.2.1",
@@ -96,7 +96,7 @@ func TestDeterminePluginVersion(t *testing.T) {
 		},
 		{
 			input: "10!3.2.1",
-			err:   fmt.Errorf("Epochs are not supported"),
+			err:   fmt.Errorf("epochs are not supported"),
 		},
 		{
 			input:    "3.2.post1.dev0",

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -33,7 +33,7 @@ const (
 	pythonShimCmdFormat = "pulumi-%s-shim.cmd"
 )
 
-// Find the correct path and command for Python. If the `PULUMI_PYTHON_CMD`
+// CommandPath finds the correct path and command for Python. If the `PULUMI_PYTHON_CMD`
 // variable is set it will be looked for on `PATH`, otherwise, `python3` and
 // `python` will be looked for.
 func CommandPath() (string /*pythonPath*/, string /*pythonCmd*/, error) {


### PR DESCRIPTION
This is a rebase and squash of #10984 with an additional commit added to satisfy `make lint` and revert a few changes to methods to use value receivers, where the original PR altered marshaling/unmarshaling behavior.