### PR TITLE
allow package.json to be located in a parent directory of the pulumi …

### DIFF
--- a/changelog/pending/20221017--sdk-nodejs--fix-esm-support-fixes-10459.yaml
+++ b/changelog/pending/20221017--sdk-nodejs--fix-esm-support-fixes-10459.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: "Fixes lookup of closest package.json for ESM support - fixes #10459"

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -43,13 +43,29 @@ function reportModuleLoadFailure(program: string, error: Error): never {
     return process.exit(mod.nodeJSProcessExitedAfterLoggingUserActionableMessage);
 }
 
-function projectRootFromProgramPath(program: string): string {
-    const stat = fs.lstatSync(program);
+function pulumiProjectRootFromProgramPath(programPath: string): string {
+    const stat = fs.lstatSync(programPath);
     if (stat.isDirectory()) {
-        return program;
+        return programPath;
     } else {
-        return path.dirname(program);
+        return path.dirname(programPath);
     }
+}
+
+async function npmPackageRootFromProgramPath(programPath: string): Promise<string> {
+    // using dynamic import() syntax to import ESM module (pkg-dir) since we are in a CJS module.
+    const { packageDirectory: getPackageDirectory } = await import("pkg-dir");
+
+    const programDirectory = path.dirname(programPath);
+
+    const packageDirectory = await getPackageDirectory({
+        cwd: programDirectory,
+    });
+    if (packageDirectory === undefined) {
+        log.warn("Could not find a package.json file for the program. Using the pulumi program directory as the project root.");
+        return programDirectory;
+    }
+    return packageDirectory;
 }
 
 function packageObjectFromProjectRoot(projectRoot: string): Record<string, any> {
@@ -122,7 +138,7 @@ function throwOrPrintModuleLoadError(program: string, error: Error): void {
     //
     // The first step of this is trying to slurp up a package.json for this program, if
     // one exists.
-    const projectRoot = projectRootFromProgramPath(program);
+    const projectRoot = pulumiProjectRootFromProgramPath(program);
     const packageObject = packageObjectFromProjectRoot(projectRoot);
 
     console.error("Here's what we think went wrong:");
@@ -336,8 +352,8 @@ ${defaultMessage}`);
         const runProgramSpan = tracing.newSpan("language-runtime.runProgram");
 
         try {
-            const projectRoot = projectRootFromProgramPath(program);
-            const packageObject = packageObjectFromProjectRoot(projectRoot);
+            const npmPackageRoot = await npmPackageRootFromProgramPath(program);
+            const packageObject = packageObjectFromProjectRoot(npmPackageRoot);
 
             let programExport: any;
 
@@ -376,7 +392,7 @@ ${defaultMessage}`);
             };
 
             // Check compatible engines before running the program:
-            const npmRc = npmRcFromProjectRoot(projectRoot);
+            const npmRc = npmRcFromProjectRoot(npmPackageRoot);
             if (npmRc["engine-strict"] && packageObject.engines && packageObject.engines.node) {
                 // found:
                 //   - { engines: { node: "<version>" } } in package.json
@@ -387,7 +403,7 @@ ${defaultMessage}`);
                 const currentNodeVersion = process.versions.node;
                 if (!semver.satisfies(currentNodeVersion, requiredNodeVersion)) {
                     const errorMessage = [
-                        `Your current Node version is incompatible to run ${projectRoot}`,
+                        `Your current Node version is incompatible to run ${npmPackageRoot}`,
                         `Expected version: ${requiredNodeVersion} as found in package.json > engines > node`,
                         `Actual Node version: ${currentNodeVersion}`,
                         `To fix issue, install a Node version that is compatible with ${requiredNodeVersion}`,

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -25,6 +25,7 @@
         "js-yaml": "^3.14.0",
         "minimist": "^1.2.6",
         "normalize-package-data": "^2.4.0",
+        "pkg-dir": "^7.0.0",
         "read-package-tree": "^5.3.1",
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -1382,6 +1382,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-6.3.0.tgz#2abab3d3280b2dc7ac10199ef324c4e002c8c790"
+  integrity sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==
+  dependencies:
+    locate-path "^7.1.0"
+    path-exists "^5.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -1969,6 +1977,13 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+locate-path@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.1.1.tgz#8e1e5a75c7343770cef02ff93c4bf1f0aa666374"
+  integrity sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==
+  dependencies:
+    p-locate "^6.0.0"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -2290,6 +2305,13 @@ p-limit@^3.0.2:
   dependencies:
     yocto-queue "^0.1.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
@@ -2303,6 +2325,13 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
+  dependencies:
+    p-limit "^4.0.0"
 
 p-map@^3.0.0:
   version "3.0.0"
@@ -2337,6 +2366,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -2381,6 +2415,13 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-7.0.0.tgz#8f0c08d6df4476756c5ff29b3282d0bab7517d11"
+  integrity sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==
+  dependencies:
+    find-up "^6.3.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -3077,3 +3118,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1119,6 +1119,14 @@ func TestESMJS(t *testing.T) {
 	})
 }
 
+func TestESMJSWithPackageJsonInParentDir(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("nodejs", "myprogram", "esm-js-with-package-json-in-parent-dir"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+	})
+}
+
 func TestESMJSMain(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          filepath.Join("nodejs", "esm-js-main"),

--- a/tests/integration/nodejs/esm-js-with-package-json-in-parent-dir/myprogram/Pulumi.yaml
+++ b/tests/integration/nodejs/esm-js-with-package-json-in-parent-dir/myprogram/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: esm-js-with-package-json-in-parent-dir
+runtime: nodejs
+description: Use ECMAScript modules for a plain JS program.

--- a/tests/integration/nodejs/esm-js-with-package-json-in-parent-dir/myprogram/index.js
+++ b/tests/integration/nodejs/esm-js-with-package-json-in-parent-dir/myprogram/index.js
@@ -1,0 +1,10 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as fs from "fs";
+import assert from "node:assert";
+
+// ensure that import.meta.url exists which is only available in ESM modules.
+// This just serves as a verification that this module is actually treated as an ESM module.
+assert(import.meta.url !== undefined);
+
+export const res = fs.readFileSync("Pulumi.yaml").toString();

--- a/tests/integration/nodejs/esm-js-with-package-json-in-parent-dir/package.json
+++ b/tests/integration/nodejs/esm-js-with-package-json-in-parent-dir/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "esm-js-with-package-json-in-parent-dir",
+    "license": "Apache-2.0",
+    "type": "module",
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}


### PR DESCRIPTION
…program

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This uses [`pkg-dir`](https://github.com/sindresorhus/pkg-dir) to determine the package root in which the pulumi program is defined. This removes the assumption that the package.json must be in the same directory as the pulumi program root and instead allows the package.json to be present in any ancestor directory and still getting picked up.

Fixes #10459

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
