### PR TITLE
Add go 1.18 workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,6 @@
             "-sdk/nodejs/tests",
             "-sdk/python/env"
         ],
-        // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
-        "experimentalWorkspaceModule": true,
     },
 
     "omnisharp.defaultLaunchSolution": "sdk/dotnet/dotnet.sln",

--- a/go.work
+++ b/go.work
@@ -1,0 +1,8 @@
+go 1.19
+
+use (
+	./developer-docs
+	./pkg
+	./sdk
+	./tests
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,3 @@
+github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=


### PR DESCRIPTION
Remove the experimentalWorkspaceModule setting from vscode settings and add a go.work file for the four top level modules contained in this repo.