### PR TITLE
Support future glob patterns

### DIFF
--- a/changelog/pending/20221025--cli--allow-globbing-for-resources-that-do-not-yet-exist.yaml
+++ b/changelog/pending/20221025--cli--allow-globbing-for-resources-that-do-not-yet-exist.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow globbing for resources that do not yet exist

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -24,8 +24,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -168,19 +168,19 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
-			targetURNs := []resource.URN{}
+			targetURNs := []string{}
 			for _, t := range targets {
-				targetURNs = append(targetURNs, resource.URN(t))
+				targetURNs = append(targetURNs, t)
 			}
 
-			replaceURNs := []resource.URN{}
+			replaceURNs := []string{}
 			for _, r := range replaces {
-				replaceURNs = append(replaceURNs, resource.URN(r))
+				replaceURNs = append(replaceURNs, r)
 			}
 
 			for _, tr := range targetReplaces {
-				targetURNs = append(targetURNs, resource.URN(tr))
-				replaceURNs = append(replaceURNs, resource.URN(tr))
+				targetURNs = append(targetURNs, tr)
+				replaceURNs = append(replaceURNs, tr)
 			}
 
 			refreshOption, err := getRefreshOption(proj, refresh)
@@ -194,12 +194,12 @@ func newPreviewCmd() *cobra.Command {
 					Parallel:                  parallel,
 					Debug:                     debug,
 					Refresh:                   refreshOption,
-					ReplaceTargets:            replaceURNs,
+					ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
 					UseLegacyDiff:             useLegacyDiff(),
 					DisableProviderPreview:    disableProviderPreview(),
 					DisableResourceReferences: disableResourceReferences(),
 					DisableOutputValues:       disableOutputValues(),
-					UpdateTargets:             targetURNs,
+					UpdateTargets:             deploy.NewUrnTargets(targetURNs),
 					TargetDependents:          targetDependents,
 					// If we're trying to save a plan then we _need_ to generate it. We also turn this on in
 					// experimental mode to just get more testing of it.

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -212,9 +212,9 @@ func newRefreshCmd() *cobra.Command {
 				}
 			}
 
