### PR TITLE
Fix winget install in download cron

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -100,10 +100,8 @@ jobs:
     steps:
       - name: Install WinGet CLI
         shell: powershell
-        run:
-          Add-AppxPackage -Path 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
-          $wingetAlreadyInstalled = Get-AppPackage -name 'Microsoft.DesktopAppInstaller'
-          if (!$wingetAlreadyInstalled) { Add-AppxPackage -Path https://aka.ms/getwinget }
+        run: |
+          try { winget --help } catch { Add-AppxPackage -Path https://aka.ms/getwinget }
       - name: Install Pulumi Using Winget
         run: winget install pulumi
       - name: Pulumi Version Details


### PR DESCRIPTION
I think the problem was the missing `|` when using multi-line scripts 😅 now I simplified this into a one-liner (attempt nr. 3)

Tested using a Windows machine
