### PR TITLE
Guard against empty inputs for objs expressions.

### DIFF
--- a/changelog/pending/20221109--pkg--panic-in-codegen-obj-expressions.yaml
+++ b/changelog/pending/20221109--pkg--panic-in-codegen-obj-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg
+  description: Fix a panic in codegen for an edge case involving object expressions without corresponding function arguments.

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -150,7 +150,7 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 
 	// annotate the input args on the expression with the input type of the function
 	if argsObject, isObjectExpression := args[1].(*model.ObjectConsExpression); isObjectExpression {
-		if len(argsObject.Items) > 0 && fn.Inputs != nil {
+		if fn.Inputs != nil {
 			annotateObjectProperties(argsObject.Type(), fn.Inputs)
 		}
 	}

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -150,7 +150,9 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 
 	// annotate the input args on the expression with the input type of the function
 	if argsObject, isObjectExpression := args[1].(*model.ObjectConsExpression); isObjectExpression {
-		annotateObjectProperties(argsObject.Type(), fn.Inputs)
+		if len(argsObject.Items) > 0 && fn.Inputs != nil {
+			annotateObjectProperties(argsObject.Type(), fn.Inputs)
+		}
 	}
 
 	return sig, nil


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

@dirien raised an issue where tfgen would panic converting PCL under an edge case where an `ObjectExpression` had `nil` arguments. By introducing this guard, we skip annotating the the Object with the type provided by the schema the function in the schema has no args.

S/o to @Zaid-Ajaj for explaining this code to me and confirming the kill. I was lost without his aid! 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/11305

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
