### PR TITLE
Feature detect diff-based bandwidth-optimized PATCH protocol for saving checkpoints

### DIFF
--- a/changelog/pending/20221121--backend-service--allows-the-service-to-opt-into-bandwidth-optimized-diff-protocol.yaml
+++ b/changelog/pending/20221121--backend-service--allows-the-service-to-opt-into-bandwidth-optimized-diff-protocol.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/service
+  description: Allows the service to opt into a bandwidth-optimized DIFF protocol for storing checkpoints. Previously this required setting the PULUMI_OPTIMIZED_CHECKPOINT_PATCH env variable on the client. This env variable is now deprecated.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1251,7 +1251,6 @@ func (b *cloudBackend) GetHistory(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stack updates: %w", err)
 	}
-	//
 
 	// Convert apitype.UpdateInfo objects to the backend type.
 	var beUpdates []backend.UpdateInfo

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1806,7 +1806,6 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 	for _, entry := range wireLevel {
 		switch entry.Capability {
 		case apitype.DeltaCheckpointUploads:
-			// TODO should check entry.Version here?
 			var cap apitype.DeltaCheckpointUploadsConfigV1
 			if err := json.Unmarshal(entry.Configuration, &cap); err != nil {
 				msg := "decoding DeltaCheckpointUploadsConfigV1 returned %w"

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -78,6 +78,8 @@ func init() {
 		routes.Path(path).Methods(method).Name(name)
 	}
 
+	addEndpoint("GET", "/api/capabilities", "getCapabilities")
+
 	addEndpoint("GET", "/api/user", "getCurrentUser")
 	addEndpoint("GET", "/api/user/stacks", "listUserStacks")
 	addEndpoint("GET", "/api/stacks/{orgName}", "listOrganizationStacks")

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1096,7 +1096,8 @@ func is404(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == http.StatusNotFound {
+	var errResp *apitype.ErrorResponse
+	if errors.As(err, &errResp) && errResp.Code == http.StatusNotFound {
 		return true
 	}
 	return false

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -321,7 +321,7 @@ func (pc *Client) GetLatestConfiguration(ctx context.Context, stackID StackIdent
 func (pc *Client) DoesProjectExist(ctx context.Context, owner string, projectName string) (bool, error) {
 	if err := pc.restCall(ctx, "HEAD", getProjectPath(owner, projectName), nil, nil, nil); err != nil {
 		// If this was a 404, return false - project not found.
-		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == http.StatusNotFound {
+		if is404(err) {
 			return false, nil
 		}
 
@@ -1069,4 +1069,28 @@ func (pc *Client) GetDeploymentUpdates(ctx context.Context, stack StackIdentifie
 		return nil, fmt.Errorf("getting deployment %s updates failed: %w", id, err)
 	}
 	return resp, nil
+}
+
+func (pc *Client) GetCapabilities(ctx context.Context) (*apitype.CapabilitiesResponse, error) {
+	var resp apitype.CapabilitiesResponse
+	err := pc.restCall(ctx, http.MethodGet, "/api/capabilities", nil, nil, &resp)
+	if is404(err) {
+		// The client continues to support legacy backends. They do not support /api/capabilities and are
+		// assumed here to have no additional capabilities.
+		return &apitype.CapabilitiesResponse{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying capabilities failed: %w", err)
+	}
+	return &resp, nil
+}
+
+func is404(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == http.StatusNotFound {
+		return true
+	}
+	return false
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -49,6 +49,9 @@ type Client struct {
 	apiOrgs  []string
 	diag     diag.Sink
 	client   restClient
+
+	// If true, do not probe the backend with GET /api/capabilities and assume no capabilities.
+	DisableCapabilityProbing bool
 }
 
 // newClient creates a new Pulumi API client with the given URL and API token. It is a variable instead of a regular
@@ -1072,6 +1075,10 @@ func (pc *Client) GetDeploymentUpdates(ctx context.Context, stack StackIdentifie
 }
 
 func (pc *Client) GetCapabilities(ctx context.Context) (*apitype.CapabilitiesResponse, error) {
+	if pc.DisableCapabilityProbing {
+		return &apitype.CapabilitiesResponse{}, nil
+	}
+
 	var resp apitype.CapabilitiesResponse
 	err := pc.restCall(ctx, http.MethodGet, "/api/capabilities", nil, nil, &resp)
 	if is404(err) {

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -181,7 +181,9 @@ func TestPatchUpdateCheckpointVerbatimPreservesIndent(t *testing.T) {
 }
 
 func TestGetCapabilities(t *testing.T) {
+	t.Parallel()
 	t.Run("legacy-service-404", func(t *testing.T) {
+		t.Parallel()
 		s := newMockServer(404, "NOT FOUND")
 		defer s.Close()
 
@@ -192,6 +194,7 @@ func TestGetCapabilities(t *testing.T) {
 		assert.Empty(t, resp.Capabilities)
 	})
 	t.Run("updated-service-with-delta-checkpoint-capability", func(t *testing.T) {
+		t.Parallel()
 		cfg := apitype.DeltaCheckpointUploadsConfigV1{
 			CheckpointCutoffSizeBytes: 1024 * 1024 * 4,
 		}

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -179,3 +179,43 @@ func TestPatchUpdateCheckpointVerbatimPreservesIndent(t *testing.T) {
 
 	assert.Equal(t, string(indented), string(request.UntypedDeployment))
 }
+
+func TestGetCapabilities(t *testing.T) {
+	t.Run("legacy-service-404", func(t *testing.T) {
+		s := newMockServer(404, "NOT FOUND")
+		defer s.Close()
+
+		c := newMockClient(s)
+		resp, err := c.GetCapabilities(context.Background())
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Empty(t, resp.Capabilities)
+	})
+	t.Run("updated-service-with-delta-checkpoint-capability", func(t *testing.T) {
+		cfg := apitype.DeltaCheckpointUploadsConfigV1{
+			CheckpointCutoffSizeBytes: 1024 * 1024 * 4,
+		}
+		cfgJSON, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		actualResp := apitype.CapabilitiesResponse{
+			Capabilities: []apitype.APICapabilityConfig{{
+				Version:       3,
+				Capability:    apitype.DeltaCheckpointUploads,
+				Configuration: json.RawMessage(cfgJSON),
+			}},
+		}
+		respJSON, err := json.Marshal(actualResp)
+		require.NoError(t, err)
+		s := newMockServer(200, string(respJSON))
+		defer s.Close()
+
+		c := newMockClient(s)
+		resp, err := c.GetCapabilities(context.Background())
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Len(t, resp.Capabilities, 1)
+		assert.Equal(t, apitype.DeltaCheckpointUploads, resp.Capabilities[0].Capability)
+		assert.Equal(t, `{"checkpointCutoffSizeBytes":4194304}`,
+			string(resp.Capabilities[0].Configuration))
+	})
+}

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -134,7 +134,7 @@ func (cb *cloudBackend) newSnapshotPersister(ctx context.Context, update client.
 		sm:          sm,
 	}
 
-	caps := cb.capabilities()
+	caps := cb.capabilities(ctx)
 	deltaCaps := caps.deltaCheckpointUpdates
 	if deltaCaps != nil {
 		p.deploymentDiffState = newDeploymentDiffState(deltaCaps.CheckpointCutoffSizeBytes)

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -26,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -82,9 +80,6 @@ func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 			return err
 		}
 		if err := persister.saveDiff(ctx, diff, token); err != nil {
-			if differ.strictMode {
-				return err
-			}
 			if logging.V(3) {
 				logging.V(3).Infof("ignoring error saving checkpoint "+
 					"with PatchUpdateCheckpointDelta, falling back to "+
@@ -139,17 +134,10 @@ func (cb *cloudBackend) newSnapshotPersister(ctx context.Context, update client.
 		sm:          sm,
 	}
 
-	if cmdutil.IsTruthy(os.Getenv("PULUMI_OPTIMIZED_CHECKPOINT_PATCH")) {
-		p.deploymentDiffState = newDeploymentDiffState()
-
-		if cmdutil.IsTruthy(os.Getenv("PULUMI_OPTIMIZED_CHECKPOINT_PATCH_STRICT")) {
-			p.deploymentDiffState.strictMode = true
-		}
-
-		if cmdutil.IsTruthy(os.Getenv("PULUMI_OPTIMIZED_CHECKPOINT_PATCH_NO_CHECKSUMS")) {
-			p.deploymentDiffState.noChecksums = true
-		}
+	caps := cb.capabilities()
+	deltaCaps := caps.deltaCheckpointUpdates
+	if deltaCaps != nil {
+		p.deploymentDiffState = newDeploymentDiffState(deltaCaps.CheckpointCutoffSizeBytes)
 	}
-
 	return p
 }

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -126,7 +126,7 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 			UpdateKind:      apitype.UpdateUpdate,
 			UpdateID:        updateID,
 		}, newMockTokenSource(), nil)
-		persister.deploymentDiffState = newDeploymentDiffState()
+		persister.deploymentDiffState = newDeploymentDiffState(1)
 		persister.deploymentDiffState.minimalDiffSize = 1
 		return persister
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Starts using diff-based PATCH protocol for saving checkpoints for backends that indicate that they support it via `GET /api/capabilities`. Removes flags that opted into the feature. Specifically:

- call GET /api/capabilities in parallel with GetStack call so as not to add to critical path latency
- interpret 404 Not Found as "no capabilities" for backwards compatibility and not forcing a simultaneous backend update
- let the response from /api/capabilities configure a minimal stack size cutoff for opting into the diff-based protocol
- opens the possibility to tune the optimal cutoff with service experimentation

Fixes https://github.com/pulumi/home/issues/2425

I've tested the change against the mainline backend that does not support capabilities yet (404 path) and the experimental backend that does, including both sides of the size cutoff, and it seems to work as expected.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
