### PR TITLE
Disable auto stack parenting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "go.buildTags": "all,smoke",
+    "go.buildTags": "all",
     "go.testTimeout": "1h",
     "gopls": {
         // A couple of modules get copied as part of builds and this confuse gopls as it sees the module name twice, just ignore the copy in the build folders.

--- a/changelog/pending/20221107--engine--disable-auto-parenting-to-see-if-that-fixes-10950.yaml
+++ b/changelog/pending/20221107--engine--disable-auto-parenting-to-see-if-that-fixes-10950.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: "Disable auto parenting to see if that fixes #10950."

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -4116,6 +4116,7 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 
 func TestDefaultParents(t *testing.T) {
 	t.Parallel()
+	t.Skipf("Default parents disabled due to https://github.com/pulumi/pulumi/issues/10950")
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -140,11 +140,22 @@ func (sg *stepGenerator) checkParent(parent resource.URN, resourceType tokens.Ty
 			}
 		} else {
 			// Else try and set it to the root stack
-			for urn := range sg.urns {
-				if urn.Type() == resource.RootStackType {
-					return urn, nil
-				}
-			}
+
+			// TODO: It looks like this currently has some issues with state ordering (see
+			// https://github.com/pulumi/pulumi/issues/10950). Best I can guess is the stack resource is
+			// hitting the step generator and so saving it's URN to sg.urns and issuing a Create step but not
+			// actually getting to writing it's state to the snapshot. Then in parallel with this something
+			// else is causing a pulumi:providers:pulumi default provider to be created, this picks up the
+			// stack URN from sg.urns and so sets it's parent automatically, but then races the step executor
+			// to write itself to state before the stack resource manages to. Long term we want to ensure
+			// there's always a stack resource present, and so that all resources (except the stack) have a
+			// parent (this will save us some work in each SDK), but for now lets just turn this support off.
+
+			//for urn := range sg.urns {
+			//	if urn.Type() == resource.RootStackType {
+			//		return urn, nil
+			//	}
+			//}
 		}
 	}
 

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -306,8 +306,9 @@ func TestStackParenting(t *testing.T) {
 					case "g":
 						assert.Equal(t, urns["f"], res.Parent)
 					case "default":
-						// Default providers should have the stack as a parent.
-						assert.Equal(t, stackRes.URN, res.Parent)
+						// Default providers should have the stack as a parent, but auto-parenting has been
+						// disabled so they won't have a parent for now.
+						assert.Equal(t, resource.URN(""), res.Parent)
 					default:
 						t.Fatalf("unexpected name %s", res.URN.Name())
 					}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Might fix https://github.com/pulumi/pulumi/issues/10950, but I've not been able to reproduce that bug so this is just a best guess.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
