### PR TITLE
Make OutputState pass the `-race` detector

### DIFF
--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -129,10 +129,14 @@ func (o *OutputState) elementType() reflect.Type {
 	return o.element
 }
 
+// Fetch the dependencies of an OutputState. It is not thread-safe to mutate values inside
+// returned slice.
 func (o *OutputState) dependencies() []Resource {
 	if o == nil {
 		return nil
 	}
+	o.cond.L.Lock()
+	defer o.cond.L.Unlock()
 	return o.deps
 }
 


### PR DESCRIPTION
This is the last step necessary to allow pulumi-yaml to run a subset of its tests with `-race=true`. 

The race is is between `ApplyT` and `fulfillValue` on copying a slice. 

Both me (@iwahbe) and @t0yv0 have independently confirmed that the race is not hiding a deeper issue. Further discussion of the issue is at https://github.com/pulumi/pulumi/pull/11186.

A stack trace from the `-race` flag that this issue fixes:
```
WARNING: DATA RACE
Write at 0x00c000422ec0 by goroutine 463:
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*OutputState).fulfillValue()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/types.go:198 +0x590
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*OutputState).ApplyTWithContext.func1()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/types.go:516 +0x8a5

Previous read at 0x00c000422ec0 by goroutine 306:
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*OutputState).dependencies()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/types.go:136 +0x406
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*OutputState).ApplyTWithContext()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/types.go:492 +0x14a
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*OutputState).ApplyT()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/types.go:440 +0xb8
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.AnyOutput.ApplyT()
      <autogenerated>:1 +0x49
  github.com/pulumi/pulumi-yaml/pkg/pulumiyaml.TestSplit.func1.1()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/run_test.go:890 +0x1d3
  github.com/pulumi/pulumi-yaml/pkg/pulumiyaml.testTemplateDiags.func2()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/run_test.go:286 +0x516
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.RunWithContext()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/run.go:120 +0x258
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.runErrInner()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/run.go:96 +0x4b1
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.RunErr()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/run.go:63 +0x23a
  github.com/pulumi/pulumi-yaml/pkg/pulumiyaml.testTemplateDiags()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/run_test.go:274 +0x2e
  github.com/pulumi/pulumi-yaml/pkg/pulumiyaml.testTemplate()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/run_test.go:335 +0x44
  github.com/pulumi/pulumi-yaml/pkg/pulumiyaml.TestSplit.func1()
      /Users/ianwahbe/go/src/github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/run_test.go:886 +0x2f5
  testing.tRunner()
      /usr/local/Cellar/go/1.19.2/libexec/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/Cellar/go/1.19.2/libexec/src/testing/testing.go:1493 +0x47
```