### PR TITLE
[cli] Experimental support for remote operations

### DIFF
--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -52,4 +52,5 @@ type Options struct {
 	Debug                bool                // true to enable debug output.
 	Stdout               io.Writer           // the writer to use for stdout. Defaults to os.Stdout if unset.
 	Stderr               io.Writer           // the writer to use for stderr. Defaults to os.Stderr if unset.
+	SuppressTimings      bool                // true to suppress displaying timings of resource actions
 }

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1324,6 +1324,11 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return ""
 			}
 		}
+
+		if display.opts.SuppressTimings {
+			return opText
+		}
+
 		start, ok := display.opStopwatch.start[step.URN]
 		if !ok {
 			return opText
@@ -1493,6 +1498,10 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		default:
 			contract.Failf("Unrecognized resource step op: %v", op)
 			return ""
+		}
+
+		if display.opts.SuppressTimings {
+			return opText
 		}
 
 		// Calculate operation time elapsed.

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -62,6 +62,7 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 			return nil, err
 		}
 
+		// nolint: goconst
 		if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
 			return newCloudSecretsManager(s.Ref().Name(), configFile, ps.SecretsProvider)
 		}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -97,7 +97,8 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			secretsProvider := args[0]
 			rotatePassphraseProvider := secretsProvider == "passphrase"
 			// Create the new secrets provider and set to the currentStack
