### PR TITLE
Allow decoding *asset and *archive values

### DIFF
--- a/changelog/pending/20221017--sdk-go--decode-ptr-asset-and-ptr-archive-values.yaml
+++ b/changelog/pending/20221017--sdk-go--decode-ptr-asset-and-ptr-archive-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Allow decoding *asset and *archive values

--- a/sdk/go/common/resource/mapper_test.go
+++ b/sdk/go/common/resource/mapper_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"
+)
+
+type complexBag struct {
+	asset   resource.Asset
+	archive resource.Archive
+
+	optionalAsset   *resource.Asset
+	optionalArchive *resource.Archive
+}
+
+func TestAssetsAndArchives(t *testing.T) {
+	t.Parallel()
+
+	newAsset := func(s string) *resource.Asset {
+		a, err := resource.NewTextAsset(s)
+		require.NoError(t, err, "creating asset %s", s)
+		return a
+	}
+	newArchive := func(m map[string]interface{}) *resource.Archive {
+		a, err := resource.NewAssetArchive(m)
+		require.NoError(t, err, "creating asset %#v", m)
+		return a
+	}
+
+	bigArchive := func() *resource.Archive {
+		return newArchive(map[string]interface{}{
+			"asset1": newAsset("asset1"),
+			"archive1": newArchive(map[string]interface{}{
+				"asset2": newAsset("asset2"),
+				"asset3": newAsset("asset3"),
+			}),
+		})
+	}
+	tree := map[string]interface{}{
+		"asset":           newAsset("simple asset"),
+		"optionalAsset":   newAsset("simple optional asset"),
+		"archive":         bigArchive(),
+		"optionalArchive": bigArchive(),
+	}
+
+	bag := complexBag{}
+	md := mapper.New(nil)
+
+	t.Run("asset", func(t *testing.T) { //nolint:parallelTest
+		err := md.DecodeValue(tree, reflect.TypeOf(complexBag{}), "asset", &bag.asset, false)
+		assert.Nil(t, err)
+	})
+	t.Run("optionalAsset", func(t *testing.T) { //nolint:parallelTest
+		err := md.DecodeValue(tree, reflect.TypeOf(complexBag{}), "optionalAsset", &bag.optionalAsset, false)
+		assert.Nil(t, err)
+	})
+	t.Run("archive", func(t *testing.T) { //nolint:parallelTest
+		err := md.DecodeValue(tree, reflect.TypeOf(complexBag{}), "archive", &bag.archive, false)
+		assert.Nil(t, err)
+	})
+	t.Run("optionalArchive", func(t *testing.T) { //nolint:parallelTest
+		err := md.DecodeValue(tree, reflect.TypeOf(complexBag{}), "optionalArchive", &bag.optionalArchive, false)
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We handle ptr sources in deserialization. This is necessary since `pulumi.New*Asset` and `pulumi.New*Archive` return `*resource.Asset` and `*resource.Archive` respectively.

This will fix https://github.com/pulumi/pulumi-command/issues/143 when it is picked up.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
