### PR TITLE
[auto/nodejs] Support for remote operations

### DIFF
--- a/changelog/pending/20221027--auto-nodejs--support-for-remote-operations.yaml
+++ b/changelog/pending/20221027--auto-nodejs--support-for-remote-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Support for remote operations

--- a/sdk/nodejs/automation/index.ts
+++ b/sdk/nodejs/automation/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,3 +21,5 @@ export * from "./projectSettings";
 export * from "./localWorkspace";
 export * from "./workspace";
 export * from "./events";
+export * from "./remoteStack";
+export * from "./remoteWorkspace";

--- a/sdk/nodejs/automation/remoteStack.ts
+++ b/sdk/nodejs/automation/remoteStack.ts
@@ -1,0 +1,170 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EngineEvent } from "./events";
+import { LocalWorkspace } from "./localWorkspace";
+import {
+    DestroyResult,
+    OutputMap,
+    PreviewResult,
+    RefreshResult,
+    Stack,
+    UpdateSummary,
+    UpResult,
+} from "./stack";
+import { Deployment } from "./workspace";
+
+/**
+ * RemoteStack is an isolated, independencly configurable instance of a Pulumi program that is
+ * operated on remotely (up/preview/refresh/destroy).
+ */
+export class RemoteStack {
+    /** @internal */
+    static create(stack: Stack): RemoteStack {
+        return new RemoteStack(stack);
+    }
+
+    private constructor(private readonly stack: Stack) {
+        const ws = stack.workspace;
+        if (!(ws instanceof LocalWorkspace)) {
+            throw new Error("expected workspace to be an instance of LocalWorkspace");
+        }
+    }
+
+    /**
+     * The name identifying the Stack.
+     */
+    get name(): string {
+        return this.stack.name;
+    }
+
+    /**
+     * Creates or updates the resources in a stack by executing the program in the Workspace.
+     * https://www.pulumi.com/docs/reference/cli/pulumi_up/
+     * This operation runs remotely.
+     *
+     * @param opts Options to customize the behavior of the update.
+     */
+    up(opts?: RemoteUpOptions): Promise<UpResult> {
+        return this.stack.up(opts);
+    }
+
+    /**
+     * Performs a dry-run update to a stack, returning pending changes.
+     * https://www.pulumi.com/docs/reference/cli/pulumi_preview/
+     * This operation runs remotely.
+     *
+     * @param opts Options to customize the behavior of the preview.
+     */
+    preview(opts?: RemotePreviewOptions): Promise<PreviewResult> {
+        return this.stack.preview(opts);
+    }
+
+    /**
+     * Compares the current stack’s resource state with the state known to exist in the actual
+     * cloud provider. Any such changes are adopted into the current stack.
+     * This operation runs remotely.
+     *
+     * @param opts Options to customize the behavior of the refresh.
+     */
+    refresh(opts?: RemoteRefreshOptions): Promise<RefreshResult> {
+        return this.stack.refresh(opts);
+    }
+
+    /**
+     * Destroy deletes all resources in a stack, leaving all history and configuration intact.
+     * This operation runs remotely.
+     *
+     * @param opts Options to customize the behavior of the destroy.
+     */
+    destroy(opts?: RemoteDestroyOptions): Promise<DestroyResult> {
+        return this.stack.destroy(opts);
+    }
+
+    /**
+     * Gets the current set of Stack outputs from the last Stack.up().
+     */
+    outputs(): Promise<OutputMap> {
+        return this.stack.outputs();
+    }
+
+    /**
+     * Returns a list summarizing all previous and current results from Stack lifecycle operations
+     * (up/preview/refresh/destroy).
+     */
+    history(pageSize?: number, page?: number): Promise<UpdateSummary[]> {
+        // TODO: Find a way to allow showSecrets as an option that doesn't require loading the project.
+        return this.stack.history(pageSize, page, false);
+    }
+
+    /**
+     * Cancel stops a stack's currently running update. It returns an error if no update is currently running.
+     * Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
+     * if a resource operation was pending when the update was canceled.
+     * This command is not supported for local backends.
+     */
+    cancel(): Promise<void> {
+        return this.stack.cancel();
+    }
+
+    /**
+     * exportStack exports the deployment state of the stack.
+     * This can be combined with Stack.importStack to edit a stack's state (such as recovery from failed deployments).
+     */
+    exportStack(): Promise<Deployment> {
+        return this.stack.exportStack();
+    }
+
+    /**
+     * importStack imports the specified deployment state into a pre-existing stack.
+     * This can be combined with Stack.exportStack to edit a stack's state (such as recovery from failed deployments).
+     *
+     * @param state the stack state to import.
+     */
+    importStack(state: Deployment): Promise<void> {
+        return this.stack.importStack(state);
+    }
+}
+
+/**
+ * Options controlling the behavior of a RemoteStack.up() operation.
+ */
+export interface RemoteUpOptions {
+    onOutput?: (out: string) => void;
+    onEvent?: (event: EngineEvent) => void;
+}
+
+/**
+ * Options controlling the behavior of a RemoteStack.preview() operation.
+ */
+export interface RemotePreviewOptions {
+    onOutput?: (out: string) => void;
+    onEvent?: (event: EngineEvent) => void;
+}
+
+/**
+ * Options controlling the behavior of a RemoteStack.refresh() operation.
+ */
+export interface RemoteRefreshOptions {
+    onOutput?: (out: string) => void;
+    onEvent?: (event: EngineEvent) => void;
+}
+
+/**
+ * Options controlling the behavior of a RemoteStack.destroy() operation.
+ */
+export interface RemoteDestroyOptions {
+    onOutput?: (out: string) => void;
+    onEvent?: (event: EngineEvent) => void;
+}

