### PR TITLE
[auto] detect concurrent update error from local backend

### DIFF
--- a/changelog/pending/20221025--auto-dotnet-go-nodejs-python--detect-concurrent-update-error-from-local-backend.yaml
+++ b/changelog/pending/20221025--auto-dotnet-go-nodejs-python--detect-concurrent-update-error-from-local-backend.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/dotnet,go,nodejs,python
+  description: detect concurrent update error from local backend.

--- a/sdk/dotnet/Pulumi.Automation/Commands/Exceptions/CommandException.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/Exceptions/CommandException.cs
@@ -23,11 +23,13 @@ namespace Pulumi.Automation.Commands.Exceptions
         private static readonly Regex _notFoundRegexPattern = new Regex("no stack named.*found");
         private static readonly Regex _alreadyExistsRegexPattern = new Regex("stack.*already exists");
         private static readonly string _conflictText = "[409] Conflict: Another update is currently in progress.";
+        private static readonly string _localBackendConflictText = "the stack is currently locked by";
 
         internal static CommandException CreateFromResult(CommandResult result)
             => _notFoundRegexPattern.IsMatch(result.StandardError) ? new StackNotFoundException(result)
             : _alreadyExistsRegexPattern.IsMatch(result.StandardError) ? new StackAlreadyExistsException(result)
             : result.StandardError.IndexOf(_conflictText, StringComparison.Ordinal) >= 0 ? new ConcurrentUpdateException(result)
+            : result.StandardError.IndexOf(_localBackendConflictText, StringComparison.Ordinal) >= 0 ? new ConcurrentUpdateException(result)
             : new CommandException(result);
     }
 }

--- a/sdk/go/auto/errors.go
+++ b/sdk/go/auto/errors.go
@@ -47,7 +47,9 @@ func IsConcurrentUpdateError(e error) bool {
 		return false
 	}
 
-	return strings.Contains(ae.stderr, "[409] Conflict: Another update is currently in progress.")
+	conflictText := "[409] Conflict: Another update is currently in progress."
+	localBackendConflictText := "the stack is currently locked by"
+	return strings.Contains(ae.stderr, conflictText) || strings.Contains(ae.stderr, localBackendConflictText)
 }
 
 // IsSelectStack404Error returns true if the error was a result of selecting a stack that does not exist.

--- a/sdk/nodejs/automation/errors.ts
+++ b/sdk/nodejs/automation/errors.ts
@@ -62,14 +62,16 @@ export class StackAlreadyExistsError extends CommandError {
 const notFoundRegex = new RegExp("no stack named.*found");
 const alreadyExistsRegex = new RegExp("stack.*already exists");
 const conflictText = "[409] Conflict: Another update is currently in progress.";
+const localBackendConflictText = "the stack is currently locked by";
 
 /** @internal */
 export function createCommandError(result: CommandResult): CommandError {
     const stderr = result.stderr;
     return (
-        notFoundRegex.test(stderr) ? new StackNotFoundError(result) :
-            alreadyExistsRegex.test(stderr) ? new StackAlreadyExistsError(result) :
-                stderr.indexOf(conflictText) >= 0 ? new ConcurrentUpdateError(result) :
-                    new CommandError(result)
+        notFoundRegex.test(stderr) ? new StackNotFoundError(result)
+            : alreadyExistsRegex.test(stderr) ? new StackAlreadyExistsError(result)
+                : stderr.indexOf(conflictText) >= 0 ? new ConcurrentUpdateError(result)
+                    : stderr.indexOf(localBackendConflictText) >= 0 ? new ConcurrentUpdateError(result)
+                        : new CommandError(result)
     );
 }

--- a/sdk/python/lib/pulumi/automation/errors.py
+++ b/sdk/python/lib/pulumi/automation/errors.py
@@ -68,6 +68,7 @@ class InvalidVersionError(Exception):
 not_found_regex = re.compile("no stack named.*found")
 already_exists_regex = re.compile("stack.*already exists")
 conflict_text = "[409] Conflict: Another update is currently in progress."
+local_backend_conflict_text = "the stack is currently locked by"
 inline_source_error_text = "python inline source runtime error"
 runtime_error_regex = re.compile(
     "failed with an unhandled exception|panic: runtime error|an unhandled error occurred:"
@@ -85,6 +86,8 @@ def create_command_error(command_result: "CommandResult") -> CommandError:
     if already_exists_regex.search(stderr):
         return StackAlreadyExistsError(command_result)
     if conflict_text in stderr:
+        return ConcurrentUpdateError(command_result)
+    if local_backend_conflict_text in stderr:
         return ConcurrentUpdateError(command_result)
     if compilation_error_regex.search(stdout):
         return CompilationError(command_result)


### PR DESCRIPTION
Fixes #11108

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
