### PR TITLE
triage: move issues back into triage when unstale

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -13,12 +13,13 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 // v6.0.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        only-labels: awaiting-feedback
+        any-of-labels:
+          - awaiting-feedback
+          - awaiting-feedback-stale
         stale-issue-message: 'Since we haven''t heard back from you, closing this issue for now. Please feel free to comment with more information and we can get this reopened.'
         stale-issue-label: awaiting-feedback-stale
         days-before-stale: 14
-        close-issue-label: resolution/no-repro
-        days-before-close: 1
+        labels-to-add-when-unstale: needs-triage


### PR DESCRIPTION
When an issue has label `awaiting-feedback-stale`, instead of closing the issue after one day, the job will check for any updates to the issue since the application of the label and on discovering any update, add `needs-triage`. If my reading of the code is correct, it will _also_ remove `awaiting-feedback-stale`, leaving only `needs-triage`. (Source here: https://github.com/actions/stale/blob/8e8a0e6680dcd91c625405f57bdac762102e4b7d/src/classes/issues-processor.ts#L699-L702).

I also found that issue #9571 was skipped. It has `awaiting-feedback-stale`, but since the "only-labels" option was set to `awaiting-feedback`, it missed this issue. From the logs job yesterday:

> [#9571] Found this issue last updated at: 2022-09-08T15:47:01Z
> [#9571] The option only-labels (​[https://github.com/actions/stale#only-labels​)](https://github.com/actions/stale#only-labels%E2%80%8B)) was specified to only process issues and pull requests with all those labels (1)
> [#9571] └── Skipping this issue because it doesn't have all the required labels

Source: https://github.com/pulumi/pulumi/actions/runs/3377961423/jobs/5607541587#step:2:1231

So this PR uses the `any-of-labels` option instead of `only-labels`, and specifies that it will check for activity on either. I think that's why we haven't noticed it closing issues: once an issue was marked stale, the stale message that it would be closed would appear and then the action would skip the issue on its next check.