### PR TITLE
Do not fail pulumi policy new on invalid template(s)

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -823,32 +823,22 @@ func chooseTemplate(templates []workspace.Template, opts display.Options) (works
 	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
 	surveycore.DisableColor = true
 
-	var selectedOption workspace.Template
+	options, optionToTemplateMap := templatesToOptionArrayAndMap(templates, true)
+	nopts := len(options)
+	pageSize := optimalPageSize(optimalPageSizeOpts{nopts: nopts})
+	message := fmt.Sprintf("\rPlease choose a template (%d/%d shown):\n", pageSize, nopts)
+	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
 
-	for {
-		options, optionToTemplateMap := templatesToOptionArrayAndMap(templates, true)
-		nopts := len(options)
-		pageSize := optimalPageSize(optimalPageSizeOpts{nopts: nopts})
-		message := fmt.Sprintf("\rPlease choose a template (%d/%d shown):\n", pageSize, nopts)
-		message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
-
-		var option string
-		if err := survey.AskOne(&survey.Select{
-			Message:  message,
-			Options:  options,
-			PageSize: pageSize,
-		}, &option, surveyIcons(opts.Color)); err != nil {
-			return workspace.Template{}, errors.New(chooseTemplateErr)
-		}
-
-		var has bool
-		selectedOption, has = optionToTemplateMap[option]
-		if has {
-			break
-		}
+	var option string
+	if err := survey.AskOne(&survey.Select{
+		Message:  message,
+		Options:  options,
+		PageSize: pageSize,
+	}, &option, surveyIcons(opts.Color)); err != nil {
+		return workspace.Template{}, errors.New(chooseTemplateErr)
 	}
 
-	return selectedOption, nil
+	return optionToTemplateMap[option], nil
 }
 
 // parseConfig parses the config values passed via command line flags.

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -184,7 +184,11 @@ func (repo TemplateRepository) PolicyTemplates() ([]PolicyPackTemplate, error) {
 
 			template, err := LoadPolicyPackTemplate(filepath.Join(path, name))
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				return nil, err
+				logging.V(2).Infof(
+					"Failed to load template %s: %s",
+					name, err.Error(),
+				)
+				result = append(result, PolicyPackTemplate{Name: name, Error: err})
 			} else if err == nil {
 				result = append(result, template)
 			}
@@ -217,6 +221,12 @@ type PolicyPackTemplate struct {
 	Dir         string // The directory containing PulumiPolicy.yaml.
 	Name        string // The name of the template.
 	Description string // Description of the template.
+	Error       error  // Non-nil if the template is broken.
+}
+
+// Errored returns if the template has an error
+func (t PolicyPackTemplate) Errored() bool {
+	return t.Error != nil
 }
 
 // cleanupLegacyTemplateDir deletes an existing ~/.pulumi/templates directory if it isn't a git repository.


### PR DESCRIPTION
Extension of https://github.com/pulumi/pulumi/pull/11435, but for `pulumi policy new`. 
Part of #11434 