### PR TITLE
codegen/go: Remove superfluous newline in doc.go

### DIFF
--- a/changelog/pending/20221111--sdkgen-go--fixes-superfluous-newline-being-added-between-documentation-comment-and-package-statement-in-doc-go.yaml
+++ b/changelog/pending/20221111--sdkgen-go--fixes-superfluous-newline-being-added-between-documentation-comment-and-package-statement-in-doc-go.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Fixes superfluous newline being added between documentation comment and package statement in doc.go

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -841,6 +841,9 @@ func (pkg *pkgContext) toOutputMethod(t schema.Type) string {
 	return "To" + outputTypeName
 }
 
+// printComment filters examples for the Go languages and prepends double forward slash to each line in the given
+// comment. If indent is true, each line is indented with tab character. It returns the number of lines in the
+// resulting comment. It guarantees that each line is terminated with newline character.
 func printComment(w io.Writer, comment string, indent bool) int {
 	comment = codegen.FilterExamples(comment, "go")
 
@@ -1315,7 +1318,6 @@ func (pkg *pkgContext) fieldName(r *schema.Resource, field *schema.Property) str
 
 func (pkg *pkgContext) genPlainType(w io.Writer, name, comment, deprecationMessage string,
 	properties []*schema.Property) {
-
 	printCommentWithDeprecationMessage(w, comment, deprecationMessage, false)
 	fmt.Fprintf(w, "type %s struct {\n", name)
 	for _, p := range properties {
@@ -3605,7 +3607,6 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			} else {
 				fmt.Fprintf(buffer, "// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.\n", name)
 			}
-			fmt.Fprintf(buffer, "\n")
 			fmt.Fprintf(buffer, "package %s\n", name)
 
 			setFile(path.Join(mod, "doc.go"), buffer.String())

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/go/azure/doc.go
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/go/azure/doc.go
@@ -1,3 +1,2 @@
 // A native Pulumi package for creating and managing Azure resources.
-
 package azure

--- a/pkg/codegen/testing/test/testdata/cyclic-types/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/doc.go
@@ -1,3 +1,2 @@
 // Package foo exports types, functions, subpackages for provisioning foo resources.
-
 package foo

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/doc.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/doc.go
@@ -1,3 +1,2 @@
 // Package plantprovider exports types, functions, subpackages for provisioning plantprovider resources.
-
 package plantprovider

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/doc.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/doc.go
@@ -1,3 +1,2 @@
 // Package plant exports types, functions, subpackages for provisioning plant resources.
-
 package plant

--- a/pkg/codegen/testing/test/testdata/enum-reference/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/enum-reference/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/functions-secrets/go/mypkg/doc.go
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/go/mypkg/doc.go
@@ -1,3 +1,2 @@
 // Package mypkg exports types, functions, subpackages for provisioning mypkg resources.
-
 package mypkg

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/doc.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/doc.go
@@ -1,3 +1,2 @@
 // Package repro exports types, functions, subpackages for provisioning repro resources.
-
 package repro

--- a/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/doc.go
+++ b/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/doc.go
@@ -1,3 +1,2 @@
 // Package repro exports types, functions, subpackages for provisioning repro resources.
-
 package repro

--- a/pkg/codegen/testing/test/testdata/hyphen-url/go/registrygeoreplication/doc.go
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/go/registrygeoreplication/doc.go
@@ -1,3 +1,2 @@
 // Package registrygeoreplication exports types, functions, subpackages for provisioning registrygeoreplication resources.
-
 package registrygeoreplication

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/doc.go
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/go/repro/doc.go
@@ -1,3 +1,2 @@
 // Package repro exports types, functions, subpackages for provisioning repro resources.
-
 package repro

--- a/pkg/codegen/testing/test/testdata/internal-dependencies-go/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/internal-dependencies-go/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/doc.go
@@ -1,3 +1,2 @@
 // Package foo exports types, functions, subpackages for provisioning foo resources.
-
 package foo

--- a/pkg/codegen/testing/test/testdata/nested-module/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/nested-module/go/foo/doc.go
@@ -1,3 +1,2 @@
 // Package foo exports types, functions, subpackages for provisioning foo resources.
-
 package foo

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/doc.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/doc.go
@@ -1,3 +1,2 @@
 // Package myedgeorder exports types, functions, subpackages for provisioning myedgeorder resources.
-
 package myedgeorder

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/doc.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/doc.go
@@ -1,3 +1,2 @@
 // Package mypkg exports types, functions, subpackages for provisioning mypkg resources.
-
 package mypkg

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/doc.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/doc.go
@@ -1,3 +1,2 @@
 // Package mypkg exports types, functions, subpackages for provisioning mypkg resources.
-
 package mypkg

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/doc.go
@@ -1,3 +1,2 @@
 // Package foo exports types, functions, subpackages for provisioning foo resources.
-
 package foo

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/doc.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/doc.go
@@ -1,3 +1,2 @@
 // Package xyz exports types, functions, subpackages for provisioning xyz resources.
-
 package xyz

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/doc.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/doc.go
@@ -1,3 +1,2 @@
 // Package configstation exports types, functions, subpackages for provisioning configstation resources.
-
 package configstation

--- a/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/doc.go
+++ b/pkg/codegen/testing/test/testdata/regress-8403/go/mongodbatlas/doc.go
@@ -1,3 +1,2 @@
 // Package mongodbatlas exports types, functions, subpackages for provisioning mongodbatlas resources.
-
 package mongodbatlas

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/doc.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/doc.go
@@ -1,3 +1,2 @@
 // Package world exports types, functions, subpackages for provisioning world resources.
-
 package world

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/doc.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/doc.go
@@ -1,3 +1,2 @@
 // Package my8664 exports types, functions, subpackages for provisioning my8664 resources.
-
 package my8664

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/doc.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/doc.go
@@ -1,3 +1,2 @@
 // Package my8110 exports types, functions, subpackages for provisioning my8110 resources.
-
 package my8110

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/secrets/go/mypkg/doc.go
+++ b/pkg/codegen/testing/test/testdata/secrets/go/mypkg/doc.go
@@ -1,3 +1,2 @@
 // Package mypkg exports types, functions, subpackages for provisioning mypkg resources.
-
 package mypkg

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/doc.go
@@ -1,3 +1,2 @@
 // Package plant exports types, functions, subpackages for provisioning plant resources.
-
 package plant

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/doc.go
@@ -1,3 +1,2 @@
 // Package different exports types, functions, subpackages for provisioning different resources.
-
 package different

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/doc.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/doc.go
@@ -1,3 +1,2 @@
 // Package example exports types, functions, subpackages for provisioning example resources.
-
 package example


### PR DESCRIPTION
# Description

This change fixes the package documentation comment generation that was broken since #10317.

That is, Go requires package documentation comment to be strictly before the package statement without newlines in-between.

**Good**
```
// Package good has documentation comment.
package bad
```

**Bad**
```
// Package bad does no have a documentation comment.

package bad
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
