### PR TITLE
ci: Implement smoke tests for pkg/cmd, fix examples smoke tests

### DIFF
--- a/pkg/cmd/pulumi/new_smoke_test.go
+++ b/pkg/cmd/pulumi/new_smoke_test.go
@@ -1,0 +1,222 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func chdir(t *testing.T, dir string) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(dir)) // Set directory
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(cwd)) // Restore directory
+		restoredDir, err := os.Getwd()
+		assert.NoError(t, err)
+		assert.Equal(t, cwd, restoredDir)
+	})
+}
+
+//nolint:paralleltest // changes directory for process
+func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
+	skipIfShortOrNoPulumiAccessToken(t)
+
+	tempdir, _ := ioutil.TempDir("", "test-env")
+	defer os.RemoveAll(tempdir)
+	chdir(t, tempdir)
+
+	var args = newArgs{
+		interactive:       false,
+		yes:               true,
+		prompt:            promptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		templateNameOrURL: "typescript",
+	}
+
+	err := runNew(context.Background(), args)
+	assert.NoError(t, err)
+
+	assert.Equal(t, stackName, loadStackName(t))
+	removeStack(t, stackName)
+}
+
+//nolint:paralleltest // changes directory for process
+func TestCreatingStackWithPromptedName(t *testing.T) {
+	skipIfShortOrNoPulumiAccessToken(t)
+
+	tempdir, _ := ioutil.TempDir("", "test-env")
+	defer os.RemoveAll(tempdir)
+	chdir(t, tempdir)
+	uniqueProjectName := filepath.Base(tempdir)
+
+	var args = newArgs{
+		interactive:       true,
+		prompt:            promptMock(uniqueProjectName, stackName),
+		secretsProvider:   "default",
+		templateNameOrURL: "typescript",
+	}
+
+	err := runNew(context.Background(), args)
+	assert.NoError(t, err)
+
+	assert.Equal(t, stackName, loadStackName(t))
+	removeStack(t, stackName)
+}
+
+//nolint:paralleltest // changes directory for process
+func TestCreatingProjectWithDefaultName(t *testing.T) {
+	skipIfShortOrNoPulumiAccessToken(t)
+
+	tempdir, _ := ioutil.TempDir("", "test-env")
+	defer os.RemoveAll(tempdir)
+	chdir(t, tempdir)
+	defaultProjectName := filepath.Base(tempdir)
+
+	var args = newArgs{
+		interactive:       true,
+		prompt:            promptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		templateNameOrURL: "typescript",
+		yes:               true,
+	}
+
+	err := runNew(context.Background(), args)
+	assert.NoError(t, err)
+
+	removeStack(t, stackName)
+
+	proj := loadProject(t, tempdir)
+	assert.Equal(t, defaultProjectName, proj.Name.String())
+}
+
+//nolint:paralleltest // mutates environment variables
+func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
+	skipIfShortOrNoPulumiAccessToken(t)
+	ctx := context.Background()
+
+	b, err := currentBackend(ctx, display.Options{})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
+
+	fileStateDir, _ := ioutil.TempDir("", "local-state-dir")
+	defer os.RemoveAll(fileStateDir)
+
+	// Now override to local filesystem backend
+	backendURL := "file://" + filepath.ToSlash(fileStateDir)
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "how now brown cow")
+	t.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
+
+	backendInstance = nil
+	tempdir, _ := ioutil.TempDir("", "test-env-local")
+	defer os.RemoveAll(tempdir)
+	chdir(t, tempdir)
+	defaultProjectName := filepath.Base(tempdir)
+
+	var args = newArgs{
+		interactive:       true,
+		prompt:            promptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		templateNameOrURL: "typescript",
+		yes:               true,
+	}
+
+	assert.NoError(t, runNew(context.Background(), args))
+	proj := loadProject(t, tempdir)
+	assert.Equal(t, defaultProjectName, proj.Name.String())
+	// Expect the stack directory to have a checkpoint file for the stack.
+	_, err = os.Stat(filepath.Join(fileStateDir, workspace.BookkeepingDir, workspace.StackDir, stackName+".json"))
+	assert.NoError(t, err)
+
+	b, err = currentBackend(ctx, display.Options{})
+	require.NoError(t, err)
+	assert.Equal(t, backendURL, b.URL())
+}
+
+const projectName = "test_project"
+const stackName = "test_stack"
+
+func promptMock(name string, stackName string) promptForValueFunc {
+	return func(yes bool, valueType string, defaultValue string, secret bool,
+		isValidFn func(value string) error, opts display.Options) (string, error) {
+		if valueType == "project name" {
+			err := isValidFn(name)
+			return name, err
+		}
+		if valueType == "stack name" {
+			err := isValidFn(stackName)
+			return stackName, err
+		}
+		return defaultValue, nil
+	}
+}
+
+func loadProject(t *testing.T, dir string) *workspace.Project {
+	path, err := workspace.DetectProjectPathFrom(dir)
+	assert.NoError(t, err)
+	proj, err := workspace.LoadProject(path)
+	assert.NoError(t, err)
+	return proj
+}
+
+func currentUser(t *testing.T) string {
+	ctx := context.Background()
+	b, err := currentBackend(ctx, display.Options{})
+	assert.NoError(t, err)
+	currentUser, _, err := b.CurrentUser()
+	assert.NoError(t, err)
+	return currentUser
+}
+
+func loadStackName(t *testing.T) string {
+	w, err := workspace.New()
+	assert.NoError(t, err)
+	return w.Settings().Stack
+}
+
+func removeStack(t *testing.T, name string) {
+	ctx := context.Background()
+	b, err := currentBackend(ctx, display.Options{})
+	assert.NoError(t, err)
+	ref, err := b.ParseStackReference(name)
+	assert.NoError(t, err)
+	stack, err := b.GetStack(context.Background(), ref)
+	assert.NoError(t, err)
+	_, err = b.RemoveStack(context.Background(), stack, false)
+	assert.NoError(t, err)
+}
+
+func skipIfShortOrNoPulumiAccessToken(t *testing.T) {
+	_, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN")
+	if !ok {
+		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
+	}
+	if testing.Short() {
+		t.Skip("Skipped in short test run")
+	}
+}

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (
@@ -19,53 +20,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 )
-
-func chdir(t *testing.T, dir string) {
-	cwd, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chdir(dir)) // Set directory
-	t.Cleanup(func() {
-		assert.NoError(t, os.Chdir(cwd)) // Restore directory
-		restoredDir, err := os.Getwd()
-		assert.NoError(t, err)
-		assert.Equal(t, cwd, restoredDir)
-	})
-}
-
-//nolint:paralleltest // changes directory for process
-func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
-	skipIfShortOrNoPulumiAccessToken(t)
-
-	tempdir, _ := ioutil.TempDir("", "test-env")
-	defer os.RemoveAll(tempdir)
-	chdir(t, tempdir)
-
-	var args = newArgs{
-		interactive:       false,
-		yes:               true,
-		prompt:            promptForValue,
-		secretsProvider:   "default",
-		stack:             stackName,
-		templateNameOrURL: "typescript",
-	}
-
-	err := runNew(context.Background(), args)
-	assert.NoError(t, err)
-
-	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, stackName)
-}
 
 //nolint:paralleltest // changes directory for process
 func TestFailInInteractiveWithoutYes(t *testing.T) {
@@ -86,29 +46,6 @@ func TestFailInInteractiveWithoutYes(t *testing.T) {
 
 	err := runNew(context.Background(), args)
 	assert.Error(t, err)
-}
-
-//nolint:paralleltest // changes directory for process
-func TestCreatingStackWithPromptedName(t *testing.T) {
-	skipIfShortOrNoPulumiAccessToken(t)
-
-	tempdir, _ := ioutil.TempDir("", "test-env")
-	defer os.RemoveAll(tempdir)
-	chdir(t, tempdir)
-	uniqueProjectName := filepath.Base(tempdir)
-
-	var args = newArgs{
-		interactive:       true,
-		prompt:            promptMock(uniqueProjectName, stackName),
-		secretsProvider:   "default",
-		templateNameOrURL: "typescript",
-	}
-
-	err := runNew(context.Background(), args)
-	assert.NoError(t, err)
-
-	assert.Equal(t, stackName, loadStackName(t))
-	removeStack(t, stackName)
 }
 
 //nolint:paralleltest // changes directory for process
@@ -188,77 +125,6 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 
 	assert.Equal(t, stackName, loadStackName(t))
 	removeStack(t, stackName)
-}
-
-//nolint:paralleltest // changes directory for process
-func TestCreatingProjectWithDefaultName(t *testing.T) {
-	skipIfShortOrNoPulumiAccessToken(t)
-
-	tempdir, _ := ioutil.TempDir("", "test-env")
-	defer os.RemoveAll(tempdir)
-	chdir(t, tempdir)
-	defaultProjectName := filepath.Base(tempdir)
-
-	var args = newArgs{
-		interactive:       true,
-		prompt:            promptForValue,
-		secretsProvider:   "default",
-		stack:             stackName,
-		templateNameOrURL: "typescript",
-		yes:               true,
-	}
-
-	err := runNew(context.Background(), args)
-	assert.NoError(t, err)
-
-	removeStack(t, stackName)
-
-	proj := loadProject(t, tempdir)
-	assert.Equal(t, defaultProjectName, proj.Name.String())
-}
-
-//nolint:paralleltest // mutates environment variables
-func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
-	skipIfShortOrNoPulumiAccessToken(t)
-	ctx := context.Background()
-
-	b, err := currentBackend(ctx, display.Options{})
-	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
-
-	fileStateDir, _ := ioutil.TempDir("", "local-state-dir")
-	defer os.RemoveAll(fileStateDir)
-
-	// Now override to local filesystem backend
-	backendURL := "file://" + filepath.ToSlash(fileStateDir)
-	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "how now brown cow")
-	t.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
-
-	backendInstance = nil
-	tempdir, _ := ioutil.TempDir("", "test-env-local")
-	defer os.RemoveAll(tempdir)
-	chdir(t, tempdir)
-	defaultProjectName := filepath.Base(tempdir)
-
-	var args = newArgs{
-		interactive:       true,
-		prompt:            promptForValue,
-		secretsProvider:   "default",
-		stack:             stackName,
-		templateNameOrURL: "typescript",
-		yes:               true,
-	}
-
-	assert.NoError(t, runNew(context.Background(), args))
-	proj := loadProject(t, tempdir)
-	assert.Equal(t, defaultProjectName, proj.Name.String())
-	// Expect the stack directory to have a checkpoint file for the stack.
-	_, err = os.Stat(filepath.Join(fileStateDir, workspace.BookkeepingDir, workspace.StackDir, stackName+".json"))
-	assert.NoError(t, err)
-
-	b, err = currentBackend(ctx, display.Options{})
-	require.NoError(t, err)
-	assert.Equal(t, backendURL, b.URL())
 }
 
 //nolint:paralleltest // changes directory for process
