### PR TITLE
[typescript/sdk-gen] Generate JS doc comments for output-versioned invokes

### DIFF
--- a/changelog/pending/20221202--sdkgen-nodejs--generate-js-doc-comments-for-output-versioned-invokes-and-use-explicit-any-type.yaml
+++ b/changelog/pending/20221202--sdkgen-nodejs--generate-js-doc-comments-for-output-versioned-invokes-and-use-explicit-any-type.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/nodejs
+  description: Generate JS doc comments for output-versioned invokes and use explicit any type.

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1182,6 +1182,13 @@ func (mod *modContext) genFunctionOutputVersion(
 		return info, nil
 	}
 
+	// Write the TypeDoc/JSDoc for the data source function.
+	printComment(w, codegen.FilterExamples(fun.Comment, "typescript"), "", "")
+
+	if fun.DeprecationMessage != "" {
+		fmt.Fprintf(w, "/** @deprecated %s */\n", fun.DeprecationMessage)
+	}
+
 	originalName := tokenToFunctionName(fun.Token)
 	fnOutput := fmt.Sprintf("%sOutput", originalName)
 	info.functionOutputVersionName = fnOutput
@@ -1195,9 +1202,8 @@ func (mod *modContext) genFunctionOutputVersion(
 	}
 	argsig = fmt.Sprintf("args%s: %s, ", optFlag, argTypeName)
 
