### PR TITLE
Standardize pkg loading for TestReferenceRenderer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ schema-%: curl.ensure jq.ensure
 # As a courtesy to reviewers, please make changes to this list and the committed schema files in a
 # separate commit from other changes, as online code review tools may balk at rendering these diffs.
 get_schemas: \
+			schema-aws!4.15.0           \
 			schema-aws!4.26.0           \
 			schema-aws!4.36.0           \
 			schema-aws!4.37.1           \

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -26,6 +26,7 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 	// schema files in the given schema directory. This is the minimal set of schemas that must be
 	// supplied.
 	return deploytest.NewPluginHost(nil, nil, nil,
+		mockProvider("aws", "4.15.0"),
 		mockProvider("aws", "4.26.0"),
 		mockProvider("aws", "4.36.0"),
 		mockProvider("aws", "4.37.1"),


### PR DESCRIPTION
Fixes #11252

I've been unable to repro locally, but the underlying issue is encountered while binding packages, (not the functionality under test). I've changed the loading mechanism to use our standard `utils.NewHost` framework. Hopefully this will eliminate the flaky behavior.

Fully binding ecs correctly requires `aws@4.15.0`.

I've also limited the test to only run once on each named schemas. I don't think we need to produce and check docs for every version of every schema. 