@@ -843,68 +709,5 @@ func TestSetFail(t *testing.T) {
 			_, err := parseConfig(test.Array, true /*path*/)
 			assert.Error(t, err)
 		})
-	}
-}
-
-const projectName = "test_project"
-const stackName = "test_stack"
-
-func promptMock(name string, stackName string) promptForValueFunc {
-	return func(yes bool, valueType string, defaultValue string, secret bool,
-		isValidFn func(value string) error, opts display.Options) (string, error) {
-		if valueType == "project name" {
-			err := isValidFn(name)
-			return name, err
-		}
-		if valueType == "stack name" {
-			err := isValidFn(stackName)
-			return stackName, err
-		}
-		return defaultValue, nil
-	}
-}
-
-func loadProject(t *testing.T, dir string) *workspace.Project {
-	path, err := workspace.DetectProjectPathFrom(dir)
-	assert.NoError(t, err)
-	proj, err := workspace.LoadProject(path)
-	assert.NoError(t, err)
-	return proj
-}
-
-func currentUser(t *testing.T) string {
-	ctx := context.Background()
-	b, err := currentBackend(ctx, display.Options{})
-	assert.NoError(t, err)
-	currentUser, _, err := b.CurrentUser()
-	assert.NoError(t, err)
-	return currentUser
-}
-
-func loadStackName(t *testing.T) string {
-	w, err := workspace.New()
-	assert.NoError(t, err)
-	return w.Settings().Stack
-}
-
-func removeStack(t *testing.T, name string) {
-	ctx := context.Background()
-	b, err := currentBackend(ctx, display.Options{})
-	assert.NoError(t, err)
-	ref, err := b.ParseStackReference(name)
-	assert.NoError(t, err)
-	stack, err := b.GetStack(context.Background(), ref)
-	assert.NoError(t, err)
-	_, err = b.RemoveStack(context.Background(), stack, false)
-	assert.NoError(t, err)
-}
-
-func skipIfShortOrNoPulumiAccessToken(t *testing.T) {
-	_, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN")
-	if !ok {
-		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
-	}
-	if testing.Short() {
-		t.Skip("Skipped in short test run")
 	}
 }

