### PR TITLE
Do not fail pulumi new on invalid template(s)

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -50,6 +50,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+const (
+	brokenTemplateDescription = "(This template is currently broken)"
+)
+
 type promptForValueFunc func(yes bool, valueType string, defaultValue string, secret bool,
 	isValidFn func(value string) error, opts display.Options) (string, error)
 
@@ -154,6 +158,10 @@ func runNew(ctx context.Context, args newArgs) error {
 		if template, err = chooseTemplate(templates, opts); err != nil {
 			return err
 		}
+
+	}
+	if template.Errored() {
+		return fmt.Errorf("template '%s' is currently broken: %w", template.Name, template.Error)
 	}
 
 	// Do a dry run, if we're not forcing files to be overwritten.
@@ -1073,21 +1081,32 @@ func templatesToOptionArrayAndMap(templates []workspace.Template,
 
 	// Build the array and map.
 	var options []string
+	var brokenOptions []string
 	nameToTemplateMap := make(map[string]workspace.Template)
 	for _, template := range templates {
 		// If showAll is false, then only include templates marked Important
 		if !showAll && !template.Important {
 			continue
 		}
+		// If template is broken, indicate it in the project description.
+		if template.Errored() {
+			template.ProjectDescription = brokenTemplateDescription
+		}
+
 		// Create the option string that combines the name, padding, and description.
 		desc := workspace.ValueOrDefaultProjectDescription("", template.ProjectDescription, template.Description)
 		option := fmt.Sprintf(fmt.Sprintf("%%%ds    %%s", -maxNameLength), template.Name, desc)
 
-		// Add it to the array and map.
-		options = append(options, option)
 		nameToTemplateMap[option] = template
+		if template.Errored() {
+			brokenOptions = append(brokenOptions, option)
+		} else {
+			options = append(options, option)
+		}
 	}
+	// After sorting the options, add the broken templates to the end
 	sort.Strings(options)
+	options = append(options, brokenOptions...)
 
 	if !showAll {
 		// If showAll is false, include an option to show all

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -130,7 +130,11 @@ func (repo TemplateRepository) Templates() ([]Template, error) {
 
 			template, err := LoadTemplate(filepath.Join(path, name))
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				return nil, err
+				logging.V(2).Infof(
+					"Failed to load template %s: %s",
+					name, err.Error(),
+				)
+				result = append(result, Template{Name: name, Error: err})
 			} else if err == nil {
 				result = append(result, template)
 			}
@@ -197,9 +201,15 @@ type Template struct {
 	Quickstart  string                                // Optional text to be displayed after template creation.
 	Config      map[string]ProjectTemplateConfigValue // Optional template config.
 	Important   bool                                  // Indicates whether the template should be listed by default.
+	Error       error                                 // Non-nil if the template is broken.
 
 	ProjectName        string // Name of the project.
 	ProjectDescription string // Optional description of the project.
+}
+
+// Errored returns if the template has an error
+func (t Template) Errored() bool {
+	return t.Error != nil
 }
 
 // PolicyPackTemplate represents a Policy Pack template.


### PR DESCRIPTION
Fixes #11434 
If one or more templates are invalid in a repo, we should omit showing those to users instead of failing completely.