### PR TITLE
[auto/dotnet] Support for remote operations

### DIFF
--- a/changelog/pending/20221031--auto-dotnet--support-for-remote-operations.yaml
+++ b/changelog/pending/20221031--auto-dotnet--support-for-remote-operations.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/dotnet
+  description: Support for remote operations

--- a/sdk/dotnet/Pulumi.Automation.Tests/RemoteWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/RemoteWorkspaceTests.cs
@@ -1,0 +1,24 @@
+// Copyright 2016-2022, Pulumi Corporation
+
+using Xunit;
+
+namespace Pulumi.Automation.Tests
+{
+    public class RemoteWorkspaceTests
+    {
+        [Theory]
+        [InlineData("owner/project/stack", true)]
+        [InlineData("", false)]
+        [InlineData("name", false)]
+        [InlineData("owner/name", false)]
+        [InlineData("/", false)]
+        [InlineData("//", false)]
+        [InlineData("///", false)]
+        [InlineData("owner/project/stack/wat", false)]
+        public void IsFullyQualifiedStackName(string input, bool expected)
+        {
+            var actual = RemoteWorkspace.IsFullyQualifiedStackName(input);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/EnvironmentVariableValue.cs
+++ b/sdk/dotnet/Pulumi.Automation/EnvironmentVariableValue.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    public class EnvironmentVariableValue
+    {
+        public string Value { get; set; }
+
+        public bool IsSecret { get; set; }
+
+        public EnvironmentVariableValue(
+            string value,
+            bool isSecret = false)
+        {
+            Value = value;
+            IsSecret = isSecret;
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2021, Pulumi Corporation
+﻿// Copyright 2016-2022, Pulumi Corporation
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
@@ -64,5 +64,25 @@ namespace Pulumi.Automation
         /// <see cref="LocalWorkspace.SaveStackSettingsAsync(string, Automation.StackSettings, System.Threading.CancellationToken)"/>.
         /// </summary>
         public IDictionary<string, StackSettings>? StackSettings { get; set; }
+
+        /// <summary>
+        /// Whether the workspace is a remote workspace.
+        /// </summary>
+        internal bool Remote { get; set; }
+
+        /// <summary>
+        /// Args for remote workspace with Git source.
+        /// </summary>
+        internal RemoteGitProgramArgs? RemoteGitProgramArgs { get; set; }
+
+        /// <summary>
+        /// Environment values scoped to the remote workspace. These will be passed to remote operations.
+        /// </summary>
+        internal IDictionary<string, EnvironmentVariableValue>? RemoteEnvironmentVariables { get; set; }
+
+        /// <summary>
+        /// An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
+        /// </summary>
+        internal IList<string>? RemotePreRunCommands { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt
@@ -13,6 +13,12 @@ Pulumi.Automation.DestroyOptions
 Pulumi.Automation.DestroyOptions.DestroyOptions() -> void
 Pulumi.Automation.DestroyOptions.TargetDependents.get -> bool?
 Pulumi.Automation.DestroyOptions.TargetDependents.set -> void
+Pulumi.Automation.EnvironmentVariableValue
+Pulumi.Automation.EnvironmentVariableValue.EnvironmentVariableValue(string value, bool isSecret = false) -> void
+Pulumi.Automation.EnvironmentVariableValue.IsSecret.get -> bool
+Pulumi.Automation.EnvironmentVariableValue.IsSecret.set -> void
+Pulumi.Automation.EnvironmentVariableValue.Value.get -> string
+Pulumi.Automation.EnvironmentVariableValue.Value.set -> void
 Pulumi.Automation.Events.CancelEvent
 Pulumi.Automation.Events.DiagnosticEvent
 Pulumi.Automation.Events.DiagnosticEvent.Color.get -> string
@@ -255,6 +261,63 @@ Pulumi.Automation.RefreshOptions
 Pulumi.Automation.RefreshOptions.ExpectNoChanges.get -> bool?
 Pulumi.Automation.RefreshOptions.ExpectNoChanges.set -> void
 Pulumi.Automation.RefreshOptions.RefreshOptions() -> void
+Pulumi.Automation.RemoteDestroyOptions
+Pulumi.Automation.RemoteDestroyOptions.RemoteDestroyOptions() -> void
+Pulumi.Automation.RemoteGitAuthArgs
+Pulumi.Automation.RemoteGitAuthArgs.Password.get -> string?
+Pulumi.Automation.RemoteGitAuthArgs.Password.set -> void
+Pulumi.Automation.RemoteGitAuthArgs.PersonalAccessToken.get -> string?
+Pulumi.Automation.RemoteGitAuthArgs.PersonalAccessToken.set -> void
+Pulumi.Automation.RemoteGitAuthArgs.SshPrivateKey.get -> string?
+Pulumi.Automation.RemoteGitAuthArgs.SshPrivateKey.set -> void
+Pulumi.Automation.RemoteGitAuthArgs.SshPrivateKeyPath.get -> string?
+Pulumi.Automation.RemoteGitAuthArgs.SshPrivateKeyPath.set -> void
+Pulumi.Automation.RemoteGitAuthArgs.Username.get -> string?
+Pulumi.Automation.RemoteGitAuthArgs.Username.set -> void
+Pulumi.Automation.RemoteGitProgramArgs
+Pulumi.Automation.RemoteGitProgramArgs.Auth.get -> Pulumi.Automation.RemoteGitAuthArgs?
+Pulumi.Automation.RemoteGitProgramArgs.Auth.set -> void
+Pulumi.Automation.RemoteGitProgramArgs.Branch.get -> string?
+Pulumi.Automation.RemoteGitProgramArgs.Branch.set -> void
+Pulumi.Automation.RemoteGitProgramArgs.CommitHash.get -> string?
+Pulumi.Automation.RemoteGitProgramArgs.CommitHash.set -> void
+Pulumi.Automation.RemoteGitProgramArgs.ProjectPath.get -> string?
+Pulumi.Automation.RemoteGitProgramArgs.ProjectPath.set -> void
+Pulumi.Automation.RemoteGitProgramArgs.RemoteGitProgramArgs(string stackName, string url) -> void
+Pulumi.Automation.RemoteGitProgramArgs.StackName.get -> string
+Pulumi.Automation.RemoteGitProgramArgs.Url.get -> string
+Pulumi.Automation.RemotePreviewOptions
+Pulumi.Automation.RemotePreviewOptions.RemotePreviewOptions() -> void
+Pulumi.Automation.RemoteRefreshOptions
+Pulumi.Automation.RemoteRefreshOptions.RemoteRefreshOptions() -> void
+Pulumi.Automation.RemoteUpOptions
+Pulumi.Automation.RemoteUpOptions.RemoteUpOptions() -> void
+Pulumi.Automation.RemoteUpdateOptions
+Pulumi.Automation.RemoteUpdateOptions.OnEvent.get -> System.Action<Pulumi.Automation.Events.EngineEvent>
+Pulumi.Automation.RemoteUpdateOptions.OnEvent.set -> void
+Pulumi.Automation.RemoteUpdateOptions.OnStandardError.get -> System.Action<string>
+Pulumi.Automation.RemoteUpdateOptions.OnStandardError.set -> void
+Pulumi.Automation.RemoteUpdateOptions.OnStandardOutput.get -> System.Action<string>
+Pulumi.Automation.RemoteUpdateOptions.OnStandardOutput.set -> void
+Pulumi.Automation.RemoteUpdateOptions.RemoteUpdateOptions() -> void
+Pulumi.Automation.RemoteWorkspace
+Pulumi.Automation.RemoteWorkspaceOptions
+Pulumi.Automation.RemoteWorkspaceOptions.RemoteWorkspaceOptions() -> void
+Pulumi.Automation.RemoteWorkspaceOptions.EnvironmentVariables.get -> System.Collections.Generic.IDictionary<string, Pulumi.Automation.EnvironmentVariableValue>?
+Pulumi.Automation.RemoteWorkspaceOptions.EnvironmentVariables.set -> void
+Pulumi.Automation.RemoteWorkspaceOptions.PreRunCommands.get -> System.Collections.Generic.IList<string>?
+Pulumi.Automation.RemoteWorkspaceOptions.PreRunCommands.set -> void
+Pulumi.Automation.RemoteWorkspaceStack
+Pulumi.Automation.RemoteWorkspaceStack.DestroyAsync(Pulumi.Automation.RemoteDestroyOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.UpdateResult>
+Pulumi.Automation.RemoteWorkspaceStack.Dispose() -> void
+Pulumi.Automation.RemoteWorkspaceStack.ExportStackAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.StackDeployment>
+Pulumi.Automation.RemoteWorkspaceStack.GetHistoryAsync(Pulumi.Automation.HistoryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableList<Pulumi.Automation.UpdateSummary>>
+Pulumi.Automation.RemoteWorkspaceStack.GetOutputsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.OutputValue>>
+Pulumi.Automation.RemoteWorkspaceStack.ImportStackAsync(Pulumi.Automation.StackDeployment state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Pulumi.Automation.RemoteWorkspaceStack.Name.get -> string
+Pulumi.Automation.RemoteWorkspaceStack.PreviewAsync(Pulumi.Automation.RemotePreviewOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.PreviewResult>
+Pulumi.Automation.RemoteWorkspaceStack.RefreshAsync(Pulumi.Automation.RemoteRefreshOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.UpdateResult>
+Pulumi.Automation.RemoteWorkspaceStack.UpAsync(Pulumi.Automation.RemoteUpOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.UpResult>
 Pulumi.Automation.StackSettings
 Pulumi.Automation.StackSettings.Config.get -> System.Collections.Generic.IDictionary<string, Pulumi.Automation.StackSettingsConfigValue>
 Pulumi.Automation.StackSettings.Config.set -> void
@@ -454,6 +517,12 @@ static Pulumi.Automation.PulumiFn.Create(System.Func<System.Threading.Tasks.Task
 static Pulumi.Automation.PulumiFn.Create(System.IServiceProvider serviceProvider, System.Type stackType) -> Pulumi.Automation.PulumiFn
 static Pulumi.Automation.PulumiFn.Create<TStack>() -> Pulumi.Automation.PulumiFn
 static Pulumi.Automation.PulumiFn.Create<TStack>(System.IServiceProvider serviceProvider) -> Pulumi.Automation.PulumiFn
+static Pulumi.Automation.RemoteWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs args) -> System.Threading.Tasks.Task<Pulumi.Automation.RemoteWorkspaceStack>
+static Pulumi.Automation.RemoteWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs args, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Pulumi.Automation.RemoteWorkspaceStack>
+static Pulumi.Automation.RemoteWorkspace.CreateStackAsync(Pulumi.Automation.RemoteGitProgramArgs args) -> System.Threading.Tasks.Task<Pulumi.Automation.RemoteWorkspaceStack>
+static Pulumi.Automation.RemoteWorkspace.CreateStackAsync(Pulumi.Automation.RemoteGitProgramArgs args, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Pulumi.Automation.RemoteWorkspaceStack>
+static Pulumi.Automation.RemoteWorkspace.SelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs args) -> System.Threading.Tasks.Task<Pulumi.Automation.RemoteWorkspaceStack>
+static Pulumi.Automation.RemoteWorkspace.SelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs args, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Pulumi.Automation.RemoteWorkspaceStack>
 static Pulumi.Automation.WorkspaceStack.CreateAsync(string name, Pulumi.Automation.Workspace workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>
 static Pulumi.Automation.WorkspaceStack.CreateOrSelectAsync(string name, Pulumi.Automation.Workspace workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>
 static Pulumi.Automation.WorkspaceStack.SelectAsync(string name, Pulumi.Automation.Workspace workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -361,6 +361,11 @@
         <member name="P:Pulumi.Automation.LocalWorkspace.EnvironmentVariables">
             <inheritdoc/>
         </member>
+        <member name="P:Pulumi.Automation.LocalWorkspace.Remote">
+            <summary>
+            Whether this workspace is a remote workspace.
+            </summary>
+        </member>
         <member name="M:Pulumi.Automation.LocalWorkspace.CreateAsync(Pulumi.Automation.LocalWorkspaceOptions,System.Threading.CancellationToken)">
             <summary>
             Creates a workspace using the specified options. Used for maximal control and
@@ -675,6 +680,26 @@
             <see cref="M:Pulumi.Automation.LocalWorkspace.SaveStackSettingsAsync(System.String,Pulumi.Automation.StackSettings,System.Threading.CancellationToken)"/>.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.LocalWorkspaceOptions.Remote">
+            <summary>
+            Whether the workspace is a remote workspace.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.LocalWorkspaceOptions.RemoteGitProgramArgs">
+            <summary>
+            Args for remote workspace with Git source.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.LocalWorkspaceOptions.RemoteEnvironmentVariables">
+            <summary>
+            Environment values scoped to the remote workspace. These will be passed to remote operations.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.LocalWorkspaceOptions.RemotePreRunCommands">
+            <summary>
+            An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
+            </summary>
+        </member>
         <member name="P:Pulumi.Automation.PluginInstallOptions.ExactVersion">
             <summary>
             If <c>true</c>, force installation of an exact version match (usually >= is accepted).
@@ -855,6 +880,273 @@
             Show config secrets when they appear.
             </summary>
         </member>
+        <member name="T:Pulumi.Automation.RemoteDestroyOptions">
+            <summary>
+            Options controlling the behavior of an <see cref="M:Pulumi.Automation.RemoteWorkspaceStack.DestroyAsync(Pulumi.Automation.RemoteDestroyOptions,System.Threading.CancellationToken)"/> operation.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.RemoteGitAuthArgs">
+             <summary>
+             Authentication options for the repository that can be specified for a private Git repo.
+             There are three different authentication paths:
+            
+             <list type="bullet">
+             <item><description>Personal accesstoken</description></item>
+             <item><description>SSH private key (and its optional password)</description></item>
+             <item><description>Basic auth username and password</description></item>
+             </list>
+            
+             Only one authentication path is valid.
+             </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitAuthArgs.SshPrivateKeyPath">
+            <summary>
+            The absolute path to a private key for access to the git repo.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitAuthArgs.SshPrivateKey">
+            <summary>
+            The (contents) private key for access to the git repo.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitAuthArgs.Password">
+            <summary>
+            The password that pairs with a username or as part of an SSH Private Key.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitAuthArgs.PersonalAccessToken">
+            <summary>
+            PersonalAccessToken is a Git personal access token in replacement of your password.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitAuthArgs.Username">
+            <summary>
+            Username is the username to use when authenticating to a git repository.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.RemoteGitProgramArgs">
+            <summary>
+            Description of a stack backed by a remote Pulumi program in a Git repository.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitProgramArgs.StackName">
+            <summary>
+            The name of the associated Stack.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitProgramArgs.Url">
+            <summary>
+            The URL of the repository.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitProgramArgs.ProjectPath">
+            <summary>
+            Optional path relative to the repo root specifying location of the Pulumi program.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitProgramArgs.Branch">
+            <summary>
+            Optional branch to checkout.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitProgramArgs.CommitHash">
+            <summary>
+            Optional commit to checkout.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteGitProgramArgs.Auth">
+            <summary>
+            Authentication options for the repository.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.RemotePreviewOptions">
+            <summary>
+            Options controlling the behavior of an <see cref="M:Pulumi.Automation.RemoteWorkspaceStack.PreviewAsync(Pulumi.Automation.RemotePreviewOptions,System.Threading.CancellationToken)"/> operation.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.RemoteRefreshOptions">
+            <summary>
+            Options controlling the behavior of an <see cref="M:Pulumi.Automation.RemoteWorkspaceStack.RefreshAsync(Pulumi.Automation.RemoteRefreshOptions,System.Threading.CancellationToken)"/> operation.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.RemoteUpdateOptions">
+            <summary>
+            Common options controlling the behavior of update actions taken
+            against an instance of <see cref="T:Pulumi.Automation.RemoteWorkspaceStack"/>.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteUpdateOptions.OnStandardOutput">
+            <summary>
+            Optional callback which is invoked whenever StandardOutput is written into
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteUpdateOptions.OnStandardError">
+            <summary>
+            Optional callback which is invoked whenever StandardError is written into
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteUpdateOptions.OnEvent">
+            <summary>
+            Optional callback which is invoked with the engine events
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.RemoteUpOptions">
+            <summary>
+            Options controlling the behavior of an <see cref="M:Pulumi.Automation.RemoteWorkspaceStack.UpAsync(Pulumi.Automation.RemoteUpOptions,System.Threading.CancellationToken)"/> operation.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspace.CreateStackAsync(Pulumi.Automation.RemoteGitProgramArgs)">
+            <summary>
+            PREVIEW: Creates a Stack backed by a RemoteWorkspace with source code from the specified Git repository.
+            Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+            </summary>
+            <param name="args">
+            A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+            </param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspace.CreateStackAsync(Pulumi.Automation.RemoteGitProgramArgs,System.Threading.CancellationToken)">
+            <summary>
+            PREVIEW: Creates a Stack backed by a RemoteWorkspace with source code from the specified Git repository.
+            Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+            </summary>
+            <param name="args">
+            A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+            </param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspace.SelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs)">
+            <summary>
+            PREVIEW: Selects an existing Stack backed by a RemoteWorkspace with source code from the specified Git
+            repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+            </summary>
+            <param name="args">
+            A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+            </param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspace.SelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs,System.Threading.CancellationToken)">
+            <summary>
+            PREVIEW: Selects an existing Stack backed by a RemoteWorkspace with source code from the specified Git
+            repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+            </summary>
+            <param name="args">
+            A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+            </param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs)">
+            <summary>
+            PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
+            Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+            </summary>
+            <param name="args">
+            A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+            </param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.RemoteGitProgramArgs,System.Threading.CancellationToken)">
+            <summary>
+            PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
+            Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+            </summary>
+            <param name="args">
+            A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+            </param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="T:Pulumi.Automation.RemoteWorkspaceOptions">
+            <summary>
+            Extensibility options to configure a RemoteWorkspace.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteWorkspaceOptions.EnvironmentVariables">
+            <summary>
+            Environment values scoped to the remote workspace. These will be passed to remote operations.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteWorkspaceOptions.PreRunCommands">
+            <summary>
+            An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteWorkspaceStack.Name">
+            <summary>
+            The name identifying the Stack.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.UpAsync(Pulumi.Automation.RemoteUpOptions,System.Threading.CancellationToken)">
+            <summary>
+            Creates or updates the resources in a stack by executing the program in the Workspace.
+            This operation runs remotely.
+            <para/>
+            https://www.pulumi.com/docs/reference/cli/pulumi_up/
+            </summary>
+            <param name="options">Options to customize the behavior of the update.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.PreviewAsync(Pulumi.Automation.RemotePreviewOptions,System.Threading.CancellationToken)">
+            <summary>
+            Performs a dry-run update to a stack, returning pending changes.
+            This operation runs remotely.
+            <para/>
+            https://www.pulumi.com/docs/reference/cli/pulumi_preview/
+            </summary>
+            <param name="options">Options to customize the behavior of the update.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.RefreshAsync(Pulumi.Automation.RemoteRefreshOptions,System.Threading.CancellationToken)">
+            <summary>
+            Compares the current stack’s resource state with the state known to exist in the actual
+            cloud provider. Any such changes are adopted into the current stack.
+            This operation runs remotely.
+            </summary>
+            <param name="options">Options to customize the behavior of the refresh.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.DestroyAsync(Pulumi.Automation.RemoteDestroyOptions,System.Threading.CancellationToken)">
+            <summary>
+            Destroy deletes all resources in a stack, leaving all history and configuration intact.
+            This operation runs remotely.
+            </summary>
+            <param name="options">Options to customize the behavior of the destroy.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.GetOutputsAsync(System.Threading.CancellationToken)">
+            <summary>
+            Gets the current set of Stack outputs from the last <see cref="M:Pulumi.Automation.RemoteWorkspaceStack.UpAsync(Pulumi.Automation.RemoteUpOptions,System.Threading.CancellationToken)"/>.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.GetHistoryAsync(Pulumi.Automation.HistoryOptions,System.Threading.CancellationToken)">
+            <summary>
+            Returns a list summarizing all previews and current results from Stack lifecycle operations (up/preview/refresh/destroy).
+            </summary>
+            <param name="options">Options to customize the behavior of the fetch history action.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.ExportStackAsync(System.Threading.CancellationToken)">
+            <summary>
+            Exports the deployment state of the stack.
+            <para/>
+            This can be combined with ImportStackAsync to edit a
+            stack's state (such as recovery from failed deployments).
+            </summary>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.ImportStackAsync(Pulumi.Automation.StackDeployment,System.Threading.CancellationToken)">
+            <summary>
+            Imports the specified deployment state into a pre-existing stack.
+            <para/>
+            This can be combined with ExportStackAsync to edit a
+            stack's state (such as recovery from failed deployments).
+            </summary>
+        </member>
+        <member name="M:Pulumi.Automation.RemoteWorkspaceStack.CancelAsync(System.Threading.CancellationToken)">
+            <summary>
+            Cancel stops a stack's currently running update. It throws
+            an exception if no update is currently running. Note that
+            this operation is _very dangerous_, and may leave the
+            stack in an inconsistent state if a resource operation was
+            pending when the update was canceled. This command is not
+            supported for local backends.
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.StackDeployment">
             <summary>
             Represents the state of a stack deployment as used by
@@ -947,6 +1239,11 @@
         <member name="P:Pulumi.Automation.UpdateOptions.Debug">
             <summary>
             Print detailed debugging output during resource operations
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.UpdateOptions.Json">
+            <summary>
+            Format standard output as JSON not text.
             </summary>
         </member>
         <member name="T:Pulumi.Automation.UpOptions">

--- a/sdk/dotnet/Pulumi.Automation/RemoteDestroyOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteDestroyOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Options controlling the behavior of an <see cref="RemoteWorkspaceStack.DestroyAsync(RemoteDestroyOptions, System.Threading.CancellationToken)"/> operation.
+    /// </summary>
+    public sealed class RemoteDestroyOptions : RemoteUpdateOptions
+    {
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteGitAuthArgs.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteGitAuthArgs.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Authentication options for the repository that can be specified for a private Git repo.
+    /// There are three different authentication paths:
+    ///
+    /// <list type="bullet">
+    /// <item><description>Personal accesstoken</description></item>
+    /// <item><description>SSH private key (and its optional password)</description></item>
+    /// <item><description>Basic auth username and password</description></item>
+    /// </list>
+    ///
+    /// Only one authentication path is valid.
+    /// </summary>
+    public class RemoteGitAuthArgs
+    {
+        /// <summary>
+        /// The absolute path to a private key for access to the git repo.
+        /// </summary>
+        public string? SshPrivateKeyPath { get; set; }
+
+        /// <summary>
+        /// The (contents) private key for access to the git repo.
+        /// </summary>
+        public string? SshPrivateKey { get; set; }
+
+        /// <summary>
+        /// The password that pairs with a username or as part of an SSH Private Key.
+        /// </summary>
+        public string? Password { get; set; }
+
+        /// <summary>
+        /// PersonalAccessToken is a Git personal access token in replacement of your password.
+        /// </summary>
+        public string? PersonalAccessToken { get; set; }
+
+        /// <summary>
+        /// Username is the username to use when authenticating to a git repository.
+        /// </summary>
+        public string? Username { get; set; }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteGitProgramArgs.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteGitProgramArgs.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Description of a stack backed by a remote Pulumi program in a Git repository.
+    /// </summary>
+    public class RemoteGitProgramArgs : RemoteWorkspaceOptions
+    {
+        /// <summary>
+        /// The name of the associated Stack.
+        /// </summary>
+        public string StackName { get; }
+
+        /// <summary>
+        /// The URL of the repository.
+        /// </summary>
+        public string Url { get; }
+
+        public RemoteGitProgramArgs(
+            string stackName,
+            string url)
+        {
+            StackName = stackName;
+            Url = url;
+        }
+
+        /// <summary>
+        /// Optional path relative to the repo root specifying location of the Pulumi program.
+        /// </summary>
+        public string? ProjectPath { get; set; }
+
+        /// <summary>
+        /// Optional branch to checkout.
+        /// </summary>
+        public string? Branch { get; set; }
+
+        /// <summary>
+        /// Optional commit to checkout.
+        /// </summary>
+        public string? CommitHash { get; set; }
+
+        /// <summary>
+        /// Authentication options for the repository.
+        /// </summary>
+        public RemoteGitAuthArgs? Auth { get; set; }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemotePreviewOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemotePreviewOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Options controlling the behavior of an <see cref="RemoteWorkspaceStack.PreviewAsync(RemotePreviewOptions, System.Threading.CancellationToken)"/> operation.
+    /// </summary>
+    public sealed class RemotePreviewOptions : RemoteUpdateOptions
+    {
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteRefreshOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteRefreshOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Options controlling the behavior of an <see cref="RemoteWorkspaceStack.RefreshAsync(RemoteRefreshOptions, System.Threading.CancellationToken)"/> operation.
+    /// </summary>
+    public sealed class RemoteRefreshOptions : RemoteUpdateOptions
+    {
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteUpOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteUpOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Options controlling the behavior of an <see cref="RemoteWorkspaceStack.UpAsync(RemoteUpOptions, System.Threading.CancellationToken)"/> operation.
+    /// </summary>
+    public sealed class RemoteUpOptions : RemoteUpdateOptions
+    {
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteUpdateOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteUpdateOptions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+using System;
+using Pulumi.Automation.Events;
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Common options controlling the behavior of update actions taken
+    /// against an instance of <see cref="RemoteWorkspaceStack"/>.
+    /// </summary>
+    public class RemoteUpdateOptions
+    {
+        /// <summary>
+        /// Optional callback which is invoked whenever StandardOutput is written into
+        /// </summary>
+        public Action<string>? OnStandardOutput { get; set; }
+
+        /// <summary>
+        /// Optional callback which is invoked whenever StandardError is written into
+        /// </summary>
+        public Action<string>? OnStandardError { get; set; }
+
+        /// <summary>
+        /// Optional callback which is invoked with the engine events
+        /// </summary>
+        public Action<EngineEvent>? OnEvent { get; set; }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteWorkspace.cs
@@ -1,0 +1,136 @@
+// Copyright 2016-2022, Pulumi Corporation
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Pulumi.Automation.Commands;
+
+namespace Pulumi.Automation
+{
+    public static class RemoteWorkspace
+    {
+        /// <summary>
+        /// PREVIEW: Creates a Stack backed by a RemoteWorkspace with source code from the specified Git repository.
+        /// Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+        /// </summary>
+        /// <param name="args">
+        /// A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+        /// </param>
+        public static Task<RemoteWorkspaceStack> CreateStackAsync(RemoteGitProgramArgs args)
+            => CreateStackAsync(args, default);
+
+        /// <summary>
+        /// PREVIEW: Creates a Stack backed by a RemoteWorkspace with source code from the specified Git repository.
+        /// Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+        /// </summary>
+        /// <param name="args">
+        /// A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public static Task<RemoteWorkspaceStack> CreateStackAsync(RemoteGitProgramArgs args, CancellationToken cancellationToken)
+            => CreateStackHelperAsync(args, WorkspaceStack.CreateAsync, cancellationToken);
+
+        /// <summary>
+        /// PREVIEW: Selects an existing Stack backed by a RemoteWorkspace with source code from the specified Git
+        /// repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+        /// </summary>
+        /// <param name="args">
+        /// A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+        /// </param>
+        public static Task<RemoteWorkspaceStack> SelectStackAsync(RemoteGitProgramArgs args)
+            => SelectStackAsync(args, default);
+
+        /// <summary>
+        /// PREVIEW: Selects an existing Stack backed by a RemoteWorkspace with source code from the specified Git
+        /// repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+        /// </summary>
+        /// <param name="args">
+        /// A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public static Task<RemoteWorkspaceStack> SelectStackAsync(RemoteGitProgramArgs args, CancellationToken cancellationToken)
+            => CreateStackHelperAsync(args, WorkspaceStack.SelectAsync, cancellationToken);
+
+        /// <summary>
+        /// PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
+        /// Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+        /// </summary>
+        /// <param name="args">
+        /// A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+        /// </param>
+        public static Task<RemoteWorkspaceStack> CreateOrSelectStackAsync(RemoteGitProgramArgs args)
+            => CreateOrSelectStackAsync(args, default);
+
+        /// <summary>
+        /// PREVIEW: Creates or selects an existing Stack backed by a RemoteWorkspace with source code from the specified
+        /// Git repository. Pulumi operations on the stack (Preview, Update, Refresh, and Destroy) are performed remotely.
+        /// </summary>
+        /// <param name="args">
+        /// A set of arguments to initialize a RemoteStack with a remote Pulumi program from a Git repository.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public static Task<RemoteWorkspaceStack> CreateOrSelectStackAsync(RemoteGitProgramArgs args, CancellationToken cancellationToken)
+            => CreateStackHelperAsync(args, WorkspaceStack.CreateOrSelectAsync, cancellationToken);
+
+        private static async Task<RemoteWorkspaceStack> CreateStackHelperAsync(
+            RemoteGitProgramArgs args,
+            Func<string, Workspace, CancellationToken, Task<WorkspaceStack>> initFunc,
+            CancellationToken cancellationToken)
+        {
+            if (!IsFullyQualifiedStackName(args.StackName))
+            {
+                throw new ArgumentException($"{nameof(args.StackName)} not fully qualified.");
+            }
+            if (string.IsNullOrWhiteSpace(args.Url))
+            {
+                throw new ArgumentException($"{nameof(args.Url)} is required.");
+            }
+            if (!string.IsNullOrWhiteSpace(args.CommitHash) && !string.IsNullOrWhiteSpace(args.Branch))
+            {
+                throw new ArgumentException($"{nameof(args.CommitHash)} and {nameof(args.Branch)} cannot both be specified.");
+            }
+            if (string.IsNullOrWhiteSpace(args.CommitHash) && string.IsNullOrWhiteSpace(args.Branch))
+            {
+                throw new ArgumentException($"either {nameof(args.CommitHash)} or {nameof(args.Branch)} is required.");
+            }
+            if (!(args.Auth is null))
+            {
+                if (!string.IsNullOrWhiteSpace(args.Auth.SshPrivateKey) &&
+                    !string.IsNullOrWhiteSpace(args.Auth.SshPrivateKeyPath))
+                {
+                    throw new ArgumentException($"{nameof(args.Auth.SshPrivateKey)} and {nameof(args.Auth.SshPrivateKeyPath)} cannot both be specified.");
+                }
+            }
+
+            var localArgs = new LocalWorkspaceOptions
+            {
+                Remote = true,
+                RemoteGitProgramArgs = args,
+                RemoteEnvironmentVariables = args.EnvironmentVariables,
+                RemotePreRunCommands = args.PreRunCommands,
+            };
+
+            var ws = new LocalWorkspace(
+                new LocalPulumiCmd(),
+                localArgs,
+                cancellationToken);
+            await ws.ReadyTask.ConfigureAwait(false);
+
+            var stack = await initFunc(args.StackName, ws, cancellationToken).ConfigureAwait(false);
+            return new RemoteWorkspaceStack(stack);
+        }
+
+        internal static bool IsFullyQualifiedStackName(string stackName)
+        {
+            if (string.IsNullOrWhiteSpace(stackName))
+            {
+                return false;
+            }
+            var split = stackName.Split("/");
+            return split.Length == 3
+                && !string.IsNullOrWhiteSpace(split[0])
+                && !string.IsNullOrWhiteSpace(split[1])
+                && !string.IsNullOrWhiteSpace(split[2]);
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteWorkspaceOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteWorkspaceOptions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2016-2022, Pulumi Corporation
+
+using System.Collections.Generic;
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Extensibility options to configure a RemoteWorkspace.
+    /// </summary>
+    public class RemoteWorkspaceOptions
+    {
+        private IDictionary<string, EnvironmentVariableValue>? _environmentVariables;
+        private IList<string>? _preRunCommands;
+
+        /// <summary>
+        /// Environment values scoped to the remote workspace. These will be passed to remote operations.
+        /// </summary>
+        public IDictionary<string, EnvironmentVariableValue> EnvironmentVariables
+        {
+            get => _environmentVariables ??= new Dictionary<string, EnvironmentVariableValue>();
+            set => _environmentVariables = value;
+        }
+
+        /// <summary>
+        /// An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
+        /// </summary>
+        public IList<string> PreRunCommands
+        {
+            get => _preRunCommands ??= new List<string>();
+            set => _preRunCommands = value;
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/RemoteWorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/RemoteWorkspaceStack.cs
@@ -1,0 +1,155 @@
+// Copyright 2016-2022, Pulumi Corporation
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pulumi.Automation
+{
+    public sealed class RemoteWorkspaceStack : IDisposable
+    {
+        private readonly WorkspaceStack _stack;
+
+        /// <summary>
+        /// The name identifying the Stack.
+        /// </summary>
+        public string Name => _stack.Name;
+
+        internal RemoteWorkspaceStack(WorkspaceStack stack)
+        {
+            _stack = stack;
+        }
+
+        /// <summary>
+        /// Creates or updates the resources in a stack by executing the program in the Workspace.
+        /// This operation runs remotely.
+        /// <para/>
+        /// https://www.pulumi.com/docs/reference/cli/pulumi_up/
+        /// </summary>
+        /// <param name="options">Options to customize the behavior of the update.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public Task<UpResult> UpAsync(
+            RemoteUpOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var upOptions = new UpOptions
+            {
+                OnStandardOutput = options?.OnStandardOutput,
+                OnStandardError = options?.OnStandardError,
+                OnEvent = options?.OnEvent,
+            };
+            return _stack.UpAsync(upOptions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Performs a dry-run update to a stack, returning pending changes.
+        /// This operation runs remotely.
+        /// <para/>
+        /// https://www.pulumi.com/docs/reference/cli/pulumi_preview/
+        /// </summary>
+        /// <param name="options">Options to customize the behavior of the update.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public Task<PreviewResult> PreviewAsync(
+            RemotePreviewOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var previewOptions = new PreviewOptions
+            {
+                OnStandardOutput = options?.OnStandardOutput,
+                OnStandardError = options?.OnStandardError,
+                OnEvent = options?.OnEvent,
+            };
+            return _stack.PreviewAsync(previewOptions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Compares the current stack’s resource state with the state known to exist in the actual
+        /// cloud provider. Any such changes are adopted into the current stack.
+        /// This operation runs remotely.
+        /// </summary>
+        /// <param name="options">Options to customize the behavior of the refresh.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public Task<UpdateResult> RefreshAsync(
+            RemoteRefreshOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var refreshOptions = new RefreshOptions
+            {
+                OnStandardOutput = options?.OnStandardOutput,
+                OnStandardError = options?.OnStandardError,
+                OnEvent = options?.OnEvent,
+            };
+            return _stack.RefreshAsync(refreshOptions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Destroy deletes all resources in a stack, leaving all history and configuration intact.
+        /// This operation runs remotely.
+        /// </summary>
+        /// <param name="options">Options to customize the behavior of the destroy.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public Task<UpdateResult> DestroyAsync(
+            RemoteDestroyOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var destroyOptions = new DestroyOptions
+            {
+                OnStandardOutput = options?.OnStandardOutput,
+                OnStandardError = options?.OnStandardError,
+                OnEvent = options?.OnEvent,
+            };
+            return _stack.DestroyAsync(destroyOptions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the current set of Stack outputs from the last <see cref="UpAsync(RemoteUpOptions?, CancellationToken)"/>.
+        /// </summary>
+        public Task<ImmutableDictionary<string, OutputValue>> GetOutputsAsync(CancellationToken cancellationToken = default)
+            => _stack.GetOutputsAsync(cancellationToken);
+
+        /// <summary>
+        /// Returns a list summarizing all previews and current results from Stack lifecycle operations (up/preview/refresh/destroy).
+        /// </summary>
+        /// <param name="options">Options to customize the behavior of the fetch history action.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public Task<ImmutableList<UpdateSummary>> GetHistoryAsync(
+            HistoryOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            return _stack.GetHistoryAsync(options, cancellationToken);
+        }
+
+        /// <summary>
+        /// Exports the deployment state of the stack.
+        /// <para/>
+        /// This can be combined with ImportStackAsync to edit a
+        /// stack's state (such as recovery from failed deployments).
+        /// </summary>
+        public Task<StackDeployment> ExportStackAsync(CancellationToken cancellationToken = default)
+            => _stack.ExportStackAsync(cancellationToken);
+
+        /// <summary>
+        /// Imports the specified deployment state into a pre-existing stack.
+        /// <para/>
+        /// This can be combined with ExportStackAsync to edit a
+        /// stack's state (such as recovery from failed deployments).
+        /// </summary>
+        public Task ImportStackAsync(StackDeployment state, CancellationToken cancellationToken = default)
+            => _stack.ImportStackAsync(state, cancellationToken);
+
+        /// <summary>
+        /// Cancel stops a stack's currently running update. It throws
+        /// an exception if no update is currently running. Note that
+        /// this operation is _very dangerous_, and may leave the
+        /// stack in an inconsistent state if a resource operation was
+        /// pending when the update was canceled. This command is not
+        /// supported for local backends.
+        /// </summary>
+        public Task CancelAsync(CancellationToken cancellationToken = default)
+            => _stack.CancelAsync(cancellationToken);
+
+        public void Dispose()
+            => _stack.Dispose();
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2021, Pulumi Corporation
+﻿// Copyright 2016-2022, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;
@@ -325,6 +325,9 @@ namespace Pulumi.Automation
             var env = new Dictionary<string, string?>();
             if (!string.IsNullOrWhiteSpace(this.PulumiHome))
                 env["PULUMI_HOME"] = this.PulumiHome;
+
+            if (this is LocalWorkspace localWorkspace && localWorkspace.Remote)
+                env["PULUMI_EXPERIMENTAL"] = "true";
 
             if (this.EnvironmentVariables != null)
             {


### PR DESCRIPTION
This change adds preview support for remote operations in .NET's Automation API.

**Note:** ~~I've tried _many_ incantations of `dotnet format dotnet.sln analyzers --diagnostics=RS0016`, but have not been able to get the code fix applied to update `sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt`. Perhaps a .NET 6 bug (I'm running on an M1 Mac)? https://github.com/dotnet/format/issues/1416 might be relevant. I'll try again a bit later, but I might have to manually update the file, unless someone else's tools are working and can pull down the branch and run it.~~

Update: I didn't see any failures in the PR related to not having updated `sdk/dotnet/Pulumi.Automation/PublicAPI.Shipped.txt`, so maybe we're no longer checking this or something is broken? In any case, I still wasn't able to get `dotnet format` to automatically apply the updates, so I manually edited `PublicAPI.Shipped.txt`. I _think_ I got everything, but it's possible I missed something. Let's see what CI says.

Here's an example of using it:

```c#
using System;
using System.Linq;
using Pulumi.Automation;

bool destroy = args.Any() && args[0] == "destroy";

const string org = "justinvp";
const string projectName = "aws-ts-s3-folder";
var stackName = $"{org}/{projectName}/devdotnet";

var stackArgs = new RemoteGitProgramArgs(stackName, "https://github.com/pulumi/examples.git")
{
    Branch = "refs/heads/master",
    ProjectPath = projectName,
    EnvironmentVariables =
   {
      { "AWS_REGION", new EnvironmentVariableValue("us-west-2") },
      { "AWS_ACCESS_KEY_ID", RequireFromEnvironment("AWS_ACCESS_KEY_ID") },
      { "AWS_SECRET_ACCESS_KEY", RequireFromEnvironment("AWS_SECRET_ACCESS_KEY", isSecret: true) },
      { "AWS_SESSION_TOKEN", RequireFromEnvironment("AWS_SESSION_TOKEN", isSecret: true) },
   },
};
var stack = await RemoteWorkspace.CreateOrSelectStackAsync(stackArgs);

if (destroy)
{
    await stack.DestroyAsync(new RemoteDestroyOptions { OnStandardOutput = Console.WriteLine });
}
else
{
    Console.WriteLine("updating stack...");
    var result = await stack.UpAsync(new RemoteUpOptions { OnStandardOutput = Console.WriteLine });

    if (result.Summary.ResourceChanges != null)
    {
        Console.WriteLine("update summary:");
        foreach (var change in result.Summary.ResourceChanges)
            Console.WriteLine($"    {change.Key}: {change.Value}");
    }

    Console.WriteLine($"url: {result.Outputs["websiteUrl"].Value}");
}

static EnvironmentVariableValue RequireFromEnvironment(string variable, bool isSecret = false)
{
    var value = Environment.GetEnvironmentVariable(variable)
       ?? throw new InvalidOperationException($"Required environment variable {variable} not set.");
    return new EnvironmentVariableValue(value, isSecret);
}
```

I will add sanity tests subsequently.