### PR TITLE
Library for environmental variable access

### DIFF
--- a/pkg/cmd/pulumi/convert_test.go
+++ b/pkg/cmd/pulumi/convert_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,18 +33,20 @@ func TestYamlConvert(t *testing.T) {
 		t.Fatalf("Pulumi.yaml is a directory, not a file")
 	}
 
-	result := runConvert("convert_testdata", []string{}, "yaml", "go", "convert_testdata/go", true)
+	result := runConvert(env.Global(), "convert_testdata", []string{}, "yaml", "go", "convert_testdata/go", true)
 	require.Nil(t, result, "convert failed: %v", result)
 }
 
-//nolint:paralleltest // sets env var, must be run in isolation
 func TestPclConvert(t *testing.T) {
-	t.Setenv("PULUMI_DEV", "TRUE")
+	t.Parallel()
+	env := env.NewEnv(env.MapStore{
+		env.Dev.Var().Name(): "true",
+	})
 
 	// Check that we can run convert from PCL to PCL
 	tmp := t.TempDir()
 
-	result := runConvert("pcl_convert_testdata", []string{}, "pcl", "pcl", tmp, true)
+	result := runConvert(env, "pcl_convert_testdata", []string{}, "pcl", "pcl", tmp, true)
 	assert.Nil(t, result)
 
 	// Check that we made one file

--- a/pkg/cmd/pulumi/env.go
+++ b/pkg/cmd/pulumi/env.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A small library for creating consistent and documented environmental variable accesses.
+//
+// Public environmental variables should be declared as a module level variable.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+)
+
+func newEnvCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "env",
+		Short: "An overview of the environmental variables used by pulumi",
+		Args:  cmdutil.NoArgs,
+		// Since most variables won't be included here, we hide the command. We will
+		// unhide once most existing variables are using the new env var framework and
+		// show up here.
+		Hidden: !env.Experimental.Value(),
+		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			table := cmdutil.Table{
+				Headers: []string{"Variable", "Description", "Value"},
+			}
+			var foundError bool
+			for _, v := range declared.Variables() {
+				foundError = foundError || emitEnvVarDiag(v)
+				table.Rows = append(table.Rows, cmdutil.TableRow{
+					Columns: []string{v.Name(), v.Description, v.Value.String()},
+				})
+			}
+			cmdutil.PrintTable(table)
+			if foundError {
+				return result.Error("Invalid environmental variables found")
+			}
+			return nil
+		}),
+	}
+}
+
+func emitEnvVarDiag(val declared.Var) bool {
+	err := val.Value.Validate()
+	if err.Error != nil {
+		cmdutil.Diag().Errorf(&diag.Diag{
+			Message: fmt.Sprintf("%s: %v", val.Name(), err.Error),
+		})
+	}
+	if err.Warning != nil {
+		cmdutil.Diag().Warningf(&diag.Diag{
+			Message: fmt.Sprintf("%s: %v", val.Name(), err.Warning),
+		})
+	}
+	return err.Error != nil
+}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
@@ -225,7 +226,7 @@ func NewPulumiCmd() *cobra.Command {
 				}
 			}
 