--- a/sdk/nodejs/automation/remoteWorkspace.ts
+++ b/sdk/nodejs/automation/remoteWorkspace.ts
@@ -1,0 +1,186 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LocalWorkspace, LocalWorkspaceOptions } from "./localWorkspace";
+import { RemoteStack } from "./remoteStack";
+import { Stack } from "./stack";
+
+/**
+ * RemoteWorkspace is the execution context containing a single remote Pulumi project.
+ */
+export class RemoteWorkspace {
+    /**
+     * PREVIEW: Creates a Stack backed by a RemoteWorkspace with source code from the specified Git repository.
+     * Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+     *
+     * @param args A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+     * @param opts Additional customizations to be applied to the Workspace.
+     */
+    static async createStack(args: RemoteGitProgramArgs, opts?: RemoteWorkspaceOptions): Promise<RemoteStack> {
+        const ws = await createLocalWorkspace(args, opts);
+        const stack = await Stack.create(args.stackName, ws);
+        return RemoteStack.create(stack);
+    }
+
+    /**
+     * PREVIEW: Selects an existing Stack backed by a RemoteWorkspace with source code from the specified Git
+     * repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+     *
+     * @param args A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+     * @param opts Additional customizations to be applied to the Workspace.
+     */
+    static async selectStack(args: RemoteGitProgramArgs, opts?: RemoteWorkspaceOptions): Promise<RemoteStack> {
+        const ws = await createLocalWorkspace(args, opts);
+        const stack = await Stack.select(args.stackName, ws);
+        return RemoteStack.create(stack);
+    }
+    /**
+     * PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
+     * Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+     *
+     * @param args A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+     * @param opts Additional customizations to be applied to the Workspace.
+     */
+    static async createOrSelectStack(args: RemoteGitProgramArgs, opts?: RemoteWorkspaceOptions): Promise<RemoteStack> {
+        const ws = await createLocalWorkspace(args, opts);
+        const stack = await Stack.createOrSelect(args.stackName, ws);
+        return RemoteStack.create(stack);
+    }
+
+    private constructor() {} // eslint-disable-line @typescript-eslint/no-empty-function
+}
+
+/**
+ * Description of a stack backed by a remote Pulumi program in a Git repository.
+ */
+export interface RemoteGitProgramArgs {
+    /**
+     * The name of the associated Stack
+     */
+    stackName: string;
+
+    /**
+     * The URL of the repository.
+     */
+    url: string;
+
+    /**
+     * Optional path relative to the repo root specifying location of the Pulumi program.
+     */
+    projectPath?: string;
+
+    /**
+     * Optional branch to checkout.
+     */
+    branch?: string;
+
+    /**
+     * Optional commit to checkout.
+     */
+    commitHash?: string;
+
+    /**
+     * Authentication options for the repository.
+     */
+    auth?: RemoteGitAuthArgs;
+}
+
+/**
+ * Authentication options for the repository that can be specified for a private Git repo.
+ * There are three different authentication paths:
+ *  - Personal accesstoken
+ *  - SSH private key (and its optional password)
+ *  - Basic auth username and password
+ *
+ * Only one authentication path is valid.
+ */
+export interface RemoteGitAuthArgs {
+    /**
+     * The absolute path to a private key for access to the git repo.
+     */
+    sshPrivateKeyPath?: string;
+
+    /**
+     * The (contents) private key for access to the git repo.
+     */
+    sshPrivateKey?: string;
+
+    /**
+     * The password that pairs with a username or as part of an SSH Private Key.
+     */
+    password?: string;
+
+    /**
+     * PersonalAccessToken is a Git personal access token in replacement of your password.
+     */
+    personalAccessToken?: string;
+
+    /**
+     * Username is the username to use when authenticating to a git repository
+     */
+    username?: string;
+}
+
+/**
+ * Extensibility options to configure a RemoteWorkspace.
+ */
+export interface RemoteWorkspaceOptions {
+    /**
+     * Environment values scoped to the remote workspace. These will be passed to remote operations.
+     */
+    envVars?: { [key: string]: string | { secret: string } };
+
+    /**
+     * An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
+     */
+    preRunCommands?: string[];
+}
+
+async function createLocalWorkspace(args: RemoteGitProgramArgs, opts?: RemoteWorkspaceOptions): Promise<LocalWorkspace> {
+    if (!isFullyQualifiedStackName(args.stackName)) {
+        throw new Error(`"${args.stackName}" stack name must be fully qualified`);
+    }
+
+    if (!args.url) {
+        throw new Error("url is required.");
+    }
+    if (args.commitHash && args.branch) {
+        throw new Error("commitHash and branch cannot both be specified.");
+    }
+    if (!args.commitHash && !args.branch) {
+        throw new Error("at least commitHash or branch are required.");
+    }
+    if (args.auth) {
+        if (args.auth.sshPrivateKey && args.auth.sshPrivateKeyPath) {
+            throw new Error("sshPrivateKey and sshPrivateKeyPath cannot both be specified.");
+        }
+    }
+
+    const localOpts: LocalWorkspaceOptions = {
+        remote: true,
+        remoteGitProgramArgs: args,
+        remoteEnvVars: opts?.envVars,
+        remotePreRunCommands: opts?.preRunCommands,
+    };
+    return await LocalWorkspace.create(localOpts);
+}
+
+/** @internal exported only so it can be tested */
+export function isFullyQualifiedStackName(stackName: string): boolean {
+    if (!stackName) {
+        return false;
+    }
+    const split = stackName.split("/");
+    return split.length === 3 && !!split[0] && !!split[1] && !!split[2];
+}

