### PR TITLE
[sdk/nodejs] Avoid eslint error in VS Code

### DIFF
--- a/sdk/nodejs/.eslintrc.js
+++ b/sdk/nodejs/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": "tsconfig.json",
+        "tsconfigRootDir": __dirname,
         "sourceType": "module"
     },
     "plugins": [


### PR DESCRIPTION
I often open VS Code in the root `pulumi/pulumi` directory, and when I do that and edit any `sdk/nodejs` files, eslint complains with:

> Parsing error: File '/users/user/go/src/github.com/pulumi/pulumi/tsconfig.json' not found.

This is because it looks for `tsconfig.json` in the current working directory by default. To fix this, `tsconfigRootDir` can be set in `.eslintrc.js`.