### PR TITLE
Fix update plans with dependent replacements

### DIFF
--- a/changelog/pending/20221013--engine--update-plan-dbr.yaml
+++ b/changelog/pending/20221013--engine--update-plan-dbr.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix a bug in update plans handling resources being replaced due to other resources being deleted before replacement.

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -151,6 +151,10 @@ func (m *resourcePlans) set(urn resource.URN, plan *ResourcePlan) {
 	m.m.Lock()
 	defer m.m.Unlock()
 
+	if _, ok := m.plans.ResourcePlans[urn]; ok {
+		panic(fmt.Sprintf("tried to set resource plan for %s but it's already been set", urn))
+	}
+
 	m.plans.ResourcePlans[urn] = plan
 }
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -253,16 +253,21 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, res
 
 	// Check each proposed step against the relevant resource plan, if any
 	for _, s := range steps {
+		logging.V(5).Infof("Checking step %s for %s", s.Op(), s.URN())
+
 		if sg.deployment.plan != nil {
 			if resourcePlan, ok := sg.deployment.plan.ResourcePlans[s.URN()]; ok {
 				if len(resourcePlan.Ops) == 0 {
 					return nil, result.Errorf("%v is not allowed by the plan: no more steps were expected for this resource", s.Op())
 				}
 				constraint := resourcePlan.Ops[0]
+				// We remove the Op from the list before doing the constraint check.
+				// This is because we look at Ops at the end to see if any expected operations didn't attempt to happen.
+				// This op has been attempted, it just might fail its constraint.
+				resourcePlan.Ops = resourcePlan.Ops[1:]
 				if !ConstrainedTo(s.Op(), constraint) {
 					return nil, result.Errorf("%v is not allowed by the plan: this resource is constrained to %v", s.Op(), constraint)
 				}
-				resourcePlan.Ops = resourcePlan.Ops[1:]
 			} else {
 				if !ConstrainedTo(s.Op(), OpSame) {
 					return nil, result.Errorf("%v is not allowed by the plan: no steps were expected for this resource", s.Op())
@@ -601,11 +606,22 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 		}
 		inputDiff := oldInputs.Diff(inputs)
 
-		// Generate the output goal plan
-		newResourcePlan := &ResourcePlan{
-			Seed: randomSeed,
-			Goal: NewGoalPlan(inputDiff, goal)}
-		sg.deployment.newPlans.set(urn, newResourcePlan)
+		// Generate the output goal plan, if we're recreating this it should already exist
+		if recreating {
+			plan, ok := sg.deployment.newPlans.get(urn)
+			if !ok {
+				return nil, result.FromError(fmt.Errorf("no plan for resource %v", urn))
+			}
+			// The plan will have had it's Ops already partially filled in for the delete operation, but we
+			// now have the information needed to fill in Seed and Goal.
+			plan.Seed = randomSeed
+			plan.Goal = NewGoalPlan(inputDiff, goal)
+		} else {
+			newResourcePlan := &ResourcePlan{
+				Seed: randomSeed,
+				Goal: NewGoalPlan(inputDiff, goal)}
+			sg.deployment.newPlans.set(urn, newResourcePlan)
+		}
 	}
 
 	// If there is a plan for this resource, validate that the program goal conforms to the plan.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We weren't correctly handling the case where a resource was marked for deletion due to one of it's dependencies being deleted. We would add an entry to it's "Ops" list, but then overwrite that "Ops" list when we came to generate the recreation step.

Fixes https://github.com/pulumi/pulumi/issues/10924

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
