### PR TITLE
read github hostname from the environment

### DIFF
--- a/changelog/pending/20221122--engine--read-plugindownloadurl-github-hostname-from-environment.yaml
+++ b/changelog/pending/20221122--engine--read-plugindownloadurl-github-hostname-from-environment.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Read PluginDownloadURL Github Hostname from Environment

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -222,11 +222,18 @@ func newGithubSource(url *url.URL, name string, kind PluginKind) (*githubSource,
 	}
 
 	host := url.Host
-	parts := strings.Split(strings.Trim(url.Path, "/"), "/")
+
+	if os.Getenv("GITHUB_HOSTNAME") != "" {
+		logging.Warningf("Overriding PluginDownloadURL hostname with value set in env var GITHUB_HOSTNAME")
+		host = os.Getenv("GITHUB_HOSTNAME")
+	}
 
 	if host == "" {
 		return nil, fmt.Errorf("github:// url must have a host part, was: %s", url.String())
 	}
+
+	parts := strings.Split(strings.Trim(url.Path, "/"), "/")
+
 
 	if len(parts) != 1 && len(parts) != 2 {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # Github Hostnames can now have hierarchical slashes

Github Enterprise API endpoints usually contain hierarchical slashes. An example format of a private host would be "github_hostname/api/v2" . This is not supported with the current method of splitting the PluginDownloadURL. We can't assume the last two parts are the Organization and Repo since the Repo is an optional field. 

I added the ability to read the Github Hostname from an Env Var so in the case users have a hostname with slashes, they can set it in the env and still be able to download the plugin dynamically

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
