### PR TITLE
fix(engine): update stackreference diffing behavior

### DIFF
--- a/changelog/pending/20221109--engine--no-longer-replaces-stackreferences-on-name-change.yaml
+++ b/changelog/pending/20221109--engine--no-longer-replaces-stackreferences-on-name-change.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: No longer replaces stackreferences on name change

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -980,7 +980,7 @@ func TestStackReference(t *testing.T) {
 				switch urn := entry.Step.URN(); urn {
 				case resURN:
 					switch entry.Step.Op() {
-					case deploy.OpCreateReplacement, deploy.OpDeleteReplaced, deploy.OpReplace:
+					case deploy.OpUpdate:
 						// OK
 					default:
 						t.Fatalf("unexpected journal operation: %v", entry.Step.Op())


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11271 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
