### PR TITLE
Redirect 'log' output to 'logging'

### DIFF
--- a/changelog/pending/20221012--cli-display--fix-gocloud-stderr.yaml
+++ b/changelog/pending/20221012--cli-display--fix-gocloud-stderr.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix gocloud unconditonally writing to stderr.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This is all very sad and makes me miss [ILogger](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger) from the dotnet world 😞 

Fixes https://github.com/pulumi/pulumi/issues/10996

Ignore the fact that this blob doesn't work, but note how it doesn't print "azureblob" at the start anymore.
```
fraser@IBASA-PC:~/projects/example$ ~/.pulumi/bin/pulumi login azblob://badblob?storage_account=fraser
2022/10/12 18:06:42 azureblob: constructed service URL: https://fraser.blob.core.windows.net
2022/10/12 18:06:42 azureblob.URLOpener: using NewDefaultAzureCredential
error: problem logging in: unable to check if bucket azblob://badblob?storage_account=fraser is accessible: blob (code=Unknown): GET https://fraser.blob.core.windows.net/badblob
--------------------------------------------------------------------------------
RESPONSE 401: 401 Server failed to authenticate the request. Please refer to the information in the www-authenticate header.
ERROR CODE: InvalidAuthenticationInfo
--------------------------------------------------------------------------------
﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidAuthenticationInfo</Code><Message>Server failed to authenticate the request. Please refer to the information in the www-authenticate header.
RequestId:62cfd3fb-401e-0037-4f5d-de9c60000000
Time:2022-10-12T17:06:47.6896488Z</Message><AuthenticationErrorDetail>Issuer validation failed. Issuer did not match.</AuthenticationErrorDetail></Error>
--------------------------------------------------------------------------------

fraser@IBASA-PC:~/projects/example$ /home/fraser/go/bin/pulumi login azblob://badblob?storage_account=fraser
error: problem logging in: unable to check if bucket azblob://badblob?storage_account=fraser is accessible: blob (code=Unknown): GET https://fraser.blob.core.windows.net/badblob
--------------------------------------------------------------------------------
RESPONSE 401: 401 Server failed to authenticate the request. Please refer to the information in the www-authenticate header.
ERROR CODE: InvalidAuthenticationInfo
--------------------------------------------------------------------------------
﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidAuthenticationInfo</Code><Message>Server failed to authenticate the request. Please refer to the information in the www-authenticate header.
RequestId:109305ab-b01e-006d-605d-de9ae1000000
Time:2022-10-12T17:06:59.0114531Z</Message><AuthenticationErrorDetail>Issuer validation failed. Issuer did not match.</AuthenticationErrorDetail></Error>
--------------------------------------------------------------------------------
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
