### PR TITLE
Test import program generation

### DIFF
--- a/pkg/cmd/pulumi/import_test.go
+++ b/pkg/cmd/pulumi/import_test.go
@@ -1,0 +1,152 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+type testLoader struct {
+	packages map[string]map[string]*schema.Package
+}
+
+func (loader *testLoader) LoadPackage(pkg string, version *semver.Version) (*schema.Package, error) {
+	versionStr := ""
+	if version != nil {
+		versionStr = version.String()
+	}
+
+	pack, ok := loader.packages[pkg][versionStr]
+	if !ok {
+		return nil, fmt.Errorf("could not load package %s %s", pkg, versionStr)
+	}
+
+	return pack, nil
+}
+
+// NewTestLoader creates a loader supporting multiple package versions in tests. This
+// enables running tests offline.
+func NewTestLoader(packages map[string]map[string]*schema.Package) schema.Loader {
+	return &testLoader{
+		packages: packages,
+	}
+}
+
+func TestGenerateLanguageDefinitions_Simple(t *testing.T) {
+	t.Parallel()
+
+	spec := schema.PackageSpec{
+		Name: "testprovider",
+		Resources: map[string]schema.ResourceSpec{
+			"testprovider:index:TestResource": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"out": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					Required: []string{
+						"out",
+					},
+				},
+				InputProperties: map[string]schema.PropertySpec{
+					"in": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+		Provider: schema.ResourceSpec{},
+	}
+	testSchema, err := schema.ImportSpec(spec, nil)
+	assert.NoError(t, err)
+
+	loader := NewTestLoader(map[string]map[string]*schema.Package{
+		"testprovider": {
+			"": testSchema,
+		},
+	})
+
+	states := []*resource.State{
+		{
+			Type:   "testprovider:index:TestResource",
+			URN:    resource.NewURN("teststack", "testproject", "", "testprovider:index:TestResource", "testResource"),
+			Inputs: resource.NewPropertyMapFromMap(map[string]interface{}{"in": "input"}),
+		},
+	}
+
+	program, err := generateLanguageDefinitions(loader, states, nil)
+	assert.NoError(t, err)
+
+	source := program.Source()
+	expectedSource := map[string]string{
+		"anonymous.pp": "resource testResource \"testprovider:index:TestResource\" {\n    in = \"input\"\n\n}\n",
+	}
+	assert.Equal(t, expectedSource, source)
+}
+
+func TestGenerateLanguageDefinitions_EscapeTemplates(t *testing.T) {
+	t.Parallel()
+	t.Skip("PCL binding doesn't handle literal occurrences of ${} in resource inputs")
+
+	// Regression test for https://github.com/pulumi/pulumi/issues/11507
+
+	spec := schema.PackageSpec{
+		Name: "testprovider",
+		Resources: map[string]schema.ResourceSpec{
+			"testprovider:index:TestResource": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"out": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					Required: []string{
+						"out",
+					},
+				},
+				InputProperties: map[string]schema.PropertySpec{
+					"in": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+		Provider: schema.ResourceSpec{},
+	}
+	testSchema, err := schema.ImportSpec(spec, nil)
+	assert.NoError(t, err)
+
+	loader := NewTestLoader(map[string]map[string]*schema.Package{
+		"testprovider": {
+			"": testSchema,
+		},
+	})
+
+	states := []*resource.State{
+		{
+			Type:   "testprovider:index:TestResource",
+			URN:    resource.NewURN("teststack", "testproject", "", "testprovider:index:TestResource", "testResource"),
+			Inputs: resource.NewPropertyMapFromMap(map[string]interface{}{"in": "${not_really_a_template}"}),
+		},
+	}
+
+	program, err := generateLanguageDefinitions(loader, states, nil)
+	assert.NoError(t, err)
+
+	source := program.Source()
+	expectedSource := map[string]string{
+		"anonymous.pp": "resource testResource \"testprovider:index:TestResource\" {\n    in = \"$${not_really_a_template}\"\n\n}\n",
+	}
+	assert.Equal(t, expectedSource, source)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Includes a test to demonstrate why https://github.com/pulumi/pulumi/issues/11507 is currently broken.
Fix will require some changes in PCL binding to correctly handle '${' tokens in literal strings, currently I've just set the test to skip so we can get it in and someone can work on it.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
