### PR TITLE
attempts to select the stack before creating

### DIFF
--- a/changelog/pending/20221021--sdk-python--pulumi-automation-create_or_select_stack-attempts-to-select-the-stack-before-attempting-to-create.yaml
+++ b/changelog/pending/20221021--sdk-python--pulumi-automation-create_or_select_stack-attempts-to-select-the-stack-before-attempting-to-create.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: pulumi.automation.create_or_select_stack() attempts to select the stack before attempting to create

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -186,9 +186,9 @@ class Stack:
             workspace.select_stack(name)
         elif mode is StackInitMode.CREATE_OR_SELECT:
             try:
-                workspace.create_stack(name)
-            except StackAlreadyExistsError:
                 workspace.select_stack(name)
+            except StackNotFoundError:
+                workspace.create_stack(name)
 
     def __repr__(self):
         return f"Stack(stack_name={self.name!r}, workspace={self.workspace!r}, mode={self._mode!r})"


### PR DESCRIPTION
# Description

`pulumi.automation.create_or_select_stack()` first tries to create the stack, and on failure it then tries to select the stack.

For an account that has restrictive access and no permissions to create stacks, this prevents them from using this function. If Pulumi first attempts to select the stack, and only on failure attempt to create it, then member accounts with limited access can still use the function.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
