### PR TITLE
Add prelim interface contract for Capabilities API

### DIFF
--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import "encoding/json"
+
+// An APICapability is the name of a capability or feature that a service backend
+// may or may not support.
+type APICapability string
+
+const (
+	// DeltaCheckpointUploads is the feature that enables the CLI to upload checkpoints
+	// via the PatchUpdateCheckpointDeltaRequest API to save on network bytes.
+	DeltaCheckpointUploads APICapability = "delta-checkpoint-uploads"
+)
+
+type DeltaCheckpointUploadsConfigV1 struct {
+	// CheckpointCutoffSizeBytes defines the size of a checkpoint file, in bytes,
+	// at which the CLI should cutover to using delta checkpoint uploads.
+	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
+}
+
+// APICapabilityConfig captures a service backend capability and any associated
+// configuration that may be required for integration.
+type APICapabilityConfig struct {
+	Capability    APICapability   `json:"capability"`
+	Version       int             `json:"version,omitempty"`
+	Configuration json.RawMessage `json:"configuration,omitempty"`
+}
+
+// CapabilitiesResponse defines all feature sets that are available in the service
+// backend and are therefore available for the CLI to integrate against.
+type CapabilitiesResponse struct {
+	Capabilities []APICapabilityConfig `json:"capabilities"`
+}


### PR DESCRIPTION
# Description

Add request shapes for Capabilities API, which will moving forward help cement service/client contract in dynamically indicating which features are available in a given backend for the CLI to use.

Related: https://github.com/pulumi/pulumi-service/issues/10510

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
