### PR TITLE
Don't print the update plan message if using --json

### DIFF
--- a/changelog/pending/20221123--cli--dont-print-update-plan-message-with-json.yaml
+++ b/changelog/pending/20221123--cli--dont-print-update-plan-message-with-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Don't print update plan message with --json.

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -261,14 +261,16 @@ func newPreviewCmd() *cobra.Command {
 						return result.FromError(err)
 					}
 
-					// Write out message on how to use the plan
-					var buf bytes.Buffer
-					fprintf(&buf, "Update plan written to '%s'", planFilePath)
-					fprintf(
-						&buf,
-						"\nRun `pulumi up --plan='%s'` to constrain the update to the operations planned by this preview",
-						planFilePath)
-					cmdutil.Diag().Infof(diag.RawMessage("" /*urn*/, buf.String()))
+					// Write out message on how to use the plan (if not writing out --json)
+					if !jsonDisplay {
+						var buf bytes.Buffer
+						fprintf(&buf, "Update plan written to '%s'", planFilePath)
+						fprintf(
+							&buf,
+							"\nRun `pulumi up --plan='%s'` to constrain the update to the operations planned by this preview",
+							planFilePath)
+						cmdutil.Diag().Infof(diag.RawMessage("" /*urn*/, buf.String()))
+					}
 				}
 				return nil
 			}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/11453

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