--- a/pkg/cmd/pulumi/policy_new_smoke_test.go
+++ b/pkg/cmd/pulumi/policy_new_smoke_test.go
@@ -1,0 +1,55 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:paralleltest // changes directory for process
+func TestCreatingPolicyPackWithArgsSpecifiedName(t *testing.T) {
+	skipIfShortOrNoPulumiAccessToken(t)
+
+	tempdir, _ := ioutil.TempDir("", "test-env")
+	defer os.RemoveAll(tempdir)
+	chdir(t, tempdir)
+
+	var args = newPolicyArgs{
+		interactive:       false,
+		yes:               true,
+		templateNameOrURL: "aws-typescript",
+	}
+
+	err := runNewPolicyPack(context.TODO(), args)
+	assert.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(tempdir, "PulumiPolicy.yaml"))
+	assert.FileExists(t, filepath.Join(tempdir, "index.ts"))
+}
+
+func assertNotFoundError(t *testing.T, err error) {
+	msg := err.Error()
+	if strings.Contains(msg, "not found") || strings.Contains(msg, "no such file or directory") {
+		return
+	}
+	assert.Failf(t, "Error message does not contain \"not found\" or \"no such file or directory\": %s", msg)
+}

--- a/pkg/cmd/pulumi/policy_new_test.go
+++ b/pkg/cmd/pulumi/policy_new_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build !smoke
+
 package main
 
 import (
@@ -18,32 +21,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-//nolint:paralleltest // changes directory for process
-func TestCreatingPolicyPackWithArgsSpecifiedName(t *testing.T) {
-	skipIfShortOrNoPulumiAccessToken(t)
-
-	tempdir, _ := ioutil.TempDir("", "test-env")
-	defer os.RemoveAll(tempdir)
-	chdir(t, tempdir)
-
-	var args = newPolicyArgs{
-		interactive:       false,
-		yes:               true,
-		templateNameOrURL: "aws-typescript",
-	}
-
-	err := runNewPolicyPack(context.TODO(), args)
-	assert.NoError(t, err)
-
-	assert.FileExists(t, filepath.Join(tempdir, "PulumiPolicy.yaml"))
-	assert.FileExists(t, filepath.Join(tempdir, "index.ts"))
-}
 
 //nolint:paralleltest // changes directory for process
 func TestCreatingPolicyPackWithPromptedName(t *testing.T) {
@@ -105,12 +86,4 @@ func TestInvalidPolicyPackTemplateName(t *testing.T) {
 		assert.Error(t, err)
 		assertNotFoundError(t, err)
 	})
-}
-
-func assertNotFoundError(t *testing.T, err error) {
-	msg := err.Error()
-	if strings.Contains(msg, "not found") || strings.Contains(msg, "no such file or directory") {
-		return
-	}
-	assert.Failf(t, "Error message does not contain \"not found\" or \"no such file or directory\": %s", msg)
 }

