### PR TITLE
Disable failing windows-winget-install wokflow from download cron job

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -94,27 +94,6 @@ jobs:
         run: |
           echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
           exit 1
-  windows-winget-install:
-    name: Install Pulumi with WinGet on Windows
-    runs-on: windows-latest
-    steps:
-      - name: Install WinGet CLI
-        shell: powershell
-        run: |
-          try { winget --help } catch { Add-AppxPackage -Path https://aka.ms/getwinget }
-      - name: Install Pulumi Using Winget
-        run: winget install pulumi
-      - name: Pulumi Version Details
-        id: vars
-        shell: bash
-        run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
-      - name: Error if incorrect version found
-        if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
-        run: |
-          echo "Expected version ${{ steps.vars.outputs.expected-version }} but found ${{ steps.vars.outputs.installed-version }}"
-          exit 1
   windows-direct-install:
     name: Install Pulumi via script on Windows
     runs-on: windows-latest


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Partially addresses #11342 because there is no sane way to install winget-cli unless already installed and it keeps failing our CI checks. For the time being, disabling the check so that we don't get failures and look into the issue again 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
