### PR TITLE
[cli] Add a newline in the refresh confirmation prompt

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -168,7 +168,7 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 		if kind == apitype.RefreshUpdate {
 			prompt += "\n" +
 				opts.Display.Color.Colorize(colors.SpecImportant+
-					"No resources will be modified as part of this refresh; just your stack's state will be."+
+					"No resources will be modified as part of this refresh; just your stack's state will be.\n"+
 					colors.Reset)
 		}
 


### PR DESCRIPTION
The lack of a newline causes the prompt to wrap in terminals that are fewer than 120 or so columns wide. The wrapping confuses the survey package's redraw, which causes the repeated prompts each time the survey is redrawn (i.e. on every keypress). Removing the wrapping by adding a newline avoids this issue.