### PR TITLE
[sdk/nodejs] Fix regression when passing a provider to a MLC

### DIFF
--- a/changelog/pending/20221201--sdk-nodejs--fix-regression-when-passing-a-provider-to-a-mlc.yaml
+++ b/changelog/pending/20221201--sdk-nodejs--fix-regression-when-passing-a-provider-to-a-mlc.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix regression when passing a provider to a MLC

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -529,7 +529,7 @@ async function prepareResource(label: string, res: Resource, parent: Resource | 
 
         let providerRef: string | undefined;
         let importID: ID | undefined;
-        if (custom || remote) {
+        if (custom) {
             const customOpts = <CustomResourceOptions>opts;
             importID = customOpts.import;
             providerRef = await ProviderResource.register(opts.provider);

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -1214,6 +1214,7 @@ describe("rpc", () => {
                                propertyDeps?: any, ignoreChanges?: string[], version?: string, importID?: string,
                                replaceOnChanges?: string[], providers?: any) => {
                 if (name === "singular" || name === "map" || name === "array") {
+                    assert.strictEqual(provider, "");
                     assert.deepStrictEqual(Object.keys(providers), ["test"]);
                 }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };


### PR DESCRIPTION
#11093 changed the Node.js SDK to pass a provider specified in a MLC's `ResourceOptions.provider` to the engine.

Unfortunately, this regresses behavior that existing programs rely on. For example:

```ts
import * as aws from "@pulumi/aws";
import * as awsx from "@pulumi/awsx";

const myRegion = new aws.Provider("us-east-1", {
  region: "us-east-1",
});

const vpc = new awsx.ec2.Vpc("awsx-nodejs-default-args", {}, { provider: myRegion });
```

In the above program, an explicit _aws_ provider is being passed to the _aws**x**_ `VPC` component, with the intention that the _aws_ provider will be used as the provider for all of `Vpc`'s children.

With the change in #11093, the engine would try to call `Construct` for the `Vpc` using the specified `aws` provider, which does not work (it fails with `plugins that can construct components must support secrets`).

This change reverts the problematic change from #11093 and adds a regression test to lock-in the previous behavior.

Note: We do want to be able to support specifying a MLC's provider (to allow explicit providers for MLCs), but we'll address that in a separate change. (I'll open an issue).

Fixes #11316