### PR TITLE
Fix NodeJS SDK when a component is using another component from the same schema as a property

### DIFF
--- a/changelog/pending/20221125--sdkgen-nodejs--fix-nodejs-sdk-when-a-component-is-using-another-component-from-the-same-schema-as-a-property.yaml
+++ b/changelog/pending/20221125--sdkgen-nodejs--fix-nodejs-sdk-when-a-component-is-using-another-component-from-the-same-schema-as-a-property.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/nodejs
+  description: Fix NodeJS SDK when a component is using another component from the same schema as a property

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -250,10 +250,12 @@ func (mod *modContext) resourceType(r *schema.ResourceType) string {
 		pkg = r.Resource.Package
 	}
 	namingCtx, pkgName, external := mod.namingContext(pkg)
-	if external {
-		pkgName = externalModuleName(pkgName)
+	if !external {
+		name := tokenToName(r.Token)
+		return title(name)
 	}
 
+	pkgName = externalModuleName(pkgName)
 	modName, name := namingCtx.tokenToModName(r.Token), tokenToName(r.Token)
 
 	return pkgName + modName + title(name)


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The code generated for the NodeJS SDK is broken when a component is using another component from the same schema as a property where the token doesn't start with `<provider-name>:index:`.

Fixes #11466

I've created a test project to verify the issue and to verify the fix:

- Using pulumi upstream: https://github.com/pasqualet/test-pulumi-schema
- Using pulumi this fix: https://github.com/pasqualet/test-pulumi-schema/tree/fix

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
