### PR TITLE
Prevent race when resolving a property map

### DIFF
--- a/changelog/pending/20221028--sdk-go-yaml--prevent-race-on-resource-output.yaml
+++ b/changelog/pending/20221028--sdk-go-yaml--prevent-race-on-resource-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go,yaml
+  description: Prevent race on resource output

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1178,8 +1178,6 @@ func (state *resourceState) resolve(ctx *Context, err error, inputs *resourceInp
 		return
 	}
 
-	state.rawOutputs.getState().resolve(outprops, true, false, nil)
-
 	outprops["urn"] = resource.NewStringProperty(urn)
 	if id != "" || !dryrun {
 		outprops["id"] = resource.NewStringProperty(id)
@@ -1203,6 +1201,10 @@ func (state *resourceState) resolve(ctx *Context, err error, inputs *resourceInp
 			outprops[""] = resource.NewObjectProperty(remaining)
 		}
 	}
+
+	// We need to wait until after we finish mutating outprops to resolve. Resolving
+	// unlocks multithreaded access to the resolved value, making mutation a data race.
+	state.rawOutputs.getState().resolve(outprops, true, false, nil)
 
 	for k, output := range state.outputs {
 		// If this is an unknown or missing value during a dry run, do nothing.


### PR DESCRIPTION
I encountered a problem trying to flush non-determinism out of pulumi-yaml. Running our tests with high `--count=N` values resulted in panics from concurrent accesses to `Ouptput` values. These changes allow running `go test -count=500 -race  ./...` without errors (caused by pulumi/pulumi).