-			targetUrns := []resource.URN{}
+			targetUrns := []string{}
 			for _, t := range *targets {
-				targetUrns = append(targetUrns, resource.URN(t))
+				targetUrns = append(targetUrns, t)
 			}
 
 			opts.Engine = engine.UpdateOptions{
@@ -224,7 +224,7 @@ func newRefreshCmd() *cobra.Command {
 				DisableProviderPreview:    disableProviderPreview(),
 				DisableResourceReferences: disableResourceReferences(),
 				DisableOutputValues:       disableOutputValues(),
-				RefreshTargets:            targetUrns,
+				RefreshTargets:            deploy.NewUrnTargets(targetUrns),
 			}
 
 			changes, res := s.Refresh(ctx, backend.UpdateOperation{

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -336,7 +336,7 @@ func validateRefreshDeleteCombination(t *testing.T, names []string, targets []st
 		refreshTargets = append(refreshTargets, pickURN(t, urns, names, target))
 	}
 
-	p.Options.RefreshTargets = refreshTargets
+	p.Options.RefreshTargets = deploy.NewUrnTargetsFromUrns(refreshTargets)
 
 	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{
@@ -496,10 +496,10 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 	refreshTargets := []resource.URN{}
 
 	for _, target := range targets {
-		refreshTargets = append(p.Options.RefreshTargets, pickURN(t, urns, names, target))
+		refreshTargets = append(p.Options.RefreshTargets.Literals(), pickURN(t, urns, names, target))
 	}
 
-	p.Options.RefreshTargets = refreshTargets
+	p.Options.RefreshTargets = deploy.NewUrnTargetsFromUrns(refreshTargets)
 
 	newResource := func(urn resource.URN, id resource.ID, delete bool, dependencies ...resource.URN) *resource.State {
 		return &resource.State{

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -113,16 +113,16 @@ type UpdateOptions struct {
 	Refresh bool
 
 	// Specific resources to refresh during a refresh operation.
-	RefreshTargets []resource.URN
+	RefreshTargets deploy.UrnTargets
 
 	// Specific resources to replace during an update operation.
-	ReplaceTargets []resource.URN
+	ReplaceTargets deploy.UrnTargets
 
 	// Specific resources to destroy during a destroy operation.
-	DestroyTargets []resource.URN
+	DestroyTargets deploy.UrnTargets
 
 	// Specific resources to update during an update operation.
-	UpdateTargets []resource.URN
+	UpdateTargets deploy.UrnTargets
 
 	// true if we're allowing dependent targets to change, even if not specified in one of the above
 	// XXXTargets lists.

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"regexp"
+	"strings"
 	"sync"
 
 	uuid "github.com/gofrs/uuid"
@@ -50,20 +52,20 @@ type BackendClient interface {
 
 // Options controls the deployment process.
 type Options struct {
-	Events                    Events         // an optional events callback interface.
-	Parallel                  int            // the degree of parallelism for resource operations (<=1 for serial).
-	Refresh                   bool           // whether or not to refresh before executing the deployment.
-	RefreshOnly               bool           // whether or not to exit after refreshing.
-	RefreshTargets            []resource.URN // The specific resources to refresh during a refresh op.
-	ReplaceTargets            []resource.URN // Specific resources to replace.
-	DestroyTargets            []resource.URN // Specific resources to destroy.
-	UpdateTargets             []resource.URN // Specific resources to update.
-	TargetDependents          bool           // true if we're allowing things to proceed, even with unspecified targets
-	TrustDependencies         bool           // whether or not to trust the resource dependency graph.
-	UseLegacyDiff             bool           // whether or not to use legacy diffing behavior.
-	DisableResourceReferences bool           // true to disable resource reference support.
-	DisableOutputValues       bool           // true to disable output value support.
-	GeneratePlan              bool           // true to enable plan generation.
+	Events                    Events     // an optional events callback interface.
+	Parallel                  int        // the degree of parallelism for resource operations (<=1 for serial).
+	Refresh                   bool       // whether or not to refresh before executing the deployment.
+	RefreshOnly               bool       // whether or not to exit after refreshing.
+	RefreshTargets            UrnTargets // The specific resources to refresh during a refresh op.
+	ReplaceTargets            UrnTargets // Specific resources to replace.
+	DestroyTargets            UrnTargets // Specific resources to destroy.
+	UpdateTargets             UrnTargets // Specific resources to update.
+	TargetDependents          bool       // true if we're allowing things to proceed, even with unspecified targets
+	TrustDependencies         bool       // whether or not to trust the resource dependency graph.
+	UseLegacyDiff             bool       // whether or not to use legacy diffing behavior.
+	DisableResourceReferences bool       // true to disable resource reference support.
+	DisableOutputValues       bool       // true to disable output value support.
+	GeneratePlan              bool       // true to enable plan generation.
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the
@@ -78,6 +80,102 @@ func (o Options) DegreeOfParallelism() int {
 // InfiniteParallelism returns whether or not the requested level of parallelism is unbounded.
 func (o Options) InfiniteParallelism() bool {
 	return o.Parallel == math.MaxInt32
+}
+
+// An immutable set of urns to target with an operation.
+//
+// The zero value of UrnTargets is the set of all URNs.
+type UrnTargets struct {
+	// UrnTargets is internally made up of two components: literals, which are fully
+	// specified URNs and globs, which are partially specified URNs.
+
+	literals []resource.URN
+	globs    map[string]*regexp.Regexp
+}
+
+// Create a new set of targets.
+//
+// Each element is considered a glob if it contains any '*' and an URN otherwise. No other
+// URN validation is performed.
+//
+// If len(urnOrGlobs) == 0, an unconstrained set will be created.
+func NewUrnTargets(urnOrGlobs []string) UrnTargets {
+	literals, globs := []resource.URN{}, map[string]*regexp.Regexp{}
+	for _, urn := range urnOrGlobs {
+		if strings.ContainsRune(urn, '*') {
+			globs[urn] = nil
+		} else {
+			literals = append(literals, resource.URN(urn))
+		}
+	}
+	return UrnTargets{literals, globs}
+}
+
+// Create a new set of targets from fully resolved URNs.
+func NewUrnTargetsFromUrns(urns []resource.URN) UrnTargets {
+	return UrnTargets{urns, nil}
+}
+
+// Return if the target set constrains the set of acceptable URNs.
+func (t UrnTargets) IsConstrained() bool {
+	return len(t.literals) > 0 || len(t.globs) > 0
+}
+
+// Get a regexp that can match on the glob. This function caches regexp generation.
+func (t UrnTargets) getMatcher(glob string) *regexp.Regexp {
+	if r := t.globs[glob]; r != nil {
+		return r
+	}
+	segmentGlob := strings.Split(glob, "**")
+	for i, v := range segmentGlob {
+		part := strings.Split(v, "*")
+		for i, v := range part {
+			part[i] = regexp.QuoteMeta(v)
+		}
+		segmentGlob[i] = strings.Join(part, "[^:]*")
+	}
+
+	// Because we have quoted all input, this is safe to compile.
+	r := regexp.MustCompile("^" + strings.Join(segmentGlob, ".*") + "$")
+
+	// We cache and return the matcher
+	t.globs[glob] = r
+	return r
+}
+
+// Check if Targets contains the URN.
+//
+// If method receiver is not initialized, `true` is always returned.
+func (t UrnTargets) Contains(urn resource.URN) bool {
+	if !t.IsConstrained() {
+		return true
+	}
+	for _, literal := range t.literals {
+		if literal == urn {
+			return true
+		}
+	}
+	for glob := range t.globs {
+		if t.getMatcher(glob).MatchString(string(urn)) {
+			return true
+		}
+	}
+	return false
+}
+
+// URN literals specified as targets.
+//
+// It doesn't make sense to iterate over all targets, since the list of targets may be
+// infinite.
+func (t UrnTargets) Literals() []resource.URN {
+	return t.literals
+}
+
+// Adds a literal iff t is already initialized.
+func (t *UrnTargets) addLiteral(urn resource.URN) {
+	if t.IsConstrained() {
+		t.literals = append(t.literals, urn)
+	}
 }
 
 // StepExecutorEvents is an interface that can be used to hook resource lifecycle events.

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -47,3 +47,66 @@ func TestPendingOperationsDeployment(t *testing.T) {
 	_, err := NewDeployment(&plugin.Context{}, &Target{}, snap, nil, &fixedSource{}, nil, false, nil)
 	assert.NoError(t, err)
 }
+
+func TestGlobUrn(t *testing.T) {
+	t.Parallel()
+
+	globs := []struct {
+		input      string
+		expected   []resource.URN
+		unexpected []resource.URN
+	}{
+		{
+			input: "**",
+			expected: []resource.URN{
+				"urn:pulumi:stack::test::typ$aws:resource::aname",
+				"urn:pulumi:stack::test::typ$aws:resource::bar",
+				"urn:pulumi:stack::test::typ$azure:resource::bar",
+			},
+		},
+		{
+			input: "urn:pulumi:stack::test::typ*:resource::bar",
+			expected: []resource.URN{
+				"urn:pulumi:stack::test::typ$aws:resource::bar",
+				"urn:pulumi:stack::test::typ$azure:resource::bar",
+			},
+			unexpected: []resource.URN{
+				"urn:pulumi:stack::test::ty:resource::bar",
+				"urn:pulumi:stack::test::type:resource::foobar",
+			},
+		},
+		{
+			input:      "**:aname",
+			expected:   []resource.URN{"urn:pulumi:stack::test::typ$aws:resource::aname"},
+			unexpected: []resource.URN{"urn:pulumi:stack::test::typ$aws:resource::somename"},
+		},
+		{
+			input: "*:*:stack::test::typ$aws:resource::*",
+			expected: []resource.URN{
+				"urn:pulumi:stack::test::typ$aws:resource::aname",
+				"urn:pulumi:stack::test::typ$aws:resource::bar",
+			},
+			unexpected: []resource.URN{
+				"urn:pulumi:stack::test::typ$azure:resource::aname",
+			},
+		},
+		{
+			input:    "stack::test::typ$aws:resource::none",
+			expected: []resource.URN{"stack::test::typ$aws:resource::none"},
+			unexpected: []resource.URN{
+				"stack::test::typ$aws:resource::nonee",
+			},
+		},
+	}
+	for _, tt := range globs {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			targets := NewUrnTargets([]string{tt.input})
+			for _, urn := range tt.expected {
+				assert.True(t, targets.Contains(urn))
+			}
+		})
+	}
+}

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -25,57 +25,6 @@ func createSnapshotPtr() *Snapshot {
 	return &s
 }
 
-func TestGlobUrn(t *testing.T) {
-	t.Parallel()
-
-	snap := createSnapshot()
-
-	globs := []struct {
-		input    string
-		expected []resource.URN
-	}{
-		{
-			input: "**",
-			expected: []resource.URN{
-				"urn:pulumi:stack::test::typ$aws:resource::aname",
-				"urn:pulumi:stack::test::typ$aws:resource::bar",
-				"urn:pulumi:stack::test::typ$azure:resource::bar",
-			},
-		},
-		{
-			input: "urn:pulumi:stack::test::typ*:resource::bar",
-			expected: []resource.URN{
-				"urn:pulumi:stack::test::typ$aws:resource::bar",
-				"urn:pulumi:stack::test::typ$azure:resource::bar",
-			},
-		},
-		{
-			input:    "**:aname",
-			expected: []resource.URN{"urn:pulumi:stack::test::typ$aws:resource::aname"},
-		},
-		{
-			input: "*:*:stack::test::typ$aws:resource::*",
-			expected: []resource.URN{
-				"urn:pulumi:stack::test::typ$aws:resource::aname",
-				"urn:pulumi:stack::test::typ$aws:resource::bar",
-			},
-		},
-		{
-			input:    "stack::test::typ$aws:resource::none",
-			expected: []resource.URN{"stack::test::typ$aws:resource::none"},
-		},
-	}
-	for _, tt := range globs {
-		tt := tt
-		t.Run(tt.input, func(t *testing.T) {
-			t.Parallel()
-
-			actual := snap.GlobUrn(resource.URN(tt.input))
-			assert.Equal(t, tt.expected, actual)
-		})
-	}
-}
-
 func TestSnapshotNormalizeURNReferences(t *testing.T) {
 	t.Parallel()
 	s1 := createSnapshotPtr()


### PR DESCRIPTION
Fixes #8956

This changes how the various `--target` globs work. Instead of expanding the glob on the current snapshot, we now push the glob into the engine itself. This allows us to glob on resources not yet created.

In exchange for this feature, we give up the ability to reject globs that expand to nothing ahead of running a pulumi up. We gain a much more intuitive interface: globs work as expected, _without caveats_.