### PR TITLE
Fix stack selection behavior

### DIFF
--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -356,6 +356,8 @@ func chooseStack(ctx context.Context,
 	}
 
 	// If we are offering to create a new stack, add that to the end of the list.
+	// Otherwise, default to a stack if one exists – otherwise pressing enter will result in
+	// the empty string being passed (see https://github.com/go-survey/survey/issues/342).
 	const newOption = "<create a new stack>"
 	if offerNew {
 		options = append(options, newOption)
@@ -367,6 +369,8 @@ func chooseStack(ctx context.Context,
 	} else if len(options) == 0 {
 		// If no options are available, we can't offer a choice!
 		return nil, errors.New("this command requires a stack, but there are none")
+	} else if defaultOption == "" {
+		defaultOption = options[0]
 	}
 
 	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11407 
Follow on to PR [11354](https://github.com/pulumi/pulumi/pull/11354). When we don't prompt to `create a new stack`, we should default to an existing stack so the empty string isn't populated.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
