### PR TITLE
Fix capitalization for generated `fs.readdirSync`

### DIFF
--- a/changelog/pending/20221128--programgen-nodejs--fix-capitalization-when-generating-fs-readdirsync.yaml
+++ b/changelog/pending/20221128--programgen-nodejs--fix-capitalization-when-generating-fs-readdirsync.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Fix capitalization when generating `fs.readdirSync`.

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -429,7 +429,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "readFile":
 		g.Fgenf(w, "fs.readFileSync(%v)", expr.Args[0])
 	case "readDir":
-		g.Fgenf(w, "fs.readDirSync(%v)", expr.Args[0])
+		g.Fgenf(w, "fs.readdirSync(%v)", expr.Args[0])
 	case "secret":
 		g.Fgenf(w, "pulumi.secret(%v)", expr.Args[0])
 	case "split":

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -66,13 +66,12 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:      "aws-s3-folder",
 		Description:    "AWS S3 Folder",
-		ExpectNYIDiags: allProgLanguages.Except("go"),
-		SkipCompile:    allProgLanguages.Except("dotnet"),
+		ExpectNYIDiags: codegen.NewStringSet("dotnet", "python"),
+		SkipCompile:    codegen.NewStringSet("go", "python"),
 		// Blocked on python: TODO[pulumi/pulumi#8062]: Re-enable this test.
 		// Blocked on go:
 		//   TODO[pulumi/pulumi#8064]
 		//   TODO[pulumi/pulumi#8065]
-		// Blocked on nodejs: TODO[pulumi/pulumi#8063]
 	},
 	{
 		Directory:   "aws-eks",

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/nodejs/aws-s3-folder.ts
@@ -9,7 +9,7 @@ const siteBucket = new aws.s3.Bucket("siteBucket", {website: {
 const siteDir = "www";
 // For each file in the directory, create an S3 object stored in `siteBucket`
 const files: aws.s3.BucketObject[] = [];
-for (const range of fs.readDirSync(siteDir).map((v, k) => ({key: k, value: v}))) {
+for (const range of fs.readdirSync(siteDir).map((v, k) => ({key: k, value: v}))) {
     files.push(new aws.s3.BucketObject(`files-${range.key}`, {
         bucket: siteBucket.id,
         key: range.value,


### PR DESCRIPTION
This lets us reenable the `"aws-s3-folder"` programgen test for nodejs.