--- a/tests/examples/examples_smoke_test.go
+++ b/tests/examples/examples_smoke_test.go
@@ -1,10 +1,24 @@
-// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
-//go:build !smoke
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package examples
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +62,37 @@ func TestAccDynamicProviderSimple_withLocalState(t *testing.T) {
 		})
 
 	integration.ProgramTest(t, &test)
+}
+
+//nolint:paralleltest // uses parallel programtest
+func TestAccFormattable_withLocalState(t *testing.T) {
+	var formattableStdout, formattableStderr bytes.Buffer
+	test := getBaseOptions().
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "formattable"),
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Note that we're abusing this hook to validate stdout. We don't actually care about the checkpoint.
+				stdout := formattableStdout.String()
+				assert.False(t, strings.Contains(stdout, "MISSING"))
+			},
+			Stdout:   &formattableStdout,
+			Stderr:   &formattableStderr,
+			CloudURL: integration.MakeTempBackend(t),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func getCwd(t *testing.T) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.FailNow()
+	}
+	return cwd
+}
+
+func getBaseOptions() integration.ProgramTestOptions {
+	return integration.ProgramTestOptions{
+		Dependencies: []string{"@pulumi/pulumi"},
+	}
 }

--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -1,10 +1,21 @@
-// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package examples
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -172,25 +183,6 @@ func TestAccFormattable(t *testing.T) {
 }
 
 //nolint:paralleltest // uses parallel programtest
