### PR TITLE
[dotnet] Simplify the format of docs comment of Output<T>

### DIFF
--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -128,11 +128,8 @@ namespace Pulumi
     /// <see cref="Output{T}"/>s are a key part of how Pulumi tracks dependencies between <see
     /// cref="Resource"/>s. Because the values of outputs are not available until resources are
     /// created, these are represented using the special <see cref="Output{T}"/>s type, which
-    /// internally represents two things:
-    /// <list type="number">
-    /// <item><description>An eventually available value of the output</description></item>
-    /// <item><description>The dependency on the source(s) of the output value</description></item>
-    /// </list>
+    /// internally represents two things: an eventually available value of the output and 
+    /// the dependency on the source(s) of the output value.
     /// In fact, <see cref="Output{T}"/>s is quite similar to <see cref="Task{TResult}"/>.
     /// Additionally, they carry along dependency information.
     /// <para/>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11120 because docfx cannot properly render ordered lists

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
