### PR TITLE
Simplified invoke gen improve bind

### DIFF
--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -42,7 +42,7 @@ type expressionBinder struct {
 }
 
 // BindExpression binds an HCL2 expression using the given scope and token map.
-func BindExpression(syntax hclsyntax.Node, scope *Scope, defintion *string, tokens _syntax.TokenMap,
+func BindExpression(syntax hclsyntax.Node, scope *Scope, definition *string, tokens _syntax.TokenMap,
 	opts ...BindOption) (Expression, hcl.Diagnostics) {
 
 	var options bindOptions
@@ -60,9 +60,9 @@ func BindExpression(syntax hclsyntax.Node, scope *Scope, defintion *string, toke
 	boundExpr, diags := b.bindExpression(syntax)
 	switch expr := boundExpr.(type) {
 	case *FunctionCallExpression:
-		if defintion != nil {
+		if definition != nil {
 			// keep track of the computed signature of the function
-			b.scope.definitionSignatures[*defintion] = &expr.Signature
+			b.scope.definitionSignatures[*definition] = &expr.Signature
 			return boundExpr, diags
 		}
 	}

--- a/pkg/codegen/hcl2/model/functions.go
+++ b/pkg/codegen/hcl2/model/functions.go
@@ -44,7 +44,7 @@ type StaticFunctionSignature struct {
 	// Determines whether the function should return a single value from the outputs bag when it only has one property.
 	ReduceSingleOutputProperty bool
 	// Determines whether the input bag should be treated as a single argument or as multiple arguments.
-	MultiArgumentInputs *[]string
+	MultiArgumentInputs bool
 }
 
 // GetSignature returns the static signature itself.

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -245,10 +245,10 @@ func (b *binder) outputVersionSignature(fn *schema.Function) (model.StaticFuncti
 	if outputPropertiesReduced {
 		returnType := b.schemaTypeToType(fn.Outputs.Properties[0].Type)
 		return b.makeSignature(argsType, model.NewOutputType(returnType)), nil
-	} else {
-		returnType := b.schemaTypeToType(fn.Outputs)
-		return b.makeSignature(argsType, model.NewOutputType(returnType)), nil
 	}
+
+	returnType := b.schemaTypeToType(fn.Outputs)
+	return b.makeSignature(argsType, model.NewOutputType(returnType)), nil
 }
 
 // Detects invoke calls that use an output version of a function.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -539,7 +539,7 @@ type Function struct {
 	// Inputs is the bag of input values for the function, if any.
 	Inputs *ObjectType
 	// Determines whether the input bag should be treated as a single argument or as multiple arguments.
-	MultiArgumentInputs *[]string
+	MultiArgumentInputs bool
 	// Outputs is the bag of output values for the function, if any.
 	Outputs *ObjectType
 	// Determines whether the function should return a single value from the outputs bag when it only has one property.
@@ -1145,6 +1145,13 @@ func (pkg *Package) marshalFunction(f *Function) (FunctionSpec, error) {
 		}
 		inputs = &ins.ObjectTypeSpec
 	}
+	var multiArgumentInputs []string
+	if f.MultiArgumentInputs {
+		multiArgumentInputs = make([]string, len(f.Inputs.Properties))
+		for i, prop := range f.Inputs.Properties {
+			multiArgumentInputs[i] = prop.Name
+		}
+	}
 
 	var outputs *ObjectTypeSpec
 	if f.Outputs != nil {
@@ -1161,10 +1168,13 @@ func (pkg *Package) marshalFunction(f *Function) (FunctionSpec, error) {
 	}
 
 	return FunctionSpec{
-		Description: f.Comment,
-		Inputs:      inputs,
-		Outputs:     outputs,
-		Language:    lang,
+		Description:         f.Comment,
+		DeprecationMessage:  f.DeprecationMessage,
+		IsOverlay:           f.IsOverlay,
+		Inputs:              inputs,
+		MultiArgumentInputs: multiArgumentInputs,
+		Outputs:             outputs,
+		Language:            lang,
 	}, nil
 }
 
@@ -1526,7 +1536,7 @@ type FunctionSpec struct {
 	// Inputs is the bag of input values for the function, if any.
 	Inputs *ObjectTypeSpec `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	// Determines whether the input bag should be treated as a single argument or as multiple arguments.
-	MultiArgumentInputs *[]string `json:"multiArgumentInputs,omitempty" yaml:"multiArgumentInputs,omitempty"`
+	MultiArgumentInputs []string `json:"multiArgumentInputs,omitempty" yaml:"multiArgumentInputs,omitempty"`
 	// Outputs is the bag of output values for the function, if any.
 	Outputs *ObjectTypeSpec `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 	// Determines whether the function should return a single value from the outputs bag when it only has one property.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1540,7 +1540,7 @@ type FunctionSpec struct {
 	// Outputs is the bag of output values for the function, if any.
 	Outputs *ObjectTypeSpec `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 	// Determines whether the function should return a single value from the outputs bag when it only has one property.
-	ReduceSingleOutputProperty bool `json:"reduceSingleOutputProperty,omitempty" yaml:"reduceSingleOutputProperty,omitempty"`
+	ReduceSingleOutputProperty bool `json:"reduceSingleOutputProperty,omitempty" yaml:"reduceSingleOutputProperty,omitempty"` //nolint:lll
 	// DeprecationMessage indicates whether or not the function is deprecated.
 	DeprecationMessage string `json:"deprecationMessage,omitempty" yaml:"deprecationMessage,omitempty"`
 	// Language specifies additional language-specific data about the function.


### PR DESCRIPTION
This PR moves validation logic for `multiArgumentInputs` from language generators to the schema binder.

If `multiArgumentInputs` matches input properties, we order the input properties to match. `schema.Function.MultiArgumentInputs` is a boolean, not a list of properties. This simplifies the check needed in downstream codegen. We reverse this process when we marshal out of `schema.Function` back to `schema.FunctionSpec`.