### PR TITLE
Fix module name for tests/integration/construct_nested_component/go/go.mod

### DIFF
--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi/tests/construct_component
+module github.com/pulumi/pulumi/tests/construct_nested_component
 
 go 1.18
 


### PR DESCRIPTION
This was a duplicate module name with tests/integration/construct_component/go/go.mod.