### PR TITLE
Make IsSecret threadsafe

### DIFF
--- a/changelog/pending/20221028--sdk-go-yaml--block-issecret-until-secretness-is-known.yaml
+++ b/changelog/pending/20221028--sdk-go-yaml--block-issecret-until-secretness-is-known.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go,yaml
+  description: Block IsSecret until secretness is known


### PR DESCRIPTION
This PR ensures that `pulumi.IsSecret` works as expected. 

`IsSecret` presented 3 problems.
1. It wasn't thread safe, which triggered go's `-race` flag. (brought up by https://github.com/pulumi/pulumi/pull/11186)
2. It returned the currently known status of secret, meaning that `[]bool{IsSecret(a), IsSecret(a)}` could evaluate to `[]bool{false, true}` if the underlying value resolved between calls.
3. `IsSecret` may return the wrong value for unknown or erred `Output`s.

This PR fixes (1) and (2) by awaiting the underlying value during the `IsSecret` call. (3) is unfixable, and I explain why in a comment.

Blocking on calls to `IsSecret` is necessary for correctness in the general case. We can add optimizations later if necessary. The two I have in mind are
1. Adding a concept of "known secret". `pulumi.Secret(output)` is always secret, so we don't need to block on `output` to resolve this.
2. Distinguishing between functions that return an `Output` (which might be secret) and functions that return raw values (`string`, `int`, ...) which never change the "secretes" of an `Output`. We don't need to block on functions that return raw values.

I believe we should merge this PR without optimizations, and ensure that `IsSecret` is as correct as we can make it. We can add optimizations as they become necessary. I don't think we have customers who rely heavily on `IsSecret` evaluating instantly on not yet resolved outputs, since that is precisely the scenario where `IsSecret` may return the wrong answer.