### PR TITLE
Fix AssertHTTPResultWithRetry

### DIFF
--- a/pkg/testing/integration/util_test.go
+++ b/pkg/testing/integration/util_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type fakeTestingT struct {
+	logs   []string
+	errors []string
+}
+
+func (t *fakeTestingT) Logf(format string, args ...interface{}) {
+	t.logs = append(t.logs, fmt.Sprintf(format, args...))
+}
+
+func (t *fakeTestingT) Errorf(format string, args ...interface{}) {
+	t.errors = append(t.errors, fmt.Sprintf(format, args...))
+}
+
+func TestAssertHTTPResultWithRetryNoPanic(t *testing.T) {
+	t.Parallel()
+	tt := &fakeTestingT{}
+	// this just checks it doesn't panic
+	AssertHTTPResultWithRetry(tt, "https://localhost:76547/invalid-port-number", nil, time.Second, func(string) bool {
+		return true
+	})
+	// now check there was an error logged for the attempt failing
+	if len(tt.errors) != 1 {
+		t.Errorf("expected error to have been reported, got %#v", tt.errors)
+	}
+}


### PR DESCRIPTION
`err` is declared outside the retry loop, and tested after all the retries to see if it is non-nil; however, err is shadowed inside the loop so will never be non-nil outside. If all the attempts are failures, it'll time out then try to read the body of the response and probably panic.

This commit fixes that problem by only assigning to err inside the loop. A related problem is that failing all the attempts doesn't result in an error, it just breaks the loop. Again it's possible to get a panic. So: assign an error value when abandoning the retries.

Also: if the request was successful at all, read the body and close it so the connection can be kept alive.

Lastly, a tweak that helps fail faster: rather than sleeping then seeing if the deadline has passed, check whether sleeping will break the deadline. It will always try once, in any case.
