### PR TITLE
Improve the experience of selecting a broken template

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -158,6 +158,10 @@ func runNew(ctx context.Context, args newArgs) error {
 		if template, err = chooseTemplate(templates, opts); err != nil {
 			return err
 		}
+
+	}
+	if template.Errored() {
+		return fmt.Errorf("template '%s' is currently broken: %w", template.Name, template.Error)
 	}
 
 	// Do a dry run, if we're not forcing files to be overwritten.
@@ -1085,7 +1089,7 @@ func templatesToOptionArrayAndMap(templates []workspace.Template,
 			continue
 		}
 		// If template is broken, indicate it in the project description.
-		if template.Broken {
+		if template.Errored() {
 			template.ProjectDescription = brokenTemplateDescription
 		}
 
@@ -1093,11 +1097,11 @@ func templatesToOptionArrayAndMap(templates []workspace.Template,
 		desc := workspace.ValueOrDefaultProjectDescription("", template.ProjectDescription, template.Description)
 		option := fmt.Sprintf(fmt.Sprintf("%%%ds    %%s", -maxNameLength), template.Name, desc)
 
-		if template.Broken {
+		nameToTemplateMap[option] = template
+		if template.Errored() {
 			brokenOptions = append(brokenOptions, option)
 		} else {
 			options = append(options, option)
-			nameToTemplateMap[option] = template
 		}
 	}
 	// After sorting the options, add the broken templates to the end

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -134,7 +134,7 @@ func (repo TemplateRepository) Templates() ([]Template, error) {
 					"Failed to load template %s: %s",
 					name, err.Error(),
 				)
-				result = append(result, Template{Name: name, Broken: true})
+				result = append(result, Template{Name: name, Error: err})
 			} else if err == nil {
 				result = append(result, template)
 			}
@@ -201,10 +201,15 @@ type Template struct {
 	Quickstart  string                                // Optional text to be displayed after template creation.
 	Config      map[string]ProjectTemplateConfigValue // Optional template config.
 	Important   bool                                  // Indicates whether the template should be listed by default.
-	Broken      bool                                  // Indicates whether the template is currently broken.
+	Error       error                                 // Non-nil if the template is broken.
 
 	ProjectName        string // Name of the project.
 	ProjectDescription string // Optional description of the project.
+}
+
+// Errored returns if the template has an error
+func (t Template) Errored() bool {
+	return t.Error != nil
 }
 
 // PolicyPackTemplate represents a Policy Pack template.


### PR DESCRIPTION
Instead of doing nothing if a broken template is selected, display the reason why its broken:

Example:
```
X pulumi new --offline
Please choose a template (88/203 shown):
 go                                 (This template is currently broken)
error: template 'go' is currently broken: could not validate '~/.pulumi/templates/go/Pulumi.yaml': project is missing a 'runtime' attribute
```

I'm not sure if failing to select a broken template was the intended behavior, but it is really confusing. Here the selection works, but errors with the reason whey the template is broken.