### PR TITLE
[dotnet/auto] allow deserializing complex stack config values

### DIFF
--- a/changelog/pending/20221025--auto-dotnet--allow-deserializing-complex-stack-config-values.yaml
+++ b/changelog/pending/20221025--auto-dotnet--allow-deserializing-complex-stack-config-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/dotnet
+  description: allow deserializing complex stack config values.

--- a/sdk/dotnet/Pulumi.Automation.Tests/Serialization/StackSettingsConfigValueJsonConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Serialization/StackSettingsConfigValueJsonConverterTests.cs
@@ -56,25 +56,47 @@ namespace Pulumi.Automation.Tests.Serialization
         }
 
         [Fact]
-        public void CannotDeserializeObject()
+        public void DeserializeObjectWorks()
         {
             const string json = @"
 {
     ""config"": {
         ""value"": {
-            ""test"": ""test"",
-            ""nested"": {
-                ""one"": 1,
-                ""two"": true,
-                ""three"": ""three""
-            }
+            ""hello"": ""world""
         }
     } 
 }
 ";
 
-            Assert.Throws<NotSupportedException>(
-                () => _serializer.DeserializeJson<StackSettings>(json));
+            var settings = _serializer.DeserializeJson<StackSettings>(json);
+            Assert.NotNull(settings.Config);
+            Assert.True(settings!.Config!.ContainsKey("value"));
+
+            var value = settings.Config["value"];
+            Assert.NotNull(value);
+            Assert.Equal("{\"hello\":\"world\"}", value.Value);
+            Assert.False(value.IsSecure);
+        }
+
+        [Fact]
+        public void DeserializeArrayWorks()
+        {
+            const string json = @"
+{
+    ""config"": {
+        ""value"": [1,2,3,4,5]
+    } 
+}
+";
+
+            var settings = _serializer.DeserializeJson<StackSettings>(json);
+            Assert.NotNull(settings.Config);
+            Assert.True(settings!.Config!.ContainsKey("value"));
+
+            var value = settings.Config["value"];
+            Assert.NotNull(value);
+            Assert.Equal("[1,2,3,4,5]", value.Value);
+            Assert.False(value.IsSecure);
         }
 
         [Fact]

--- a/sdk/dotnet/Pulumi.Automation.Tests/Serialization/StackSettingsConfigValueYamlConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Serialization/StackSettingsConfigValueYamlConverterTests.cs
@@ -49,20 +49,22 @@ config:
         }
 
         [Fact]
-        public void CannotDeserializeObject()
+        public void CanDeserializeObject()
         {
             const string yaml = @"
 config:
   value:
-    test: test
-    nested:
-      one: 1
-      two: true
-      three: three
+    hello: world
 ";
 
-            Assert.Throws<YamlException>(
-                () => _serializer.DeserializeYaml<StackSettings>(yaml));
+            var settings = _serializer.DeserializeYaml<StackSettings>(yaml);
+            Assert.NotNull(settings.Config);
+            Assert.True(settings!.Config!.ContainsKey("value"));
+
+            var value = settings.Config["value"];
+            Assert.NotNull(value);
+            Assert.Equal("{\"hello\":\"world\"}", value.Value);
+            Assert.False(value.IsSecure);
         }
 
         [Fact]


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11107 now instead of failing, we JSON-ify the complex stack config value 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
