### PR TITLE
Add debug GRPC interceptors that print conversations in JSON

### DIFF
--- a/changelog/pending/20221102--cli--pulumi-debug-grpc.yaml
+++ b/changelog/pending/20221102--cli--pulumi-debug-grpc.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: "Enables debug tracing of Pulumi gRPC internals: `PULUMI_DEBUG_GRPC=$PWD/grpc.json pulumi up`"

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,10 +32,7 @@ type clientLanguageRuntimeHost struct {
 
 func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host, error) {
 	// Dial the language runtime.
-	conn, err := grpc.Dial(address, grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()),
-		grpc.WithStreamInterceptor(rpcutil.OpenTracingStreamClientInterceptor()),
-		rpcutil.GrpcChannelOptions())
+	conn, err := grpc.Dial(address, langRuntimePluginDialOptions(ctx, address)...)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to language host: %w", err)
 	}
@@ -49,4 +46,25 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 
 func (host *clientLanguageRuntimeHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
 	return host.languageRuntime, nil
+}
+
+func langRuntimePluginDialOptions(ctx *plugin.Context, address string) []grpc.DialOption {
+	dialOpts := append(
+		rpcutil.OpenTracingInterceptorDialOptions(),
+		grpc.WithInsecure(),
+		rpcutil.GrpcChannelOptions(),
+	)
+
+	if ctx.DialOptions != nil {
+		metadata := map[string]interface{}{
+			"mode": "client",
+			"kind": "language",
+		}
+		if address != "" {
+			metadata["address"] = address
+		}
+		dialOpts = append(dialOpts, ctx.DialOptions(metadata)...)
+	}
+
+	return dialOpts
 }

