### PR TITLE
[SDK/Python] Respect --parallel flag

### DIFF
--- a/changelog/pending/20221022--sdk-python--python-runtime-now-respects-parallel-flag.yaml
+++ b/changelog/pending/20221022--sdk-python--python-runtime-now-respects-parallel-flag.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Python runtime now respects the --parallel flag.

--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -57,6 +57,7 @@ def _set_default_executor(loop, parallelism: Optional[int]):
     '''configure this event loop to respect the settings provided.'''
     if parallelism is None:
         return
+    parallelism = max(parallelism, 1)
     exec = ThreadPoolExecutor(max_workers=parallelism)
     loop.set_default_executor(exec)
 

--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -3,11 +3,13 @@
 
 import argparse
 import asyncio
+from typing import Optional
 import logging
 import os
 import sys
 import traceback
 import runpy
+from concurrent.futures import ThreadPoolExecutor
 
 # The user might not have installed Pulumi yet in their environment - provide a high-quality error message in that case.
 try:
@@ -50,6 +52,13 @@ def _get_user_stacktrace(user_program_abspath: str) -> str:
 
     # we did not detect a __main__ program, return normal traceback
     return traceback.format_exc()
+
+def _set_default_executor(loop, parallelism: Optional[int]):
+    '''configure this event loop to respect the settings provided.'''
+    if parallelism is None:
+        return
+    exec = ThreadPoolExecutor(max_workers=parallelism)
+    loop.set_default_executor(exec)
 
 if __name__ == "__main__":
     # Parse the arguments, program name, and optional arguments.
@@ -125,6 +134,9 @@ if __name__ == "__main__":
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
+    
+    # Configure the event loop to respect the parallelism value provided as input.
+    _set_default_executor(loop, settings.parallel)
 
     # We are (unfortunately) suppressing the log output of asyncio to avoid showing to users some of the bad things we
     # do in our programming model.

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -208,6 +208,7 @@ def get_engine() -> Optional[Union[engine_pb2_grpc.EngineStub, Any]]:
     """
     return SETTINGS.engine
 
+
 def get_root_resource() -> Optional["Resource"]:
     """
     Returns the implicit root stack resource for all resources created in this program.

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -208,10 +208,6 @@ def get_engine() -> Optional[Union[engine_pb2_grpc.EngineStub, Any]]:
     """
     return SETTINGS.engine
 
-
-ROOT: ContextVar[Optional[Resource]] = ContextVar("root_resource", default=None)
-
-
 def get_root_resource() -> Optional["Resource"]:
     """
     Returns the implicit root stack resource for all resources created in this program.
@@ -224,6 +220,9 @@ def set_root_resource(root: "Resource"):
     Sets the current root stack resource for all resources subsequently to be created in this program.
     """
     ROOT.set(root)
+
+
+ROOT: ContextVar[Optional[Resource]] = ContextVar("root_resource", default=None)
 
 
 async def monitor_supports_feature(feature: str) -> bool:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR sets the default futures executor to use the `--parallel` flag to determine thread count.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #1116

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works. **(Not unit tests, but I ran a thorough experiment.)**
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
