### PR TITLE
Improve error message for invalid enum values on `pulumi convert`

### DIFF
--- a/changelog/pending/20221201--programgen--improve-error-message-for-invalid-enum-values-on-pulumi-convert.yaml
+++ b/changelog/pending/20221201--programgen--improve-error-message-for-invalid-enum-values-on-pulumi-convert.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen
+  description: Improve error message for invalid enum values on `pulumi convert`.

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -335,9 +335,12 @@ func (g *generator) genIntrensic(w io.Writer, from model.Expression, to model.Ty
 		if isOutput {
 			g.Fgenf(w, "%.v.Apply(%s)", from, convertFn)
 		} else {
-			pcl.GenEnum(to, from, g.genSafeEnum(w, to), func(from model.Expression) {
+			diag := pcl.GenEnum(to, from, g.genSafeEnum(w, to), func(from model.Expression) {
 				g.Fgenf(w, "%s(%v)", convertFn, from)
 			})
+			if diag != nil {
+				g.diagnostics = append(g.diagnostics, diag)
+			}
 		}
 	default:
 		g.Fgenf(w, "%.v", from) // <- probably wrong w.r.t. precedence

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -205,9 +205,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 					from, enumTag, underlyingType)
 				return
 			}
-			pcl.GenEnum(to, from, g.genSafeEnum(w, to), func(from model.Expression) {
+			diag := pcl.GenEnum(to, from, g.genSafeEnum(w, to), func(from model.Expression) {
 				g.Fgenf(w, "%s(%v)", enumTag, from)
 			})
+			if diag != nil {
+				g.diagnostics = append(g.diagnostics, diag)
+			}
 			return
 		}
 		switch arg := from.(type) {

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -336,13 +336,16 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				if isOutput {
 					g.Fgenf(w, "%.v.apply((x) => %s[x])", from, enum)
 				} else {
-					pcl.GenEnum(to, from, func(member *schema.Enum) {
+					diag := pcl.GenEnum(to, from, func(member *schema.Enum) {
 						memberTag, err := enumMemberName(tokenToName(to.Token), member)
 						contract.AssertNoErrorf(err, "Failed to get member name on enum '%s'", enum)
 						g.Fgenf(w, "%s.%s", enum, memberTag)
 					}, func(from model.Expression) {
 						g.Fgenf(w, "%s[%.v]", enum, from)
 					})
+					if diag != nil {
+						g.diagnostics = append(g.diagnostics, diag)
+					}
 				}
 			} else {
 				g.Fgenf(w, "%v", from)

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -4,9 +4,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
 )
 
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")
@@ -18,4 +21,35 @@ func BenchmarkLoadPackage(b *testing.B) {
 		_, err := NewPackageCache().loadPackageSchema(loader, "aws", "")
 		contract.AssertNoError(err)
 	}
+}
+
+func TestGenEnum(t *testing.T) {
+	t.Parallel()
+	enum := &model.EnumType{
+		Elements: []cty.Value{
+			cty.StringVal("foo"),
+			cty.StringVal("bar"),
+		},
+		Type:  model.StringType,
+		Token: "my:enum",
+		Annotations: []interface{}{
+			enumSchemaType{
+				Type: &schema.EnumType{Elements: []*schema.Enum{{Value: "foo"}, {Value: "bar"}}},
+			},
+		},
+	}
+	safeEnumFunc := func(member *schema.Enum) {}
+	unsafeEnumFunc := func(from model.Expression) {}
+
+	d := GenEnum(enum, &model.LiteralValueExpression{
+		Value: cty.StringVal("foo"),
+	}, safeEnumFunc, unsafeEnumFunc)
+	assert.Nil(t, d)
+
+	d = GenEnum(enum, &model.LiteralValueExpression{
+		Value: cty.StringVal("Bar"),
+	}, safeEnumFunc, unsafeEnumFunc)
+	assert.Equal(t, d.Summary, `"Bar" is not a valid value of the enum "my:enum"`)
+	assert.Equal(t, d.Detail, `Valid members are "foo", "bar"`)
+
 }

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -247,7 +247,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			if isOutput {
 				g.Fgenf(w, "%.v.apply(lambda x: %s.%s(x))", from, pkg, enumName)
 			} else {
-				pcl.GenEnum(to, from, func(member *schema.Enum) {
+				diag := pcl.GenEnum(to, from, func(member *schema.Enum) {
 					tag := member.Name
 					if tag == "" {
 						tag = fmt.Sprintf("%v", member.Value)
@@ -258,6 +258,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				}, func(from model.Expression) {
 					g.Fgenf(w, "%s.%s(%.v)", pkg, enumName, from)
 				})
+				if diag != nil {
+					g.diagnostics = append(g.diagnostics, diag)
+				}
 			}
 		default:
 			switch arg := from.(type) {


### PR DESCRIPTION
Fixes #10814 

Currently if an invalid enum value is provided, `(nil, true)` is returned [here](https://github.com/pulumi/pulumi/blob/master/pkg/codegen/pcl/binder_schema.go#L498). On `pulumi convert`, we still try to translate the PCL to the resulting language [here](https://github.com/pulumi/pulumi/blob/master/pkg/codegen/pcl/binder_schema.go#L569), causing an unhelpful error message `(PANIC=Format method: runtime error: invalid memory address or nil pointer dereference)` to be injected into the invalid program text (example in #10814).

This change improves it a bit so that the valid enum values are provided in the error message, i.e. `(PANIC=Format method: fatal: A failure has occurred: Invalid enum provided: valid values are [Block Append])`