### PR TITLE
Do not reference Pulumi nuget if a project reference to Pulumi.csproj already exists

### DIFF
--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Random" Version="4.2" ExcludeAssets="contentFiles" />

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.28.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
     <PackageReference Include="Pulumi.Random" Version="4.2.0" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When generating dotnet SDKs, if a schema doesn't specify a package reference to Pulumi nuget, we add it automatically by default. However, when generating test dotnet sdks, we also use project references that refer to the local Pulumi SDK and it is not correct to have either (although usually it compiles if you don't use latest SDK changes) 

This PR makes it so that if we are already referencing a local Pulumi SDK via a project reference, then we don't add a package reference to Pulumi

