### PR TITLE
`pulumi about` outputs the fully qualified stack reference

### DIFF
--- a/changelog/pending/20221118--cli-about--add-fully-qualified-stack-name-to-current-stack.yaml
+++ b/changelog/pending/20221118--cli-about--add-fully-qualified-stack-name-to-current-stack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/about
+  description: Add fully qualified stack name to current stack.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -76,8 +76,8 @@ type StackReference interface {
 	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.Name
 
-	// Fully qualified name is the name
-	FullyQualifiedName() tokens.Name
+	// Fully qualified name of the stack.
+	FullyQualifiedName() tokens.QName
 }
 
 // PolicyPackReference is an opaque type that refers to a PolicyPack managed by a backend. The CLI

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -75,6 +75,9 @@ type StackReference interface {
 	// name may not uniquely identify the stack (e.g. the cloud backend embeds owner information in the StackReference
 	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.Name
+
+	// Fully qualified name is the name
+	FullyQualifiedName() tokens.Name
 }
 
 // PolicyPackReference is an opaque type that refers to a PolicyPack managed by a backend. The CLI

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -99,9 +99,8 @@ func (r localBackendReference) Name() tokens.Name {
 	return r.name
 }
 
-func (c localBackendReference) FullyQualifiedName() tokens.Name {
-	// TODO[pulumi/pulumi#11390]: Unable to provide this value until we solve this issue.
-	return tokens.Name("")
+func (r localBackendReference) FullyQualifiedName() tokens.Name {
+	return r.Name()
 }
 
 func IsFileStateBackendURL(urlstr string) bool {

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -99,8 +99,8 @@ func (r localBackendReference) Name() tokens.Name {
 	return r.name
 }
 
-func (r localBackendReference) FullyQualifiedName() tokens.Name {
-	return r.Name()
+func (r localBackendReference) FullyQualifiedName() tokens.QName {
+	return r.Name().Q()
 }
 
 func IsFileStateBackendURL(urlstr string) bool {

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -99,6 +99,11 @@ func (r localBackendReference) Name() tokens.Name {
 	return r.name
 }
 
+func (c localBackendReference) FullyQualifiedName() tokens.Name {
+	// TODO[pulumi/pulumi#11390]: Unable to provide this value until we solve this issue.
+	return tokens.Name("")
+}
+
 func IsFileStateBackendURL(urlstr string) bool {
 	u, err := url.Parse(urlstr)
 	if err != nil {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -74,8 +74,8 @@ func (c cloudBackendReference) Name() tokens.Name {
 	return c.name
 }
 
-func (c cloudBackendReference) FullyQualifiedName() tokens.Name {
-	return tokens.Name(fmt.Sprintf("%v/%v/%v", c.owner, c.project, c.name.String()))
+func (c cloudBackendReference) FullyQualifiedName() tokens.QName {
+	return tokens.IntoQName(fmt.Sprintf("%v/%v/%v", c.owner, c.project, c.name.String()))
 }
 
 // cloudStack is a cloud stack descriptor.

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -74,6 +74,10 @@ func (c cloudBackendReference) Name() tokens.Name {
 	return c.name
 }
 
+func (c cloudBackendReference) FullyQualifiedName() tokens.Name {
+	return tokens.Name(fmt.Sprintf("%v/%v/%v", c.owner, c.project, c.name.String()))
+}
+
 // cloudStack is a cloud stack descriptor.
 type cloudStack struct {
 	// ref is the stack's unique name.

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -188,7 +188,6 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 		tmp := getBackendAbout(backend)
 		result.Backend = &tmp
 	}
-
 	return result
 }
 
@@ -427,8 +426,8 @@ func (current currentStackAbout) String() string {
 		}.String() + "\n"
 	}
 	stackName := current.Name
-	if stackName != current.FullyQualifiedName {
-		stackName += fmt.Sprintf(" (fully qualified to %q)", current.FullyQualifiedName)
+	if current.FullyQualifiedName != "" {
+		stackName = current.FullyQualifiedName
 	}
 	return fmt.Sprintf("Current Stack: %s\n\n%s\n%s", stackName, resources, pending)
 }

--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -86,17 +86,16 @@ type summaryAbout struct {
 	// We use pointers here to allow the field to be nullable. When
 	// constructing, we either fill in a field or add an error. We still
 	// indicate that the field should be present when we serialize the struct.
-	Plugins        []pluginAbout            `json:"plugins"`
-	Host           *hostAbout               `json:"host"`
-	Backend        *backendAbout            `json:"backend"`
-	CurrentStack   *currentStackAbout       `json:"currentStack"`
-	CLI            *cliAbout                `json:"cliAbout"`
-	Runtime        *projectRuntimeAbout     `json:"runtime"`
-	Dependencies   []programDependencyAbout `json:"dependencies"`
-	ErrorMessages  []string                 `json:"errors"`
-	StackReference string                   `json:"stackReference"`
-	Errors         []error                  `json:"-"`
-	LogMessage     string                   `json:"-"`
+	Plugins       []pluginAbout            `json:"plugins"`
+	Host          *hostAbout               `json:"host"`
+	Backend       *backendAbout            `json:"backend"`
+	CurrentStack  *currentStackAbout       `json:"currentStack"`
+	CLI           *cliAbout                `json:"cliAbout"`
+	Runtime       *projectRuntimeAbout     `json:"runtime"`
+	Dependencies  []programDependencyAbout `json:"dependencies"`
+	ErrorMessages []string                 `json:"errors"`
+	Errors        []error                  `json:"-"`
+	LogMessage    string                   `json:"-"`
 }
 
 func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedStack string) summaryAbout {
@@ -427,12 +426,11 @@ func (current currentStackAbout) String() string {
 			Rows:    rows,
 		}.String() + "\n"
 	}
-	return fmt.Sprintf(`Current Stack: %s
-
-Fully qualified stack name: %s
-
-%s
-%s`, current.Name, current.FullyQualifiedName, resources, pending)
+	stackName := current.Name
+	if stackName != current.FullyQualifiedName {
+		stackName += fmt.Sprintf(" (fully qualified to %q)", current.FullyQualifiedName)
+	}
+	return fmt.Sprintf("Current Stack: %s\n\n%s\n%s", stackName, resources, pending)
 }
 
 func simpleTableRows(arr [][]string) []cmdutil.TableRow {

--- a/pkg/cmd/pulumi/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack_ls_test.go
@@ -82,8 +82,8 @@ func (msr *mockStackReference) Name() tokens.Name {
 	return tokens.Name(msr.name)
 }
 
-func (msr *mockStackReference) FullyQualifiedName() tokens.Name {
-	return msr.Name()
+func (msr *mockStackReference) FullyQualifiedName() tokens.QName {
+	return msr.Name().Q()
 }
 
 func (msr *mockStackReference) String() string {

--- a/pkg/cmd/pulumi/stack_ls_test.go
+++ b/pkg/cmd/pulumi/stack_ls_test.go
@@ -82,6 +82,10 @@ func (msr *mockStackReference) Name() tokens.Name {
 	return tokens.Name(msr.name)
 }
 
+func (msr *mockStackReference) FullyQualifiedName() tokens.Name {
+	return msr.Name()
+}
+
 func (msr *mockStackReference) String() string {
 	return msr.name
 }


### PR DESCRIPTION
Resolves #11386

```shell
$ pulumi about 
# current output would go here until after this line:
Current Stack: dev

Fully qualified stack name: Fully qualified stack name: friel/tmp.knCczy5IiO/dev

Found no resources associated with dev

Found no pending operations associated with dev
# and regular output
```

```shell
$ pulumi about --json | jq '.currentStack.fullyQualifiedName'
"friel/tmp.knCczy5IiO/dev"
```

When there is no valid stack, the `currentStack` value is `null`. 

Due to an existing bug, when the backend is filestate the `currentStack` value is `null`. It appears on filestate backends we do not render the current stack.