### PR TITLE
Replace macos-latest with macos-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ on:
         type: string
       smoke-test-platforms:
         required: false
-        default: windows-latest macos-latest
+        default: windows-latest macos-11
         description: Platforms on which to run integration tests, as a space delimited list
         type: string
       enable-coverage:
@@ -115,8 +115,8 @@ jobs:
               { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-latest" },
-              { "os": "darwin",  "arch": "amd64", "build-platform": "macos-latest" },
-              { "os": "darwin",  "arch": "arm64", "build-platform": "macos-latest" }
+              { "os": "darwin",  "arch": "amd64", "build-platform": "macos-11" },
+              { "os": "darwin",  "arch": "arm64", "build-platform": "macos-11" }
             ]'
           fi
 
@@ -236,10 +236,10 @@ jobs:
   unit-test:
     # By putting a variable in the name, we remove GitHub's auto-generated matrix parameters from
     # appearing in the rendered title of the job name: It changes this:
-    #   CI / Unit Test (cd sdk/dotnet && make dotnet_test, cd sdk/dotnet && make dotnet_test, macos-latest, mi... / sdk/dotnet dotnet_test on macos-latest/current
+    #   CI / Unit Test (cd sdk/dotnet && make dotnet_test, cd sdk/dotnet && make dotnet_test, macos-11, mi... / sdk/dotnet dotnet_test on macos-11/current
     #   (See: https://github.com/pulumi/pulumi/runs/8241055084?check_suite_focus=true#logs)
     # To this:
-    #   CI / Unit Test / sdk/dotnet dotnet_test on macos-latest/current
+    #   CI / Unit Test / sdk/dotnet dotnet_test on macos-11/current
     name: Unit Test${{ matrix.platform && '' }}
     needs: [matrix]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   macos-homebrew-install:
     name: Install Pulumi with Homebrew on macOS
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: homedate homebrew formulae
         run: brew update
@@ -29,7 +29,7 @@ jobs:
           exit 1
   macOS-direct-install:
     name: Install Pulumi via script on macOS
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - run: curl -fsSL https://get.pulumi.com | sh
       - run: echo "/Users/runner/.pulumi/bin" >> "${GITHUB_PATH}"
@@ -46,7 +46,7 @@ jobs:
           exit 1
   macos-verify-download-link:
     name: Verify Direct Download link on macOS
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Direct Download
         run: curl -L -o pulumi.tar.gz "https://get.pulumi.com/releases/sdk/pulumi-v$(curl -sS https://www.pulumi.com/latest-version)-darwin-x64.tar.gz"
@@ -167,7 +167,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-11"]
     steps:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -57,7 +57,7 @@ jobs:
       smoke-test-platforms: >- # No newlines or trailing newline.
         ${{
           contains(github.event.pull_request.labels.*.name, 'ci/test')
-          && 'macos-latest windows-latest'
+          && 'macos-11 windows-latest'
           || ''
         }}
       enable-coverage: true

--- a/changelog/pending/20221026--build--fix-release-build-to-continue-to-use-macos-11.yaml
+++ b/changelog/pending/20221026--build--fix-release-build-to-continue-to-use-macos-11.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: build
+  description: Fix release build to continue to use MacOS 11.

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -90,7 +90,7 @@ MAKEFILE_UNIT_TESTS: List[MakefileTest] = [
     {"name": "sdk/nodejs sxs_tests", "run": "cd sdk/nodejs && ../../scripts/retry make sxs_tests", "eta": 3},
 ]
 
-ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
+ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-11"]
 
 
 MINIMUM_SUPPORTED_VERSION_SET = {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

GitHub are rolling out macos 12 for the -latest image (https://github.com/actions/runner-images/issues/6384), but we need to continue to support and build for macos 11.

Fixes https://github.com/pulumi/pulumi/issues/11152

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
