### PR TITLE
feat: sign pulumi binaries with cosign

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -48,6 +48,9 @@ jobs:
     env:
       PULUMI_VERSION: ${{ inputs.version }}
 
+    permissions:
+      id-token: write
+
     steps:
       - name: "Windows cache workaround"
         # https://github.com/actions/cache/issues/752#issuecomment-1222415717

--- a/.github/workflows/ci-prepare-release.yml
+++ b/.github/workflows/ci-prepare-release.yml
@@ -3,6 +3,8 @@ name: Prepare
 permissions:
   # To create a draft release
   contents: write
+  # To sign artifacts.
+  id-token: write
 
 on:
   workflow_call:
@@ -47,28 +49,40 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Install rsign2
-        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
-        with:
-          crate: rsign2
-          version: 0.6.1
-
       - name: Install b3sum
         uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
         with:
           crate: b3sum
           version: 1.3.0
 
+      - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+
       - name: Download all artifacts
         uses: actions/download-artifact@v2
         with:
           path: artifacts.tmp
-
+      - name: Rename SDKs
+        # This step must match the rename SDKs step in the "publish" job below.
+        run: |
+          (
+            cd artifacts.tmp/artifacts-python-sdk
+            for file in *.whl ; do
+              mv -vT "$file" "sdk-python-$file"
+            done
+          )
+          (
+            cd artifacts.tmp/artifacts-nodejs-sdk
+            for file in *.tgz ; do
+              mv -vT "$file" "sdk-nodejs-$file"
+            done
+          )
       - name: Flatten artifact directories
         run: |
           mkdir -p ./artifacts
-          mkdir -p ./sums.tmp
           mv ./artifacts.tmp/artifacts-*/* ./artifacts
+
+      - name: Create sums.tmp
+        run: mkdir -p ./sums.tmp ./sigs.tmp
 
         # Each of these commands strips the ./ prefix to match existing (<=3.39) formatting.
       - name: Checksums with SHA256
@@ -85,37 +99,33 @@ jobs:
         working-directory: artifacts
         run: sha512sum ./* | sed 's/.\///' | tee ../sums.tmp/SHA512SUMS
 
-      - name: Sign checksums
-        working-directory: sums.tmp
-        # Requires a signing key to be configured.
-        if: false
+      - name: Sign binaries and checksums
         shell: bash
         env:
-          # RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
           version: ${{ inputs.version }}
         run: |
-          set -u
-          releaseKey="$(mktemp -d)/release.key"
-          echo "$RELEASE_KEY" > "${releaseKey}"
-          set -x
-          for file in *; do
-            echo | rsign sign \
-              -p "${GITHUB_WORKSPACE}/.github/workflows/release.pub" \
-              -s "${releaseKey}" \
-              -t "${{ inputs.project }} v$version signed with automated key" \
-              -c 'see website for signing information' \
-              -x "${file}.auto.minisig" \
-              "${file}"
+          ls -la
+          # Sign all artifacts and checksums:
+          for dir in "artifacts" "sums.tmp"; do
+            pushd "$dir"
+            for file in ./*; do
+                echo "$file"
+                COSIGN_EXPERIMENTAL=1 cosign sign-blob \
+                  --bundle="../sigs.tmp/${file}".sig  \
+                  "${file}"
+            done
+            popd
           done
-          rm "${releaseKey}"
-          cat ./*.auto.minisig
+
+          # flatten to a single directory to upload:
+          mv sums.tmp/* sigs.tmp
 
       - uses: actions/upload-artifact@v2
         with:
           name: artifacts-signatures
           retention-days: 1
           path: |
-            sums.tmp/*
+            sigs.tmp/*
           if-no-files-found: error
 
   publish:
@@ -136,6 +146,7 @@ jobs:
         with:
           path: artifacts.tmp
       - name: Rename SDKs
+        # This step must match the rename SDKs step in the "sign" job above.
         run: |
           (
             cd artifacts.tmp/artifacts-python-sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_call:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -3,6 +3,8 @@ name: Merge
 permissions:
   # To create a draft release.
   contents: write
+  # To sign artifacts.
+  id-token: write
 
 on:
   push:
@@ -37,6 +39,8 @@ jobs:
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
+      # To sign artifacts.
+      id-token: write
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
@@ -49,6 +53,8 @@ jobs:
     uses: ./.github/workflows/ci-prepare-release.yml
     permissions:
       contents: write
+      # To sign artifacts.
+      id-token: write
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -1,8 +1,12 @@
 name: Pull Request
 
 permissions:
+  # To create a draft release.
   contents: write
+  # To comment on PRs.
   pull-requests: write
+  # To sign artifacts.
+  id-token: write
 
 on:
   pull_request:
@@ -48,6 +52,8 @@ jobs:
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
+      # To sign artifacts.
+      id-token: write
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
@@ -80,6 +86,8 @@ jobs:
     uses: ./.github/workflows/ci-prepare-release.yml
     permissions:
       contents: write
+      # To sign artifacts.
+      id-token: write
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -12,6 +12,8 @@ permissions:
   contents: read
   # Only the 'changelog-comment' job should use this permission.
   pull-requests: write
+  # To sign artifacts.
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.client_payload.pull_request.number }}
@@ -51,6 +53,8 @@ jobs:
     uses: pulumi/pulumi/.github/workflows/ci.yml@master
     permissions:
       contents: read
+      # To sign artifacts.
+      id-token: write
     with:
       ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
       version: ${{ needs.info.outputs.version }}

--- a/changelog/pending/20221109--ci--sign-pulumi-binaries-with-cosign.yaml
+++ b/changelog/pending/20221109--ci--sign-pulumi-binaries-with-cosign.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: ci
+  description: GitHub release artifacts are now signed using [cosign](https://github.com/sigstore/cosign) and signatures are uploaded to the [Rekor transparency log](https://rekor.tlog.dev/).


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR adds cosign to the build process of the Pulumi binaries. I changed the pipeline so cosign can sign without keys by authenticating with OIDC. GitHub supports this.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