-	fmt.Fprintf(w, `
-export function %s(%sopts?: pulumi.InvokeOptions): pulumi.Output<%s> {
-    return pulumi.output(args).apply(a => %s(a, opts))
+	fmt.Fprintf(w, `export function %s(%sopts?: pulumi.InvokeOptions): pulumi.Output<%s> {
+    return pulumi.output(args).apply((a: any) => %s(a, opts))
 }
 `, fnOutput, argsig, functionReturnType(fun), originalName)
 	fmt.Fprintf(w, "\n")

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/argFunction.ts
@@ -22,9 +22,8 @@ export interface ArgFunctionArgs {
 export interface ArgFunctionResult {
     readonly age?: number;
 }
-
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply(a => argFunction(a, opts))
+    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
 }
 
 export interface ArgFunctionOutputArgs {

--- a/pkg/codegen/testing/test/testdata/functions-secrets/nodejs/funcWithSecrets.ts
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/nodejs/funcWithSecrets.ts
@@ -24,9 +24,8 @@ export interface FuncWithSecretsResult {
     readonly id: string;
     readonly plaintext: string;
 }
-
 export function funcWithSecretsOutput(args: FuncWithSecretsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithSecretsResult> {
-    return pulumi.output(args).apply(a => funcWithSecrets(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithSecrets(a, opts))
 }
 
 export interface FuncWithSecretsOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listConfigurations.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listConfigurations.ts
@@ -49,9 +49,12 @@ export interface ListConfigurationsResult {
      */
     readonly value: outputs.ConfigurationResponse[];
 }
-
+/**
+ * The list of configurations.
+ * API Version: 2020-12-01-preview.
+ */
 export function listConfigurationsOutput(args: ListConfigurationsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListConfigurationsResult> {
-    return pulumi.output(args).apply(a => listConfigurations(a, opts))
+    return pulumi.output(args).apply((a: any) => listConfigurations(a, opts))
 }
 
 export interface ListConfigurationsOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listProductFamilies.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listProductFamilies.ts
@@ -54,9 +54,12 @@ export interface ListProductFamiliesResult {
      */
     readonly value: outputs.ProductFamilyResponse[];
 }
-
+/**
+ * The list of product families.
+ * API Version: 2020-12-01-preview.
+ */
 export function listProductFamiliesOutput(args: ListProductFamiliesOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListProductFamiliesResult> {
-    return pulumi.output(args).apply(a => listProductFamilies(a, opts))
+    return pulumi.output(args).apply((a: any) => listProductFamilies(a, opts))
 }
 
 export interface ListProductFamiliesOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/getAmiIds.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/getAmiIds.ts
@@ -71,9 +71,12 @@ export interface GetAmiIdsResult {
     readonly owners: string[];
     readonly sortAscending?: boolean;
 }
-
+/**
+ * Taken from pulumi-AWS to regress an issue
+ */
+/** @deprecated aws.getAmiIds has been deprecated in favor of aws.ec2.getAmiIds */
 export function getAmiIdsOutput(args: GetAmiIdsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetAmiIdsResult> {
-    return pulumi.output(args).apply(a => getAmiIds(a, opts))
+    return pulumi.output(args).apply((a: any) => getAmiIds(a, opts))
 }
 
 /**

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
@@ -44,9 +44,12 @@ export interface ListStorageAccountKeysResult {
      */
     readonly keys: outputs.StorageAccountKeyResponse[];
 }
-
+/**
+ * The response from the ListKeys operation.
+ * API Version: 2021-02-01.
+ */
 export function listStorageAccountKeysOutput(args: ListStorageAccountKeysOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListStorageAccountKeysResult> {
-    return pulumi.output(args).apply(a => listStorageAccountKeys(a, opts))
+    return pulumi.output(args).apply((a: any) => listStorageAccountKeys(a, opts))
 }
 
 export interface ListStorageAccountKeysOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithAllOptionalInputs.ts
@@ -31,9 +31,11 @@ export interface FuncWithAllOptionalInputsArgs {
 export interface FuncWithAllOptionalInputsResult {
     readonly r: string;
 }
-
+/**
+ * Check codegen of functions with all optional inputs.
+ */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply(a => funcWithAllOptionalInputs(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDefaultValue.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDefaultValue.ts
@@ -24,9 +24,11 @@ export interface FuncWithDefaultValueArgs {
 export interface FuncWithDefaultValueResult {
     readonly r: string;
 }
-
+/**
+ * Check codegen of functions with default values.
+ */
 export function funcWithDefaultValueOutput(args: FuncWithDefaultValueOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithDefaultValueResult> {
-    return pulumi.output(args).apply(a => funcWithDefaultValue(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithDefaultValue(a, opts))
 }
 
 export interface FuncWithDefaultValueOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDictParam.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDictParam.ts
@@ -25,9 +25,11 @@ export interface FuncWithDictParamArgs {
 export interface FuncWithDictParamResult {
     readonly r: string;
 }
-
+/**
+ * Check codegen of functions with a Dict<str,str> parameter.
+ */
 export function funcWithDictParamOutput(args?: FuncWithDictParamOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithDictParamResult> {
-    return pulumi.output(args).apply(a => funcWithDictParam(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithDictParam(a, opts))
 }
 
 export interface FuncWithDictParamOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithEmptyOutputs.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithEmptyOutputs.ts
@@ -24,9 +24,11 @@ export interface FuncWithEmptyOutputsArgs {
 
 export interface FuncWithEmptyOutputsResult {
 }
-
+/**
+ * n/a
+ */
 export function funcWithEmptyOutputsOutput(args: FuncWithEmptyOutputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithEmptyOutputsResult> {
-    return pulumi.output(args).apply(a => funcWithEmptyOutputs(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithEmptyOutputs(a, opts))
 }
 
 export interface FuncWithEmptyOutputsOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithListParam.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithListParam.ts
@@ -25,9 +25,11 @@ export interface FuncWithListParamArgs {
 export interface FuncWithListParamResult {
     readonly r: string;
 }
-
+/**
+ * Check codegen of functions with a List parameter.
+ */
 export function funcWithListParamOutput(args?: FuncWithListParamOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithListParamResult> {
-    return pulumi.output(args).apply(a => funcWithListParam(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithListParam(a, opts))
 }
 
 export interface FuncWithListParamOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getBastionShareableLink.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getBastionShareableLink.ts
@@ -44,9 +44,12 @@ export interface GetBastionShareableLinkResult {
      */
     readonly nextLink?: string;
 }
-
+/**
+ * Response for all the Bastion Shareable Link endpoints.
+ * API Version: 2020-11-01.
+ */
 export function getBastionShareableLinkOutput(args: GetBastionShareableLinkOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetBastionShareableLinkResult> {
-    return pulumi.output(args).apply(a => getBastionShareableLink(a, opts))
+    return pulumi.output(args).apply((a: any) => getBastionShareableLink(a, opts))
 }
 
 export interface GetBastionShareableLinkOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
@@ -53,9 +53,12 @@ export interface GetIntegrationRuntimeObjectMetadatumResult {
      */
     readonly value?: (outputs.SsisEnvironmentResponse | outputs.SsisFolderResponse | outputs.SsisPackageResponse | outputs.SsisProjectResponse)[];
 }
-
+/**
+ * Another failing example. A list of SSIS object metadata.
+ * API Version: 2018-06-01.
+ */
 export function getIntegrationRuntimeObjectMetadatumOutput(args: GetIntegrationRuntimeObjectMetadatumOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetIntegrationRuntimeObjectMetadatumResult> {
-    return pulumi.output(args).apply(a => getIntegrationRuntimeObjectMetadatum(a, opts))
+    return pulumi.output(args).apply((a: any) => getIntegrationRuntimeObjectMetadatum(a, opts))
 }
 
 export interface GetIntegrationRuntimeObjectMetadatumOutputArgs {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/listStorageAccountKeys.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/listStorageAccountKeys.ts
@@ -44,9 +44,12 @@ export interface ListStorageAccountKeysResult {
      */
     readonly keys: outputs.StorageAccountKeyResponse[];
 }
-
+/**
+ * The response from the ListKeys operation.
+ * API Version: 2021-02-01.
+ */
 export function listStorageAccountKeysOutput(args: ListStorageAccountKeysOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ListStorageAccountKeysResult> {
-    return pulumi.output(args).apply(a => listStorageAccountKeys(a, opts))
+    return pulumi.output(args).apply((a: any) => listStorageAccountKeys(a, opts))
 }
 
 export interface ListStorageAccountKeysOutputArgs {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -33,9 +33,11 @@ export interface FuncWithAllOptionalInputsArgs {
 export interface FuncWithAllOptionalInputsResult {
     readonly r: string;
 }
-
+/**
+ * Check codegen of functions with all optional inputs.
+ */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply(a => funcWithAllOptionalInputs(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -33,9 +33,11 @@ export interface FuncWithAllOptionalInputsArgs {
 export interface FuncWithAllOptionalInputsResult {
     readonly r: string;
 }
-
+/**
+ * Check codegen of functions with all optional inputs.
+ */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply(a => funcWithAllOptionalInputs(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/funcWithAllOptionalInputs.ts
@@ -31,9 +31,11 @@ export interface FuncWithAllOptionalInputsArgs {
 export interface FuncWithAllOptionalInputsResult {
     readonly r: string;
 }
-
+/**
+ * Check codegen of functions with all optional inputs.
+ */
 export function funcWithAllOptionalInputsOutput(args?: FuncWithAllOptionalInputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithAllOptionalInputsResult> {
-    return pulumi.output(args).apply(a => funcWithAllOptionalInputs(a, opts))
+    return pulumi.output(args).apply((a: any) => funcWithAllOptionalInputs(a, opts))
 }
 
 export interface FuncWithAllOptionalInputsOutputArgs {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
@@ -22,9 +22,8 @@ export interface ArgFunctionArgs {
 export interface ArgFunctionResult {
     readonly result?: Resource;
 }
-
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply(a => argFunction(a, opts))
+    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
 }
 
 export interface ArgFunctionOutputArgs {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/argFunction.ts
@@ -22,9 +22,8 @@ export interface ArgFunctionArgs {
 export interface ArgFunctionResult {
     readonly result?: Resource;
 }
-
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply(a => argFunction(a, opts))
+    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
 }
 
 export interface ArgFunctionOutputArgs {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/argFunction.ts
@@ -22,9 +22,8 @@ export interface ArgFunctionArgs {
 export interface ArgFunctionResult {
     readonly result?: Resource;
 }
-
 export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<ArgFunctionResult> {
-    return pulumi.output(args).apply(a => argFunction(a, opts))
+    return pulumi.output(args).apply((a: any) => argFunction(a, opts))
 }
 
 export interface ArgFunctionOutputArgs {


### PR DESCRIPTION
 - Generate JS doc comments for output-versioned invokes
 - Use explicit `any` type within apply lambda

This is part of #11418 but irrelevant to that (big) PR so this will help make the changes smaller and more clear 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
