### PR TITLE
Improve the error for a denied component provider

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1119,6 +1119,10 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	var outputDeps map[string]*pulumirpc.RegisterResourceResponse_PropertyDependencies
 	if remote {
 		provider, ok := rm.providers.GetProvider(providerRef)
+		if providers.IsDenyDefaultsProvider(providerRef) {
+			msg := diag.GetDefaultProviderDenied(resource.URN(t.String())).Message
+			return nil, fmt.Errorf(msg, t.Package().String(), t.String())
+		}
 		if !ok {
 			return nil, fmt.Errorf("unknown provider '%v'", providerRef)
 		}

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -522,7 +522,7 @@ async function prepareResource(label: string, res: Resource, parent: Resource | 
 
         let providerRef: string | undefined;
         let importID: ID | undefined;
-        if (custom) {
+        if (custom || remote) {
             const customOpts = <CustomResourceOptions>opts;
             importID = customOpts.import;
             providerRef = await ProviderResource.register(opts.provider);


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This improves the error message for https://github.com/pulumi/pulumi-awsx/issues/930.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
