### PR TITLE
Don't import types referenced from local variables

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -449,10 +449,14 @@ func (g *generator) collectConvertImports(
 		//
 		// Fully solving this is deferred for later:
 		// TODO[pulumi/pulumi#8324].
-		if expr, ok := call.Args[0].(*model.TemplateExpression); ok {
-			if lit, ok := expr.Parts[0].(*model.LiteralValueExpression); ok &&
-				model.StringType.AssignableFrom(lit.Type()) &&
+		switch arg0 := call.Args[0].(type) {
+		case *model.TemplateExpression:
+			if lit, ok := arg0.Parts[0].(*model.LiteralValueExpression); ok &&
 				call.Type().AssignableFrom(lit.Type()) {
+				return
+			}
+		case *model.ScopeTraversalExpression:
+			if call.Type().AssignableFrom(arg0.Type()) {
 				return
 			}
 		}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -57,7 +57,6 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "assets-archives",
 		Description: "Assets and archives",
-		SkipCompile: codegen.NewStringSet("go"),
 	},
 	{
 		Directory:   "synthetic-resource-properties",

--- a/pkg/codegen/testing/test/testdata/assets-archives-pp/go/assets-archives.go
+++ b/pkg/codegen/testing/test/testdata/assets-archives-pp/go/assets-archives.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lambda"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"


### PR DESCRIPTION
Don't import types if the type is only referenced in a scoped traversal (`foo.bar`), not named directly.

Part of https://github.com/pulumi/pulumi/issues/11427
Relates to https://github.com/pulumi/pulumi/issues/8324
