### PR TITLE
Keep resource refs when invoking `pulumi:pulumi:getResource`

### DIFF
--- a/changelog/pending/20221116--engine--always-keep-resources-when-pulumi-pulumi-getresource-is-invoked.yaml
+++ b/changelog/pending/20221116--engine--always-keep-resources-when-pulumi-pulumi-getresource-is-invoked.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Always keep resources when pulumi:pulumi:getResource is invoked

--- a/changelog/pending/20221116--sdk-go-nodejs-python--set-acceptresources-when-invoking-pulumi-pulumi-getresource.yaml
+++ b/changelog/pending/20221116--sdk-go-nodejs-python--set-acceptresources-when-invoking-pulumi-pulumi-getresource.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go,nodejs,python
+  description: Set acceptResources when invoking pulumi:pulumi:getResource

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -723,8 +723,9 @@ func (ctx *Context) getResource(urn string) (*pulumirpc.RegisterResourceResponse
 	tok := "pulumi:pulumi:getResource"
 	logging.V(9).Infof("Invoke(%s, #args=%d): RPC call being made synchronously", tok, len(resolvedArgsMap))
 	resp, err := ctx.monitor.Invoke(ctx.ctx, &pulumirpc.ResourceInvokeRequest{
-		Tok:  "pulumi:pulumi:getResource",
-		Args: rpcArgs,
+		Tok:             "pulumi:pulumi:getResource",
+		Args:            rpcArgs,
+		AcceptResources: !disableResourceReferences,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("invoke(%s, ...): error: %v", tok, err)

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -114,6 +114,7 @@ export function getResource(res: Resource, parent: Resource | undefined, props: 
         req.setArgs(gstruct.Struct.fromJavaScript(inputs));
         req.setProvider("");
         req.setVersion("");
+        req.setAcceptresources(!utils.disableResourceReferences);
 
         // Now run the operation, serializing the invocation if necessary.
         const opLabel = `monitor.getResource(${label})`;

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -243,8 +243,17 @@ def get_resource(
 
             monitor = settings.get_monitor()
             inputs = await rpc.serialize_properties({"urn": urn}, {})
+
+            accept_resources = not (
+                os.getenv("PULUMI_DISABLE_RESOURCE_REFERENCES", "").upper()
+                in {"TRUE", "1"}
+            )
             req = resource_pb2.ResourceInvokeRequest(
-                tok="pulumi:pulumi:getResource", args=inputs, provider="", version=""
+                tok="pulumi:pulumi:getResource",
+                args=inputs,
+                provider="",
+                version="",
+                acceptResources=accept_resources,
             )
 
             def do_invoke():


### PR DESCRIPTION
We used to always keep resource references when marshaling the results of `pulumi:pulumi:getResource`, but this regressed in #9323 to only keep resource if the invoke request's `acceptResources` flag was set. Unfortunately, that flag is not being set when calling `pulumi:pulumi:getResource` in the Go, Node.js, and Python SDKs (although, it is being set for .NET and Java).

Two fixes:
1. Update the monitor to go back to always keeping resources when `pulumi:pulumi:getResource` is being invoked. This way, older SDKs that are not setting `acceptResources` will go back to the original behavior.
2. Update the SDKs to always set `acceptResources`, so that these newer versions of the SDKs will work with older engines that are checking `acceptResources`.

(2) will help us with EKS 1.0. We'll be able to update EKS to use a version of `@pulumi/pulumi` with the fix to set the `acceptResources` flag.

Note: We definitely need tests to lock-in the behavior here so it doesn't re-regress in the future. But I also would like to get the nodejs SDK fix in the next release, because we need it for EKS. So, I'd like to add the tests as a follow-up to this PR, unless someone feels strongly it needs to be included with this change.

Fixes #11380