### PR TITLE
[auto/python] Support for remote operations

### DIFF
--- a/changelog/pending/20221027--auto-python--support-for-remote-operations.yaml
+++ b/changelog/pending/20221027--auto-python--support-for-remote-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Support for remote operations

--- a/sdk/python/lib/pulumi/automation/__init__.py
+++ b/sdk/python/lib/pulumi/automation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021, Pulumi Corporation.
+# Copyright 2016-2022, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,6 +88,16 @@ conflicts::
 
 """
 
+from pulumi.automation._remote_workspace import (
+    RemoteWorkspaceOptions,
+    RemoteGitAuth,
+    create_remote_stack_git_source,
+    create_or_select_remote_stack_git_source,
+    select_remote_stack_git_source,
+)
+
+from pulumi.automation._remote_stack import RemoteStack
+
 from ._cmd import CommandResult, OnOutput
 
 from ._config import ConfigMap, ConfigValue
@@ -126,6 +136,7 @@ from .events import (
 from ._local_workspace import (
     LocalWorkspace,
     LocalWorkspaceOptions,
+    Secret,
     create_stack,
     select_stack,
     create_or_select_stack,
@@ -197,6 +208,7 @@ __all__ = [
     # _local_workspace
     "LocalWorkspace",
     "LocalWorkspaceOptions",
+    "Secret",
     "create_stack",
     "select_stack",
     "create_or_select_stack",
@@ -225,6 +237,14 @@ __all__ = [
     "RefreshResult",
     "DestroyResult",
     "fully_qualified_stack_name",
+    # _remote_workspace
+    "RemoteWorkspaceOptions",
+    "RemoteGitAuth",
+    "create_remote_stack_git_source",
+    "create_or_select_remote_stack_git_source",
+    "select_remote_stack_git_source",
+    # _remote_stack
+    "RemoteStack",
     # sub-modules
     "errors",
     "events",

--- a/sdk/python/lib/pulumi/automation/_remote_stack.py
+++ b/sdk/python/lib/pulumi/automation/_remote_stack.py
@@ -1,0 +1,156 @@
+# Copyright 2016-2022, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+from pulumi.automation._cmd import OnOutput
+from pulumi.automation._output import OutputMap
+from pulumi.automation._stack import (
+    DestroyResult,
+    OnEvent,
+    PreviewResult,
+    RefreshResult,
+    Stack,
+    UpResult,
+    UpdateSummary,
+)
+from pulumi.automation._workspace import Deployment
+
+
+class RemoteStack:
+    """
+    RemoteStack is an isolated, independencly configurable instance of a Pulumi program that is
+    operated on remotely (up/preview/refresh/destroy).
+    """
+
+    __stack: Stack
+
+    @property
+    def name(self) -> str:
+        return self.__stack.name
+
+    def __init__(self, stack: Stack):
+        self.__stack = stack
+
+    def up(
+        self,
+        on_output: Optional[OnOutput] = None,
+        on_event: Optional[OnEvent] = None,
+    ) -> UpResult:
+        """
+        Creates or updates the resources in a stack by executing the program in the Workspace.
+        https://www.pulumi.com/docs/reference/cli/pulumi_up/
+
+        :param on_output: A function to process the stdout stream.
+        :param on_event: A function to process structured events from the Pulumi event stream.
+        :returns: UpResult
+        """
+        return self.__stack.up(on_output=on_output, on_event=on_event)
+
+    def preview(
+        self,
+        on_output: Optional[OnOutput] = None,
+        on_event: Optional[OnEvent] = None,
+    ) -> PreviewResult:
+        """
+        Performs a dry-run update to a stack, returning pending changes.
+        https://www.pulumi.com/docs/reference/cli/pulumi_preview/
+
+        :param on_output: A function to process the stdout stream.
+        :param on_event: A function to process structured events from the Pulumi event stream.
+        :returns: PreviewResult
+        """
+        return self.__stack.preview(on_output=on_output, on_event=on_event)
+
+    def refresh(
+        self,
+        on_output: Optional[OnOutput] = None,
+        on_event: Optional[OnEvent] = None,
+    ) -> RefreshResult:
+        """
+        Compares the current stack’s resource state with the state known to exist in the actual
+        cloud provider. Any such changes are adopted into the current stack.
+
+        :param on_output: A function to process the stdout stream.
+        :param on_event: A function to process structured events from the Pulumi event stream.
+        :returns: RefreshResult
+        """
+        return self.__stack.refresh(on_output=on_output, on_event=on_event)
+
+    def destroy(
+        self,
+        on_output: Optional[OnOutput] = None,
+        on_event: Optional[OnEvent] = None,
+    ) -> DestroyResult:
+        """
+        Destroy deletes all resources in a stack, leaving all history and configuration intact.
+
+        :param on_output: A function to process the stdout stream.
+        :param on_event: A function to process structured events from the Pulumi event stream.
+        :returns: DestroyResult
+        """
+        return self.__stack.destroy(on_output=on_output, on_event=on_event)
+
+    def outputs(self) -> OutputMap:
+        """
+        Gets the current set of Stack outputs from the last Stack.up().
+
+        :returns: OutputMap
+        """
+        return self.__stack.outputs()
+
+    def history(
+        self,
+        page_size: Optional[int] = None,
+        page: Optional[int] = None,
+    ) -> List[UpdateSummary]:
+        """
+        Returns a list summarizing all previous and current results from Stack lifecycle operations
+        (up/preview/refresh/destroy).
+
+        :param page_size: Paginate history entries (used in combination with page), defaults to all.
+        :param page: Paginate history entries (used in combination with page_size), defaults to all.
+        :param show_secrets: Show config secrets when they appear in history.
+
+        :returns: List[UpdateSummary]
+        """
+        # Note: Find a way to allow show_secrets as an option that doesn't require loading the project.
+        return self.__stack.history(page_size=page_size, page=page, show_secrets=False)
+
+    def cancel(self) -> None:
+        """
+        Cancel stops a stack's currently running update. It returns an error if no update is currently running.
+        Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
+        if a resource operation was pending when the update was canceled.
+        This command is not supported for local backends.
+        """
+        self.__stack.cancel()
+
+    def export_stack(self) -> Deployment:
+        """
+        export_stack exports the deployment state of the stack.
+        This can be combined with Stack.import_state to edit a stack's state (such as recovery from failed deployments).
+
+        :returns: Deployment
+        """
+        return self.__stack.export_stack()
+
+    def import_stack(self, state: Deployment) -> None:
+        """
+        import_stack imports the specified deployment state into a pre-existing stack.
+        This can be combined with Stack.export_state to edit a stack's state (such as recovery from failed deployments).
+
+        :param state: The deployment state to import.
+        """
+        self.__stack.import_stack(state=state)

--- a/sdk/python/lib/pulumi/automation/_remote_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_remote_workspace.py
@@ -1,0 +1,225 @@
+# Copyright 2016-2022, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Mapping, Optional, Union
+
+from pulumi.automation._local_workspace import LocalWorkspace, Secret
+from pulumi.automation._remote_stack import RemoteStack
+from pulumi.automation._stack import Stack, StackInitMode
+
+
+class RemoteWorkspaceOptions:
+    """
+    Extensibility options to configure a RemoteWorkspace.
+    """
+
+    env_vars: Optional[Mapping[str, Union[str, Secret]]]
+    pre_run_commands: Optional[List[str]]
+
+    def __init__(
+        self,
+        *,
+        env_vars: Optional[Mapping[str, Union[str, Secret]]] = None,
+        pre_run_commands: Optional[List[str]] = None,
+    ):
+        self.env_vars = env_vars
+        self.pre_run_commands = pre_run_commands
+
+
+class RemoteGitAuth:
+    """
+    Authentication options for the repository that can be specified for a private Git repo.
+    There are three different authentication paths:
+     - Personal accesstoken
+     - SSH private key (and its optional password)
+     - Basic auth username and password
+
+    Only one authentication path is valid.
+    """
+
+    ssh_private_key_path: Optional[str]
+    """
+    The absolute path to a private key for access to the git repo.
+    """
+
+    ssh_private_key: Optional[str]
+    """
+    The (contents) private key for access to the git repo.
+    """
+
+    password: Optional[str]
+    """
+    The password that pairs with a username or as part of an SSH Private Key.
+    """
+
+    personal_access_token: Optional[str]
+    """
+    A Git personal access token in replacement of your password.
+    """
+
+    username: Optional[str]
+    """
+    The username to use when authenticating to a git repository.
+    """
+
+    def __init__(
+        self,
+        *,
+        ssh_private_key_path: Optional[str] = None,
+        ssh_private_key: Optional[str] = None,
+        password: Optional[str] = None,
+        personal_access_token: Optional[str] = None,
+        username: Optional[str] = None,
+    ):
+        self.ssh_private_key_path = ssh_private_key_path
+        self.ssh_private_key = ssh_private_key
+        self.password = password
+        self.personal_access_token = personal_access_token
+        self.username = username
+
+
+def create_remote_stack_git_source(
+    stack_name: str,
+    url: str,
+    *,
+    branch: Optional[str] = None,
+    commit_hash: Optional[str] = None,
+    project_path: Optional[str] = None,
+    auth: Optional[RemoteGitAuth] = None,
+    opts: Optional[RemoteWorkspaceOptions] = None,
+) -> RemoteStack:
+    """
+    PREVIEW: Creates a Stack backed by a RemoteWorkspace with source code from the specified Git repository.
+    Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+    """
+    if not _is_fully_qualified_stack_name(stack_name):
+        raise Exception(f'"{stack_name}" stack name must be fully qualified.')
+
+    ws = _create_local_workspace(
+        url=url,
+        project_path=project_path,
+        branch=branch,
+        commit_hash=commit_hash,
+        auth=auth,
+        opts=opts,
+    )
+    stack = Stack.create(stack_name, ws)
+    return RemoteStack(stack)
+
+
+def create_or_select_remote_stack_git_source(
+    stack_name: str,
+    url: str,
+    *,
+    branch: Optional[str] = None,
+    commit_hash: Optional[str] = None,
+    project_path: Optional[str] = None,
+    auth: Optional[RemoteGitAuth] = None,
+    opts: Optional[RemoteWorkspaceOptions] = None,
+) -> RemoteStack:
+    """
+    PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
+    Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+    """
+    if not _is_fully_qualified_stack_name(stack_name):
+        raise Exception(f'"{stack_name}" stack name must be fully qualified.')
+
+    ws = _create_local_workspace(
+        url=url,
+        project_path=project_path,
+        branch=branch,
+        commit_hash=commit_hash,
+        auth=auth,
+        opts=opts,
+    )
+    stack = Stack.create_or_select(stack_name, ws)
+    return RemoteStack(stack)
+
+
+def select_remote_stack_git_source(
+    stack_name: str,
+    url: str,
+    *,
+    branch: Optional[str] = None,
+    commit_hash: Optional[str] = None,
+    project_path: Optional[str] = None,
+    auth: Optional[RemoteGitAuth] = None,
+    opts: Optional[RemoteWorkspaceOptions] = None,
+) -> RemoteStack:
+    """
+    PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
+    Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+    """
+    if not _is_fully_qualified_stack_name(stack_name):
+        raise Exception(f'"{stack_name}" stack name must be fully qualified.')
+
+    ws = _create_local_workspace(
+        url=url,
+        project_path=project_path,
+        branch=branch,
+        commit_hash=commit_hash,
+        auth=auth,
+        opts=opts,
+    )
+    stack = Stack.select(stack_name, ws)
+    return RemoteStack(stack)
+
+
+def _create_local_workspace(
+    url: str,
+    branch: Optional[str] = None,
+    commit_hash: Optional[str] = None,
+    project_path: Optional[str] = None,
+    auth: Optional[RemoteGitAuth] = None,
+    opts: Optional[RemoteWorkspaceOptions] = None,
+) -> LocalWorkspace:
+
+    if commit_hash is not None and branch is not None:
+        raise Exception("commit_hash and branch cannot both be specified.")
+    if commit_hash is None and branch is None:
+        raise Exception("at least commit_hash or branch are required.")
+    if auth is not None:
+        if auth.ssh_private_key is not None and auth.ssh_private_key_path is not None:
+            raise Exception(
+                "ssh_private_key and ssh_private_key_path cannot both be specified."
+            )
+
+    env_vars = None
+    pre_run_commands = None
+    if opts is not None:
+        env_vars = opts.env_vars
+        pre_run_commands = opts.pre_run_commands
+
+    ws = LocalWorkspace()
+    ws._remote = True
+    ws._remote_env_vars = env_vars
+    ws._remote_pre_run_commands = pre_run_commands
+    ws._remote_git_url = url
+    ws._remote_git_project_path = project_path
+    ws._remote_git_branch = branch
+    ws._remote_git_commit_hash = commit_hash
+    ws._remote_git_auth = auth
+
+    # Ensure the CLI supports --remote.
+    if not ws._version_check_opt_out() and not ws._remote_supported():
+        raise Exception(
+            "The Pulumi CLI does not support remote operations. Please upgrade."
+        )
+
+    return ws
+
+
+def _is_fully_qualified_stack_name(stack: str) -> bool:
+    split = stack.split("/")
+    return len(split) == 3 and split[0] != "" and split[1] != "" and split[2] != ""

--- a/sdk/python/lib/test/automation/test_remote_workspace.py
+++ b/sdk/python/lib/test/automation/test_remote_workspace.py
@@ -1,0 +1,31 @@
+# Copyright 2016-2022, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from pulumi.automation._remote_workspace import _is_fully_qualified_stack_name
+
+@pytest.mark.parametrize("input,expected", [
+    ("owner/project/stack", True),
+    ("", False),
+    ("name", False),
+    ("owner/name", False),
+    ("/", False),
+    ("//", False),
+    ("///", False),
+    ("owner/project/stack/wat", False),
+])
+def test_config_get_with_defaults(input, expected):
+    actual = _is_fully_qualified_stack_name(input)
+    assert expected == actual


### PR DESCRIPTION
This change adds preview support for remote operations in Python's Automation API.

Here's an example of using it:

```python
import sys
import os

import pulumi.automation as auto


args = sys.argv[1:]
destroy = args and args[0] == "destroy"

org = "justinvp"
project_name = "aws-ts-s3-folder"
stack_name = auto.fully_qualified_stack_name(org, project_name, "devpy")

stack = auto.create_or_select_remote_stack_git_source(
    stack_name=stack_name,
    url="https://github.com/pulumi/examples.git",
    branch="refs/heads/master",
    project_path=project_name,
    opts=auto.RemoteWorkspaceOptions(
        env_vars={
            "AWS_REGION":            "us-west-2",
            "AWS_ACCESS_KEY_ID":     os.environ["AWS_ACCESS_KEY_ID"],
            "AWS_SECRET_ACCESS_KEY": auto.Secret(os.environ["AWS_SECRET_ACCESS_KEY"]),
            "AWS_SESSION_TOKEN":     auto.Secret(os.environ["AWS_SESSION_TOKEN"]),
        },
    ),
)

if destroy:
    stack.destroy(on_output=print)
    print("Stack successfully destroyed")
    sys.exit()

up_res = stack.up(on_output=print)
print(f"Update succeeded!")
print(f"url: {up_res.outputs['websiteUrl'].value}")
```

I will add sanity tests subsequently.