### PR TITLE
chore(ci): bumps python version in matrix to 3.11

### DIFF
--- a/changelog/pending/20221103--ci--bumps-python-version-in-matrix-to-3-11.yaml
+++ b/changelog/pending/20221103--ci--bumps-python-version-in-matrix-to-3-11.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: ci
+  description: Bumps python version in matrix to 3.11

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -125,7 +125,7 @@ CURRENT_VERSION_SET = {
     "dotnet": "7",
     "go": "1.20.x",
     "nodejs": "19.x",
-    "python": "3.10.x",
+    "python": "3.11.x",
 }
 
 

--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -164,8 +164,13 @@ if __name__ == "__main__":
             try:
                 return runpy.run_path(args.PROGRAM, run_name='__main__')
             except ImportError as e:
+                def fix_module_file(m: str) -> str:
+                    # Work around python 11 reporting "<frozen runpy>" rather
+                    # than runpy.__file__ in the traceback.
+                    return runpy.__file__ if m == "<frozen runpy>" else m
+
                 # detect if the main pulumi python program does not exist
-                stack_modules = [f.filename for f in traceback.extract_tb(e.__traceback__)]
+                stack_modules = [fix_module_file(f.filename) for f in traceback.extract_tb(e.__traceback__)]
                 unique_modules = set(module for module in stack_modules)
                 last_module_name = stack_modules[-1]
 

--- a/tests/integration/enums/python/__main__.py
+++ b/tests/integration/enums/python/__main__.py
@@ -40,4 +40,4 @@ tree = Tree("myTree", type=RubberTreeVariety.BURGUNDY, farm=Farm.PULUMI_PLANTERS
 
 export("myTreeType", tree.type)
 export("myTreeFarmChanged", tree.farm.apply(lambda x: x + "foo"))
-export("mySentence", Output.all(tree.type, tree.farm).apply(lambda args: f"My {args[0]} Rubber tree is from {args[1]}"))
+export("mySentence", Output.all(tree.type, tree.farm).apply(lambda args: f"My {args[0].value} Rubber tree is from {args[1]}"))


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11205 
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
