### PR TITLE
ci: Reduce Windows test parallelism

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -98,6 +98,13 @@ jobs:
           echo "$TOOL_BIN" | tee -a "$GITHUB_PATH"
           command -v tar
           tar --version
+      - name: Reduce Windows test parallelism
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          echo "GO_TEST_PARALLELISM=4" >> "$GITHUB_ENV"
+          echo "GO_TEST_PKG_PARALLELISM=1" >> "$GITHUB_ENV"
+          # For debugging:
+          ps aux
       - name: "macOS use coreutils"
         if: ${{ runner.os == 'macOS' }}
         run: |


### PR DESCRIPTION
Increases likelihood of CI passing on Windows due to longstanding CPU exhaustion bug on runners. (GitHub support ticket 1791026 on my account.)