-			if err := createSecretsManager(ctx, currentStack, secretsProvider, rotatePassphraseProvider); err != nil {
+			if err := createSecretsManager(ctx, currentStack, secretsProvider, rotatePassphraseProvider,
+				false /*creatingStack*/); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -33,6 +33,7 @@ func newStackInitCmd() *cobra.Command {
 	var secretsProvider string
 	var stackName string
 	var stackToCopy string
+	var noSelect bool
 
 	cmd := &cobra.Command{
 		Use:   "init [<org-name>/]<stack-name>",
@@ -72,10 +73,6 @@ func newStackInitCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			proj, _, err := readProject()
-			if err != nil {
-				return err
-			}
 			b, err := currentBackend(ctx, opts)
 			if err != nil {
 				return err
@@ -122,12 +119,17 @@ func newStackInitCmd() *cobra.Command {
 			}
 
 			var createOpts interface{} // Backend-specific config options, none currently.
-			newStack, err := createStack(ctx, b, stackRef, createOpts, true /*setCurrent*/, secretsProvider)
+			newStack, err := createStack(ctx, b, stackRef, createOpts, !noSelect, secretsProvider)
 			if err != nil {
 				return err
 			}
 
 			if stackToCopy != "" {
+				proj, _, err := readProject()
+				if err != nil {
+					return err
+				}
+
 				// load the old stack and its project
 				copyStack, err := requireStack(ctx, stackToCopy, false, opts, false /*setCurrent*/)
 				if err != nil {
@@ -157,5 +159,7 @@ func newStackInitCmd() *cobra.Command {
 		&secretsProvider, "secrets-provider", "default", possibleSecretsProviderChoices)
 	cmd.PersistentFlags().StringVar(
 		&stackToCopy, "copy-config-from", "", "The name of the stack to copy existing config from")
+	cmd.PersistentFlags().BoolVar(
+		&noSelect, "no-select", false, "Do not select the stack")
 	return cmd
 }

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -1,0 +1,313 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+)
+
+// This is a variable instead of a constant so it can be set in certain builds of the CLI that do not
+// support remote deployments.
+var disableRemote bool
+
+// remoteSupported returns true if the CLI supports remote deployments.
+func remoteSupported() bool {
+	return !disableRemote && hasExperimentalCommands()
+}
+
+// parseEnv parses a `--remote-env` flag value for `--remote`. A value should be of the form
+// "NAME=value".
+func parseEnv(input string) (string, string, error) {
+	pair := strings.SplitN(input, "=", 2)
+	if len(pair) != 2 {
+		return "", "", fmt.Errorf(`expected value of the form "NAME=value": missing "=" in %q`, input)
+	}
+	name, value := pair[0], pair[1]
+
+	if name == "" {
+		return "", "", fmt.Errorf("expected non-empty environment name in %q", input)
+	}
+
+	return name, value, nil
+}
+
+// validateUnsupportedRemoteFlags returns an error if any unsupported flags are set when --remote is set.
+func validateUnsupportedRemoteFlags(
+	expectNop bool,
+	configArray []string,
+	configPath bool,
+	client string,
+	jsonDisplay bool,
+	policyPackPaths []string,
+	policyPackConfigPaths []string,
+	refresh string,
+	showConfig bool,
+	showReplacementSteps bool,
+	showSames bool,
+	showReads bool,
+	suppressOutputs bool,
+	secretsProvider string,
+	targets *[]string,
+	replaces []string,
+	targetReplaces []string,
+	targetDependents bool,
+	planFilePath string,
+	stackConfigFile string,
+) error {
+
+	if expectNop {
+		return errors.New("--expect-no-changes is not supported with --remote")
+	}
+	if len(configArray) > 0 {
+		return errors.New("--config is not supported with --remote")
+	}
+	if configPath {
+		return errors.New("--config-path is not supported with --remote")
+	}
+	if client != "" {
+		return errors.New("--client is not supported with --remote")
+	}
+	// We should be able to make --json work, but it doesn't work currently.
+	if jsonDisplay {
+		return errors.New("--json is not supported with --remote")
+	}
+	if len(policyPackPaths) > 0 {
+		return errors.New("--policy-pack is not supported with --remote")
+	}
+	if len(policyPackConfigPaths) > 0 {
+		return errors.New("--policy-pack-config is not supported with --remote")
+	}
+	if refresh != "" {
+		return errors.New("--refresh is not supported with --remote")
+	}
+	if showConfig {
+		return errors.New("--show-config is not supported with --remote")
+	}
+	if showReplacementSteps {
+		return errors.New("--show-replacement-steps is not supported with --remote")
+	}
+	if showSames {
+		return errors.New("--show-sames is not supported with --remote")
+	}
+	if showReads {
+		return errors.New("--show-reads is not supported with --remote")
+	}
+	if suppressOutputs {
+		return errors.New("--suppress-outputs is not supported with --remote")
+	}
+	if secretsProvider != "default" {
+		return errors.New("--secrets-provider is not supported with --remote")
+	}
+	if targets != nil && len(*targets) > 0 {
+		return errors.New("--target is not supported with --remote")
+	}
+	if len(replaces) > 0 {
+		return errors.New("--replace is not supported with --remote")
+	}
+	if len(replaces) > 0 {
+		return errors.New("--replace is not supported with --remote")
+	}
+	if len(targetReplaces) > 0 {
+		return errors.New("--target-replace is not supported with --remote")
+	}
+	if targetDependents {
+		return errors.New("--target-dependents is not supported with --remote")
+	}
+	if planFilePath != "" {
+		return errors.New("--plan is not supported with --remote")
+	}
+	if stackConfigFile != "" {
+		return errors.New("--config-file is not supported with --remote")
+	}
+
+	return nil
+}
+
+// Flags for remote operations.
+type RemoteArgs struct {
+	remote                   bool
+	envVars                  []string
+	secretEnvVars            []string
+	preRunCommands           []string
+	gitBranch                string
+	gitCommit                string
+	gitRepoDir               string
+	gitAuthAccessToken       string
+	gitAuthSSHPrivateKey     string
+	gitAuthSSHPrivateKeyPath string
+	gitAuthPassword          string
+	gitAuthUsername          string
+}
+
+// Add flags to support remote operations
+func (r *RemoteArgs) applyFlags(cmd *cobra.Command) {
+	if !remoteSupported() {
+		return
+	}
+
+	cmd.PersistentFlags().BoolVar(
+		&r.remote, "remote", false,
+		"[EXPERIMENTAL] Run the operation remotely")
+	cmd.PersistentFlags().StringArrayVar(
+		&r.envVars, "remote-env", []string{},
+		"[EXPERIMENTAL] Environment variables to use in the remote operation of the form NAME=value "+
+			"(e.g. `--remote-env FOO=bar`)")
+	cmd.PersistentFlags().StringArrayVar(
+		&r.secretEnvVars, "remote-env-secret", []string{},
+		"[EXPERIMENTAL] Environment variables with secret values to use in the remote operation of the form "+
+			"NAME=secretvalue (e.g. `--remote-env FOO=secret`)")
+	cmd.PersistentFlags().StringArrayVar(
+		&r.preRunCommands, "remote-pre-run-command", []string{},
+		"[EXPERIMENTAL] Commands to run before the remote operation")
+	cmd.PersistentFlags().StringVar(
+		&r.gitBranch, "remote-git-branch", "",
+		"[EXPERIMENTAL] Git branch to deploy; this is mutually exclusive with --remote-git-branch; "+
+			"either value needs to be specified")
+	cmd.PersistentFlags().StringVar(
+		&r.gitCommit, "remote-git-commit", "",
+		"[EXPERIMENTAL] Git commit hash of the commit to deploy (if used, HEAD will be in detached mode); "+
+			"this is mutually exclusive with --remote-git-branch; either value needs to be specified")
+	cmd.PersistentFlags().StringVar(
+		&r.gitRepoDir, "remote-git-repo-dir", "",
+		"[EXPERIMENTAL] The directory to work from in the project's source repository "+
+			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthAccessToken, "remote-git-auth-access-token", "",
+		"[EXPERIMENTAL] Git personal access token")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthSSHPrivateKey, "remote-git-auth-ssh-private-key", "",
+		"[EXPERIMENTAL] Git SSH private key; use --remote-git-auth-password for the password, if needed")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthSSHPrivateKeyPath, "remote-git-auth-ssh-private-key-path", "",
+		"[EXPERIMENTAL] Git SSH private key path; use --remote-git-auth-password for the password, if needed")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthPassword, "remote-git-auth-password", "",
+		"[EXPERIMENTAL] Git password; for use with username or with an SSH private key")
+	cmd.PersistentFlags().StringVar(
+		&r.gitAuthUsername, "remote-git-auth-username", "",
+		"[EXPERIMENTAL] Git username")
+}
+
+// runDeployment kicks off a remote deployment.
+func runDeployment(ctx context.Context, opts display.Options, operation apitype.PulumiOperation, stack, url string,
+	args RemoteArgs) result.Result {
+
+	b, err := currentBackend(ctx, opts)
+	if err != nil {
+		return result.FromError(err)
+	}
+
+	// Ensure the cloud backend is being used.
+	cb, isCloud := b.(httpstate.Backend)
+	if !isCloud {
+		return result.FromError(errors.New("the Pulumi service backend must be used for remote operations; " +
+			"use `pulumi login` without arguments to log into the Pulumi service backend"))
+	}
+
+	stackRef, err := b.ParseStackReference(stack)
+	if err != nil {
+		return result.FromError(err)
+	}
+
+	if url == "" {
+		return result.FromError(errors.New("the url arg must be specified"))
+	}
+	if args.gitCommit != "" && args.gitBranch != "" {
+		return result.FromError(errors.New("`--remote-git-branch` and `--remote-git-commit` cannot both be specified"))
+	}
+	if args.gitCommit == "" && args.gitBranch == "" {
+		return result.FromError(errors.New("either `--remote-git-branch` or `--remote-git-commit` is required"))
+	}
+
+	env := map[string]apitype.SecretValue{}
+	for i, e := range append(args.envVars, args.secretEnvVars...) {
+		name, value, err := parseEnv(e)
+		if err != nil {
+			return result.FromError(err)
+		}
+		env[name] = apitype.SecretValue{
+			Value:  value,
+			Secret: i >= len(args.envVars),
+		}
+	}
+
+	var gitAuth *apitype.GitAuthConfig
+	if args.gitAuthAccessToken != "" || args.gitAuthSSHPrivateKey != "" || args.gitAuthSSHPrivateKeyPath != "" ||
+		args.gitAuthPassword != "" || args.gitAuthUsername != "" {
+
+		gitAuth = &apitype.GitAuthConfig{}
+		switch {
+		case args.gitAuthAccessToken != "":
+			gitAuth.PersonalAccessToken = &apitype.SecretValue{Value: args.gitAuthAccessToken, Secret: true}
+
+		case args.gitAuthSSHPrivateKey != "" || args.gitAuthSSHPrivateKeyPath != "":
+			sshAuth := &apitype.SSHAuth{}
+			if args.gitAuthSSHPrivateKeyPath != "" {
+				content, err := os.ReadFile(args.gitAuthSSHPrivateKeyPath)
+				if err != nil {
+					return result.FromError(fmt.Errorf(
+						"reading SSH private key path %q: %w", args.gitAuthSSHPrivateKeyPath, err))
+				}
+				sshAuth.SSHPrivateKey = apitype.SecretValue{Value: string(content), Secret: true}
+			} else {
+				sshAuth.SSHPrivateKey = apitype.SecretValue{Value: args.gitAuthSSHPrivateKey, Secret: true}
+			}
+			if args.gitAuthPassword != "" {
+				sshAuth.Password = &apitype.SecretValue{Value: args.gitAuthPassword, Secret: true}
+			}
+			gitAuth.SSHAuth = sshAuth
+
+		case args.gitAuthUsername != "":
+			basicAuth := &apitype.BasicAuth{UserName: apitype.SecretValue{Value: args.gitAuthUsername, Secret: true}}
+			if args.gitAuthPassword != "" {
+				basicAuth.Password = apitype.SecretValue{Value: args.gitAuthPassword, Secret: true}
+			}
+			gitAuth.BasicAuth = basicAuth
+		}
+	}
+
+	req := apitype.CreateDeploymentRequest{
+		Source: &apitype.SourceContext{
+			Git: &apitype.SourceContextGit{
+				RepoURL: url,
+				Branch:  args.gitBranch,
+				RepoDir: args.gitRepoDir,
+				GitAuth: gitAuth,
+			},
+		},
+		Operation: &apitype.OperationContext{
+			Operation:            operation,
+			PreRunCommands:       args.preRunCommands,
+			EnvironmentVariables: env,
+		},
+	}
+	err = cb.RunDeployment(ctx, stackRef, req, opts)
+	if err != nil {
+		return result.FromError(err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/pulumi/util_remote_test.go
+++ b/pkg/cmd/pulumi/util_remote_test.go
@@ -1,0 +1,55 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input     string
+		name      string
+		value     string
+		errString string
+	}{
+		"name val":            {input: "FOO=bar", name: "FOO", value: "bar"},
+		"name empty val":      {input: "FOO=", name: "FOO"},
+		"name val extra seps": {input: "FOO=bar=baz", name: "FOO", value: "bar=baz"},
+		"empty":               {input: "", errString: `expected value of the form "NAME=value": missing "=" in ""`},
+		"no sep":              {input: "foo", errString: `expected value of the form "NAME=value": missing "=" in "foo"`},
+		"empty name val":      {input: "=", errString: `expected non-empty environment name in "="`},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			name, value, err := parseEnv(tc.input)
+			if tc.errString != "" {
+				assert.EqualError(t, err, tc.errString)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.name, name)
+			assert.Equal(t, tc.value, value)
+		})
+	}
+}

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -85,5 +85,5 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -1,0 +1,209 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import (
+	"encoding/json"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PulumiOperation describes what operation to perform on the
+// stack as defined in the Job spec.
+type PulumiOperation string
+
+// The possible operations we can deploy.
+const (
+	Update  PulumiOperation = "update"
+	Preview PulumiOperation = "preview"
+	Destroy PulumiOperation = "destroy"
+	Refresh PulumiOperation = "refresh"
+)
+
+// CreateDeploymentRequest defines the request payload that is expected when
+// creating a new deployment.
+type CreateDeploymentRequest struct {
+	// Executor defines options that the executor is going to use to run the job.
+	Executor *ExecutorContext `json:"executorContext"`
+
+	// Source defines how the source code to the Pulumi program will be gathered.
+	Source *SourceContext `json:"sourceContext,omitempty"`
+
+	// Operation defines the options that the executor will use to run the Pulumi commands.
+	Operation *OperationContext `json:"operationContext"`
+}
+
+type ExecutorContext struct {
+	// WorkingDirectory defines the path where the work should be done when executing.
+	WorkingDirectory string `json:"workingDirectory"`
+
+	// Defines the image that the pulumi operations should run in.
+	ExecutorImage string `json:"executorImage,omitempty"`
+}
+
+// SourceContext describes some source code, and how to obtain it.
+type SourceContext struct {
+	Git *SourceContextGit `json:"git,omitempty"`
+}
+
+type SourceContextGit struct {
+	RepoURL string `json:"repoURL"`
+
+	Branch string `json:"branch"`
+
+	// (optional) RepoDir is the directory to work from in the project's source repository
+	// where Pulumi.yaml is located. It is used in case Pulumi.yaml is not
+	// in the project source root.
+	RepoDir string `json:"repoDir,omitempty"`
+
+	// (optional) Commit is the hash of the commit to deploy. If used, HEAD will be in detached mode. This
+	// is mutually exclusive with the Branch setting. Either value needs to be specified.
+	Commit string `json:"commit,omitempty"`
+
+	// (optional) GitAuth allows configuring git authentication options
+	// There are 3 different authentication options:
+	//   * SSH private key (and its optional password)
+	//   * Personal access token
+	//   * Basic auth username and password
+	// Only one authentication mode will be considered if more than one option is specified,
+	// with ssh private key/password preferred first, then personal access token, and finally
+	// basic auth credentials.
+	GitAuth *GitAuthConfig `json:"gitAuth,omitempty"`
+}
+
+// GitAuthConfig specifies git authentication configuration options.
+// There are 3 different authentication options:
+//   - Personal access token
+//   - SSH private key (and its optional password)
+//   - Basic auth username and password
+//
+// Only 1 authentication mode is valid.
+type GitAuthConfig struct {
+	PersonalAccessToken *SecretValue `json:"accessToken,omitempty"`
+	SSHAuth             *SSHAuth     `json:"sshAuth,omitempty"`
+	BasicAuth           *BasicAuth   `json:"basicAuth,omitempty"`
+}
+
+// SSHAuth configures ssh-based auth for git authentication.
+// SSHPrivateKey is required but password is optional.
+type SSHAuth struct {
+	SSHPrivateKey SecretValue  `json:"sshPrivateKey"`
+	Password      *SecretValue `json:"password,omitempty"`
+}
+
+// BasicAuth configures git authentication through basic auth —
+// i.e. username and password. Both UserName and Password are required.
+type BasicAuth struct {
+	UserName SecretValue `json:"userName"`
+	Password SecretValue `json:"password"`
+}
+
+// OperationContext describes what to do.
+type OperationContext struct {
+	// PreRunCommands is an optional list of arbitrary commands to run before Pulumi
+	// is invoked.
+	// ref: https://github.com/pulumi/pulumi/issues/9397
+	PreRunCommands []string `json:"preRunCommands"`
+
+	// Operation is what we plan on doing.
+	Operation PulumiOperation `json:"operation"`
+
+	// EnvironmentVariables contains environment variables to be applied during the execution.
+	EnvironmentVariables map[string]SecretValue `json:"environmentVariables"`
+}
+
+// CreateDeploymentResponse defines the response given when a new Deployment is created.
+type CreateDeploymentResponse struct {
+	// ID represents the generated Deployment ID.
+	ID string `json:"id"`
+	// ConsoleURL is the Console URL for the deployment.
+	ConsoleURL string `json:"consoleUrl"`
+}
+
+type DeploymentLogLine struct {
+	Header    string    `json:"header,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Line      string    `json:"line,omitempty"`
+}
+
+type DeploymentLogs struct {
+	Lines     []DeploymentLogLine `json:"lines,omitempty"`
+	NextToken string              `json:"nextToken,omitempty"`
+}
+
+// A SecretValue describes a possibly-secret value.
+type SecretValue struct {
+	Value  string // Plaintext if Secret is false; ciphertext otherwise.
+	Secret bool
+}
+
+type secretWorkflowValue struct {
+	Secret string `json:"secret" yaml:"secret"`
+}
+
+func (v SecretValue) MarshalJSON() ([]byte, error) {
+	if v.Secret {
+		return json.Marshal(secretWorkflowValue{Secret: v.Value})
+	}
+	return json.Marshal(v.Value)
+}
+
+func (v *SecretValue) UnmarshalJSON(bytes []byte) error {
+	var secret secretWorkflowValue
+	if err := json.Unmarshal(bytes, &secret); err == nil {
+		v.Value, v.Secret = secret.Secret, true
+		return nil
+	}
+
+	var plaintext string
+	if err := json.Unmarshal(bytes, &plaintext); err != nil {
+		return err
+	}
+	v.Value, v.Secret = plaintext, false
+	return nil
+}
+
+func (v SecretValue) MarshalYAML() (interface{}, error) {
+	if v.Secret {
+		return secretWorkflowValue{Secret: v.Value}, nil
+	}
+	return v.Value, nil
+}
+
+func (v *SecretValue) UnmarshalYAML(node *yaml.Node) error {
+	var secret secretWorkflowValue
+	if err := node.Decode(&secret); err == nil {
+		v.Value, v.Secret = secret.Secret, true
+		return nil
+	}
+
+	var plaintext string
+	if err := node.Decode(&plaintext); err != nil {
+		return err
+	}
+	v.Value, v.Secret = plaintext, false
+	return nil
+}
+
+type GetDeploymentUpdatesUpdateInfo struct {
+	// UpdateID is the underlying Update's ID on the PPC.
+	UpdateID string `json:"updateID"`
+
+	// Version of the stack that this UpdateInfo describe.
+	Version int `json:"version"`
+	// LatestVersion of the stack in general. i.e. the latest when Version == LatestVersion.
+	LatestVersion int `json:"latestVersion"`
+}

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -212,3 +212,16 @@ type EngineEvent struct {
 type EngineEventBatch struct {
 	Events []EngineEvent `json:"events"`
 }
+
+// GetUpdateEventsResponse contains the engine events for an update.
+type GetUpdateEventsResponse struct {
+	// Events are returned sorted by their internal sequence number (not exposed to the API).
+	// So the last Event in the slice is the most recent event which was stored in the database.
+	// (Should sort identical to timestamp, but may not if we support parallel writes.)
+	Events []EngineEvent `json:"events"`
+
+	// ContinuationToken is an opaque value the client can send to fetch more recent
+	// events if the update is still in progress. Will be nil once all events have
+	// been returned and the update is complete.
+	ContinuationToken *string `json:"continuationToken"`
+}

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -63,6 +63,7 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )


### PR DESCRIPTION
This change adds experimental CLI support for remote operations. For the new CLI flags to show up `PULUMI_EXPERIMENTAL` envvar must best to a truthy value. Automation API (separate PRs for each language forthcoming), leverage these commands and flags under the covers.

Here's an example:

```
PULUMI_EXPERIMENTAL=true pulumi up --remote https://github.com/pulumi/examples.git \
    --stack="justinvp/aws-ts-s3-folder/dev" \
    --remote-git-branch="refs/heads/master" \
    --remote-git-repo-dir="aws-ts-s3-folder" \
    --remote-env="AWS_REGION=us-west-2" \
    --remote-env="AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
    --remote-env-secret="AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
    --remote-env-secret="AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
```

And similar for `preview`, `refresh`, and `destroy` commands.

Note: While this will initially be behind `PULUMI_EXPERIMENTAL`, I expect we will make these flags available by default for regular CLI use at some point.

In addition to the code review, I'm looking for feedback on the following:

1. This leverages `pulumi up`'s existing `pulumi up [url]` URL argument (and adds a similar URL argument to the other commands). When `--remote` is specified, the URL arg means the git repo URL to pass to the deployment API. I was debating whether `--remote-git-branch` and `--remote-git-commit` (one of those must be set; mutually exclusive) should be a second arg like `pulumi up [url] [ref]`, and additionally if `--remote-git-repo-dir` should be a third arg like `pulumi up [url] [ref] [dir]`. I decided to go with flags because it's possible we'll make branch/commit optional in the future, which would make it awkward if you have to pass a repo-dir as a third arg (requiring specifying a branch/commit second arg). Also, having branch/commit as a single arg would mean we'd have to try to determine whether it looks like a commit hash vs. a branch. Open to feedback here.

2. ~~The deployment API supports secrets for envvar values. I may have gone too cute with how these are specified via the CLI. Regular values are specified with `NAME=value` (`=` separator). Secret values are specified like `NAME#=secretvalue` (`#=` separator). Alternatively, I could have separate flags like `--remote-env` and `--remote-env-secret` which is probably more straightforward. Feedback appreciated.~~

    **Update:** Added a separate `--remote-env-secret` flag for envvar secrets.

Note: I do plan to include some sanity tests, but need to make sure whatever account we use when `PULUMI_ACCESS_TOKEN` is set has the feature enabled in the service. Will do that as a follow-up.