### PR TITLE
Expanding the JSON Schema definition for `language` of the Pulumi Schema

### DIFF
--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -641,10 +641,29 @@
             "description": "Describes Java specific settings",
             "type": "object",
             "properties": {
+                "packages": {
+                    "$ref": "#/$defs/schemaStringMap"
+                },
                 "basePackage": {
                     "description": "Base Java package name for the generated Java provider SDK",
                     "type": "string",
                     "default": "com.pulumi"
+                },
+                "buildFiles": {
+                    "description": "If set to \"gradle\" enables a generation of a basic set of Gradle build files.",
+                    "type": "string"
+                },
+                "dependencies": {
+                    "description": "Specifies Maven-style dependencies for the generated code.",
+                    "$ref": "#/$defs/schemaStringMap"
+                },
+                "gradleNexusPublishPluginVersion": {
+                    "description": "Enables the use of a given version of io.github.gradle-nexus.publish-plugin in the generated Gradle build files (only when `buildFiles=\"gradle\")",
+                    "type": "string"
+                },
+                "gradleTest": {
+                    "description": "generates a test section to enable `gradle test` command to run unit tests over the generated code. Supported values: \"JUnitPlatform\" (only when `buildFiles=\"gradle\")",
+                    "enum": ["JUnitPlatform"]
                 }
             }
         },

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -140,6 +140,12 @@
             "$comment": "In the regex below, the 'module' portion of the token is optional. However, a missing module component creates a '::', which breaks URNs ('::' is the URN delimiter). We have many test schemas that use an empty module component successfully, as they never create URNs; while these are _probably_ the only places that need updating, it might be possible that there are module-less type tokens in the wild elsewhere and we may need to remain compatible with those tokens.",
             "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/-]*)?:[^0-9][a-zA-Z0-9._/]*$"
         },
+        "schemaStringMap": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "typeSpec": {
             "title": "Type Reference",
             "description": "A reference to a type. The particular kind of type referenced is determined based on the contents of the \"type\" property and the presence or absence of the \"additionalProperties\", \"items\", \"oneOf\", and \"$ref\" properties.",
@@ -524,6 +530,143 @@
                 "isOverlay": {
                     "description": "Indicates that the implementation of the function should not be generated from the schema, and is instead provided out-of-band by the package author",
                     "type": "boolean"
+                }
+            }
+        },
+        "csharpLanguageSpec": {
+            "title": "C# Language Overrides Definition",
+            "description": "Describes C# specific settings",
+            "type": "object",
+            "properties": {
+                "compatibility": {
+                    "description": "",
+                    "type": "string"
+                },
+                "namespaces": {
+                    "$ref": "#/$defs/schemaStringMap"
+                },
+                "packageReferences": {
+                    "$ref": "#/$defs/schemaStringMap"
+                },
+                "rootNamespace": {
+                    "desciption": "Root namespace for the generated .NET SDK"
+                }
+            }
+        },
+        "goLanguageSpec": {
+            "title": "Go Language Overrides Definition",
+            "description": "Describes Go specific settings",
+            "type": "object",
+            "properties": {
+                "generateExtraInputTypes": {
+                    "description": "",
+                    "type": "boolean"
+                },
+                "generateResourceContainerTypes": {
+                    "description": "",
+                    "type": "boolean"
+                },
+                "importBasePath": {
+                    "description": "Base import path for the Go package",
+                    "type": "string"
+                }
+            }
+        },
+        "nodejsLanguageSpec": {
+            "title": "NodeJS Language Overrides Definition",
+            "description": "Describes NodeJS specific settings",
+            "type": "object",
+            "properties": {
+                "packageName": {
+                    "description": "NPM package name (includes @namespace)",
+                    "type": "string"
+                },
+                "packageDescription": {
+                    "description": "NPM package description",
+                    "type": "string"
+                },
+                "readme": {
+                    "description": "Content of the generated package README.md file.",
+                    "type": "string"
+                },
+                "compatibility": {
+                    "description": "",
+                    "type": "string",
+                    "enum": ["tfbridge20"]
+                },
+                "dependencies": {
+                    "description": "NPM package dependencies",
+                    "$ref": "#/$defs/schemaStringMap"
+                },
+                "devDependencies": {
+                    "description": "NPM package devDependencies",
+                    "$ref": "#/$defs/schemaStringMap"
+                },
+                "disableUnionOutputTypes": {
+                    "description": "",
+                    "type": "boolean"
+                },
+                "typescriptVersion": {
+                    "description": "Typescript Version",
+                    "type": "string"
+                }
+            }
+        },
+        "pythonLanguageSpec": {
+            "title": "Python Language Overrides Definition",
+            "description": "Describes Python specific settings",
+            "type": "object",
+            "properties": {
+                "packageName": {
+                    "description": "NPM package name (includes @namespace)",
+                    "type": "string"
+                },
+                "readme": {
+                    "description": "Content of the generated package README.md file.",
+                    "type": "string"
+                },
+                "compatibility": {
+                    "description": "",
+                    "type": "string",
+                    "enum": ["tfbridge20"]
+                },
+                "requires": {
+                    "description": "Python package dependencies for the generated Python SDK",
+                    "$ref": "#/$defs/schemaStringMap"
+                }
+            }
+        },
+        "javaLanguageSpec": {
+            "title": "Java Language Overrides Definition",
+            "description": "Describes Java specific settings",
+            "type": "object",
+            "properties": {
+                "basePackage": {
+                    "description": "Base Java package name for the generated Java provider SDK",
+                    "type": "string",
+                    "default": "com.pulumi"
+                }
+            }
+        },
+        "languageSpec": {
+            "title": "Language Overrides Definition",
+            "description": "Describes programming language specific settings",
+            "type": "object",
+            "properties": {
+                "csharp": {
+                    "$ref": "#/$defs/csharpLanguageSpec"
+                },
+                "go": {
+                    "$ref": "#/$defs/goLanguageSpec"
+                },
+                "nodejs": {
+                    "$ref": "#/$defs/nodejsLanguageSpec"
+                },
+                "python": {
+                    "$ref": "#/$defs/pythonLanguageSpec"
+                },
+                "java": {
+                    "$ref": "#/$defs/javaLanguageSpec"
                 }
             }
         }

