### PR TITLE
ci: Re-enable version sets for .NET, test GA version of 6 and 7

### DIFF
--- a/.github/workflows/ci-build-sdks.yml
+++ b/.github/workflows/ci-build-sdks.yml
@@ -137,11 +137,11 @@ jobs:
           version: ${{ inputs.version }}
         run: |
           ./scripts/versions.sh | tee -a "${GITHUB_ENV}"
-      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
-      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-      #   uses: actions/setup-dotnet@v2
-      #   with:
-      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+        with:
+          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+          dotnet-quality: ga
       - name: Build the .NET SDK package
         run: |
           cd sdk/dotnet

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -66,11 +66,11 @@ jobs:
           python-version: ${{ fromJson(inputs.version-set).python }}
           cache: pip
           cache-dependency-path: sdk/python/requirements.txt
-      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
-      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-      #   uses: actions/setup-dotnet@v2
-      #   with:
-      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+        with:
+          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+          dotnet-quality: ga
       - run: mkdir -p "${{ runner.temp }}/opt/pulumi/nuget"
       - name: Add NuGet packages as a local NuGet source
         run: |

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -155,11 +155,11 @@ jobs:
           python-version: ${{ fromJson(inputs.version-set).python }}
           cache: pip
           cache-dependency-path: sdk/python/requirements.txt
-      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
-      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-      #   uses: actions/setup-dotnet@v2
-      #   with:
-      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+        with:
+          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+          dotnet-quality: ga
       - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -46,11 +46,11 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9.x # TODO(friel) use version_set
-      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
-      # - name: Set up DotNet
-      #   uses: actions/setup-dotnet@v2
-      #   with:
-      #     dotnet-version: 6.0.x # TODO(friel) use version_set
+      - name: Set up DotNet
+        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+        with:
+          dotnet-version: 6.0.x # TODO(friel) use version_set
+          dotnet-quality: ga
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Check out source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,12 +83,12 @@ jobs:
         if: ${{ matrix.language == 'python' }}
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
-      # TODO: https://github.com/pulumi/pulumi/issues/11000, this step causes spurious errors.
-      # - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-      #   if: ${{ matrix.language == 'dotnet' }}
-      #   uses: actions/setup-dotnet@v1
-      #   with:
-      #     dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+        if: ${{ matrix.language == 'dotnet' }}
+        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+        with:
+          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+          dotnet-quality: ga
       - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
         if: ${{ matrix.language == 'nodejs' }}
         uses: actions/setup-node@v3

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -95,7 +95,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-11"]
 
 MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
-    "dotnet": "6.0.x",
+    "dotnet": "6",
     "go": "1.18.x",
     "nodejs": "14.x",
     "python": "3.9.x",
@@ -103,7 +103,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 
 CURRENT_VERSION_SET = {
     "name": "current",
-    "dotnet": "6.0.x",
+    "dotnet": "7",
     "go": "1.19.x",
     "nodejs": "19.x",
     "python": "3.10.x",


### PR DESCRIPTION
The `actions/setup-dotnet` action published v3.0.3 two weeks ago addressing the ECONNRESET issues discovered in #10997.

Reverts #11001

Resolves #11000