### PR TITLE
[color] Use graphemes to measure strings.

### DIFF
--- a/changelog/pending/20221109--cli-display--fix-text-cutting-off-prior-to-the-edge-of-the-terminal.yaml
+++ b/changelog/pending/20221109--cli-display--fix-text-cutting-off-prior-to-the-edge-of-the-terminal.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix text cutting off prior to the edge of the terminal

--- a/pkg/backend/display/jsonmessage.go
+++ b/pkg/backend/display/jsonmessage.go
@@ -193,9 +193,7 @@ func (r *messageRenderer) tick(display *ProgressDisplay) {
 func (r *messageRenderer) renderRow(display *ProgressDisplay,
 	id string, colorizedColumns []string, maxColumnLengths []int) {
 
-	uncolorizedColumns := display.uncolorizeColumns(colorizedColumns)
-
-	row := renderRow(colorizedColumns, uncolorizedColumns, maxColumnLengths)
+	row := renderRow(colorizedColumns, maxColumnLengths)
 	if r.isInteractive {
 		// Ensure we don't go past the end of the terminal.  Note: this is made complex due to
 		// msgWithColors having the color code information embedded with it.  So we need to get

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -137,10 +136,6 @@ type ProgressDisplay struct {
 
 	// Maps used so we can generate short IDs for resource urns.
 	urnToID map[resource.URN]string
-
-	// Cache of colorized to uncolorized text.  We go between the two a lot, so caching helps
-	// prevent lots of recomputation
-	colorizedToUncolorized map[string]string
 
 	// Structure that tracks the time taken to perform an action on a resource.
 	opStopwatch opStopwatch
@@ -260,20 +255,19 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Name,
 	}
 
 	display := &ProgressDisplay{
-		action:                 action,
-		isPreview:              isPreview,
-		isTerminal:             isInteractive,
-		opts:                   opts,
-		renderer:               renderer,
-		stack:                  stack,
-		proj:                   proj,
-		eventUrnToResourceRow:  make(map[resource.URN]ResourceRow),
-		suffixColumn:           int(statusColumn),
-		suffixesArray:          []string{"", ".", "..", "..."},
-		urnToID:                make(map[resource.URN]string),
-		colorizedToUncolorized: make(map[string]string),
-		displayOrderCounter:    1,
-		opStopwatch:            newOpStopwatch(),
+		action:                action,
+		isPreview:             isPreview,
+		isTerminal:            isInteractive,
+		opts:                  opts,
+		renderer:              renderer,
+		stack:                 stack,
+		proj:                  proj,
+		eventUrnToResourceRow: make(map[resource.URN]ResourceRow),
+		suffixColumn:          int(statusColumn),
+		suffixesArray:         []string{"", ".", "..", "..."},
+		urnToID:               make(map[resource.URN]string),
+		displayOrderCounter:   1,
+		opStopwatch:           newOpStopwatch(),
 	}
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -289,27 +283,7 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.Name,
 }
 
 func (display *ProgressDisplay) println(line string) {
-	display.renderer.println(display, display.opts.Color.Colorize(line))
-}
-
-func (display *ProgressDisplay) uncolorizeString(v string) string {
-	uncolorized, has := display.colorizedToUncolorized[v]
-	if !has {
-		uncolorized = colors.Never.Colorize(v)
-		display.colorizedToUncolorized[v] = uncolorized
-	}
-
-	return uncolorized
-}
-
-func (display *ProgressDisplay) uncolorizeColumns(columns []string) []string {
-	uncolorizedColumns := make([]string, len(columns))
-
-	for i, v := range columns {
-		uncolorizedColumns[i] = display.uncolorizeString(v)
-	}
-
-	return uncolorizedColumns
+	display.renderer.println(display, line)
 }
 
 type treeNode struct {
@@ -415,10 +389,9 @@ func (display *ProgressDisplay) convertNodesToRows(
 		}
 
 		colorizedColumns := make([]string, len(node.colorizedColumns))
-		uncolorisedColumns := display.uncolorizeColumns(node.colorizedColumns)
 
 		for i, colorizedColumn := range node.colorizedColumns {
-			columnWidth := utf8.RuneCountInString(uncolorisedColumns[i])
+			columnWidth := colors.MeasureColorizedString(colorizedColumn)
 
 			if i == display.suffixColumn {
 				columnWidth += maxSuffixLength

--- a/pkg/backend/display/tableutil.go
+++ b/pkg/backend/display/tableutil.go
@@ -16,7 +16,6 @@ package display
 
 import (
 	"strings"
-	"unicode/utf8"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -26,9 +25,9 @@ func columnHeader(msg string) string {
 	return colors.Underline + colors.BrightBlue + msg + colors.Reset
 }
 
-func messagePadding(message string, maxLength, extraPadding int) string {
-	extraWhitespace := maxLength - utf8.RuneCountInString(message)
-	contract.Assertf(extraWhitespace >= 0, "Neg whitespace. %v %s", maxLength, message)
+func messagePadding(message string, maxWidth, extraPadding int) string {
+	extraWhitespace := maxWidth - colors.MeasureColorizedString(message)
+	contract.Assertf(extraWhitespace >= 0, "Neg whitespace. %v %s", maxWidth, message)
 
 	// Place two spaces between all columns (except after the first column).  The first
 	// column already has a ": " so it doesn't need the extra space.
@@ -38,12 +37,12 @@ func messagePadding(message string, maxLength, extraPadding int) string {
 }
 
 // Gets the padding necessary to prepend to a column in order to keep it aligned in the terminal.
-func columnPadding(uncolorizedColumns []string, columnIndex int, maxColumnLengths []int) string {
+func columnPadding(columns []string, columnIndex int, maxColumnWidths []int) string {
 	extraWhitespace := " "
-	if columnIndex >= 0 && len(maxColumnLengths) > 0 {
-		column := uncolorizedColumns[columnIndex]
-		maxLength := maxColumnLengths[columnIndex]
-		extraWhitespace = messagePadding(column, maxLength, 2)
+	if columnIndex >= 0 && len(maxColumnWidths) > 0 {
+		column := columns[columnIndex]
+		maxWidth := maxColumnWidths[columnIndex]
+		extraWhitespace = messagePadding(column, maxWidth, 2)
 	}
 	return extraWhitespace
 }
@@ -52,11 +51,11 @@ func columnPadding(uncolorizedColumns []string, columnIndex int, maxColumnLength
 // status, then some amount of optional padding, then some amount of msgWithColors, then the
 // suffix.  Importantly, if there isn't enough room to display all of that on the terminal, then
 // the msg will be truncated to try to make it fit.
-func renderRow(colorizedColumns, uncolorizedColumns []string, maxColumnLengths []int) string {
+func renderRow(columns []string, maxColumnWidths []int) string {
 	var row strings.Builder
-	for i := 0; i < len(colorizedColumns); i++ {
-		row.WriteString(columnPadding(uncolorizedColumns, i-1, maxColumnLengths))
-		row.WriteString(colorizedColumns[i])
+	for i := 0; i < len(columns); i++ {
+		row.WriteString(columnPadding(columns, i-1, maxColumnWidths))
+		row.WriteString(columns[i])
 	}
 	return row.String()
 }

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80-cooked.stdout.txt
@@ -1399,585 +1399,585 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRule  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -1985,41 +1985,41 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2027,42 +2027,42 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2070,42 +2070,42 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2113,43 +2113,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2157,43 +2157,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2201,43 +2201,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2246,43 +2246,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2291,44 +2291,44 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2337,44 +2337,44 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2383,45 +2383,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2430,45 +2430,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2477,45 +2477,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2525,45 +2525,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2573,45 +2573,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2622,45 +2622,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2671,45 +2671,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2721,45 +2721,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2770,1230 +2770,1230 @@
  <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-eks-k8s                       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%bold%}><{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%bold%}><{%fg 3%}>updatin<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%bold%}><{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%bold%}><{%fg 3%}>updating<{%reset%}><{%bold%}><{%fg 3%}><{%reset%}>   
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 
 
 <{%fg 13%}><{%bold%}>Diagnostics:<{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-100x80.stdout.txt
@@ -1399,585 +1399,585 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRule  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole            cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                  cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment  cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment  cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix           cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup            cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule        cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -1985,41 +1985,41 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2027,42 +2027,42 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2070,42 +2070,42 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2113,43 +2113,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2157,43 +2157,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2201,43 +2201,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2246,43 +2246,43 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2291,44 +2291,44 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2337,44 +2337,44 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2383,45 +2383,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%bold%}><{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2430,45 +2430,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2477,45 +2477,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2525,45 +2525,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2573,45 +2573,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2622,45 +2622,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2671,45 +2671,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2721,45 +2721,45 @@
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                  <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                        running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>        
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                   <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                          <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                 <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                   <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                               <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                  <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role             <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2         <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97         <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                       <{%reset%}><{%reset%}>            
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>          
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>          
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99              <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup       <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule  <{%reset%}><{%reset%}>            
@@ -2770,1230 +2770,1230 @@
  <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-eks-k8s                       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%bold%}><{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%bold%}><{%fg 3%}>updatin<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%bold%}><{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%bold%}><{%fg 3%}>updating<{%reset%}><{%bold%}><{%fg 3%}><{%reset%}>   
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     └─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%bold%}><{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             running<{%bold%}><{%reset%}><{%reset%}>    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                                       <{%underline%}><{%fg 12%}>Status<{%reset%}>     
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                             <{%reset%}><{%reset%}>           
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>       
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                               <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                                      <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                                        <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99                   <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName                       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRule       <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile                    <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup                  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                            <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngressRule  <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule              <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule                 <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule          <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                         <{%reset%}><{%reset%}>           
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration            <{%reset%}><{%reset%}>           
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                              <{%fg 3%}>updated<{%reset%}>    
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                           <{%reset%}><{%reset%}>           
 
 
 <{%fg 13%}><{%bold%}>Diagnostics:<{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24-cooked.stdout.txt
@@ -221,2303 +221,2303 @@
  <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%bold%}><{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%bold%}><{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%bold%}><{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%bold%}><{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%bold%}><{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
                                                                           more  [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
                                                                           more  [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                    <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                    
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                     <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%bold%}><{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                     
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                     
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                         
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role   
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295b
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f9
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole               
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role        
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823    
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99    
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName          
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGrou
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgre
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster            
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni               
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup     
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s               
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerCluster
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule 
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressR
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule    
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressR
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess            
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguratio
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                 
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule 
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule 
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  
 
 
 <{%fg 13%}><{%bold%}>Diagnostics:<{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/template-body.json.interactive-80x24.stdout.txt
@@ -221,2303 +221,2303 @@
  <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%bold%}><{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>        └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%bold%}><{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%bold%}><{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%bold%}><{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%bold%}><{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                       <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev             running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>         
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>       
- <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>         
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1              <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1               <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                      <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                        <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                    <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role  <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole            <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role       <{%reset%}><{%reset%}>            
+ <{%reset%}>  <{%reset%}>     └─ eks:index:RandomSuffix      cluster-cfnStackName       <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
- <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%bold%}><{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%bold%}><{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     └─ aws:ec2:SecurityGroup       cluster-eksClusterSecurityGroup  <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix      cluster-cfnStackName             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
                                                                           more  [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-eksRole-role             <{%reset%}><{%reset%}>       
                                                                           more  [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-eksRole                  <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                    <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}> 
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:Role             cluster-instanceRole-role        <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole       cluster-instanceRole             <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                    
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                     <{%bold%}><{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                              <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>Status<{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack               aws-ts-eks-dev                   running<{%bold%}><{%reset%}><{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                   
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                    
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                           
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}> 
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-0                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-0                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-0                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway  vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-private-1                    <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable       vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet           vpc-public-1                     <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway       vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip              vpc-1                            <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                 vpc                              <{%reset%}><{%reset%}>       
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster              cluster                          <{%reset%}><{%reset%}>       
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                        
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                   cluster                          <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%bold%}><{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                             <{%underline%}><{%fg 12%}>St<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                   ru
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                  <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                              <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                    <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                     <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                            <{%reset%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                              <{%reset%}><{%reset%}>  
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                   <{%underline%}><{%fg 12%}>Name<{%reset%}>                               
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                    aws-ts-eks-dev                     
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                      
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig            
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                          
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                        
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                 
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1               
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                        
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                      
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                          
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                      vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-0                              
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                vpc-public-0                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                 vpc-public-0-ig                    
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway       vpc                                
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-private-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable            vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                vpc-public-1                       
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway            vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                   vpc-1                              
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                      vpc                                
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                     
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                     
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig           
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-public-1-ig                   
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%bold%}><{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
                                                                           more⬇ [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                                    <{%underline%}><{%fg 12%}>Name<{%reset%}>                              
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack                     aws-ts-eks-dev                    
- <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                           
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                     
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                         
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1               
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1             
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1       
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig           
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1              
- <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                       
- <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                     
- <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                     
- <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                         
- <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                       
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole          
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role   
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295b
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f9
- <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole               
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role        
- <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823    
- <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99    
- <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName          
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGrou
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgre
- <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile       
- <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster            
- <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni               
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup     
- <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s               
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerCluster
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule 
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressR
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule    
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressR
- <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess            
- <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguratio
- <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                 
- <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider              
+ <{%reset%}>  <{%reset%}>  ├─ awsx:x:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-0                             
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-0-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-0                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-0                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-0-nat-0               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:InternetGateway        vpc                               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTableAssociation  vpc-private-1                     
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:Route                  vpc-private-1-nat-1               
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:RouteTable             vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Subnet                 vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Route                  vpc-public-1-ig                   
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:RouteTableAssociation  vpc-public-1                      
+ <{%reset%}>  <{%reset%}>  │  ├─ awsx:x:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  ├─ aws:ec2:Eip                    vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  │  └─ aws:ec2:NatGateway             vpc-1                             
+ <{%reset%}>  <{%reset%}>  │  └─ aws:ec2:Vpc                       vpc                               
+ <{%reset%}>  <{%reset%}>  └─ eks:index:Cluster                    cluster                           
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-instanceRole              
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-instanceRole-role         
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-e1b295bd     
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-instanceRole-3eb088f2     
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-instanceRole-03516f97     
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:ServiceRole             cluster-eksRole                   
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:Role                   cluster-eksRole-role              
+ <{%reset%}>  <{%reset%}>     │  ├─ aws:iam:RolePolicyAttachment   cluster-eksRole-4b490823          
+ <{%reset%}>  <{%reset%}>     │  └─ aws:iam:RolePolicyAttachment   cluster-eksRole-90eb1c99          
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:RandomSuffix            cluster-cfnStackName              
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-eksClusterSecurityGroup   
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterInternetEgressRu
+ <{%reset%}>  <{%reset%}>     ├─ aws:iam:InstanceProfile           cluster-instanceProfile           
+ <{%reset%}>  <{%reset%}>     ├─ aws:eks:Cluster                   cluster-eksCluster                
+ <{%reset%}>  <{%reset%}>     ├─ eks:index:VpcCni                  cluster-vpc-cni                   
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroup             cluster-nodeSecurityGroup         
+ <{%reset%}>  <{%reset%}>     ├─ pulumi:providers:kubernetes       cluster-eks-k8s                   
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksExtApiServerClusterIngr
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksClusterIngressRule     
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeInternetEgressRule 
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeIngressRule        
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:SecurityGroupRule         cluster-eksNodeClusterIngressRule 
+ <{%reset%}>  <{%reset%}>     ├─ kubernetes:core/v1:ConfigMap      cluster-nodeAccess                
+ <{%reset%}>  <{%reset%}>     ├─ aws:ec2:LaunchConfiguration       cluster-nodeLaunchConfiguration   
+ <{%fg 3%}>~ <{%reset%}>     ├─ aws:cloudformation:Stack          cluster-nodes                     
+ <{%reset%}>  <{%reset%}>     └─ pulumi:providers:kubernetes       cluster-provider                  
 
 
 <{%fg 13%}><{%bold%}>Diagnostics:<{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24-cooked.stdout.txt
@@ -33,40 +33,40 @@
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             
- <{%bold%}><{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%fg 3%}>updating<{%reset%}><{%bold%}><{%fg 3%}><{%reset%}>     
+ <{%bold%}><{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%fg 3%}>updating<{%reset%}><{%bold%}><{%fg 3%}><{%reset%}>     [dif
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%reset%}><{%reset%}>            
 
 

--- a/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-4.json.interactive-80x24.stdout.txt
@@ -33,40 +33,40 @@
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             
- <{%bold%}><{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%fg 3%}>updating<{%reset%}><{%bold%}><{%fg 3%}><{%reset%}>     
+ <{%bold%}><{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%fg 3%}>updating<{%reset%}><{%bold%}><{%fg 3%}><{%reset%}>     [dif
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            
- <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [
+ <{%fg 3%}>~ <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%fg 3%}>updated<{%reset%}>     [diff
  <{%reset%}>  <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%reset%}><{%reset%}>            
 
 

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80-cooked.stdout.txt
@@ -12,58 +12,58 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePo<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-100x80.stdout.txt
@@ -12,58 +12,58 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePo<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24-cooked.stdout.txt
@@ -12,60 +12,60 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Conf
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [dif
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 

--- a/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up-5.json.interactive-80x24.stdout.txt
@@ -12,60 +12,60 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Conf
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [dif
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80-cooked.stdout.txt
@@ -12,58 +12,58 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePo<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-100x80.stdout.txt
@@ -12,58 +12,58 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePo<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Configuration:<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>message<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePol<{%reset%}>
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff: <{%fg 2%}>+__defaults<{%reset%}><{%reset%}>]
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24-cooked.stdout.txt
@@ -12,60 +12,60 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Conf
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [dif
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 

--- a/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/up.json.interactive-80x24.stdout.txt
@@ -12,60 +12,60 @@
  <{%reset%}>  <{%reset%}>  └─ aws:iam:Role      eks-role  <{%reset%}><{%reset%}>            [diff: <{%fg 3%}>~assumeRolePolicy<{%reset%}><{%reset%}>]
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%bold%}><{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  └─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%bold%}><{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%bold%}><{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Conf
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>             [dif
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>             [dif
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>             
  <{%bold%}><{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%bold%}><{%fg 2%}>creating<{%reset%}><{%bold%}><{%fg 2%}><{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 running<{%bold%}><{%reset%}><{%reset%}>     <{%reset%}>Confi
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                             <{%underline%}><{%fg 12%}>Name<{%reset%}>                    <{%underline%}><{%fg 12%}>Status<{%reset%}>      <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack              eks-dev                 <{%reset%}><{%reset%}>            1 <{%fg 5%}>mes<{%reset%}>
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [
- <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:Role                  eks-role                <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-service-policy  <{%reset%}><{%reset%}>            [diff
+ <{%reset%}>  <{%reset%}>  ├─ aws:iam:RolePolicyAttachment  eks-rpa-cluster-policy  <{%reset%}><{%reset%}>            [diff
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup         eks-sg                  <{%reset%}><{%reset%}>            
  <{%fg 2%}>+ <{%reset%}>  └─ aws:eks:Cluster               eks-cluster             <{%fg 2%}>created<{%reset%}>     
 

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24-cooked.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24-cooked.stdout.txt
@@ -12,40 +12,40 @@
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>                   <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>                  <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                      
- <{%bold%}><{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 10%}>creating replacement<{%reset%}><{%bold%}><{%fg 10%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                         
+ <{%bold%}><{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 10%}>creating replacement<{%reset%}><{%bold%}><{%fg 10%}><{%reset%}>     [
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>                  <{%underline%}><{%fg 12%}>In<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>                 <{%reset%}>Co
- <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                      
- <{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 10%}>created replacement<{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                        
+ <{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 10%}>created replacement<{%reset%}>     [d
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>        <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>       <{%reset%}>Configuratio
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>              
- <{%bold%}><{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 13%}>replacing<{%reset%}><{%bold%}><{%fg 13%}><{%reset%}>     [diff: <{%fg 3%}>~<{%reset%}>
+ <{%bold%}><{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 13%}>replacing<{%reset%}><{%bold%}><{%fg 13%}><{%reset%}>     [diff: <{%fg 3%}>~user<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>                <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>               <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                      
- <{%bold%}><{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 9%}>deleting original<{%reset%}><{%bold%}><{%fg 9%}><{%reset%}>     
+ <{%bold%}><{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 9%}>deleting original<{%reset%}><{%bold%}><{%fg 9%}><{%reset%}>     [dif
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>               <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>              <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                     
- <{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 9%}>deleted original<{%reset%}>     [
+ <{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 9%}>deleted original<{%reset%}>     [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  <{%reset%}><{%reset%}>             1 <{%fg 5%}>message<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  <{%reset%}><{%reset%}>             1 <{%fg 5%}>message<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 
 
 <{%fg 13%}><{%bold%}>Diagnostics:<{%reset%}>

--- a/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24.stdout.txt
+++ b/pkg/backend/display/testdata/not-truncated/webserver-userdata.json.interactive-80x24.stdout.txt
@@ -12,40 +12,40 @@
  <{%reset%}>  <{%reset%}>  └─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>            
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>                   <{%underline%}><{%fg 12%}>I<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>                  <{%reset%}>C
- <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                      
- <{%bold%}><{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 10%}>creating replacement<{%reset%}><{%bold%}><{%fg 10%}><{%reset%}>  
+ <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                         
+ <{%bold%}><{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 10%}>creating replacement<{%reset%}><{%bold%}><{%fg 10%}><{%reset%}>     [
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>                  <{%underline%}><{%fg 12%}>In<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>                 <{%reset%}>Co
- <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                      
- <{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 10%}>created replacement<{%reset%}>   
+ <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                        
+ <{%fg 10%}>++<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 10%}>created replacement<{%reset%}>     [d
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>        <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>       <{%reset%}>Configuratio
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>              
- <{%bold%}><{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 13%}>replacing<{%reset%}><{%bold%}><{%fg 13%}><{%reset%}>     [diff: <{%fg 3%}>~<{%reset%}>
+ <{%bold%}><{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 13%}>replacing<{%reset%}><{%bold%}><{%fg 13%}><{%reset%}>     [diff: <{%fg 3%}>~user<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>      <{%reset%}>Configuration
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>                <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>               <{%reset%}>Conf
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                      
- <{%bold%}><{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 9%}>deleting original<{%reset%}><{%bold%}><{%fg 9%}><{%reset%}>     
+ <{%bold%}><{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%bold%}><{%fg 9%}>deleting original<{%reset%}><{%bold%}><{%fg 9%}><{%reset%}>     [dif
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>               <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  running<{%bold%}><{%reset%}><{%reset%}>              <{%reset%}>Confi
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>                     
- <{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 9%}>deleted original<{%reset%}>     [
+ <{%fg 9%}>--<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 9%}>deleted original<{%reset%}>     [diff
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  <{%reset%}><{%reset%}>             1 <{%fg 5%}>message<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 [1K[K[1A[1K[K[1A[1K[K[1A[1K[K[1A[1K[K     <{%underline%}><{%fg 12%}>Type<{%reset%}>                      <{%underline%}><{%fg 12%}>Name<{%reset%}>                  <{%underline%}><{%fg 12%}>Status<{%reset%}>       <{%underline%}><{%fg 12%}>Info<{%reset%}>
  <{%reset%}>  <{%reset%}>  pulumi:pulumi:Stack       aws-ts-webserver-dev  <{%reset%}><{%reset%}>             1 <{%fg 5%}>message<{%reset%}>
  <{%reset%}>  <{%reset%}>  ├─ aws:ec2:SecurityGroup  web-secgrp            <{%reset%}><{%reset%}>             
- <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~u<{%reset%}>
+ <{%fg 13%}>+-<{%reset%}>  └─ aws:ec2:Instance       web-server-www        <{%fg 13%}>replaced<{%reset%}>     [diff: <{%fg 3%}>~userD<{%reset%}>
 
 
 <{%fg 13%}><{%bold%}>Diagnostics:<{%reset%}>

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -139,8 +139,7 @@ func (r *treeRenderer) render(display *ProgressDisplay) {
 
 	r.treeTableRows = r.treeTableRows[:0]
 	for _, row := range treeTableRows {
-		uncolorizedRow := display.uncolorizeColumns(row)
-		rendered := renderRow(row, uncolorizedRow, maxColumnLengths)
+		rendered := renderRow(row, maxColumnLengths)
 		r.treeTableRows = append(r.treeTableRows, rendered)
 	}
 

--- a/sdk/go/common/diag/colors/colors.go
+++ b/sdk/go/common/diag/colors/colors.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/rivo/uniseg"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -133,61 +135,111 @@ func writeDirective(w io.StringWriter, c Colorization, directive Color) {
 	}
 }
 
-func colorizeText(s string, c Colorization, maxLen int) string {
-	var buf bytes.Buffer
+type iterator struct {
+	input string
+}
 
-	textLen, reset := 0, false
-	for input := s; len(input) > 0; {
-		// Do we have another directive to process?
-		nextDirectiveStart := strings.Index(input, colorLeft)
-		if nextDirectiveStart == -1 {
-			// If there are no more directives and we still have the entire original string, return it as-is: there
-			// must not have been any directives.
-			if len(input) == len(s) {
-				if maxLen >= 0 && len(input) > maxLen {
-					return input[:maxLen]
-				}
-				return input
-			}
+func (it *iterator) next(text, directive *string) bool {
+	if len(it.input) == 0 {
+		return false
+	}
 
-			// Otherwise, set the start of the next directive to the end of the string and continue.
-			nextDirectiveStart = len(input)
-		}
-		if buf.Cap() < len(input) {
-			buf.Grow(len(input))
-		}
+	// Do we have another directive to process?
+	nextDirectiveStart := strings.Index(it.input, colorLeft)
+	if nextDirectiveStart == -1 {
+		*text, *directive, it.input = it.input, "", ""
+		return true
+	}
 
-		// Copy the text up to but not including the delimiter into the buffer.
-		text := input[:nextDirectiveStart]
-		if maxLen >= 0 && textLen+len(text) > maxLen {
-			_, err := buf.WriteString(text[:maxLen-textLen])
-			contract.IgnoreError(err)
-			if reset {
-				writeDirective(&buf, c, Reset)
-			}
-			break
-		}
-		_, err := buf.WriteString(text)
-		contract.IgnoreError(err)
-		textLen += len(text)
+	// Copy the text up to but not including the delimiter into the buffer.
+	*text = it.input[:nextDirectiveStart]
 
-		// If we have a start delimiter but no end delimiter, terminate. The partial command will not be present in the
-		// output. Make sure we look for the for end delimiter _after_ the start delimiter.
-		nextDirectiveEnd := strings.Index(input[nextDirectiveStart:], colorRight)
-		if nextDirectiveEnd == -1 {
-			break
-		}
+	// If we have a start delimiter but no end delimiter, terminate. The partial command will not be present in the
+	// output. Make sure we look for the for end delimiter _after_ the start delimiter.
+	nextDirectiveEnd := strings.Index(it.input[nextDirectiveStart:], colorRight)
+	if nextDirectiveEnd != -1 {
 		// Correct the index given we searched starting from nextDirectiveStart
 		nextDirectiveEnd += nextDirectiveStart
 
-		directive := input[nextDirectiveStart : nextDirectiveEnd+len(colorRight)]
-		writeDirective(&buf, c, directive)
-		input = input[nextDirectiveEnd+len(colorRight):]
+		*directive = it.input[nextDirectiveStart : nextDirectiveEnd+len(colorRight)]
+
+		it.input = it.input[nextDirectiveEnd+len(colorRight):]
+	} else {
+		*directive, it.input = "", ""
+	}
+	return true
+}
+
+func colorizeText(s string, c Colorization, maxWidth int) string {
+	var buf bytes.Buffer
+	width, reset := 0, false
+
+	i := iterator{s}
+	var text, directive string
+	for i.next(&text, &directive) {
+		// If the text is the entire original string, return it as-is.
+		if len(text) == len(s) {
+			if maxWidth >= 0 {
+				return clampString(text, maxWidth)
+			}
+			return text
+		}
+
+		if buf.Cap() < len(text) {
+			buf.Grow(len(text))
+		}
+
+		if maxWidth >= 0 {
+			graphemes := uniseg.NewGraphemes(text)
+			for graphemes.Next() {
+				if width == maxWidth {
+					if reset {
+						writeDirective(&buf, c, Reset)
+					}
+					return buf.String()
+				}
+				start, end := graphemes.Positions()
+				_, err := buf.WriteString(text[start:end])
+				contract.IgnoreError(err)
+				width++
+			}
+		} else {
+			_, err := buf.WriteString(text)
+			contract.IgnoreError(err)
+		}
+
+		if directive != "" {
+			writeDirective(&buf, c, directive)
+		}
 
 		reset = directive != Reset
 	}
 
 	return buf.String()
+}
+
+func measureText(s string) int {
+	width := 0
+
+	i := iterator{s}
+	var text, directive string
+	for i.next(&text, &directive) {
+		width += uniseg.GraphemeClusterCount(text)
+	}
+
+	return width
+}
+
+func clampString(s string, maxWidth int) string {
+	width, end := 0, 0
+
+	graphemes := uniseg.NewGraphemes(s)
+	for width < maxWidth && graphemes.Next() {
+		_, end = graphemes.Positions()
+		width++
+	}
+
+	return s[:end]
 }
 
 // Highlight takes an input string, a sequence of commands, and replaces all occurrences of that string with

--- a/sdk/go/common/diag/colors/colors_test.go
+++ b/sdk/go/common/diag/colors/colors_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rivo/uniseg"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,6 +85,9 @@ func TestColorizer(t *testing.T) {
 			trimmedContent := content[:3]
 			actualTrimmed := TrimColorizedString(str, len(trimmedContent))
 			assert.Equal(t, c.command+trimmedContent+Reset, actualTrimmed)
+
+			assert.Equal(t, uniseg.GraphemeClusterCount("hello\n"), measureText(str))
+			assert.Equal(t, uniseg.GraphemeClusterCount(actualNever), measureText(str))
 		})
 	}
 }
@@ -133,4 +137,7 @@ func TestTrimColorizedString(t *testing.T) {
 	plain := "hello, world!!"
 	actual = TrimColorizedString(plain, len("hello"))
 	assert.Equal(t, "hello", actual)
+
+	assert.Equal(t, uniseg.GraphemeClusterCount("hello, world!!"), measureText(str))
+	assert.Equal(t, uniseg.GraphemeClusterCount(Never.Colorize(str)), measureText(str))
 }

--- a/sdk/go/common/diag/colors/diag.go
+++ b/sdk/go/common/diag/colors/diag.go
@@ -33,15 +33,21 @@ const (
 
 // Colorize conditionally colorizes the given string based on the kind of colorization selected.
 func (c Colorization) Colorize(v string) string {
+	return c.ColorizeWithMaxWidth(v, -1)
+}
+
+// ColorizeWithMaxWidth conditionally colorizes the given string based on the kind of colorization selected.
+// The result will contain no more than maxWidth user-perceived characters (grapheme clusters).
+func (c Colorization) ColorizeWithMaxWidth(v string, maxWidth int) string {
 	switch c {
 	case Raw:
 		// Don't touch the string.  Output control sequences as is.
 		return v
 	case Always:
 		// Convert the control sequences into appropriate console escapes for the platform we're on.
-		return colorizeText(v, Always, -1)
+		return colorizeText(v, Always, maxWidth)
 	case Never:
-		return colorizeText(v, Never, -1)
+		return colorizeText(v, Never, maxWidth)
 	default:
 		contract.Failf("Unexpected colorization value: %v", c)
 		return ""
@@ -49,11 +55,17 @@ func (c Colorization) Colorize(v string) string {
 }
 
 // TrimColorizedString takes a string with embedded color tags and returns a new string (still with
-// embedded color tags) such that the length of the *non-tag* portion of the string is no greater
-// than maxLength.  This is useful for scenarios where the string has to be printed in a a context
-// where there is a max allowed width.  In these scenarios, we can't just measure the length of the
-// string as the embedded color tags would count against it, even though they end up with no length
-// when actually interpreted by the console.
-func TrimColorizedString(v string, maxRuneLength int) string {
-	return colorizeText(v, Raw, maxRuneLength)
+// embedded color tags) such that the number of user-perceived characters (grapheme clusters) in
+// the result is no greater than maxWidth. This is useful for scenarios where the string has to be
+// printed in a a context where there is a max allowed width. In these scenarios, we can't just
+// measure the length of the string as the embedded color tags would count against it, even though
+// they end up with no length when actually interpreted by the console.
+func TrimColorizedString(v string, maxWidth int) string {
+	return colorizeText(v, Raw, maxWidth)
+}
+
+// MeasureColorizedString measures the number of user-perceived characters (grapheme clusters) in the
+// given string with embedded color tags. Color tags do not contribute to the total.
+func MeasureColorizedString(v string) int {
+	return measureText(v)
 }


### PR DESCRIPTION
The number of Unicode code points in a string is not the same as the
number of user-visible characters (graphemes). When measuring colorized
strings, we want the latter rather than the former. Notably, these
changes fix some issues where the interactive display cut off before the
right edge of the terminal.