### PR TITLE
[sdk/nodejs] Mark internal APIs @internal to filter from SDK docs

### DIFF
--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -71,6 +71,7 @@ export class ResourceError extends Error {
     }
 }
 
+/** @internal */
 export function isGrpcError(err: Error): boolean {
     const code = (<any>err).code;
     return code === grpc.status.UNAVAILABLE || code === grpc.status.CANCELLED;

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -370,6 +370,7 @@ export function waitForRPCs(disconnectFromServers = false): Promise<void> {
 
 /**
  * getMaximumListeners returns the configured number of process listeners available
+ * @internal
  */
 export function getMaximumListeners(): number {
     const { settings } = getStore();

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -43,6 +43,7 @@ export function runInPulumiStack(init: () => Promise<any>): Promise<Inputs | und
 /**
  * Stack is the root resource for a Pulumi stack. Before invoking the `init` callback, it registers itself as the root
  * resource with the Pulumi engine.
+ * @internal
  */
 export class Stack extends ComponentResource<Inputs> {
     /**


### PR DESCRIPTION
These exported APIs aren't intended for public use. Marking them as `@internal` makes TypeScript remove them from the `.d.ts` files and removes them from our SDK docs. Follow-up from #10806

- `getMaximumListeners` and `Stack` was unintentionally exported in #10568
- `isGrpcError` was unintentionally exported in #5347

It's possible that someone has started using these, but unlikely. They were never intended to be exposed publicly.