### PR TITLE
Handle None being passed to register_resource_outputs

### DIFF
--- a/changelog/pending/20221102--sdk-python--handle-none-being-passed-to-register_resource_outputs.yaml
+++ b/changelog/pending/20221102--sdk-python--handle-none-being-passed-to-register_resource_outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Handle None being passed to register_resource_outputs.

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -682,7 +682,9 @@ def register_resource_outputs(
 ):
     async def do_register_resource_outputs():
         urn = await res.urn.future()
-        serialized_props = await rpc.serialize_properties(outputs, {})
+        # serialize_properties expects a collection (empty is fine) but not None, but this is called pretty
+        # much directly by users who could pass None in (although the type hints say they shouldn't).
+        serialized_props = await rpc.serialize_properties(outputs or {}, {})
         log.debug(
             f"register resource outputs prepared: urn={urn}, props={serialized_props}"
         )


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/11227.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
