### PR TITLE
Attempt to select stack then create as fallback

### DIFF
--- a/changelog/pending/20221117--sdk-nodejs--attempt-to-select-stack-then-create-as-fallback-on-createorselect.yaml
+++ b/changelog/pending/20221117--sdk-nodejs--attempt-to-select-stack-then-create-as-fallback-on-createorselect.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs,go,dotnet
+  description: Attempt to select stack then create as fallback on 'createOrSelect'

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -130,11 +130,11 @@ namespace Pulumi.Automation
                 {
                     try
                     {
-                        await workspace.CreateStackAsync(name, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (StackAlreadyExistsException)
-                    {
                         await workspace.SelectStackAsync(name, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (StackNotFoundException)
+                    {
+                        await workspace.CreateStackAsync(name, cancellationToken).ConfigureAwait(false);
                     }
                 }),
                 _ => throw new InvalidOperationException($"Unexpected Stack creation mode: {mode}")

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -24,7 +24,7 @@ import TailFile from "@logdna/tail-file";
 import * as log from "../log";
 import { CommandResult, runPulumiCmd } from "./cmd";
 import { ConfigMap, ConfigValue } from "./config";
-import { StackAlreadyExistsError } from "./errors";
+import { StackNotFoundError } from "./errors";
 import { EngineEvent, SummaryEvent } from "./events";
 import { LanguageServer, maxRPCMessageSize } from "./server";
 import { Deployment, PulumiFn, Workspace } from "./workspace";
@@ -105,9 +105,9 @@ export class Stack {
             this.ready = workspace.selectStack(name);
             return this;
         case "createOrSelect":
-            this.ready = workspace.createStack(name).catch((err) => {
-                if (err instanceof StackAlreadyExistsError) {
-                    return workspace.selectStack(name);
+            this.ready = workspace.selectStack(name).catch((err) => {
+                if (err instanceof StackNotFoundError) {
+                    return workspace.createStack(name);
                 }
                 throw err;
             });


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Fixes #11392

If a user does not have write permission (i.e. read-only), attempting to create the stack first will fail before the stack select fallback is triggered. Flip the logic to select first, then create.

https://github.com/pulumi/pulumi/commit/7695311d799f47a3cf13e6019d135eec4bb886bd changed it for python auto API already, this PR does the same for TS, Go, C#

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