--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -50,7 +50,7 @@
             "description": "The URL of the package's logo, if any.",
             "type": "string"
         },
-        "pluginDownloadUrl": {
+        "pluginDownloadURL": {
             "description": "The URL to use when downloading the provider plugin binary.",
             "type": "string"
         },


### PR DESCRIPTION
Signed-off-by: Ringo De Smet <ringo@de-smet.name>

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
The `language` section in the JSON Schema for our Pulumi schema is defined as `object` without any further details:

https://github.com/pulumi/pulumi/blob/6f21c0dacafdcd5f7a45147ed9e192281932e9c3/pkg/codegen/schema/pulumi.json#L127-L130

This PR extends the JSON schema to cover for all the properties defined in the structs of the language specific importers:

* [pkg/codegen/dotnet/importer.go](https://github.com/pulumi/pulumi/blob/6f21c0dacafdcd5f7a45147ed9e192281932e9c3/pkg/codegen/dotnet/importer.go#L29-L43)
* [pkg/codegen/go/importer.go](https://github.com/pulumi/pulumi/blob/6f21c0dacafdcd5f7a45147ed9e192281932e9c3/pkg/codegen/go/importer.go#L24-L90)
* [pkg/codegen/nodejs/importer.go](https://github.com/pulumi/pulumi/blob/6f21c0dacafdcd5f7a45147ed9e192281932e9c3/pkg/codegen/nodejs/importer.go#L30-L82)
* [pkg/codegen/python/importer.go](https://github.com/pulumi/pulumi/blob/master/pkg/codegen/python/importer.go#L35-L57)
* [pkg/codegen/java/package_info.go](https://github.com/pulumi/pulumi-java/blob/ef32ffc0fb3d44f00268a26ed8e8da3c11346486/pkg/codegen/java/package_info.go#L35-L108) in `pulumi/pulumi-java`

Fixes #8795, #10087
Related to #7875

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