--- a/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
@@ -1,0 +1,79 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from "assert";
+
+import { isFullyQualifiedStackName } from "../../automation";
+
+describe("isFullyQualifiedStackName", () => {
+    const tests = [
+        {
+            name: "fully qualified",
+            input: "owner/project/stack",
+            expected: true,
+        },
+        {
+            name: "undefined",
+            input: undefined,
+            expected: false,
+        },
+        {
+            name: "null",
+            input: null,
+            expected: false,
+        },
+        {
+            name: "empty",
+            input: "",
+            expected: false,
+        },
+        {
+            name: "name",
+            input: "name",
+            expected: false,
+        },
+        {
+            name: "name & owner",
+            input: "owner/name",
+            expected: false,
+        },
+        {
+            name: "sep",
+            input: "/",
+            expected: false,
+        },
+        {
+            name: "two seps",
+            input: "//",
+            expected: false,
+        },
+        {
+            name: "three seps",
+            input: "///",
+            expected: false,
+        },
+        {
+            name: "invalid",
+            input: "owner/project/stack/wat",
+            expected: false,
+        },
+    ];
+
+    tests.forEach(test => {
+        it(`${test.name}`, () => {
+            const actual = isFullyQualifiedStackName(test.input!);
+            assert.strictEqual(actual, test.expected);
+        });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -78,6 +78,8 @@
         "automation/localWorkspace.ts",
         "automation/minimumVersion.ts",
         "automation/projectSettings.ts",
+        "automation/remoteStack.ts",
+        "automation/remoteWorkspace.ts",
         "automation/stackSettings.ts",
         "automation/server.ts",
         "automation/stack.ts",
@@ -105,6 +107,7 @@
 
         "tests/automation/cmd.spec.ts",
         "tests/automation/localWorkspace.spec.ts",
+        "tests/automation/remoteWorkspace.spec.ts",
 
         "tests_with_mocks/mocks.spec.ts"
     ]


### PR DESCRIPTION
This change adds preview support for remote operations in Node.js's Automation API.

Here's an example of using it:

```ts
import * as process from "process";
import { RemoteWorkspace, fullyQualifiedStackName } from "@pulumi/pulumi/automation";

const args = process.argv.slice(2);
const destroy = args.length > 0 && args[0] === "destroy";

const org = "justinvp";
const projectName = "aws-ts-s3-folder";
const stackName = fullyQualifiedStackName(org, projectName, "devnode");

(async function() {
    const stack = await RemoteWorkspace.createOrSelectStack({
        stackName,
        url: "https://github.com/pulumi/examples.git",
        branch: "refs/heads/master",
        projectPath: projectName,
    }, {
        envVars: {
            AWS_REGION:            "us-west-2",
            AWS_ACCESS_KEY_ID:     process.env.AWS_ACCESS_KEY_ID ?? "",
            AWS_SECRET_ACCESS_KEY: { secret: process.env.AWS_SECRET_ACCESS_KEY ?? "" },
            AWS_SESSION_TOKEN:     { secret: process.env.AWS_SESSION_TOKEN ?? "" },
        },
    });

    if (destroy) {
        await stack.destroy({ onOutput: out => process.stdout.write(out) });
        console.log("Stack successfully destroyed");
        process.exit(0);
    }

    const upRes = await stack.up({ onOutput: out => process.stdout.write(out) });
    console.log("Update succeeded!");
    console.log(`url: ${upRes.outputs.websiteUrl.value}`);
})();
```

I will add sanity tests subsequently.