-func TestAccFormattable_withLocalState(t *testing.T) {
-	var formattableStdout, formattableStderr bytes.Buffer
-	test := getBaseOptions().
-		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "formattable"),
-			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-				// Note that we're abusing this hook to validate stdout. We don't actually care about the checkpoint.
-				stdout := formattableStdout.String()
-				assert.False(t, strings.Contains(stdout, "MISSING"))
-			},
-			Stdout:   &formattableStdout,
-			Stderr:   &formattableStderr,
-			CloudURL: integration.MakeTempBackend(t),
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-//nolint:paralleltest // uses parallel programtest
 func TestAccSecrets(t *testing.T) {
 	test := getBaseOptions().
 		With(integration.ProgramTestOptions{
@@ -279,18 +271,4 @@ func TestAccSecrets(t *testing.T) {
 		})
 
 	integration.ProgramTest(t, &test)
-}
-
-func getCwd(t *testing.T) string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.FailNow()
-	}
-	return cwd
-}
-
-func getBaseOptions() integration.ProgramTestOptions {
-	return integration.ProgramTestOptions{
-		Dependencies: []string{"@pulumi/pulumi"},
-	}
 }


### PR DESCRIPTION
Mitigate test timeouts on Windows ([recent job that timed out](https://github.com/pulumi/pulumi/actions/runs/3276024063)) and long test delays due to non-parallelizable tests on macOS. For context: integration tests run on Linux and run all tests, the smoke tests are a subset of tests that run on macOS & Windows which set the build tag "smoke", causing some test files to be skipped. These tests tend to come in pairs of files, `_test.go` and `_smoke_test.go`.

This PR fixes the `examples_test.go` which had the build flags reversed, and moves one test which checks stdout behavior to the smoke tests.

This PR also adds smoke test files for `pkg/cmd` to move some tests onto the Linux runners only, which we run with greater parallelism. This removes some of the slower and non-parallelizable tests from the Windows runner, which was one of the slowest jobs:

```
TestCreatingPolicyPackWithPromptedName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	1m27.23s	pass
TestCreatingPolicyPackWithArgsSpecifiedName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	1m21.08s	pass
TestCreatingStackWithArgsSpecifiedName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	29.15s	pass
TestCreatingProjectWithPromptedName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	25.74s	pass
TestCreatingProjectWithArgsSpecifiedName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	25.4s	pass
TestCreatingStackWithArgsSpecifiedOrgName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	25.[33](https://github.com/pulumi/pulumi/actions/runs/3275822919/jobs/5391232488#step:39:34)s	pass
TestCreatingProjectWithPulumiBackendURL	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	25.33s	pass
TestCreatingStackWithArgsSpecifiedFullNameSucceeds	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	25.06s	pass
TestCreatingStackWithPromptedOrgName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	25.06s	pass
TestCreatingStackWithPromptedName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	24.88s	pass
TestCreatingProjectWithDefaultName	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi	24.76s	pass
```

