### PR TITLE
feat(sdk/nodejs): delegates alias computation to the engine

### DIFF
--- a/changelog/pending/20221031--sdk-nodejs--delegates-alias-computation-to-engine-for-node-sdk.yaml
+++ b/changelog/pending/20221031--sdk-nodejs--delegates-alias-computation-to-engine-for-node-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Delegates alias computation to engine for Node SDK

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -415,7 +415,7 @@ func (sg *stepGenerator) inheritedChildAlias(
 	return resource.NewURN(
 		sg.deployment.Target().Name.Q(),
 		sg.deployment.source.Project(),
-		parentAlias.Type(),
+		parentAlias.QualifiedType(),
 		childType,
 		aliasName)
 }

--- a/sdk/go/common/util/env/env.go
+++ b/sdk/go/common/util/env/env.go
@@ -17,7 +17,7 @@
 //
 // Declaring a variable is as simple as declaring a module level constant.
 //
-//   var Var = env.Bool("VAR", "A boolean variable")
+//	var Var = env.Bool("VAR", "A boolean variable")
 //
 // Typed values can be retrieved by calling `Var.Value()`.
 package env

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -17,7 +17,6 @@ import { Input, Inputs, interpolate, Output, output } from "./output";
 import { getResource, readResource, registerResource, registerResourceOutputs } from "./runtime/resource";
 import { getProject, getStack } from "./runtime/settings";
 import { getStackResource } from "./runtime/state";
-import * as stacklib from "./runtime/stack";
 import { unknownValue } from "./runtime/rpc";
 import * as utils from "./utils";
 import * as log from "./log";
@@ -215,7 +214,7 @@ export abstract class Resource {
      * @internal
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match
-    private readonly __name?: string;
+    readonly __name?: string;
 
     /**
      * The set of providers to use for child resources. Keyed by package name (e.g. "aws").
@@ -332,9 +331,6 @@ export abstract class Resource {
             if (opts.protect === undefined) {
                 opts.protect = parent.__protect;
             }
-
-            // Update aliases to include the full set of aliases implied by the child and parent aliases.
-            opts.aliases = allAliases(opts.aliases || [], name, t, parent, parent.__name!);
 
             this.__providers = parent.__providers;
         }

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -518,6 +518,17 @@ export async function monitorSupportsDeletedWith(): Promise<boolean> {
     return monitorSupportsFeature("deletedWith");
 }
 
+/**
+ * monitorSupportsAliasSpecs returns a promise that when resolved tells you if the resource monitor we are
+ * connected to is able to support alias specs across its RPC interface. When it does, we marshal aliases
+ * in a special way.
+ *
+ * @internal
+ */
+export async function monitorSupportsAliasSpecs(): Promise<boolean> {
+    return monitorSupportsFeature("aliasSpecs");
+}
+
 // sxsRandomIdentifier is a module level global that is transfered to process.env.
 // the goal is to detect side by side (sxs) pulumi/pulumi situations for inline programs
 // and fail fast. See https://github.com/pulumi/pulumi/issues/7333 for details.

--- a/sdk/nodejs/tests/runtime/langhost/cases/072.large_alias_lineage_chains/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/072.large_alias_lineage_chains/index.js
@@ -11,7 +11,21 @@ class MyResource extends pulumi.CustomResource {
             name,
             {},
             {
-                aliases: aliases,
+                aliases,
+                parent
+            }
+        );
+    }
+}
+
+class MyOtherResource extends pulumi.CustomResource {
+    constructor(name, aliases, parent) {
+        super(
+            "test:index:MyOtherResource",
+            name,
+            {},
+            {
+                aliases,
                 parent
             }
         );
@@ -21,7 +35,22 @@ class MyResource extends pulumi.CustomResource {
 const resource1Aliases = Array.from(new Array(1000).keys()).map(key => `my-alias-name-${key}`);
 const resource1 = new MyResource("testResource1", resource1Aliases);
 resource1.__aliases.map(alias => alias.apply(aliasName => assert(resource1Aliases.includes(aliasName))));
+assert.equal(resource1.__aliases.length, 1000);
 
 const resource2Aliases = Array.from(new Array(1000).keys()).map(key => `my-other-alias-name-${key}`);
 const resource2 = new MyResource("testResource2", resource2Aliases, resource1)
 resource2.__aliases.map(alias => alias.apply(aliasName => assert(resource2Aliases.includes(aliasName))));
+assert.equal(resource2.__aliases.length, 1000);
+
+const resource3Aliases = Array.from(new Array(1000).keys()).map(key => {
+    return {
+        name: `my-alias-${key}`,
+        stack: "my-stack",
+        project: "my-project",
+        type: "test:index:MyOtherResource",
+    }
+});
+const resource3 = new MyOtherResource("testResource2", resource3Aliases, resource2)
+assert.equal(resource3.__aliases.length, 1000);
+// We want to ensure that the parent's type is included in computed aliases from the engine
+resource3.__aliases[0].apply(aliasName => assert(aliasName.includes("test:index:MyResource")));

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1249,14 +1249,13 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
-    /** Skipping this test case as it requires limiting the alias multiplication which occurs */
-    // "large_alias_lineage_chains": {
-        // program: path.join(base, "072.large_alias_lineage_chains"),
-        // expectResourceCount: 1,
-        // registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, ...args: any) => {
-        // return { urn: makeUrn(t, name), id: undefined, props: undefined };
-        // },
-    // }
+        "large_alias_lineage_chains": {
+            program: path.join(base, "072.large_alias_lineage_chains"),
+            expectResourceCount: 3,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, ...args: any) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {
@@ -1418,7 +1417,7 @@ describe("rpc", () => {
                     // SupportsFeature callback
                     (call: any, callback: any) => {
                         const resp = new resproto.SupportsFeatureResponse();
-                        resp.setHassupport(false);
+                        resp.setHassupport(true);
                         callback(undefined, resp);
                     },
                 );

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/protobuf v1.5.2
 	github.com/hexops/autogold v1.3.0
-	github.com/pulumi/pulumi/pkg/v3 v3.34.1
+	github.com/pulumi/pulumi/pkg/v3 v3.49.0
 	github.com/pulumi/pulumi/sdk/v3 v3.49.0
 	github.com/stretchr/testify v1.8.0
 	google.golang.org/grpc v1.51.0

--- a/tests/integration/aliases/nodejs/adopt_into_component/step2/index.ts
+++ b/tests/integration/aliases/nodejs/adopt_into_component/step2/index.ts
@@ -49,7 +49,7 @@ new Component2("unparented", {
 class Component3 extends pulumi.ComponentResource {
     constructor(name: string, opts: pulumi.ComponentResourceOptions = {}) {
         super("my:module:Component3", name, {}, opts);
-        new Component2(name + "-child", { aliases: [{ parent: opts.parent}], parent: this });
+        new Component2(name + "-child", { aliases: [{ parent: opts.parent }], parent: this });
     }
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This moves the alias computation from the node SDK to the engine (which now does these computations for us as of #10819 ).  This dramatically improves performance when resources with many aliases are parented to one another.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11062 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
