### PR TITLE
Address the `cannot traverse union(...)` error when converting examples

### DIFF
--- a/changelog/pending/20221116--programgen-dotnet-go-nodejs-python--dont-generate-traverse-error-when-typecheck-is-disabled.yaml
+++ b/changelog/pending/20221116--programgen-dotnet-go-nodejs-python--dont-generate-traverse-error-when-typecheck-is-disabled.yaml
@@ -1,0 +1,4 @@
+changes:
+  - type: fix
+    scope: programgen/dotnet,go,nodejs,python
+    description: Don't generate traverse errors when typechecking a dynamic type

--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -607,10 +607,9 @@ func (b *expressionBinder) bindScopeTraversalExpression(
 			parts[i] = DynamicType
 		}
 
-		if !b.options.allowMissingVariables {
-			diagnostics = hcl.Diagnostics{
-				undefinedVariable(rootName, syntax.Traversal.SimpleSplit().Abs.SourceRange()),
-			}
+		diagnostics = hcl.Diagnostics{
+			undefinedVariable(rootName, syntax.Traversal.SimpleSplit().Abs.SourceRange(),
+				b.options.allowMissingVariables),
 		}
 		return &ScopeTraversalExpression{
 			Syntax:    syntax,

--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -25,6 +25,10 @@ func errorf(subject hcl.Range, f string, args ...interface{}) *hcl.Diagnostic {
 	return diagf(hcl.DiagError, subject, f, args...)
 }
 
+func warnf(subject hcl.Range, f string, args ...interface{}) *hcl.Diagnostic {
+	return diagf(hcl.DiagWarning, subject, f, args...)
+}
+
 func diagf(severity hcl.DiagnosticSeverity, subject hcl.Range, f string, args ...interface{}) *hcl.Diagnostic {
 	message := fmt.Sprintf(f, args...)
 	return &hcl.Diagnostic{
@@ -111,8 +115,12 @@ func unsupportedCollectionType(collectionType Type, iteratorRange hcl.Range) *hc
 	return errorf(iteratorRange, "cannot iterate over a value of type %v", collectionType)
 }
 
-func undefinedVariable(variableName string, variableRange hcl.Range) *hcl.Diagnostic {
-	return errorf(variableRange, fmt.Sprintf("undefined variable %v", variableName))
+func undefinedVariable(variableName string, variableRange hcl.Range, warn bool) *hcl.Diagnostic {
+	f := errorf
+	if warn {
+		f = warnf
+	}
+	return f(variableRange, "undefined variable %v", variableName)
 }
 
 func internalError(rng hcl.Range, fmt string, args ...interface{}) *hcl.Diagnostic {

--- a/pkg/codegen/hcl2/model/scope.go
+++ b/pkg/codegen/hcl2/model/scope.go
@@ -140,13 +140,13 @@ func (s *Scope) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostics)
 	name, nameType := GetTraverserKey(traverser)
 	if nameType != StringType {
 		// TODO(pdg): return a better error here
-		return DynamicType, hcl.Diagnostics{undefinedVariable("", traverser.SourceRange())}
+		return DynamicType, hcl.Diagnostics{undefinedVariable("", traverser.SourceRange(), false)}
 	}
 
 	memberName := name.AsString()
 	member, hasMember := s.BindReference(memberName)
 	if !hasMember {
-		return DynamicType, hcl.Diagnostics{undefinedVariable(memberName, traverser.SourceRange())}
+		return DynamicType, hcl.Diagnostics{undefinedVariable(memberName, traverser.SourceRange(), false)}
 	}
 	return member, nil
 }

--- a/pkg/codegen/hcl2/model/traversable.go
+++ b/pkg/codegen/hcl2/model/traversable.go
@@ -103,9 +103,8 @@ func bindTraversalParts(receiver Traversable, traversal hcl.Traversal,
 		// OK
 	default:
 		// TODO(pdg): improve this diagnostic
-		if !allowMissingVariables {
-			diagnostics = append(diagnostics, undefinedVariable("", traversal.SourceRange()))
-		}
+		diagnostics = append(diagnostics, undefinedVariable("",
+			traversal.SourceRange(), allowMissingVariables))
 	}
 
 	return parts, diagnostics

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -237,7 +237,7 @@ func (b *binder) loadReferencedPackageSchemas(n Node) error {
 	contract.Assert(len(diags) == 0)
 
 	for _, name := range packageNames.SortedValues() {
-		if _, ok := b.referencedPackages[name]; ok && pkgOpts.version == "" {
+		if _, ok := b.referencedPackages[name]; ok && pkgOpts.version == "" || name == "" {
 			continue
 		}
 

--- a/pkg/codegen/report/report_test.go
+++ b/pkg/codegen/report/report_test.go
@@ -65,7 +65,7 @@ func TestReportExample(t *testing.T) {
 					"Might not bind": "error: could not locate a compatible plugin in " +
 						"deploytest, the makefile and & constructor of the plugin host " +
 						"must define the location of the schema: failed " +
-						"to locate compatible plugin",
+						`to locate compatible plugin: "not"`,
 				},
 				Files: map[string][]report.File{
 					"Might not bind": {{Name: "Might not bind", Body: "resource foo \"not:a:Resource\" { foo: \"bar\" }"}},

--- a/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/dotnet/traverse-union-repro.cs
+++ b/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/dotnet/traverse-union-repro.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+return await Deployment.RunAsync(() => 
+{
+    var test = new Aws.Fsx.OpenZfsFileSystem("test", new()
+    {
+        StorageCapacity = 64,
+        SubnetIds = new[]
+        {
+            aws_subnet.Test1.Id,
+        },
+        DeploymentType = "SINGLE_AZ_1",
+        ThroughputCapacity = 64,
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/go/traverse-union-repro.go
+++ b/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/go/traverse-union-repro.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/fsx"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := fsx.NewOpenZfsFileSystem(ctx, "test", &fsx.OpenZfsFileSystemArgs{
+			StorageCapacity: pulumi.Int(64),
+			SubnetIds: pulumi.String{
+				aws_subnet.Test1.Id,
+			},
+			DeploymentType:     pulumi.String("SINGLE_AZ_1"),
+			ThroughputCapacity: pulumi.Int(64),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/nodejs/traverse-union-repro.ts
+++ b/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/nodejs/traverse-union-repro.ts
@@ -1,0 +1,9 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const test = new aws.fsx.OpenZfsFileSystem("test", {
+    storageCapacity: 64,
+    subnetIds: [aws_subnet.test1.id],
+    deploymentType: "SINGLE_AZ_1",
+    throughputCapacity: 64,
+});

--- a/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/python/traverse-union-repro.py
+++ b/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/python/traverse-union-repro.py
@@ -1,0 +1,8 @@
+import pulumi
+import pulumi_aws as aws
+
+test = aws.fsx.OpenZfsFileSystem("test",
+    storage_capacity=64,
+    subnet_ids=[aws_subnet["test1"]["id"]],
+    deployment_type="SINGLE_AZ_1",
+    throughput_capacity=64)

--- a/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/traverse-union-repro.pp
+++ b/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/traverse-union-repro.pp
@@ -1,0 +1,6 @@
+resource "test" "aws:fsx:OpenZfsFileSystem" {
+  storageCapacity    = 64
+  subnetIds          = [aws_subnet.test1.id]
+  deploymentType     = "SINGLE_AZ_1"
+  throughputCapacity = 64
+}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1780,7 +1780,7 @@ func SelectCompatiblePlugin(
 
 	if !hasMatch {
 		logging.V(7).Infof("SelectCompatiblePlugin(..., %s): failed to find match", name)
-		return PluginInfo{}, errors.New("failed to locate compatible plugin")
+		return PluginInfo{}, fmt.Errorf("failed to locate compatible plugin: %#v", name)
 	}
 	logging.V(7).Infof("SelectCompatiblePlugin(..., %s): selecting plugin '%s': best match ", name, bestMatch.String())
 	return bestMatch, nil


### PR DESCRIPTION
Fixes #11346

In every case I examined, the original error came from mis-typed PCL. The fix here allows us to continue without error, but it won't generate correctly typed code.

This PR fixes a couple of different problems. 
1. It improves the diagognostics, both within the binder and within the test framework.
2. It moves omitted errors to warnings (instead of dropping them).
3. It prevents rewrites on dynamic types, fixing the original error.
