### PR TITLE
Add Json option to dotnet automation api

### DIFF
--- a/changelog/pending/20221025--auto-dotnet--add-json-option-to-updateoptions.yaml
+++ b/changelog/pending/20221025--auto-dotnet--add-json-option-to-updateoptions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/dotnet
+  description: Add Json option to UpdateOptions.

--- a/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
@@ -66,5 +66,10 @@ namespace Pulumi.Automation
         /// Print detailed debugging output during resource operations
         /// </summary>
         public bool? Debug { get; set; }
+
+        /// <summary>
+        /// Format standard output as JSON not text.
+        /// </summary>
+        public bool? Json { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -800,6 +800,11 @@ namespace Pulumi.Automation
             {
                 args.Add("--debug");
             }
+
+            if (options.Json is true)
+            {
+                args.Add("--json");
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
