### PR TITLE
Make convert's pcl output yaml agnostic

### DIFF
--- a/pkg/codegen/pcl/program.go
+++ b/pkg/codegen/pcl/program.go
@@ -159,3 +159,11 @@ func (p *Program) PackageSnapshots() ([]*schema.Package, error) {
 	}
 	return values, nil
 }
+
+func (p *Program) Source() map[string]string {
+	source := make(map[string]string)
+	for _, file := range p.files {
+		source[file.Name] = string(file.Bytes)
+	}
+	return source
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We're going to use convert for more data sources than just YAML (e.g. hcl, arm, etc). So we don't want the PCL output option to be YAML specific given it should be usable for any input source.