-			if cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_UPDATE_CHECK")) {
+			if env.SkipUpdateCheck.Value() {
 				logging.V(5).Infof("skipping update check")
 			} else {
 				// Run the version check in parallel so that it doesn't block executing the command.
@@ -396,7 +397,7 @@ func checkForUpdate(ctx context.Context) *diag.Diag {
 	latestVer, oldestAllowedVer, err := getCLIVersionInfo(ctx)
 	if err != nil {
 		logging.V(3).Infof("error fetching latest version information "+
-			"(set `PULUMI_SKIP_UPDATE_CHECK=true` to skip update checks): %s", err)
+			"(set `%s=true` to skip update checks): %s", env.SkipUpdateCheck.Var().Name(), err)
 	}
 
 	if oldestAllowedVer.GT(curVer) {

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -356,6 +356,7 @@ func NewPulumiCmd() *cobra.Command {
 				newConvertCmd(),
 				newWatchCmd(),
 				newLogsCmd(),
+				newEnvCmd(),
 			},
 		},
 		// We have a set of options that are useful for developers of pulumi

--- a/pkg/codegen/report/report.go
+++ b/pkg/codegen/report/report.go
@@ -29,9 +29,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	hcl2 "github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 )
 
-const ExportTargetDir = "PULUMI_CODEGEN_REPORT_DIR"
+var ExportTargetDir = env.String("CODEGEN_REPORT_DIR",
+	"The directory to generate a codegen report in")
 
 type GenerateProgramFn func(*hcl2.Program) (map[string][]byte, hcl.Diagnostics, error)
 
@@ -205,7 +207,7 @@ func (r *reporter) Close() error {
 func (r *reporter) DefaultExport() error {
 	r.m.Lock()
 	defer r.m.Unlock()
-	dir, ok := os.LookupEnv(ExportTargetDir)
+	dir, ok := ExportTargetDir.Underlying()
 	if !ok || r.reported {
 		return nil
 	}
@@ -215,7 +217,7 @@ func (r *reporter) DefaultExport() error {
 
 func (r *reporter) defaultExport(dir string) error {
 	if dir == "" {
-		err := fmt.Errorf("%q set to the empty string", ExportTargetDir)
+		err := fmt.Errorf("%q set to the empty string", ExportTargetDir.Var().Name())
 		fmt.Fprintln(os.Stderr, err.Error())
 		return err
 	}

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -1,0 +1,42 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A small library for creating consistent and documented environmental variable accesses.
+//
+// Public environmental variables should be declared as a module level variable.
+
+package env
+
+import "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+
+// Re-export some types and functions from the env library.
+
+type Env = env.Env
+type MapStore = env.MapStore
+
+func NewEnv(s env.Store) env.Env { return env.NewEnv(s) }
+
+func Global() env.Env {
+	return env.NewEnv(env.Global)
+}
+
+// That Pulumi is running in experimental mode.
+//
+// This is our standard gate for an existing feature that's not quite ready to be stable
+// and publicly consumed.
+var Experimental = env.Bool("EXPERIMENTAL", "Enable experimental options and commands")
+
+var SkipUpdateCheck = env.Bool("SKIP_UPDATE_CHECK", "Disable checking for a new version of pulumi")
+
+var Dev = env.Bool("DEV", "Enable features for hacking on pulumi itself")

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -23,10 +23,12 @@ import "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 // Re-export some types and functions from the env library.
 
 type Env = env.Env
+
 type MapStore = env.MapStore
 
 func NewEnv(s env.Store) env.Env { return env.NewEnv(s) }
 
+// Global is the environment defined by environmental variables.
 func Global() env.Env {
 	return env.NewEnv(env.Global)
 }
@@ -40,3 +42,6 @@ var Experimental = env.Bool("EXPERIMENTAL", "Enable experimental options and com
 var SkipUpdateCheck = env.Bool("SKIP_UPDATE_CHECK", "Disable checking for a new version of pulumi")
 
 var Dev = env.Bool("DEV", "Enable features for hacking on pulumi itself")
+
+var IgnoreAmbientPlugins = env.Bool("IGNORE_AMBIENT_PLUGINS",
+	"Discover additional plugins by examining the $PATH")

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -26,10 +26,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -339,7 +339,7 @@ func (host *defaultHost) Provider(pkg tokens.Package, version *semver.Version) (
 			}
 
 			// Warn if the plugin version was not what we expected
-			if version != nil && !cmdutil.IsTruthy(os.Getenv("PULUMI_DEV")) {
+			if version != nil && !env.Dev.Value() {
 				if info.Version == nil || !info.Version.GTE(*version) {
 					var v string
 					if info.Version != nil {

--- a/sdk/go/common/util/env/env.go
+++ b/sdk/go/common/util/env/env.go
@@ -1,0 +1,379 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A small library for creating consistent and documented environmental variable accesses.
+//
+// Public environmental variables should be declared as a module level variable.
+package env
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// Store holds a collection of key, value? pairs.
+//
+// Store acts like the environment that values are drawn from.
+type Store interface {
+	// Retrieve a raw value from the Store. If the value is not present, "", false should
+	// be returned.
+	Raw(key string) (string, bool)
+}
+
+// An environment backed by a Store.
+type Env interface {
+	GetString(val StringValue) string
+	GetBool(val BoolValue) bool
+	GetInt(val IntValue) int
+}
+
+func NewEnv(store Store) Env {
+	return env{store}
+}
+
+type env struct{ s Store }
+
+func (e env) GetString(val StringValue) string {
+	return StringValue{val.withStore(e.s)}.Value()
+}
+
+func (e env) GetBool(val BoolValue) bool {
+	return BoolValue{val.withStore(e.s)}.Value()
+}
+
+func (e env) GetInt(val IntValue) int {
+	return IntValue{val.withStore(e.s)}.Value()
+}
+
+type envStore struct{}
+
+func (envStore) Raw(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+type MapStore map[string]string
+
+func (m MapStore) Raw(key string) (string, bool) {
+	v, ok := m[key]
+	return v, ok
+}
+
+// The global store of values that Value.Value() uses.
+//
+// Setting this value is not thread safe, and should be restricted to testing.
+var Global Store = envStore{}
+
+// An environmental variable.
+type Var struct {
+	name        string
+	Value       Value
+	Description string
+	options     options
+}
+
+// The default prefix for a environmental variable.
+const Prefix = "PULUMI_"
+
+// The name of an environmental variable.
+//
+// Name accounts for prefix if appropriate.
+func (v Var) Name() string {
+	return v.options.name(v.name)
+}
+
+// The list of variables that a must be truthy for `v` to be set.
+func (v Var) Requires() []BoolValue { return v.options.prerequs }
+
+var envVars []Var
+
+// Variables is a list of variables declared.
+func Variables() []Var {
+	return envVars
+}
+
+// An Option to configure a environmental variable.
+type Option func(*options)
+
+type options struct {
+	prerequs []BoolValue
+	noPrefix bool
+}
+
+func (o options) name(underlying string) string {
+	if o.noPrefix {
+		return underlying
+	}
+	return Prefix + underlying
+}
+
+// Indicate that a variable can only be set if `val` is truthy.
+func Needs(val BoolValue) Option {
+	return func(o *options) {
+		o.prerequs = append(o.prerequs, val)
+	}
+}
+
+// Indicate that a variable should not have the default prefix applied.
+func NoPrefix(opts *options) {
+	opts.noPrefix = true
+}
+
+// The value of a environmental variable.
+//
+// In general, `Value`s should only be used in collections. For specific values, used the
+// typed version (StringValue, BoolValue).
+//
+// Every implementer of Value also includes a `Value() T` method that returns a typed
+// representation of the value.
+type Value interface {
+	fmt.Stringer
+
+	// Retrieve the underlying string value associated with the variable.
+	//
+	// If the variable was not set, ("", false) is returned.
+	Underlying() (string, bool)
+	// Retrieve the Var associated with this value.
+	Var() Var
+
+	Validate() ValidateError
+
+	// set the associated variable for the value. This is necessary since Value and Var
+	// are inherently cyclical.
+	setVar(Var)
+	// A type correct formatting for the value. This is used for display purposes and
+	// should not be quoted.
+	formattedValue() string
+}
+
+type ValidateError struct {
+	Warning error
+	Error   error
+}
+
+// An implementation helper for Value. New Values should be a typed wrapper around *value.
+type value struct {
+	variable Var
+	store    Store
+}
+
+func (v value) withStore(store Store) *value {
+	v.store = store // This is non-mutating since `v` is taken by value.
+	return &v
+}
+
+func (v value) String() string {
+	_, present := v.Underlying()
+	if !present {
+		return fmt.Sprintf("%#v: unset", v.Var().Name())
+	}
+	if m := v.missingPrerequs(); m != "" {
+		return fmt.Sprintf("%#v: need %s (%s)", v.Var().Name(), m, v.Var().Value.formattedValue())
+	}
+	return fmt.Sprintf("%#v: %s", v.Var().Name(), v.Var().Value.formattedValue())
+}
+
+func (v *value) setVar(variable Var) {
+	v.variable = variable
+}
+
+func (v value) Var() Var {
+	return v.variable
+}
+
+func (v value) Underlying() (string, bool) {
+	s := v.store
+	if s == nil {
+		s = Global
+	}
+	return s.Raw(v.Var().Name())
+}
+
+func (v value) missingPrerequs() string {
+	for _, p := range v.variable.options.prerequs {
+		if !p.Value() {
+			return p.Var().Name()
+		}
+	}
+	return ""
+}
+
+// A string retrieved from the environment.
+type StringValue struct{ *value }
+
+func (StringValue) Type() string { return "string" }
+
+func (s StringValue) formattedValue() string {
+	return fmt.Sprintf("%#v", s.Value())
+}
+
+func (StringValue) Validate() ValidateError { return ValidateError{} }
+
+// The string value of the variable.
+//
+// If the variable is unset, "" is returned.
+func (s StringValue) Value() string {
+	if s.missingPrerequs() != "" {
+		return ""
+	}
+	v, ok := s.Underlying()
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+// A boolean retrieved from the environment.
+type BoolValue struct{ *value }
+
+func (BoolValue) Type() string { return "bool" }
+
+func (b BoolValue) formattedValue() string {
+	return fmt.Sprintf("%#v", b.Value())
+}
+
+func (b BoolValue) Validate() ValidateError {
+	v, ok := b.Underlying()
+	if !ok || b.Value() || v != "0" || strings.EqualFold(v, "false") {
+		return ValidateError{}
+	}
+	return ValidateError{
+		Warning: fmt.Errorf("%#v is falsy, but doesn't look like a boolean", v),
+	}
+}
+
+// The boolean value of the variable.
+//
+// If the variable is unset, false is returned.
+func (b BoolValue) Value() bool {
+	if b.missingPrerequs() != "" {
+		return false
+	}
+	v, ok := b.Underlying()
+	if !ok {
+		return false
+	}
+	return cmdutil.IsTruthy(v)
+}
+
+// An integer retrieved from the environment.
+type IntValue struct{ *value }
+
+func (IntValue) Type() string { return "int" }
+
+func (i IntValue) Validate() ValidateError {
+	v, ok := i.Underlying()
+	if !ok {
+		return ValidateError{}
+	}
+	_, err := strconv.ParseInt(v, 10, 64)
+	return ValidateError{
+		Error: err,
+	}
+}
+
+// The integer value of the variable.
+//
+// If the variable is unset or not parsable, 0 is returned.
+func (i IntValue) Value() int {
+	if i.missingPrerequs() != "" {
+		return 0
+	}
+	v, ok := i.Underlying()
+	if !ok {
+		return 0
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return int(parsed)
+}
+
+func (i IntValue) formattedValue() string {
+	return fmt.Sprintf("%#v", i.Value())
+}
+
+func setVar(val Value, variable Var) Value {
+	variable.Value = val
+	val.setVar(variable)
+	envVars = append(envVars, variable)
+	return val
+}
+
+// Declare a new environmental value.
+//
+// `name` is the runtime name of the variable. Unless `NoPrefix` is passed, name is
+// pre-appended with `Prefix`. For example, a variable named "FOO" would be set by
+// declaring "PULUMI_FOO=val" in the enclosing environment.
+//
+// `description` is the string description of what the variable does.
+func String(name, description string, opts ...Option) StringValue {
+	var options options
+	for _, opt := range opts {
+		opt(&options)
+	}
+	val := StringValue{&value{}}
+	variable := Var{
+		name:        name,
+		Description: description,
+		options:     options,
+	}
+	return setVar(val, variable).(StringValue)
+}
+
+// Declare a new environmental value of type bool.
+//
+// `name` is the runtime name of the variable. Unless `NoPrefix` is passed, name is
+// pre-appended with `Prefix`. For example, a variable named "FOO" would be set by
+// declaring "PULUMI_FOO=1" in the enclosing environment.
+//
+// `description` is the string description of what the variable does.
+func Bool(name, description string, opts ...Option) BoolValue {
+	var options options
+	for _, opt := range opts {
+		opt(&options)
+	}
+	val := BoolValue{&value{}}
+	variable := Var{
+		name:        name,
+		Description: description,
+		options:     options,
+	}
+	return setVar(val, variable).(BoolValue)
+}
+
+// Declare a new environmental value of type integer.
+//
+// `name` is the runtime name of the variable. Unless `NoPrefix` is passed, name is
+// pre-appended with `Prefix`. For example, a variable named "FOO" would be set by
+// declaring "PULUMI_FOO=1" in the enclosing environment.
+//
+// `description` is the string description of what the variable does.
+func Int(name, description string, opts ...Option) IntValue {
+	var options options
+	for _, opt := range opts {
+		opt(&options)
+	}
+	val := IntValue{&value{}}
+	variable := Var{
+		name:        name,
+		Description: description,
+		options:     options,
+	}
+	return setVar(val, variable).(IntValue)
+}

--- a/sdk/go/common/util/env/env.go
+++ b/sdk/go/common/util/env/env.go
@@ -35,13 +35,14 @@ type Store interface {
 	Raw(key string) (string, bool)
 }
 
-// An environment backed by a Store.
+// A strongly typed environment.
 type Env interface {
 	GetString(val StringValue) string
 	GetBool(val BoolValue) bool
 	GetInt(val IntValue) int
 }
 
+// Create a new strongly typed Env from an untyped Store.
 func NewEnv(store Store) Env {
 	return env{store}
 }

--- a/sdk/go/common/util/env/env_test.go
+++ b/sdk/go/common/util/env/env_test.go
@@ -1,0 +1,52 @@
+package env_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	env.Global = env.MapStore{
+		"PULUMI_FOO": "1",
+		// "PULUMI_NOT_SET": explicitly not set
+		"FOO":           "bar",
+		"UNSET":         "SET",
+		"PULUMI_SET":    "SET",
+		"PULUMI_MY_INT": "3",
+	}
+}
+
+var (
+	SomeBool    = env.Bool("FOO", "A bool used for testing")
+	SomeFalse   = env.Bool("NOT_SET", "a falsy value")
+	SomeString  = env.String("FOO", "A bool used for testing", env.NoPrefix)
+	UnsetString = env.String("PULUMI_UNSET", "Should be unset", env.Needs(SomeFalse))
+	SetString   = env.String("SET", "Should be set", env.Needs(SomeBool))
+	AnInt       = env.Int("MY_INT", "Should be 3")
+)
+
+func TestInt(t *testing.T) {
+	assert.Equal(t, 3, AnInt.Value())
+	assert.Equal(t, 3, env.NewEnv(env.Global).GetInt(AnInt))
+	assert.Equal(t, 6, env.NewEnv(
+		env.MapStore{"PULUMI_MY_INT": "6"},
+	).GetInt(AnInt))
+}
+
+func TestBool(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, true, SomeBool.Value())
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "bar", SomeString.Value())
+}
+
+func TestNeeds(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", UnsetString.Value())
+	assert.Equal(t, "SET", SetString.Value())
+}

--- a/sdk/go/common/util/env/env_test.go
+++ b/sdk/go/common/util/env/env_test.go
@@ -28,6 +28,7 @@ var (
 )
 
 func TestInt(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, 3, AnInt.Value())
 	assert.Equal(t, 3, env.NewEnv(env.Global).GetInt(AnInt))
 	assert.Equal(t, 6, env.NewEnv(

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -1503,6 +1504,9 @@ func getPluginPath(info *PluginInfo) string {
 	return filepath.Join(info.Path, info.Spec().File()) + exts[0]
 }
 
+var ignoreAmbientPlugins = env.Bool("IGNORE_AMBIENT_PLUGINS",
+	"Discover additional plugins by examining the $PATH")
+
 // getPluginInfoAndPath searches for a compatible plugin kind, name, and version and returns either:
 //   - if found as an ambient plugin, nil and the path to the executable
 //   - if found in the pulumi dir's installed plugins, a PluginInfo and path to the executable
@@ -1570,8 +1574,7 @@ func getPluginInfoAndPath(
 
 	// If we have a version of the plugin on its $PATH, use it, unless we have opted out of this behavior explicitly.
 	// This supports development scenarios.
-	optOut, isFound := os.LookupEnv("PULUMI_IGNORE_AMBIENT_PLUGINS")
-	includeAmbient := !(isFound && cmdutil.IsTruthy(optOut)) || isBundled
+	includeAmbient := !(ignoreAmbientPlugins.Value()) || isBundled
 	if includeAmbient {
 		filename = (&PluginSpec{Kind: kind, Name: name}).File()
 		if path, err := exec.LookPath(filename); err == nil {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -43,10 +43,10 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -1504,9 +1504,6 @@ func getPluginPath(info *PluginInfo) string {
 	return filepath.Join(info.Path, info.Spec().File()) + exts[0]
 }
 
-var ignoreAmbientPlugins = env.Bool("IGNORE_AMBIENT_PLUGINS",
-	"Discover additional plugins by examining the $PATH")
-
 // getPluginInfoAndPath searches for a compatible plugin kind, name, and version and returns either:
 //   - if found as an ambient plugin, nil and the path to the executable
 //   - if found in the pulumi dir's installed plugins, a PluginInfo and path to the executable
@@ -1574,7 +1571,7 @@ func getPluginInfoAndPath(
 
 	// If we have a version of the plugin on its $PATH, use it, unless we have opted out of this behavior explicitly.
 	// This supports development scenarios.
-	includeAmbient := !(ignoreAmbientPlugins.Value()) || isBundled
+	includeAmbient := !(env.IgnoreAmbientPlugins.Value()) || isBundled
 	if includeAmbient {
 		filename = (&PluginSpec{Kind: kind, Name: name}).File()
 		if path, err := exec.LookPath(filename); err == nil {


### PR DESCRIPTION
Add a library to encapsulate environmental variable declaration, lookup and parsing. 

### Usage
Variables strongly typed and declared in the module scope like so:
```go
// Automatically prefixed with PULUMI_ by default
var Experimental = env.Bool("EXPERIMENTAL", "Enable experimental options and commands")
```

Values are accessed by calling `.Value()` on the module level variable:
```go
if Experimental.Value() { // .Value() returns a bool here
  // do the new exiting thing
} else {
  // do the well tested thing
}
```

Environmental variables can be predicated on other boolean type variables:
```go
var NewThingParam = env.String("NEW_THING", "pass this to the new thing", 
    env.Needs(Expiremental))
```

Predicated variables will only show up as set if there predicate is `true`:

```go
if v := NewThingParam.Value(); v != "" {
  do_thing(v)
} else {
  // do the well tested thing
}
```
The above `if` check is equivalent to 
```go
if v = os.Getenv("PULUMI_NEW_THING"); v != "" && cmduilt.IsTruthy(os.Getenv("PULUMI_EXPERIMENTAL"))
```

This makes marking and unmarking a variable as experimental a 1 line change.

--- 

All declared variables can then be iterated on for documentation with `env.Variables()`. This is how we can use this lib to build documentation for our environmental variables.

### Assumptions

#### Immutability 
The library assumes that environmental variables are inherited from the environment. Values are captured during program startup, changes to the environment are not observed. We are not resilient to environmental variables changing out from under us, so this complies with current usage. This assumption can be changed without breaking the API.

#### Known values
The library assumes that the names of environmental variables are known at compile time. If the variable to be looked up is derived from user input, a different mechanism should be used.

### Adoption

Adopting this system over our pulumi/pkg codebase will take a while. My plan is to merge in this PR without moving over our existing env vars from `os.Getenv`. We can then gradually move over existing env vars piecemeal in subsequent PRs. Any new env vars added will use the new system.

Prerequisite for https://github.com/pulumi/pulumi/issues/10747.

### Other Options - Viper
Viper looks like an excellent config retrieval package, but doesn't support at-site documentation. It also has less type safety then I would prefer as a top level api. If it would be helpful, we could switch the underlying mechanism from `os.Lookup` to `viper.Get*` without changing the API this library exposes. I don't think viper is necessary right now, but adopting this library doesn't preclude viper. 