### PR TITLE
Feature - Short Node Label for Stack Graph

### DIFF
--- a/changelog/pending/20221116--cli--adds-a-flag-that-allows-user-to-set-the-node-label-as-the-resource-name-instead-of-the-full-urn-in-the-stack-graph.yaml
+++ b/changelog/pending/20221116--cli--adds-a-flag-that-allows-user-to-set-the-node-label-as-the-resource-name-instead-of-the-full-urn-in-the-stack-graph.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Adds a flag that allows user to set the node label as the resource name instead of full URN in the stack graph

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -40,6 +40,9 @@ var dependencyEdgeColor string
 // The color of parent edges in the graph. Defaults to #AA6639, an orange.
 var parentEdgeColor string
 
+// Whether or not to return resource name as the node label for each node of the graph.
+var shortNodeName bool
+
 func newStackGraphCmd() *cobra.Command {
 	var stackName string
 
@@ -98,6 +101,8 @@ func newStackGraphCmd() *cobra.Command {
 		"Sets the color of dependency edges in the graph")
 	cmd.PersistentFlags().StringVar(&parentEdgeColor, "parent-edge-color", "#AA6639",
 		"Sets the color of parent edges in the graph")
+	cmd.PersistentFlags().BoolVar(&shortNodeName, "short-node-name", false,
+		"Sets the resource name as the node label for each node of the graph")
 	return cmd
 }
 
@@ -178,6 +183,9 @@ func (vertex *dependencyVertex) Data() interface{} {
 }
 
 func (vertex *dependencyVertex) Label() string {
+	if shortNodeName {
+		return string(vertex.resource.URN.Name())
+	}
 	return string(vertex.resource.URN)
 }
 


### PR DESCRIPTION
# Description
This feature allows the user to opt for short node labels, i.e, only the resource name part of the URN instead of the full URN that is returned as the node label in the stack graph while using ```pulumi stack graph``` command. A flag named ```short-node-name``` is added to the ```pulumi stack graph``` command that enables this feature.

## Command Usage
Existing command : ```pulumi stack graph [file-name]```
Example : ```pulumi stack graph dev```
Output for dev :
strict digraph {
    Resource0 [label="urn:pulumi:dev::Test-Simple-Stack::pulumi:pulumi:Stack::Test-Simple-Stack-dev"];
    Resource1 [label="urn:pulumi:dev::Test-Simple-Stack::pulumi:providers:aws-native::default_0_40_2"];
    Resource2 [label="urn:pulumi:dev::Test-Simple-Stack::aws-native:s3:Bucket::my-bucket2"];
    Resource2 -> Resource0 [color = "#AA6639"];
    Resource3 [label="urn:pulumi:dev::Test-Simple-Stack::aws-native:s3:Bucket::my-bucket1"];
    Resource3 -> Resource0 [color = "#AA6639"];
}

Command for using the feature : ```pulumi stack graph [file-name] --short-node-name```

Fixes #10663

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
