### PR TITLE
Use plugin link and shimless for testprovider

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1821,39 +1821,52 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 
 	if pt.opts.LocalProviders != nil {
 		for _, provider := range pt.opts.LocalProviders {
+			// LocalProviders are relative to the working directory when running tests, NOT relative to the
+			// Pulumi.yaml. This is a bit odd, but makes it easier to construct the required paths in each
+			// test.
+			absPath, err := filepath.Abs(provider.Path)
+			if err != nil {
+				return "", "", fmt.Errorf("could not get absolute path for plugin %s: %w", provider.Path, err)
+			}
+
 			projinfo.Proj.Plugins.Providers = append(projinfo.Proj.Plugins.Providers, workspace.PluginOptions{
 				Name: provider.Package,
-				Path: provider.Path,
+				Path: absPath,
 			})
 		}
 	}
 
+	// Absolute path of the source directory, for fixupPath to use below
+	absSource, err := filepath.Abs(sourceDir)
+	if err != nil {
+		return "", "", fmt.Errorf("could not get absolute path for source directory %s: %w", sourceDir, err)
+	}
+
+	// Return a fixed up path if it's relative to sourceDir but not beneath it, else just returns the input
+	fixupPath := func(path string) (string, error) {
+		if filepath.IsAbs(path) {
+			return path, nil
+		}
+		absPlugin := filepath.Join(absSource, path)
+		if !strings.HasPrefix(absPlugin, absSource+string(filepath.Separator)) {
+			return absPlugin, nil
+		}
+		return path, nil
+	}
+
 	if projinfo.Proj.Plugins != nil {
-		for i, provider := range projinfo.Proj.Plugins.Providers {
-			if !filepath.IsAbs(provider.Path) {
-				path, err := filepath.Abs(provider.Path)
-				if err != nil {
-					return "", "", fmt.Errorf("could not get absolute path for plugin %s: %w", provider.Path, err)
-				}
-				projinfo.Proj.Plugins.Providers[i].Path = path
-			}
+		optionSets := [][]workspace.PluginOptions{
+			projinfo.Proj.Plugins.Providers,
+			projinfo.Proj.Plugins.Languages,
+			projinfo.Proj.Plugins.Analyzers,
 		}
-		for i, language := range projinfo.Proj.Plugins.Languages {
-			if !filepath.IsAbs(language.Path) {
-				path, err := filepath.Abs(language.Path)
+		for _, options := range optionSets {
+			for i, opt := range options {
+				path, err := fixupPath(opt.Path)
 				if err != nil {
-					return "", "", fmt.Errorf("could not get absolute path for plugin %s: %w", language.Path, err)
+					return "", "", fmt.Errorf("could not get fixed path for plugin %s: %w", opt.Path, err)
 				}
-				projinfo.Proj.Plugins.Languages[i].Path = path
-			}
-		}
-		for i, analyzer := range projinfo.Proj.Plugins.Analyzers {
-			if !filepath.IsAbs(analyzer.Path) {
-				path, err := filepath.Abs(analyzer.Path)
-				if err != nil {
-					return "", "", fmt.Errorf("could not get absolute path for plugin %s: %w", analyzer.Path, err)
-				}
-				projinfo.Proj.Plugins.Analyzers[i].Path = path
+				options[i].Path = path
 			}
 		}
 	}

--- a/tests/integration/construct_component/go/Pulumi.yaml
+++ b/tests/integration/construct_component/go/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_go
 description: A program that constructs remote component resources.
 runtime: go
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component/nodejs/Pulumi.yaml
+++ b/tests/integration/construct_component/nodejs/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_nodejs
 description: A program that constructs remote component resources.
 runtime: nodejs
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component/python/Pulumi.yaml
+++ b/tests/integration/construct_component/python/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_py
 description: A program that constructs remote component resources.
 runtime: python
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_methods_resources/go/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_resources/go/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_methods_resources_go
 description: A program that constructs remote component resources with methods that create resources.
 runtime: go
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_methods_resources/nodejs/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_resources/nodejs/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_methods_resources_nodejs
 description: A program that constructs remote component resources with methods that create resources.
 runtime: nodejs
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_methods_resources/python/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_resources/python/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_methods_resources_py
 description: A program that constructs remote component resources with methods that create resources.
 runtime: python
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_methods_unknown/go/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_unknown/go/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_methods_unknown_go
 description: A program that constructs remote component resources with methods and unknowns.
 runtime: go
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_methods_unknown/nodejs/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_unknown/nodejs/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_methods_unknown_nodejs
 description: A program that constructs remote component resources with methods and unknowns.
 runtime: nodejs
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_methods_unknown/python/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_unknown/python/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_methods_unknown_py
 description: A program that constructs remote component resources with methods and unknowns.
 runtime: python
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_plain/go/Pulumi.yaml
+++ b/tests/integration/construct_component_plain/go/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_plain_go
 description: A program that constructs a remote component resource with prompt inputs.
 runtime: go
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_plain/nodejs/Pulumi.yaml
+++ b/tests/integration/construct_component_plain/nodejs/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_plain_nodejs
 description: A program that constructs a remote component resource with prompt inputs.
 runtime: nodejs
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_plain/python/Pulumi.yaml
+++ b/tests/integration/construct_component_plain/python/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_component_plain_py
 description: A program that constructs a remote component resource with prompt inputs.
 runtime: python
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/construct_component_unknown/go/Pulumi.yaml
+++ b/tests/integration/construct_component_unknown/go/Pulumi.yaml
@@ -1,3 +1,8 @@
 name: construct_component_unknown_go
 description: A program that constructs remote component resources with unknowns during preview.
 runtime: go
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider
+

--- a/tests/integration/construct_component_unknown/nodejs/Pulumi.yaml
+++ b/tests/integration/construct_component_unknown/nodejs/Pulumi.yaml
@@ -1,3 +1,8 @@
 name: construct_component_unknown_nodejs
 description: A program that constructs remote component resources with unknowns during preview.
 runtime: nodejs
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider
+

--- a/tests/integration/construct_component_unknown/python/Pulumi.yaml
+++ b/tests/integration/construct_component_unknown/python/Pulumi.yaml
@@ -1,3 +1,8 @@
 name: construct_component_unknown_py
 description: A program that constructs remote component resources with unknowns during preview.
 runtime: python
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider
+

--- a/tests/integration/construct_nested_component/go/Pulumi.yaml
+++ b/tests/integration/construct_nested_component/go/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: construct_nested_component_go
 description: A program that constructs remote component resources.
 runtime: go
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/gather_plugin/go/Pulumi.yaml
+++ b/tests/integration/gather_plugin/go/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: test-provider-url-go
 runtime: go
 description: A minimal Go Pulumi program
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/gather_plugin/nodejs/Pulumi.yaml
+++ b/tests/integration/gather_plugin/nodejs/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: test-provider-url
 runtime: nodejs
 description: A minimal Go Pulumi program
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/gather_plugin/python/Pulumi.yaml
+++ b/tests/integration/gather_plugin/python/Pulumi.yaml
@@ -4,3 +4,7 @@ runtime:
   options:
     virtualenv: venv
 description: A minimal Python Pulumi program
+plugins:
+  providers:
+    - name: testprovider
+      path: ../../../testprovider

--- a/tests/integration/integration_go_smoke_test.go
+++ b/tests/integration/integration_go_smoke_test.go
@@ -104,7 +104,6 @@ func TestConstructGo(t *testing.T) {
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t, optsForConstructGo(t, testDir, test.expectedResourceCount, localProviders, test.env...))
@@ -119,7 +118,6 @@ func TestNestedConstructGo(t *testing.T) {
 
 	localProviders :=
 		[]integration.LocalDependency{
-			{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 			{Package: "testcomponent", Path: filepath.Join(testDir, "testcomponent-go")},
 			{Package: "secondtestcomponent", Path: filepath.Join(testDir, "testcomponent2-go")}}
 	integration.ProgramTest(t, optsForConstructGo(t, "construct_nested_component", 18, localProviders))

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -545,7 +545,6 @@ func TestConstructPlainGo(t *testing.T) {
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t,
@@ -835,7 +834,7 @@ func TestDeletedWithGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
+			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
 		},
 		Quick: true,
 	})

--- a/tests/integration/integration_nodejs_smoke_test.go
+++ b/tests/integration/integration_nodejs_smoke_test.go
@@ -90,7 +90,6 @@ func TestConstructNode(t *testing.T) {
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t,

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -885,7 +885,6 @@ func TestConstructPlainNode(t *testing.T) {
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t,
@@ -1292,7 +1291,7 @@ func TestDeletedWithNode(t *testing.T) {
 		Dir:          filepath.Join("deleted_with", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
+			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
 		},
 		Quick: true,
 	})
@@ -1301,7 +1300,7 @@ func TestDeletedWithNode(t *testing.T) {
 // Tests custom resource type name of dynamic provider.
 func TestCustomResourceTypeNameDynamicNode(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir: filepath.Join("dynamic", "nodejs-resource-type-name"),
+		Dir:          filepath.Join("dynamic", "nodejs-resource-type-name"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			urnOut := stack.Outputs["urn"].(string)

--- a/tests/integration/integration_python_smoke_test.go
+++ b/tests/integration/integration_python_smoke_test.go
@@ -129,7 +129,6 @@ func TestConstructPython(t *testing.T) {
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t,

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -620,7 +620,6 @@ func TestConstructPlainPython(t *testing.T) {
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t,
@@ -1015,7 +1014,7 @@ func TestDeletedWithPython(t *testing.T) {
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
+			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
 		},
 		Quick: true,
 	})

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -602,9 +602,6 @@ func TestProviderDownloadURL(t *testing.T) {
 	for _, lang := range languages {
 		lang := lang
 		t.Run(lang.name, func(t *testing.T) {
-			localProvider := integration.LocalDependency{
-				Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider")),
-			}
 			dir := filepath.Join("gather_plugin", lang.name)
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
 				Dir:                    dir,
@@ -612,7 +609,6 @@ func TestProviderDownloadURL(t *testing.T) {
 				SkipPreview:            true,
 				SkipEmptyPreviewUpdate: true,
 				Dependencies:           []string{lang.dependency},
-				LocalProviders:         []integration.LocalDependency{localProvider},
 			})
 		})
 	}

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -22,13 +22,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -179,7 +177,6 @@ func testConstructUnknown(t *testing.T, lang string, dependencies ...string) {
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -222,7 +219,6 @@ func testConstructMethodsUnknown(t *testing.T, lang string, dependencies ...stri
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -238,37 +234,6 @@ func testConstructMethodsUnknown(t *testing.T, lang string, dependencies ...stri
 			})
 		})
 	}
-}
-
-func buildTestProvider(t *testing.T, providerDir string) string {
-	fn := func() {
-		providerName := "pulumi-resource-testprovider"
-		if runtime.GOOS == "windows" {
-			providerName += ".exe"
-		}
-
-		_, err := os.Stat(filepath.Join(providerDir, providerName))
-		if err == nil {
-			return
-		} else if errors.Is(err, os.ErrNotExist) {
-			// Not built yet, continue.
-		} else {
-			t.Fatalf("Unexpected error building test provider: %v", err)
-		}
-
-		cmd := exec.Command("go", "build", "-o", providerName)
-		cmd.Dir = providerDir
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			contract.AssertNoErrorf(err, "failed to run setup script: %v", string(output))
-		}
-	}
-	lockfile := filepath.Join(providerDir, ".lock")
-	timeout := 10 * time.Minute
-	synchronouslyDo(t, lockfile, timeout, fn)
-
-	// Allows us to drop this in in places where providerDir was used:
-	return providerDir
 }
 
 func runComponentSetup(t *testing.T, testDir string) {
@@ -346,7 +311,6 @@ func testConstructMethodsResources(t *testing.T, lang string, dependencies ...st
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -444,7 +408,6 @@ func testConstructOutputValues(t *testing.T, lang string, dependencies ...string
 		t.Run(test.componentDir, func(t *testing.T) {
 			localProviders :=
 				[]integration.LocalDependency{
-					{Package: "testprovider", Path: buildTestProvider(t, filepath.Join("..", "testprovider"))},
 					{Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir)},
 				}
 			integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Instead of setting testprovider via the ProgramTest.LocalProviders option use the plugin link capabilities in Pulumi.yaml instead.

This gives test coverage of both the plugin yaml option, and also the use of that option with ProgramTest (with and without LocalProviders being set as well, because we still use that for the component provider tests).

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
