### PR TITLE
feat(programtest): Enable ProgramTest for Azure-Native split modules

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2167,10 +2167,14 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 
 	// link local dependencies
 	for _, pkg := range pt.opts.Dependencies {
-
-		dep := getRewritePath(pkg, gopath, depRoot)
-
-		editStr := fmt.Sprintf("%s=%s", pkg, dep)
+		var editStr string
+		if strings.ContainsRune(pkg, '=') {
+			// Use a literal replacement path.
+			editStr = pkg
+		} else {
+			dep := getRewritePath(pkg, gopath, depRoot)
+			editStr = fmt.Sprintf("%s=%s", pkg, dep)
+		}
 		err = pt.runCommand("go-mod-edit", []string{goBin, "mod", "edit", "-replace", editStr}, cwd)
 		if err != nil {
 			return err


### PR DESCRIPTION
Unblocks Azure Native usage of ProgramTests in Go, resolves #11050's example by permitting usage such as:

```go
func genReplace(t *testing.T, subPkg string) string {
	moduleDir, err := filepath.Abs(fmt.Sprintf("../pulumi-azure-native-sdk/%s", subPkg))
	require.NoError(t, err)
	return fmt.Sprintf("github.com/pulumi/pulumi-azure-native-sdk/%s=%s", subPkg, moduleDir)
}


func getGoBaseOptions(t *testing.T) integration.ProgramTestOptions {
	base := getBaseOptions(t)
	baseGo := base.With(integration.ProgramTestOptions{
		Dependencies: map[string]string{
			genReplace("aad"),
		},
	})

	return baseGo
}
```

Resolves #11050

