### PR TITLE
Expose LogException

### DIFF
--- a/sdk/dotnet/Pulumi/Exceptions/LogException.cs
+++ b/sdk/dotnet/Pulumi/Exceptions/LogException.cs
@@ -9,7 +9,7 @@ namespace Pulumi
     /// error rpc endpoint. In this case, we have no choice but to tear ourselves down reporting
     /// whatever we can to the console instead.
     /// </summary>
-    internal class LogException : Exception
+    public class LogException : Exception
     {
         public LogException(Exception exception)
             : base("Error occurred during logging", exception)


### PR DESCRIPTION
I'd like to expose `LogException`. In general I think it's good that Exceptions are exposed, so they can be caught.

In this particular case, I'd love to be able to diagnose #9582 more effectively, and perhaps even retry if that's the type of error that happens.