### PR TITLE
Check for duplicate aliases and plain URNs

### DIFF
--- a/changelog/pending/20221101--engine--expand-duplicate-urn-checks-across-direct-urns-and-aliases.yaml
+++ b/changelog/pending/20221101--engine--expand-duplicate-urn-checks-across-direct-urns-and-aliases.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Expand duplicate URN checks across direct URNs and aliases.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -445,6 +445,12 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 		}
 	}
 
+	if previousAliasURN, alreadyAliased := sg.aliased[urn]; alreadyAliased {
+		// This resource is claiming to be X but we've already seen another resource claim that via aliases
+		invalid = true
+		sg.deployment.Diag().Errorf(diag.GetDuplicateResourceAliasedError(urn), urn, previousAliasURN)
+	}
+
 	// Check for an old resource so that we can figure out if this is a create, delete, etc., and/or
 	// to diff.  We look up first by URN and then by any provided aliases.  If it is found using an
 	// alias, record that alias so that we do not delete the aliased resource later.
@@ -460,7 +466,13 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 			oldInputs = old.Inputs
 			oldOutputs = old.Outputs
 			if urnOrAlias != urn {
+				if _, alreadySeen := sg.urns[urnOrAlias]; alreadySeen {
+					// This resource is claiming to X but we've already seen that urn created
+					invalid = true
+					sg.deployment.Diag().Errorf(diag.GetDuplicateResourceAliasError(urn), urnOrAlias, urn, urn)
+				}
 				if previousAliasURN, alreadyAliased := sg.aliased[urnOrAlias]; alreadyAliased {
+					// This resource is claiming to be X but we've already seen another resource claim that
 					invalid = true
 					sg.deployment.Diag().Errorf(diag.GetDuplicateResourceAliasError(urn), urnOrAlias, urn, previousAliasURN)
 				}

--- a/sdk/go/common/diag/errors.go
+++ b/sdk/go/common/diag/errors.go
@@ -84,3 +84,9 @@ Either include resource in --target list or pass --target-dependents to proceed.
 func GetDefaultProviderDenied(urn resource.URN) *Diag {
 	return newError(urn, 2015, `Default provider for '%v' disabled. '%v' must use an explicit provider.`)
 }
+
+func GetDuplicateResourceAliasedError(urn resource.URN) *Diag {
+	return newError(urn, 2016,
+		"Duplicate resource URN '%v' conflicting with alias on resource with URN '%v'",
+	)
+}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We need to check that for example that if a resource X is created that we don't allow another resource Y to be alias against X. Likewise if our old state has X and we then create Y aliased against X we should not then allow X to be created later in the deployment.

Fixes https://github.com/pulumi/pulumi/issues/11173

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
