### PR TITLE
Allow rotating the password non-interactively

### DIFF
--- a/changelog/pending/20221020--cli--allow-rotating-the-passphrase-non-interactively.yaml
+++ b/changelog/pending/20221020--cli--allow-rotating-the-passphrase-non-interactively.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow rotating the passphrase non-interactively

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -225,7 +225,12 @@ func PromptForNewPassphrase(rotate bool) (string, secrets.Manager, error) {
 			firstMessage = "Enter your new passphrase to protect config/secrets"
 
 			if !isInteractive() {
-				return "", nil, fmt.Errorf("passphrase rotation requires an interactive terminal")
+				text, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return "", nil, err
+				}
+				phrase = strings.TrimSpace(string(text))
+				break
 			}
 		}
 		// Here, the stack does not have an EncryptionSalt, so we will get a passphrase and create one
@@ -286,7 +291,7 @@ func readPassphrase(prompt string, useEnv bool) (phrase string, interactive bool
 			if err != nil {
 				return "", false, fmt.Errorf("unable to construct a path the PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
 			}
-			phraseDetails, err := ioutil.ReadFile(phraseFilePath)
+			phraseDetails, err := os.ReadFile(phraseFilePath)
 			if err != nil {
 				return "", false, fmt.Errorf("unable to read PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
 			}

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -1,7 +1,6 @@
 package passphrase
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -102,7 +101,7 @@ func TestPassphraseManagerCorrectPassfileReturnsSecretsManager(t *testing.T) {
 	resetEnv := resetPassphraseTestEnvVars()
 	defer resetEnv()
 
-	tmpFile, err := ioutil.TempFile("", "pulumi-secret-test")
+	tmpFile, err := os.CreateTemp("", "pulumi-secret-test")
 	assert.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 	_, err = tmpFile.WriteString("password")


### PR DESCRIPTION
Signed-off-by: Nicklas Frahm <nilfr@vestas.com>

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes #11083. Also fixes some deprecation warnings within the `passphrase` package.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have tested this locally using:
  ```bash
  export PULUMI_CONFIG_PASSPHRASE=test
  pulumi stack init -s test
  echo "hello" | pulumi stack change-secrets-provider passphrase
  export PULUMI_CONFIG_PASSPHRASE=hello
  echo "test" | pulumi stack change-secrets-provider passphrase
  ```
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
