### PR TITLE
Improve `bors` merge reliability: Windows smoke tests are advisory and run with reduced parallelism

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -50,6 +50,11 @@ on:
             "nodejs": "14.x",
             "python": "3.9.x"
           }
+      continue-on-error:
+        description: "Whether to continue running the job if the step fails"
+        required: false
+        default: false
+        type: boolean
 
 
 defaults:
@@ -83,6 +88,8 @@ jobs:
 
     runs-on: ${{ inputs.platform }}
 
+    timeout-minutes: 60
+    continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       - name: "Windows cache workaround"
         # https://github.com/actions/cache/issues/752#issuecomment-1222415717

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -132,14 +132,6 @@ jobs:
         if: ${{ inputs.enable-coverage && runner.os != 'Windows' }}
         run: |
           echo "PULUMI_TEST_COVERAGE_PATH=$(pwd)/coverage" >> "$GITHUB_ENV"
-      # See: https://github.com/actions/virtual-environments/issues/2642#issuecomment-774988591
-      - name: Configure Windows pagefile
-        uses: aaronfriel/action-configure-pagefile@v2.0-beta.1
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          minimum-size: 4GB
-          maximum-size: 4GB
-          disk-root: "D:"
       - name: Configure Go Cache Key
         env:
           CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,7 @@ jobs:
     name: Smoke Test${{ matrix.platform && '' }}
     needs: [matrix, build-binaries, build-sdks]
     if: ${{ needs.matrix.outputs.smoke-test-matrix != '{}' }}
+    # alow jobs to fail if the platform contains windows
     strategy:
       fail-fast: ${{ contains(needs.matrix.outputs.smoke-test-matrix, 'macos') }}
       matrix: ${{ fromJson(needs.matrix.outputs.smoke-test-matrix) }}
@@ -309,6 +310,7 @@ jobs:
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
       version-set: ${{ toJson(matrix.version-set) }}
+      continue-on-error: ${{ contains(matrix.platform, 'windows') }}
     secrets: inherit
 
   test-collect-reports:

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -391,6 +391,9 @@ def get_matrix(
 
         test_suites += run_gotestsum_ci_matrix_single_package(item, pkg_tests, tags)
 
+    if kind == JobKind.SMOKE_TEST:
+        platforms = list(map(lambda p: "windows-8core-2022" if p == "windows-latest" else p, platforms))
+
     return {
         "test-suite": test_suites,
         "platform": platforms,


### PR DESCRIPTION
The `continue-on-error` flag is set to true whenever the matrix platform contains "windows" for smoke tests. This does mean these jobs will allow failures and proceed, however this should substantially reduce the false negatives due to the behavior of the CI platform. Per the response from GitHub support ticket on my account:

> I've confirmed that our engineering team has an open backlog item focused around "protecting" the provisioning service in cases of resource starvation. I believe this will address your exact concerns so that high resource consumption does not result in an abandoned job.
> 
> In the meantime, there unfortunately is not much capability exposed for affecting priority on the VM. Until improvements are implemented, our team still recommends trying to reduce load on the CPU at the point(s) in the workflow where the job consistently is getting abandoned.

I hope that setting this option, reducing Windows test parallelism, and setting timeouts appropriately will help improve CI reliability. 

Our CI jobs typically complete in 35 minutes, any longer indicates high likelihood that the runner has failed.