### PR TITLE
area/cli: removed checks for PULUMI_DISABLE_RESOURCE_REFERENCES in cli

### DIFF
--- a/changelog/pending/20230114--cli-engine--removed-checks-for-pulumi_disable_resource_references.yaml
+++ b/changelog/pending/20230114--cli-engine--removed-checks-for-pulumi_disable_resource_references.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/engine
+  description: removed checks for PULUMI_DISABLE_RESOURCE_REFERENCES

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -238,16 +238,15 @@ func newDestroyCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				Parallel:                  parallel,
-				Debug:                     debug,
-				Refresh:                   refreshOption,
-				DestroyTargets:            deploy.NewUrnTargets(targetUrns),
-				TargetDependents:          targetDependents,
-				UseLegacyDiff:             useLegacyDiff(),
-				DisableProviderPreview:    disableProviderPreview(),
-				DisableResourceReferences: disableResourceReferences(),
-				DisableOutputValues:       disableOutputValues(),
-				Experimental:              hasExperimentalCommands(),
+				Parallel:               parallel,
+				Debug:                  debug,
+				Refresh:                refreshOption,
+				DestroyTargets:         deploy.NewUrnTargets(targetUrns),
+				TargetDependents:       targetDependents,
+				UseLegacyDiff:          useLegacyDiff(),
+				DisableProviderPreview: disableProviderPreview(),
+				DisableOutputValues:    disableOutputValues(),
+				Experimental:           hasExperimentalCommands(),
 			}
 
 			_, res := s.Destroy(ctx, backend.UpdateOperation{

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -213,17 +213,16 @@ func newPreviewCmd() *cobra.Command {
 
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
-					LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
-					Parallel:                  parallel,
-					Debug:                     debug,
-					Refresh:                   refreshOption,
-					ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
-					UseLegacyDiff:             useLegacyDiff(),
-					DisableProviderPreview:    disableProviderPreview(),
-					DisableResourceReferences: disableResourceReferences(),
-					DisableOutputValues:       disableOutputValues(),
-					UpdateTargets:             deploy.NewUrnTargets(targetURNs),
-					TargetDependents:          targetDependents,
+					LocalPolicyPacks:       engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
+					Parallel:               parallel,
+					Debug:                  debug,
+					Refresh:                refreshOption,
+					ReplaceTargets:         deploy.NewUrnTargets(replaceURNs),
+					UseLegacyDiff:          useLegacyDiff(),
+					DisableProviderPreview: disableProviderPreview(),
+					DisableOutputValues:    disableOutputValues(),
+					UpdateTargets:          deploy.NewUrnTargets(targetURNs),
+					TargetDependents:       targetDependents,
 					// If we're trying to save a plan then we _need_ to generate it. We also turn this on in
 					// experimental mode to just get more testing of it.
 					GeneratePlan: hasExperimentalCommands() || planFilePath != "",

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -248,14 +248,13 @@ func newRefreshCmd() *cobra.Command {
 			targetUrns = append(targetUrns, *targets...)
 
 			opts.Engine = engine.UpdateOptions{
-				Parallel:                  parallel,
-				Debug:                     debug,
-				UseLegacyDiff:             useLegacyDiff(),
-				DisableProviderPreview:    disableProviderPreview(),
-				DisableResourceReferences: disableResourceReferences(),
-				DisableOutputValues:       disableOutputValues(),
-				RefreshTargets:            deploy.NewUrnTargets(targetUrns),
-				Experimental:              hasExperimentalCommands(),
+				Parallel:               parallel,
+				Debug:                  debug,
+				UseLegacyDiff:          useLegacyDiff(),
+				DisableProviderPreview: disableProviderPreview(),
+				DisableOutputValues:    disableOutputValues(),
+				RefreshTargets:         deploy.NewUrnTargets(targetUrns),
+				Experimental:           hasExperimentalCommands(),
 			}
 
 			changes, res := s.Refresh(ctx, backend.UpdateOperation{

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -139,18 +139,17 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(err)
 		}
 		opts.Engine = engine.UpdateOptions{
-			LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
-			Parallel:                  parallel,
-			Debug:                     debug,
-			Refresh:                   refreshOption,
-			RefreshTargets:            deploy.NewUrnTargets(targetURNs),
-			ReplaceTargets:            deploy.NewUrnTargets(replaceURNs),
-			UseLegacyDiff:             useLegacyDiff(),
-			DisableProviderPreview:    disableProviderPreview(),
-			DisableResourceReferences: disableResourceReferences(),
-			DisableOutputValues:       disableOutputValues(),
-			UpdateTargets:             deploy.NewUrnTargets(targetURNs),
-			TargetDependents:          targetDependents,
+			LocalPolicyPacks:       engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
+			Parallel:               parallel,
+			Debug:                  debug,
+			Refresh:                refreshOption,
+			RefreshTargets:         deploy.NewUrnTargets(targetURNs),
+			ReplaceTargets:         deploy.NewUrnTargets(replaceURNs),
+			UseLegacyDiff:          useLegacyDiff(),
+			DisableProviderPreview: disableProviderPreview(),
+			DisableOutputValues:    disableOutputValues(),
+			UpdateTargets:          deploy.NewUrnTargets(targetURNs),
+			TargetDependents:       targetDependents,
 			// Trigger a plan to be generated during the preview phase which can be constrained to during the
 			// update phase.
 			GeneratePlan: true,

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -76,10 +76,6 @@ func disableProviderPreview() bool {
 	return env.DisableProviderPreview.Value()
 }
 
-func disableResourceReferences() bool {
-	return env.DisableResourceReferences.Value()
-}
-
 func disableOutputValues() bool {
 	return env.DisableOutputValues.Value()
 }

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -130,15 +130,14 @@ func newWatchCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
-				Parallel:                  parallel,
-				Debug:                     debug,
-				Refresh:                   refresh,
-				UseLegacyDiff:             useLegacyDiff(),
-				DisableProviderPreview:    disableProviderPreview(),
-				DisableResourceReferences: disableResourceReferences(),
-				DisableOutputValues:       disableOutputValues(),
-				Experimental:              hasExperimentalCommands(),
+				LocalPolicyPacks:       engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
+				Parallel:               parallel,
+				Debug:                  debug,
+				Refresh:                refresh,
+				UseLegacyDiff:          useLegacyDiff(),
+				DisableProviderPreview: disableProviderPreview(),
+				DisableOutputValues:    disableOutputValues(),
+				Experimental:           hasExperimentalCommands(),
 			}
 
 			res := s.Watch(ctx, backend.UpdateOperation{

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -271,20 +271,19 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions, policy
 	var walkResult result.Result
 	go func() {
 		opts := deploy.Options{
-			Events:                    actions,
-			Parallel:                  deployment.Options.Parallel,
-			Refresh:                   deployment.Options.Refresh,
-			RefreshOnly:               deployment.Options.isRefresh,
-			RefreshTargets:            deployment.Options.RefreshTargets,
-			ReplaceTargets:            deployment.Options.ReplaceTargets,
-			DestroyTargets:            deployment.Options.DestroyTargets,
-			UpdateTargets:             deployment.Options.UpdateTargets,
-			TargetDependents:          deployment.Options.TargetDependents,
-			TrustDependencies:         deployment.Options.trustDependencies,
-			UseLegacyDiff:             deployment.Options.UseLegacyDiff,
-			DisableResourceReferences: deployment.Options.DisableResourceReferences,
-			DisableOutputValues:       deployment.Options.DisableOutputValues,
-			GeneratePlan:              deployment.Options.UpdateOptions.GeneratePlan,
+			Events:              actions,
+			Parallel:            deployment.Options.Parallel,
+			Refresh:             deployment.Options.Refresh,
+			RefreshOnly:         deployment.Options.isRefresh,
+			RefreshTargets:      deployment.Options.RefreshTargets,
+			ReplaceTargets:      deployment.Options.ReplaceTargets,
+			DestroyTargets:      deployment.Options.DestroyTargets,
+			UpdateTargets:       deployment.Options.UpdateTargets,
+			TargetDependents:    deployment.Options.TargetDependents,
+			TrustDependencies:   deployment.Options.trustDependencies,
+			UseLegacyDiff:       deployment.Options.UseLegacyDiff,
+			DisableOutputValues: deployment.Options.DisableOutputValues,
+			GeneratePlan:        deployment.Options.UpdateOptions.GeneratePlan,
 		}
 		newPlan, walkResult = deployment.Deployment.Execute(ctx, opts, preview)
 		close(done)

--- a/pkg/engine/lifecycletest/resource_reference_test.go
+++ b/pkg/engine/lifecycletest/resource_reference_test.go
@@ -224,7 +224,7 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
 
 	p := &TestPlan{
-		Options: UpdateOptions{Host: host, DisableResourceReferences: true},
+		Options: UpdateOptions{Host: host},
 		Steps:   MakeBasicLifecycleSteps(t, 4),
 	}
 	p.Run(t, nil)

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -135,9 +135,6 @@ type UpdateOptions struct {
 	// true if the engine should disable provider previews.
 	DisableProviderPreview bool
 
-	// true if the engine should disable resource reference support.
-	DisableResourceReferences bool
-
 	// true if the engine should disable output value support.
 	DisableOutputValues bool
 


### PR DESCRIPTION
Removed checks for `PULUMI_DISABLE_RESOURCE_REFERENCES` env in cli and engine

Related to #11385

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

partially fixes #11385 (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