--- a/pkg/util/rpcdebug/interceptors.go
+++ b/pkg/util/rpcdebug/interceptors.go
@@ -1,0 +1,382 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcdebug
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+
+	"google.golang.org/grpc"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/metadata"
+)
+
+type DebugInterceptor struct {
+	logFile string
+	mutex   *sync.Mutex
+}
+
+type DebugInterceptorOptions struct {
+	LogFile string
+	Mutex   *sync.Mutex
+}
+
+type LogOptions struct {
+	Metadata interface{}
+}
+
+// Each LogFile should have a unique instance of DebugInterceptor for proper locking.
+func NewDebugInterceptor(opts DebugInterceptorOptions) (*DebugInterceptor, error) {
+	if opts.LogFile == "" {
+		return nil, fmt.Errorf("logFile cannot be empty")
+	}
+	i := &DebugInterceptor{logFile: opts.LogFile}
+
+	if opts.Mutex != nil {
+		i.mutex = opts.Mutex
+	} else {
+		i.mutex = &sync.Mutex{}
+	}
+
+	return i, nil
+}
+
+func (i *DebugInterceptor) ServerOptions(opts LogOptions) []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(i.DebugServerInterceptor(opts)),
+		grpc.ChainStreamInterceptor(i.DebugStreamServerInterceptor(opts)),
+	}
+}
+
+func (i *DebugInterceptor) DialOptions(opts LogOptions) []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(i.DebugClientInterceptor(opts)),
+		grpc.WithChainStreamInterceptor(i.DebugStreamClientInterceptor(opts)),
+	}
+}
+
+// Logs all gRPC converations in JSON format.
+//
+// To enable, call InitDebugInterceptors first in your process main to
+// configure the location of the Go file.
+func (i *DebugInterceptor) DebugServerInterceptor(opts LogOptions) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{},
+		info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		log := debugInterceptorLogEntry{
+			Method:   info.FullMethod,
+			Metadata: opts.Metadata,
+		}
+		i.trackRequest(&log, req)
+		resp, err := handler(ctx, req)
+		i.trackResponse(&log, resp)
+		if e := i.record(log); e != nil {
+			return resp, e
+		}
+		return resp, err
+	}
+}
+
+// Like debugServerInterceptor but for streaming calls.
+func (i *DebugInterceptor) DebugStreamServerInterceptor(opts LogOptions) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ssWrapped := &debugServerStream{
+			interceptor:       i,
+			method:            info.FullMethod,
+			innerServerStream: ss,
+			metadata:          opts.Metadata,
+		}
+		err := handler(srv, ssWrapped)
+		return err
+	}
+}
+
+// Like debugServerInterceptor but for GRPC client connections.
+func (i *DebugInterceptor) DebugClientInterceptor(opts LogOptions) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{},
+		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, gopts ...grpc.CallOption) error {
+		// Ignoring weird entries with empty method and nil req and reply.
+		if method == "" {
+			return invoker(ctx, method, req, reply, cc, gopts...)
+		}
+
+		log := debugInterceptorLogEntry{
+			Method:   method,
+			Metadata: opts.Metadata,
+		}
+		i.trackRequest(&log, req)
+		err := invoker(ctx, method, req, reply, cc, gopts...)
+		i.trackResponse(&log, reply)
+		if e := i.record(log); e != nil {
+			return e
+		}
+		return err
+	}
+}
+
+// Like debugClientInterceptor but for streaming calls.
+func (i *DebugInterceptor) DebugStreamClientInterceptor(opts LogOptions) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string,
+		streamer grpc.Streamer, gopts ...grpc.CallOption) (grpc.ClientStream, error) {
+
+		stream, err := streamer(ctx, desc, cc, method, gopts...)
+
+		wrappedStream := &debugClientStream{
+			innerClientStream: stream,
+			interceptor:       i,
+			method:            method,
+			metadata:          opts.Metadata,
+		}
+
+		return wrappedStream, err
+	}
+}
+
+func (i *DebugInterceptor) record(log debugInterceptorLogEntry) error {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	f, err := os.OpenFile(i.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("Failed to append GRPC debug logs to file %s: %v", i.logFile, err)
+	}
+	defer f.Close()
+
+	if err := json.NewEncoder(f).Encode(log); err != nil {
+		return fmt.Errorf("Failed to encode GRPC debug logs: %v", err)
+	}
+	return nil
+}
+
+func (*DebugInterceptor) track(log *debugInterceptorLogEntry, err error) {
+	log.Errors = append(log.Errors, err.Error())
+}
+
+func (i *DebugInterceptor) trackRequest(log *debugInterceptorLogEntry, req interface{}) {
+	j, err := i.transcode(req)
+	if err != nil {
+		i.track(log, err)
+	} else {
+		log.Request = j
+	}
+}
+
+func (i *DebugInterceptor) trackResponse(log *debugInterceptorLogEntry, resp interface{}) {
+	j, err := i.transcode(resp)
+	if err != nil {
+		i.track(log, err)
+	} else {
+		log.Response = j
+	}
+}
+
+func (*DebugInterceptor) transcode(obj interface{}) (json.RawMessage, error) {
+	if obj == nil {
+		return json.RawMessage("null"), nil
+	}
+
+	m, ok := obj.(proto.Message)
+	if !ok {
+		return json.RawMessage("null"),
+			fmt.Errorf("Failed to decode, expecting proto.Message, got %v",
+				reflect.TypeOf(obj))
+	}
+
+	jsonSer := jsonpb.Marshaler{}
+	buf := bytes.Buffer{}
+	if err := jsonSer.Marshal(&buf, m); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Wraps grpc.ServerStream with interceptor hooks for SendMsg, RecvMsg.
+type debugServerStream struct {
+	innerServerStream grpc.ServerStream
+	interceptor       *DebugInterceptor
+	method            string
+	metadata          interface{}
+}
+
+func (dss *debugServerStream) errorEntry(err error) debugInterceptorLogEntry {
+	return debugInterceptorLogEntry{
+		Metadata: dss.metadata,
+		Method:   dss.method,
+		Errors:   []string{err.Error()},
+	}
+}
+
+func (dss *debugServerStream) SetHeader(md metadata.MD) error {
+	return dss.innerServerStream.SetHeader(md)
+}
+
+func (dss *debugServerStream) SendHeader(md metadata.MD) error {
+	return dss.innerServerStream.SendHeader(md)
+}
+
+func (dss *debugServerStream) SetTrailer(md metadata.MD) {
+	dss.innerServerStream.SetTrailer(md)
+}
+
+func (dss *debugServerStream) Context() context.Context {
+	return dss.innerServerStream.Context()
+}
+
+func (dss *debugServerStream) SendMsg(m interface{}) error {
+	err := dss.innerServerStream.SendMsg(m)
+	if err != nil {
+		if e := dss.interceptor.record(dss.errorEntry(err)); e != nil {
+			return e
+		}
+	} else {
+		req, err := dss.interceptor.transcode(m)
+		if err != nil {
+			if e := dss.interceptor.record(dss.errorEntry(err)); e != nil {
+				return e
+			}
+		} else {
+			if e := dss.interceptor.record(debugInterceptorLogEntry{
+				Metadata: dss.metadata,
+				Method:   dss.method,
+				Request:  req,
+			}); e != nil {
+				return e
+			}
+		}
+	}
+	return err
+}
+
+func (dss *debugServerStream) RecvMsg(m interface{}) error {
+	err := dss.innerServerStream.RecvMsg(m)
+	if err == io.EOF {
+		return err
+	} else if err != nil {
+		if e := dss.interceptor.record(dss.errorEntry(err)); e != nil {
+			return e
+		}
+	} else {
+		resp, err := dss.interceptor.transcode(m)
+		if err != nil {
+			if e := dss.interceptor.record(dss.errorEntry(err)); e != nil {
+				return e
+			}
+		} else {
+			if e := dss.interceptor.record(debugInterceptorLogEntry{
+				Method:   dss.method,
+				Metadata: dss.metadata,
+				Response: resp,
+			}); e != nil {
+				return e
+			}
+		}
+	}
+	return err
+}
+
+var _ grpc.ServerStream = &debugServerStream{}
+
+// Wraps grpc.ClientStream with interceptor hooks for SendMsg, RecvMsg.
+type debugClientStream struct {
+	innerClientStream grpc.ClientStream
+	interceptor       *DebugInterceptor
+	method            string
+	metadata          interface{}
+}
+
+func (d *debugClientStream) errorEntry(err error) debugInterceptorLogEntry {
+	return debugInterceptorLogEntry{
+		Method:   d.method,
+		Metadata: d.metadata,
+		Errors:   []string{err.Error()},
+	}
+}
+
+func (d *debugClientStream) Header() (metadata.MD, error) {
+	return d.innerClientStream.Header()
+}
+
+func (d *debugClientStream) Trailer() metadata.MD {
+	return d.innerClientStream.Trailer()
+}
+
+func (d *debugClientStream) CloseSend() error {
+	return d.innerClientStream.CloseSend()
+}
+
+func (d *debugClientStream) Context() context.Context {
+	return d.innerClientStream.Context()
+}
+
+func (d *debugClientStream) SendMsg(m interface{}) error {
+	err := d.innerClientStream.SendMsg(m)
+	if err != nil {
+		if e := d.interceptor.record(d.errorEntry(err)); e != nil {
+			return e
+		}
+	} else {
+		req, err := d.interceptor.transcode(m)
+		if err != nil {
+			if e := d.interceptor.record(d.errorEntry(err)); e != nil {
+				return e
+			}
+		} else {
+			if e := d.interceptor.record(debugInterceptorLogEntry{
+				Method:   d.method,
+				Metadata: d.metadata,
+				Request:  req,
+			}); e != nil {
+				return e
+			}
+		}
+	}
+	return err
+}
+
+func (d *debugClientStream) RecvMsg(m interface{}) error {
+	err := d.innerClientStream.RecvMsg(m)
+	if err == io.EOF {
+		return err
+	} else if err != nil {
+		if e := d.interceptor.record(d.errorEntry(err)); e != nil {
+			return e
+		}
+	} else {
+		resp, err := d.interceptor.transcode(m)
+		if err != nil {
+			if e := d.interceptor.record(d.errorEntry(err)); e != nil {
+				return e
+			}
+		} else {
+			if e := d.interceptor.record(debugInterceptorLogEntry{
+				Method:   d.method,
+				Metadata: d.metadata,
+				Response: resp,
+			}); e != nil {
+				return e
+			}
+		}
+	}
+	return err
+}
+
+var _ grpc.ClientStream = &debugClientStream{}

--- a/pkg/util/rpcdebug/logformat.go
+++ b/pkg/util/rpcdebug/logformat.go
@@ -1,0 +1,30 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcdebug
+
+import (
+	"encoding/json"
+)
+
+// JSON format for tracking gRPC conversations. Normal methods have
+// one entry for each req-resp conversation, streaming methods have
+// one entry per each request or response over the stream.
+type debugInterceptorLogEntry struct {
+	Method   string          `json:"method"`
+	Request  json.RawMessage `json:"request,omitempty"`
+	Response json.RawMessage `json:"response,omitempty"`
+	Errors   []string        `json:"errors,omitempty"`
+	Metadata interface{}     `json:"metadata,omitempty"`
+}

--- a/sdk/go/auto/remote_workspace_test.go
+++ b/sdk/go/auto/remote_workspace_test.go
@@ -23,23 +23,24 @@ import (
 func TestIsFullyQualifiedStackName(t *testing.T) {
 	t.Parallel()
 
-	tests := map[string]struct {
+	tests := []struct {
+		name     string
 		input    string
 		expected bool
 	}{
-		"fully qualified": {input: "owner/project/stack", expected: true},
-		"empty":           {input: "", expected: false},
-		"name":            {input: "name", expected: false},
-		"name & owner":    {input: "owner/name", expected: false},
-		"sep":             {input: "/", expected: false},
-		"two seps":        {input: "//", expected: false},
-		"three seps":      {input: "///", expected: false},
-		"invalid":         {input: "owner/project/stack/wat", expected: false},
+		{name: "fully qualified", input: "owner/project/stack", expected: true},
+		{name: "empty", input: "", expected: false},
+		{name: "name", input: "name", expected: false},
+		{name: "name & owner", input: "owner/name", expected: false},
+		{name: "sep", input: "/", expected: false},
+		{name: "two seps", input: "//", expected: false},
+		{name: "three seps", input: "///", expected: false},
+		{name: "invalid", input: "owner/project/stack/wat", expected: false},
 	}
 
-	for name, tc := range tests {
+	for _, tc := range tests {
 		tc := tc
-		t.Run(name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			actual := isFullyQualifiedStackName(tc.input)

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -31,11 +31,11 @@ import (
 
 // hostServer is the server side of the host RPC machinery.
 type hostServer struct {
-	host   Host       // the host for this RPC server.
-	ctx    *Context   // the associated plugin context.
-	addr   string     // the address the host is listening on.
-	cancel chan bool  // a channel that can cancel the server.
-	done   chan error // a channel that resolves when the server completes.
+	host   Host         // the host for this RPC server.
+	ctx    *Context     // the associated plugin context.
+	addr   string       // the address the host is listening on.
+	cancel chan bool    // a channel that can cancel the server.
+	done   <-chan error // a channel that resolves when the server completes.
 
 	// hostServer contains little bits of state that can't be saved in the language host.
 	rootUrn atomic.Value // a root resource URN that has been saved via SetRootResource
@@ -51,15 +51,21 @@ func newHostServer(host Host, ctx *Context) (*hostServer, error) {
 	}
 
 	// Fire up a gRPC server and start listening for incomings.
-	port, done, err := rpcutil.Serve(0, engine.cancel, []func(*grpc.Server) error{
-		func(srv *grpc.Server) error {
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: engine.cancel,
+		Init: func(srv *grpc.Server) error {
 			lumirpc.RegisterEngineServer(srv, engine)
 			return nil
 		},
-	}, ctx.tracingSpan)
+		Options: rpcutil.OpenTracingServerInterceptorOptions(ctx.tracingSpan),
+	})
+
 	if err != nil {
 		return nil, err
 	}
+
+	port := handle.Port
+	done := handle.Done
 
 	engine.addr = fmt.Sprintf("127.0.0.1:%d", port)
 	engine.done = done

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,33 +44,58 @@ func IsBenignCloseErr(err error) bool {
 		strings.HasSuffix(msg, "grpc: the server has been stopped")
 }
 
-// Serve creates a new gRPC server, calls out to the supplied registration functions to bind interfaces, and then
-// listens on the supplied TCP port.  If the caller wishes for the kernel to choose a free port automatically, pass 0 as
-// the port number.  The return values are: the chosen port (the same as supplied if non-0), a channel that may
-// eventually return an error, and an error, in case something went wrong.  The channel is non-nil and waits until
-// the server is finished, in the case of a successful launch of the RPC server.
-func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
-	parentSpan opentracing.Span, options ...otgrpc.Option) (int, chan error, error) {
+type ServeOptions struct {
+	// Port to listen on. Passing 0 makes the system choose a port automatically.
+	Port int
+
+	// Initializer for the server. A typical Init registers handlers.
+	Init func(*grpc.Server) error
+
+	// If non-nil, Serve will gracefully terminate the server when Cancel is closed or receives true.
+	Cancel chan bool
+
+	// Options for serving gRPC.
+	Options []grpc.ServerOption
+}
+
+type ServeHandle struct {
+	// Port the server is listening on.
+	Port int
+
+	// The channel is non-nil and is closed when the server stops serving. The server will pass a non-nil error on
+	// this channel if something went wrong in the background and it did not terminate gracefully.
+	Done <-chan error
+}
+
+// ServeWithOptions creates a new gRPC server, calls opts.Init and listens on a TCP port.
+func ServeWithOptions(opts ServeOptions) (ServeHandle, error) {
+	h, _, err := serveWithOptions(opts)
+	return h, err
+}
+
+func serveWithOptions(opts ServeOptions) (ServeHandle, chan error, error) {
+	port := opts.Port
 
 	// Listen on a TCP port, but let the kernel choose a free port for us.
 	lis, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
 	if err != nil {
-		return port, nil, errors.Errorf("failed to listen on TCP port ':%v': %v", port, err)
+		return ServeHandle{Port: port}, nil,
+			errors.Errorf("failed to listen on TCP port ':%v': %v", port, err)
 	}
 
 	health := health.NewServer()
 
 	// Now new up a gRPC server and register any RPC interfaces the caller wants.
-	srv := grpc.NewServer(
-		grpc.UnaryInterceptor(OpenTracingServerInterceptor(parentSpan, options...)),
-		grpc.StreamInterceptor(OpenTracingStreamServerInterceptor(parentSpan, options...)),
-		grpc.MaxRecvMsgSize(maxRPCMessageSize),
-	)
-	for _, register := range registers {
-		if err := register(srv); err != nil {
-			return port, nil, errors.Errorf("failed to register RPC handler: %v", err)
+
+	srv := grpc.NewServer(append(opts.Options, grpc.MaxRecvMsgSize(maxRPCMessageSize))...)
+
+	if opts.Init != nil {
+		if err := opts.Init(srv); err != nil {
+			return ServeHandle{Port: port}, nil,
+				errors.Errorf("failed to Init GRPC to register RPC handlers: %v", err)
 		}
 	}
+
 	healthgrpc.RegisterHealthServer(srv, health) // enable health checks
 	reflection.Register(srv)                     // enable reflection.
 
@@ -87,8 +112,7 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 		port = tcpa.Port
 	}
 
-	// If the caller provided a cancellation channel, start a goroutine that will gracefully terminate the gRPC server when
-	// that channel is closed or receives a `true` value.
+	cancel := opts.Cancel
 	if cancel != nil {
 		go func() {
 			for v, ok := <-cancel; !v && ok; v, ok = <-cancel {
@@ -109,5 +133,31 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 		close(done)
 	}()
 
-	return port, done, nil
+	return ServeHandle{Port: port, Done: done}, done, nil
+}
+
+// Deprecated. Please use ServeWithOptions and OpenTracingServerInterceptorOptions.
+func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
+	parentSpan opentracing.Span, options ...otgrpc.Option) (int, chan error, error) {
+
+	opts := ServeOptions{
+		Port:   port,
+		Cancel: cancel,
+		Init: func(s *grpc.Server) error {
+			for _, r := range registers {
+				if err := r(s); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Options: OpenTracingServerInterceptorOptions(parentSpan, options...),
+	}
+
+	handle, done, err := serveWithOptions(opts)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return handle.Port, done, nil
 }

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -127,22 +127,24 @@ func main() {
 	}
 
 	// Fire up a gRPC server, letting the kernel choose a free port.
-	port, done, err := rpcutil.Serve(0, cancelChannel, []func(*grpc.Server) error{
-		func(srv *grpc.Server) error {
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancelChannel,
+		Init: func(srv *grpc.Server) error {
 			host := newLanguageHost(engineAddress, tracing, binary, buildTarget)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
-	}, nil)
+		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+	})
 	if err != nil {
 		cmdutil.Exit(errors.Wrapf(err, "could not start language host RPC server"))
 	}
 
 	// Otherwise, print out the port so that the spawner knows how to reach us.
-	fmt.Printf("%d\n", port)
+	fmt.Printf("%d\n", handle.Port)
 
 	// And finally wait for the server to stop serving.
-	if err := <-done; err != nil {
+	if err := <-handle.Done; err != nil {
 		cmdutil.Exit(errors.Wrapf(err, "language host RPC stopped serving"))
 	}
 }

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -149,22 +149,24 @@ func main() {
 	virtualenvPath := resolveVirtualEnvironmentPath(root, virtualenv)
 
 	// Fire up a gRPC server, letting the kernel choose a free port.
-	port, done, err := rpcutil.Serve(0, cancelChannel, []func(*grpc.Server) error{
-		func(srv *grpc.Server) error {
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancelChannel,
+		Init: func(srv *grpc.Server) error {
 			host := newLanguageHost(pythonExec, engineAddress, tracing, cwd, virtualenv, virtualenvPath)
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
-	}, nil)
+		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+	})
 	if err != nil {
 		cmdutil.Exit(errors.Wrapf(err, "could not start language host RPC server"))
 	}
 
 	// Otherwise, print out the port so that the spawner knows how to reach us.
-	fmt.Printf("%d\n", port)
+	fmt.Printf("%d\n", handle.Port)
 
 	// And finally wait for the server to stop serving.
-	if err := <-done; err != nil {
+	if err := <-handle.Done; err != nil {
 		cmdutil.Exit(errors.Wrapf(err, "language host RPC stopped serving"))
 	}
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #10232

`PULUMI_DEBUG_GRPC=./debug.json pulumi preview` now works.

The debug APIs are probably unstable so I moved them out to their own repo rather than hosting under sdk/.

Debug interceptors are no-op unless the process initializes them in main. Currently only `pulumi` process initializes them if the env var is set. This way we observe conversations only once, as a server for ResourceMonitor etc, and as a client for plugin conversations (language and resource).

I can now see provider conversations logged which was of interest to me.


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
