### PR TITLE
[display] Factor out the low-level progress renderer.

### DIFF
--- a/pkg/backend/display/tableutil.go
+++ b/pkg/backend/display/tableutil.go
@@ -26,13 +26,37 @@ func columnHeader(msg string) string {
 	return colors.Underline + colors.BrightBlue + msg + colors.Reset
 }
 
-func messagePadding(uncolorizedColumn string, maxLength, extraPadding int) string {
-	extraWhitespace := maxLength - utf8.RuneCountInString(uncolorizedColumn)
-	contract.Assertf(extraWhitespace >= 0, "Neg whitespace. %v %s", maxLength, uncolorizedColumn)
+func messagePadding(message string, maxLength, extraPadding int) string {
+	extraWhitespace := maxLength - utf8.RuneCountInString(message)
+	contract.Assertf(extraWhitespace >= 0, "Neg whitespace. %v %s", maxLength, message)
 
 	// Place two spaces between all columns (except after the first column).  The first
 	// column already has a ": " so it doesn't need the extra space.
 	extraWhitespace += extraPadding
 
 	return strings.Repeat(" ", extraWhitespace)
+}
+
+// Gets the padding necessary to prepend to a column in order to keep it aligned in the terminal.
+func columnPadding(uncolorizedColumns []string, columnIndex int, maxColumnLengths []int) string {
+	extraWhitespace := " "
+	if columnIndex >= 0 && len(maxColumnLengths) > 0 {
+		column := uncolorizedColumns[columnIndex]
+		maxLength := maxColumnLengths[columnIndex]
+		extraWhitespace = messagePadding(column, maxLength, 2)
+	}
+	return extraWhitespace
+}
+
+// Gets the fully padded message to be shown.  The message will always include the ID of the
+// status, then some amount of optional padding, then some amount of msgWithColors, then the
+// suffix.  Importantly, if there isn't enough room to display all of that on the terminal, then
+// the msg will be truncated to try to make it fit.
+func renderRow(colorizedColumns, uncolorizedColumns []string, maxColumnLengths []int) string {
+	var row strings.Builder
+	for i := 0; i < len(colorizedColumns); i++ {
+		row.WriteString(columnPadding(uncolorizedColumns, i-1, maxColumnLengths))
+		row.WriteString(colorizedColumns[i])
+	}
+	return row.String()
 }

--- a/pkg/cmd/pulumi/replay_events.go
+++ b/pkg/cmd/pulumi/replay_events.go
@@ -43,6 +43,7 @@ func newReplayEventsCmd() *cobra.Command {
 	var debug bool
 
 	var delay time.Duration
+	var period time.Duration
 
 	var cmd = &cobra.Command{
 		Use:   "replay-events [kind] [events-file]",
@@ -110,6 +111,9 @@ func newReplayEventsCmd() *cobra.Command {
 
 			for _, e := range events {
 				eventChannel <- e
+				if period != 0 {
+					time.Sleep(period)
+				}
 			}
 			<-doneChannel
 
@@ -148,6 +152,8 @@ func newReplayEventsCmd() *cobra.Command {
 
 	cmd.PersistentFlags().DurationVar(&delay, "delay", time.Duration(0),
 		"Delay display by the given duration. Useful for attaching a debugger.")
+	cmd.PersistentFlags().DurationVar(&period, "period", time.Duration(0),
+		"Delay each event by the given duration.")
 
 	return cmd
 }


### PR DESCRIPTION
The progress display is logically composed of two pieces:
- An event listener that transforms raw engine events into renderable data
- A renderer that renders that data on to the screen

The interface for the latter is relatively simple. It only really needs to know the following:
- When an idle interval has elapsed
- When a row has changed
- When a system message (e.g. a line printed to stdout) has arrived
- When the update is done
- When the display is closed
- When to print a raw line

This interface is general enough to accommodate multiple renderers.