### PR TITLE
Adjust bors.toml after #11364

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,5 +7,5 @@ status = [
 	'bors-ok',
 ]
 pr_status = [
-	'CI / lint / linear-history'
+	'linear-history'
 ]


### PR DESCRIPTION
This is a separate PR due to `pull_request_target` workflows running in the context of the base repository's main branch. The change in this PR is not mergeable until #11364 is merged. At which time, this will need to be rebased to trigger workflows to run, and the new workflow will run.

Fixes #11360.