### PR TITLE
Add experimental use plan option to up

### DIFF
--- a/changelog/pending/20221115--cli--add-prompt-to-up-to-use-experimental-update-plans.yaml
+++ b/changelog/pending/20221115--cli--add-prompt-to-up-to-use-experimental-update-plans.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add prompt to `up` to use experimental update plans.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1166,7 +1166,7 @@ func (b *cloudBackend) runEngineAction(
 	case apitype.PreviewUpdate:
 		plan, changes, res = engine.Update(u, engineCtx, op.Opts.Engine, true)
 	case apitype.UpdateUpdate:
-		_, changes, res = engine.Update(u, engineCtx, op.Opts.Engine, dryRun)
+		plan, changes, res = engine.Update(u, engineCtx, op.Opts.Engine, dryRun)
 	case apitype.ResourceImportUpdate:
 		_, changes, res = engine.Import(u, engineCtx, op.Opts.Engine, op.Imports, dryRun)
 	case apitype.RefreshUpdate:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Adds an option to use plans in the update prompt:
```
Do you want to perform this update?  [Use arrows to move, type to filter]
> [experimental] yes, using Update Plans (https://pulumi.com/updateplans)
  yes
  no
  details
```

Needs at least https://github.com/pulumi/pulumi-hugo/pull/2230 merged and published first.

Fixes https://github.com/pulumi/pulumi/issues/9687

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
