### PR TITLE
cli: Fix issue with pulumi new and unstaged files

### DIFF
--- a/changelog/pending/20221027--cli--hard-reset-the-templates-checkout-to-work-around-a-go-git-issue-with-ignored-files.yaml
+++ b/changelog/pending/20221027--cli--hard-reset-the-templates-checkout-to-work-around-a-go-git-issue-with-ignored-files.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Hard reset the templates checkout to work around a go-git issue with ignored files.

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -324,6 +324,16 @@ func gitCloneOrPull(url string, referenceName plumbing.ReferenceName, path strin
 				return err
 			}
 
+			// There are cases where go-git gets confused about files that were included in .gitignore
+			// and then later removed from .gitignore and added to the repository, leaving unstaged
+			// changes in the working directory after a pull. To address this, we'll first do a hard
+			// reset of the worktree before pulling to ensure it's in a good state.
+			if err := w.Reset(&git.ResetOptions{
+				Mode: git.HardReset,
+			}); err != nil {
+				return err
+			}
+
 			if cloneErr = w.Pull(&git.PullOptions{
 				ReferenceName: referenceName,
 				SingleBranch:  true,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/11121

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
