### PR TITLE
Don't block the pulumi package

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -401,7 +401,13 @@ func (d *defaultProviders) handleRequest(req providers.ProviderRequest) (provide
 
 // If req should be allowed, or if we should prevent the request.
 func (d *defaultProviders) shouldDenyRequest(req providers.ProviderRequest) (bool, error) {
-	logging.V(9).Infof("checking if %s should be denied", req)
+	logging.V(9).Infof("checking if %#v should be denied", req)
+
+	if req.Package().Name().String() == "pulumi" {
+		logging.V(9).Infof("we always allow %#v through", req)
+		return false, nil
+	}
+
 	pConfig, err := d.config.GetPackageConfig("pulumi")
 	if err != nil {
 		return true, err


### PR DESCRIPTION
This is invoked on getResource requests for stack templates.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
