### PR TITLE
Fix the aws-eks programgen example

### DIFF
--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -373,11 +373,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				g.genRange(w, call, true)
 				return
 			}
-			g.Fgenf(w, "%.20v.map((k, v)", expr.Args[0])
+			// Mapping over a list with a tuple receiver accepts (value, index).
+			g.Fgenf(w, "%.20v.map((v, k)", expr.Args[0])
 		case *model.MapType, *model.ObjectType:
 			g.Fgenf(w, "Object.entries(%.v).map(([k, v])", expr.Args[0])
 		}
-		g.Fgenf(w, " => {key: k, value: v})")
+		g.Fgenf(w, " => ({key: k, value: v}))")
 	case "fileArchive":
 		g.Fgenf(w, "new pulumi.asset.FileArchive(%.v)", expr.Args[0])
 	case "remoteArchive":

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -77,8 +77,6 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "aws-eks",
 		Description: "AWS EKS",
-		SkipCompile: codegen.NewStringSet("nodejs"),
-		// Blocked on nodejs: TODO[pulumi/pulumi#8067]
 	},
 	{
 		Directory:   "aws-fargate",

--- a/pkg/codegen/testing/test/testdata/aws-eks-pp/nodejs/aws-eks.ts
+++ b/pkg/codegen/testing/test/testdata/aws-eks-pp/nodejs/aws-eks.ts
@@ -31,7 +31,7 @@ export = async () => {
     // Subnets, one for each AZ in a region
     const zones = await aws.getAvailabilityZones({});
     const vpcSubnet: aws.ec2.Subnet[] = [];
-    for (const range of zones.names.map((k, v) => {key: k, value: v})) {
+    for (const range of zones.names.map((v, k) => ({key: k, value: v}))) {
         vpcSubnet.push(new aws.ec2.Subnet(`vpcSubnet-${range.key}`, {
             assignIpv6AddressOnCreation: false,
             vpcId: eksVpc.id,
@@ -44,7 +44,7 @@ export = async () => {
         }));
     }
     const rta: aws.ec2.RouteTableAssociation[] = [];
-    for (const range of zones.names.map((k, v) => {key: k, value: v})) {
+    for (const range of zones.names.map((v, k) => ({key: k, value: v}))) {
         rta.push(new aws.ec2.RouteTableAssociation(`rta-${range.key}`, {
             routeTableId: eksRouteTable.id,
             subnetId: vpcSubnet[range.key].id,

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
@@ -9,7 +9,7 @@ const siteBucket = new aws.s3.Bucket("siteBucket", {website: {
 const siteDir = "www";
 // For each file in the directory, create an S3 object stored in `siteBucket`
 const files: aws.s3.BucketObject[] = [];
-for (const range of fs.readDirSync(siteDir).map((k, v) => {key: k, value: v})) {
+for (const range of fs.readDirSync(siteDir).map((v, k) => ({key: k, value: v}))) {
     files.push(new aws.s3.BucketObject(`files-${range.key}`, {
         bucket: siteBucket.id,
         key: range.value,


### PR DESCRIPTION
Fix TS list iteration. This involves fixing `lambda` generation when exporting an object, as well as fixing the argument order when mapping over arrays.

Fixes #8067 