### PR TITLE
Standardize the FS abstraction for codegen

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3560,7 +3560,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 	name := packageName(pkg)
 	pathPrefix := packageRoot(pkg)
 
-	files := map[string][]byte{}
+	files := codegen.Fs{}
 
 	// Generate pulumi-plugin.json
 	pulumiPlugin := &plugin.PulumiPluginJSON{
@@ -3575,13 +3575,10 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 	if err != nil {
 		return nil, fmt.Errorf("Failed to format pulumi-plugin.json: %w", err)
 	}
-	files[path.Join(pathPrefix, "pulumi-plugin.json")] = pulumiPluginJSON
+	files.Add(path.Join(pathPrefix, "pulumi-plugin.json"), pulumiPluginJSON)
 
 	setFile := func(relPath, contents string) {
 		relPath = path.Join(pathPrefix, relPath)
-		if _, ok := files[relPath]; ok {
-			panic(fmt.Errorf("duplicate file: %s", relPath))
-		}
 
 		// Run Go formatter on the code before saving to disk
 		formattedSource, err := format.Source([]byte(contents))
@@ -3590,7 +3587,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			panic(fmt.Errorf("invalid Go source code:\n\n%s\n: %w", relPath, err))
 		}
 
-		files[relPath] = formattedSource
+		files.Add(relPath, formattedSource)
 	}
 
 	for _, mod := range pkgMods {

--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -172,3 +172,15 @@ func ExpandShortEnumName(name string) string {
 	}
 	return name
 }
+
+// A simple in memory file system.
+type Fs map[string][]byte
+
+// Add a new file to the Fs.
+//
+// Panic if the file is a duplicate.
+func (fs Fs) Add(path string, contents []byte) {
+	_, has := fs[path]
+	contract.Assertf(!has, "duplicate file: %s", path)
+	fs[path] = contents
+}


### PR DESCRIPTION
We duplicate the `fs` type in nodejs, dotnet and python. We reimplement it in go: `setFile`. This PR defines a shared `Fs` in codegen and changes all implementations to use it. 