### PR TITLE
ci: Begin testing against node 19.x

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -105,7 +105,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "6.0.x",
     "go": "1.19.x",
-    "nodejs": "18.x",
+    "nodejs": "19.x",
     "python": "3.10.x",
 }
 


### PR DESCRIPTION
Node 19 is released: https://nodejs.org/en/blog/announcements/v19-release-announce/