### PR TITLE
ci: Update deprecated set-output commands

### DIFF
--- a/.github/scripts/set-output
+++ b/.github/scripts/set-output
@@ -22,4 +22,4 @@ OUTPUT_NAME="$1"
 VALUE="$2"
 
 ESCAPED="$(echo -n "${VALUE}" | jq -Rsc ".")" # JSON encode
-echo "::set-output name=${OUTPUT_NAME}::${ESCAPED}"
+echo "${OUTPUT_NAME}=${ESCAPED}" >> "${GITHUB_STATE:?}"

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Generate artifact name
         id: goenv
         run: |
-          echo "::set-output name=CLI-TARGET::$(go env GOOS)-$(go env GOARCH)"
+          echo "CLI-TARGET=$(go env GOOS)-$(go env GOARCH)" >> "${GITHUB_OUTPUT:?}"
 
       # Ensure tests do not rely on pre-installed packages in CI. Unit tests must run absent a local
       # Pulumi install, and integration tests must only test the version built by CI.

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -106,8 +106,8 @@ jobs:
 
           popd
 
-          echo "::set-output name=branchName::${BRANCH_NAME}"
-          echo "::set-output name=prNumber::${PR_NUMBER}"
+          echo "branchName=${BRANCH_NAME}" >> "${GITHUB_OUTPUT:?}"
+          echo "prNumber=${PR_NUMBER}" >> "${GITHUB_OUTPUT:?}"
 
       - name: Create draft docs PR
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT:?}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT:?}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |
@@ -36,8 +36,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT:?}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT:?}"
       - run: command -v pulumi
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
@@ -62,8 +62,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT:?}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT:?}"
       - run: command -v pulumi
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
@@ -87,8 +87,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT:?}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT:?}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |
@@ -110,8 +110,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT:?}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT:?}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |
@@ -129,8 +129,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT:?}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT:?}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |
@@ -174,8 +174,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT:?}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT:?}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |

--- a/.github/workflows/pr-test-codegen-test-on-dispatch.yml
+++ b/.github/workflows/pr-test-codegen-test-on-dispatch.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Create URL to the run output
         id: vars
-        run: echo "::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${GITHUB_OUTPUT:?}"
       - name: Update with Result
         uses: peter-evans/create-or-update-comment@v2
         with:

--- a/scripts/retry
+++ b/scripts/retry
@@ -39,8 +39,8 @@ run_tests() {
 
 run_tests "${@}"
 
-echo "::set-output name=TEST_SUCCESS::${success}"
-echo "::set-output name=TEST_RETRIED::${retried}"
+echo "TEST_SUCCESS=${success}" >> "${GITHUB_OUTPUT:?}"
+echo "TEST_RETRIED=${retried}" >> "${GITHUB_OUTPUT:?}"
 
 if ! "${success}"; then
     exit 1


### PR DESCRIPTION
Remove warnings in our CI job such as:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/