### PR TITLE
Structured schema description

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -15,8 +15,6 @@
 package codegen
 
 import (
-	"github.com/pgavlin/goldmark/ast"
-
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
@@ -43,52 +41,6 @@ type DocLanguageHelper interface {
 	GetModuleDocLink(pkg *schema.Package, modName string) (string, string)
 }
 
-func filterExamples(source []byte, node ast.Node, lang string) {
-	var c, next ast.Node
-	for c = node.FirstChild(); c != nil; c = next {
-		filterExamples(source, c, lang)
-
-		next = c.NextSibling()
-		switch c := c.(type) {
-		case *ast.FencedCodeBlock:
-			sourceLang := string(c.Language(source))
-			if sourceLang != lang && sourceLang != "sh" {
-				node.RemoveChild(node, c)
-			}
-		case *schema.Shortcode:
-			switch string(c.Name) {
-			case schema.ExampleShortcode:
-				hasCode := false
-				for gc := c.FirstChild(); gc != nil; gc = gc.NextSibling() {
-					if gc.Kind() == ast.KindFencedCodeBlock {
-						hasCode = true
-						break
-					}
-				}
-				if hasCode {
-					var grandchild, nextGrandchild ast.Node
-					for grandchild = c.FirstChild(); grandchild != nil; grandchild = nextGrandchild {
-						nextGrandchild = grandchild.NextSibling()
-						node.InsertBefore(node, c, grandchild)
-					}
-				}
-				node.RemoveChild(node, c)
-			case schema.ExamplesShortcode:
-				if first := c.FirstChild(); first != nil {
-					first.SetBlankPreviousLines(c.HasBlankPreviousLines())
-				}
-
-				var grandchild, nextGrandchild ast.Node
-				for grandchild = c.FirstChild(); grandchild != nil; grandchild = nextGrandchild {
-					nextGrandchild = grandchild.NextSibling()
-					node.InsertBefore(node, c, grandchild)
-				}
-				node.RemoveChild(node, c)
-			}
-		}
-	}
-}
-
 // FilterExamples filters the code snippets in a schema docstring to include only those that target the given language.
 func FilterExamples(description string, lang string) string {
 	if description == "" {
@@ -97,6 +49,6 @@ func FilterExamples(description string, lang string) string {
 
 	source := []byte(description)
 	parsed := schema.ParseDocs(source)
-	filterExamples(source, parsed, lang)
+	schema.LegacyFilterExamples(source, parsed, lang)
 	return schema.RenderDocsToString(source, parsed)
 }

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -36,7 +36,7 @@ const (
 var (
 	simpleProperties = map[string]schema.PropertySpec{
 		"stringProp": {
-			Description: schema.DescriptionSpec{
+			Description: &schema.DescriptionSpec{
 				Legacy: "A string prop.",
 			},
 			TypeSpec: schema.TypeSpec{
@@ -44,7 +44,7 @@ var (
 			},
 		},
 		"boolProp": {
-			Description: schema.DescriptionSpec{
+			Description: &schema.DescriptionSpec{
 				Legacy: "A bool prop.",
 			},
 			TypeSpec: schema.TypeSpec{
@@ -66,7 +66,7 @@ func initTestPackageSpec(t *testing.T) {
 	testPackageSpec = schema.PackageSpec{
 		Name:    providerPackage,
 		Version: "0.0.1",
-		Description: schema.DescriptionSpec{
+		Description: &schema.DescriptionSpec{
 			Legacy: "A fake provider package used for testing.",
 		},
 		Meta: &schema.MetadataSpec{
@@ -76,7 +76,7 @@ func initTestPackageSpec(t *testing.T) {
 			// Package-level types.
 			"prov:/getPackageResourceOptions:getPackageResourceOptions": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "Options object for the package-level function getPackageResource.",
 					},
 					Type:       "object",
@@ -87,7 +87,7 @@ func initTestPackageSpec(t *testing.T) {
 			// Module-level types.
 			"prov:module/getModuleResourceOptions:getModuleResourceOptions": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "Options object for the module-level function getModuleResource.",
 					},
 					Type:       "object",
@@ -96,13 +96,13 @@ func initTestPackageSpec(t *testing.T) {
 			},
 			"prov:module/ResourceOptions:ResourceOptions": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "The resource options object.",
 					},
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
 						"stringProp": {
-							Description: schema.DescriptionSpec{
+							Description: &schema.DescriptionSpec{
 								Legacy: "A string prop.",
 							},
 							Language: pythonMapCase,
@@ -111,7 +111,7 @@ func initTestPackageSpec(t *testing.T) {
 							},
 						},
 						"boolProp": {
-							Description: schema.DescriptionSpec{
+							Description: &schema.DescriptionSpec{
 								Legacy: "A bool prop.",
 							},
 							Language: pythonMapCase,
@@ -120,7 +120,7 @@ func initTestPackageSpec(t *testing.T) {
 							},
 						},
 						"recursiveType": {
-							Description: schema.DescriptionSpec{
+							Description: &schema.DescriptionSpec{
 								Legacy: "I am a recursive type.",
 							},
 							Language: pythonMapCase,
@@ -133,13 +133,13 @@ func initTestPackageSpec(t *testing.T) {
 			},
 			"prov:module/ResourceOptions2:ResourceOptions2": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "The resource options object.",
 					},
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
 						"uniqueProp": {
-							Description: schema.DescriptionSpec{
+							Description: &schema.DescriptionSpec{
 								Legacy: "This is a property unique to this type.",
 							},
 							Language: pythonMapCase,
@@ -153,14 +153,14 @@ func initTestPackageSpec(t *testing.T) {
 		},
 		Provider: schema.ResourceSpec{
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: schema.DescriptionSpec{
+				Description: &schema.DescriptionSpec{
 					Legacy: fmt.Sprintf("The provider type for the %s package.", providerPackage),
 				},
 				Type: "object",
 			},
 			InputProperties: map[string]schema.PropertySpec{
 				"stringProp": {
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "A stringProp for the provider resource.",
 					},
 					TypeSpec: schema.TypeSpec{
@@ -172,7 +172,7 @@ func initTestPackageSpec(t *testing.T) {
 		Resources: map[string]schema.ResourceSpec{
 			"prov:module2/resource2:Resource2": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: `This is a module-level resource called Resource.
 {{% examples %}}
 ## Example Usage
@@ -211,7 +211,7 @@ $ pulumi import prov:module/resource:Resource test test
 				},
 				InputProperties: map[string]schema.PropertySpec{
 					"integerProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "This is integerProp's description.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -219,7 +219,7 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"stringProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "This is stringProp's description.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -227,7 +227,7 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"boolProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "A bool prop.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -245,7 +245,7 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"recursiveType": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "I am a recursive type.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -256,7 +256,7 @@ $ pulumi import prov:module/resource:Resource test test
 			},
 			"prov:module/resource:Resource": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: `This is a module-level resource called Resource.
 {{% examples %}}
 ## Example Usage
@@ -295,7 +295,7 @@ $ pulumi import prov:module/resource:Resource test test
 				},
 				InputProperties: map[string]schema.PropertySpec{
 					"integerProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "This is integerProp's description.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -303,7 +303,7 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"stringProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "This is stringProp's description.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -311,7 +311,7 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"boolProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "A bool prop.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -329,7 +329,7 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"recursiveType": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "I am a recursive type.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -340,13 +340,13 @@ $ pulumi import prov:module/resource:Resource test test
 			},
 			"prov:/packageLevelResource:PackageLevelResource": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "This is a package-level resource.",
 					},
 				},
 				InputProperties: map[string]schema.PropertySpec{
 					"prop": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "An input property.",
 						},
 						TypeSpec: schema.TypeSpec{
@@ -359,11 +359,11 @@ $ pulumi import prov:module/resource:Resource test test
 		Functions: map[string]schema.FunctionSpec{
 			// Package-level Functions.
 			"prov:/getPackageResource:getPackageResource": {
-				Description: schema.DescriptionSpec{
+				Description: &schema.DescriptionSpec{
 					Legacy: "A package-level function.",
 				},
 				Inputs: &schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "Inputs for getPackageResource.",
 					},
 					Type: "object",
@@ -376,7 +376,7 @@ $ pulumi import prov:module/resource:Resource test test
 					},
 				},
 				Outputs: &schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "Outputs for getPackageResource.",
 					},
 					Properties: simpleProperties,
@@ -386,11 +386,11 @@ $ pulumi import prov:module/resource:Resource test test
 
 			// Module-level Functions.
 			"prov:module/getModuleResource:getModuleResource": {
-				Description: schema.DescriptionSpec{
+				Description: &schema.DescriptionSpec{
 					Legacy: "A module-level function.",
 				},
 				Inputs: &schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "Inputs for getModuleResource.",
 					},
 					Type: "object",
@@ -403,7 +403,7 @@ $ pulumi import prov:module/resource:Resource test test
 					},
 				},
 				Outputs: &schema.ObjectTypeSpec{
-					Description: schema.DescriptionSpec{
+					Description: &schema.DescriptionSpec{
 						Legacy: "Outputs for getModuleResource.",
 					},
 					Properties: simpleProperties,

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -36,13 +36,17 @@ const (
 var (
 	simpleProperties = map[string]schema.PropertySpec{
 		"stringProp": {
-			Description: "A string prop.",
+			Description: schema.DescriptionSpec{
+				Legacy: "A string prop.",
+			},
 			TypeSpec: schema.TypeSpec{
 				Type: "string",
 			},
 		},
 		"boolProp": {
-			Description: "A bool prop.",
+			Description: schema.DescriptionSpec{
+				Legacy: "A bool prop.",
+			},
 			TypeSpec: schema.TypeSpec{
 				Type: "boolean",
 			},
@@ -60,9 +64,11 @@ func initTestPackageSpec(t *testing.T) {
 		"python": schema.RawMessage(`{"mapCase":false}`),
 	}
 	testPackageSpec = schema.PackageSpec{
-		Name:        providerPackage,
-		Version:     "0.0.1",
-		Description: "A fake provider package used for testing.",
+		Name:    providerPackage,
+		Version: "0.0.1",
+		Description: schema.DescriptionSpec{
+			Legacy: "A fake provider package used for testing.",
+		},
 		Meta: &schema.MetadataSpec{
 			ModuleFormat: "(.*)(?:/[^/]*)",
 		},
@@ -70,42 +76,54 @@ func initTestPackageSpec(t *testing.T) {
 			// Package-level types.
 			"prov:/getPackageResourceOptions:getPackageResourceOptions": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: "Options object for the package-level function getPackageResource.",
-					Type:        "object",
-					Properties:  simpleProperties,
+					Description: schema.DescriptionSpec{
+						Legacy: "Options object for the package-level function getPackageResource.",
+					},
+					Type:       "object",
+					Properties: simpleProperties,
 				},
 			},
 
 			// Module-level types.
 			"prov:module/getModuleResourceOptions:getModuleResourceOptions": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: "Options object for the module-level function getModuleResource.",
-					Type:        "object",
-					Properties:  simpleProperties,
+					Description: schema.DescriptionSpec{
+						Legacy: "Options object for the module-level function getModuleResource.",
+					},
+					Type:       "object",
+					Properties: simpleProperties,
 				},
 			},
 			"prov:module/ResourceOptions:ResourceOptions": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: "The resource options object.",
-					Type:        "object",
+					Description: schema.DescriptionSpec{
+						Legacy: "The resource options object.",
+					},
+					Type: "object",
 					Properties: map[string]schema.PropertySpec{
 						"stringProp": {
-							Description: "A string prop.",
-							Language:    pythonMapCase,
+							Description: schema.DescriptionSpec{
+								Legacy: "A string prop.",
+							},
+							Language: pythonMapCase,
 							TypeSpec: schema.TypeSpec{
 								Type: "string",
 							},
 						},
 						"boolProp": {
-							Description: "A bool prop.",
-							Language:    pythonMapCase,
+							Description: schema.DescriptionSpec{
+								Legacy: "A bool prop.",
+							},
+							Language: pythonMapCase,
 							TypeSpec: schema.TypeSpec{
 								Type: "boolean",
 							},
 						},
 						"recursiveType": {
-							Description: "I am a recursive type.",
-							Language:    pythonMapCase,
+							Description: schema.DescriptionSpec{
+								Legacy: "I am a recursive type.",
+							},
+							Language: pythonMapCase,
 							TypeSpec: schema.TypeSpec{
 								Ref: "#/types/prov:module/ResourceOptions:ResourceOptions",
 							},
@@ -115,12 +133,16 @@ func initTestPackageSpec(t *testing.T) {
 			},
 			"prov:module/ResourceOptions2:ResourceOptions2": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: "The resource options object.",
-					Type:        "object",
+					Description: schema.DescriptionSpec{
+						Legacy: "The resource options object.",
+					},
+					Type: "object",
 					Properties: map[string]schema.PropertySpec{
 						"uniqueProp": {
-							Description: "This is a property unique to this type.",
-							Language:    pythonMapCase,
+							Description: schema.DescriptionSpec{
+								Legacy: "This is a property unique to this type.",
+							},
+							Language: pythonMapCase,
 							TypeSpec: schema.TypeSpec{
 								Type: "number",
 							},
@@ -131,12 +153,16 @@ func initTestPackageSpec(t *testing.T) {
 		},
 		Provider: schema.ResourceSpec{
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: fmt.Sprintf("The provider type for the %s package.", providerPackage),
-				Type:        "object",
+				Description: schema.DescriptionSpec{
+					Legacy: fmt.Sprintf("The provider type for the %s package.", providerPackage),
+				},
+				Type: "object",
 			},
 			InputProperties: map[string]schema.PropertySpec{
 				"stringProp": {
-					Description: "A stringProp for the provider resource.",
+					Description: schema.DescriptionSpec{
+						Legacy: "A stringProp for the provider resource.",
+					},
 					TypeSpec: schema.TypeSpec{
 						Type: "string",
 					},
@@ -146,7 +172,8 @@ func initTestPackageSpec(t *testing.T) {
 		Resources: map[string]schema.ResourceSpec{
 			"prov:module2/resource2:Resource2": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: `This is a module-level resource called Resource.
+					Description: schema.DescriptionSpec{
+						Legacy: `This is a module-level resource called Resource.
 {{% examples %}}
 ## Example Usage
 
@@ -180,22 +207,29 @@ The import docs would be here
 $ pulumi import prov:module/resource:Resource test test
 ` + codeFence + `
 `,
+					},
 				},
 				InputProperties: map[string]schema.PropertySpec{
 					"integerProp": {
-						Description: "This is integerProp's description.",
+						Description: schema.DescriptionSpec{
+							Legacy: "This is integerProp's description.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "integer",
 						},
 					},
 					"stringProp": {
-						Description: "This is stringProp's description.",
+						Description: schema.DescriptionSpec{
+							Legacy: "This is stringProp's description.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "string",
 						},
 					},
 					"boolProp": {
-						Description: "A bool prop.",
+						Description: schema.DescriptionSpec{
+							Legacy: "A bool prop.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "boolean",
 						},
@@ -211,7 +245,9 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"recursiveType": {
-						Description: "I am a recursive type.",
+						Description: schema.DescriptionSpec{
+							Legacy: "I am a recursive type.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Ref: "#/types/prov:module/ResourceOptions:ResourceOptions",
 						},
@@ -220,7 +256,8 @@ $ pulumi import prov:module/resource:Resource test test
 			},
 			"prov:module/resource:Resource": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: `This is a module-level resource called Resource.
+					Description: schema.DescriptionSpec{
+						Legacy: `This is a module-level resource called Resource.
 {{% examples %}}
 ## Example Usage
 
@@ -254,22 +291,29 @@ The import docs would be here
 $ pulumi import prov:module/resource:Resource test test
 ` + codeFence + `
 `,
+					},
 				},
 				InputProperties: map[string]schema.PropertySpec{
 					"integerProp": {
-						Description: "This is integerProp's description.",
+						Description: schema.DescriptionSpec{
+							Legacy: "This is integerProp's description.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "integer",
 						},
 					},
 					"stringProp": {
-						Description: "This is stringProp's description.",
+						Description: schema.DescriptionSpec{
+							Legacy: "This is stringProp's description.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "string",
 						},
 					},
 					"boolProp": {
-						Description: "A bool prop.",
+						Description: schema.DescriptionSpec{
+							Legacy: "A bool prop.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "boolean",
 						},
@@ -285,7 +329,9 @@ $ pulumi import prov:module/resource:Resource test test
 						},
 					},
 					"recursiveType": {
-						Description: "I am a recursive type.",
+						Description: schema.DescriptionSpec{
+							Legacy: "I am a recursive type.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Ref: "#/types/prov:module/ResourceOptions:ResourceOptions",
 						},
@@ -294,11 +340,15 @@ $ pulumi import prov:module/resource:Resource test test
 			},
 			"prov:/packageLevelResource:PackageLevelResource": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: "This is a package-level resource.",
+					Description: schema.DescriptionSpec{
+						Legacy: "This is a package-level resource.",
+					},
 				},
 				InputProperties: map[string]schema.PropertySpec{
 					"prop": {
-						Description: "An input property.",
+						Description: schema.DescriptionSpec{
+							Legacy: "An input property.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "string",
 						},
@@ -309,10 +359,14 @@ $ pulumi import prov:module/resource:Resource test test
 		Functions: map[string]schema.FunctionSpec{
 			// Package-level Functions.
 			"prov:/getPackageResource:getPackageResource": {
-				Description: "A package-level function.",
+				Description: schema.DescriptionSpec{
+					Legacy: "A package-level function.",
+				},
 				Inputs: &schema.ObjectTypeSpec{
-					Description: "Inputs for getPackageResource.",
-					Type:        "object",
+					Description: schema.DescriptionSpec{
+						Legacy: "Inputs for getPackageResource.",
+					},
+					Type: "object",
 					Properties: map[string]schema.PropertySpec{
 						"options": {
 							TypeSpec: schema.TypeSpec{
@@ -322,18 +376,24 @@ $ pulumi import prov:module/resource:Resource test test
 					},
 				},
 				Outputs: &schema.ObjectTypeSpec{
-					Description: "Outputs for getPackageResource.",
-					Properties:  simpleProperties,
-					Type:        "object",
+					Description: schema.DescriptionSpec{
+						Legacy: "Outputs for getPackageResource.",
+					},
+					Properties: simpleProperties,
+					Type:       "object",
 				},
 			},
 
 			// Module-level Functions.
 			"prov:module/getModuleResource:getModuleResource": {
-				Description: "A module-level function.",
+				Description: schema.DescriptionSpec{
+					Legacy: "A module-level function.",
+				},
 				Inputs: &schema.ObjectTypeSpec{
-					Description: "Inputs for getModuleResource.",
-					Type:        "object",
+					Description: schema.DescriptionSpec{
+						Legacy: "Inputs for getModuleResource.",
+					},
+					Type: "object",
 					Properties: map[string]schema.PropertySpec{
 						"options": {
 							TypeSpec: schema.TypeSpec{
@@ -343,9 +403,11 @@ $ pulumi import prov:module/resource:Resource test test
 					},
 				},
 				Outputs: &schema.ObjectTypeSpec{
-					Description: "Outputs for getModuleResource.",
-					Properties:  simpleProperties,
-					Type:        "object",
+					Description: schema.DescriptionSpec{
+						Legacy: "Outputs for getModuleResource.",
+					},
+					Properties: simpleProperties,
+					Type:       "object",
 				},
 			},
 		},
@@ -485,7 +547,7 @@ func TestExamplesProcessing(t *testing.T) {
 	initTestPackageSpec(t)
 	dctx := newDocGenContext()
 
-	description := testPackageSpec.Resources["prov:module/resource:Resource"].Description
+	description := testPackageSpec.Resources["prov:module/resource:Resource"].Description.Legacy
 	docInfo := dctx.decomposeDocstring(description)
 	examplesSection := docInfo.examples
 	importSection := docInfo.importDetails

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -26,7 +26,7 @@ import (
 var testPackageSpec = schema.PackageSpec{
 	Name:    "aws",
 	Version: "0.0.1",
-	Description: schema.DescriptionSpec{
+	Description: &schema.DescriptionSpec{
 		Legacy: "A fake provider package used for testing.",
 	},
 	Meta: &schema.MetadataSpec{
@@ -35,13 +35,13 @@ var testPackageSpec = schema.PackageSpec{
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: schema.DescriptionSpec{
+				Description: &schema.DescriptionSpec{
 					Legacy: "The resource options object.",
 				},
 				Type: "object",
 				Properties: map[string]schema.PropertySpec{
 					"stringProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "A string prop.",
 						},
 						TypeSpec: schema.TypeSpec{

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -24,20 +24,26 @@ import (
 )
 
 var testPackageSpec = schema.PackageSpec{
-	Name:        "aws",
-	Version:     "0.0.1",
-	Description: "A fake provider package used for testing.",
+	Name:    "aws",
+	Version: "0.0.1",
+	Description: schema.DescriptionSpec{
+		Legacy: "A fake provider package used for testing.",
+	},
 	Meta: &schema.MetadataSpec{
 		ModuleFormat: "(.*)(?:/[^/]*)",
 	},
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: "The resource options object.",
-				Type:        "object",
+				Description: schema.DescriptionSpec{
+					Legacy: "The resource options object.",
+				},
+				Type: "object",
 				Properties: map[string]schema.PropertySpec{
 					"stringProp": {
-						Description: "A string prop.",
+						Description: schema.DescriptionSpec{
+							Legacy: "A string prop.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "string",
 						},

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -562,7 +562,7 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 
 		fmt.Fprintf(w, "%sprivate %s? %s;\n", indent, backingFieldType, backingFieldName)
 
-		if c := prop.Comment.NarrowToLanguage("csharp"); len(c) > 0 {
+		if c := prop.StructuredComment.NarrowToLanguage("csharp"); len(c) > 0 {
 			fmt.Fprintf(w, "\n")
 			printComment(w, c, indent)
 		}
@@ -611,7 +611,7 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 			initializer = " = null!;"
 		}
 
-		printComment(w, prop.Comment, indent)
+		printComment(w, prop.StructuredComment, indent)
 
 		if generateInputAttribute {
 			pt.genInputPropertyAttribute(w, indent, prop)
@@ -717,7 +717,7 @@ func (pt *plainType) genOutputType(w io.Writer, level int) {
 			typ = codegen.RequiredType(prop)
 		}
 		fieldType := pt.mod.typeString(typ, pt.propertyTypeQualifier, false, false, false)
-		printComment(w, prop.Comment, indent+"    ")
+		printComment(w, prop.StructuredComment, indent+"    ")
 		fmt.Fprintf(w, "%s    public readonly %s %s;\n", indent, fieldType, fieldName)
 	}
 	if len(pt.properties) > 0 {
@@ -889,7 +889,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "{\n")
 
 	// Write the documentation comment for the resource class
-	printComment(w, r.Comment.NarrowToLanguage("csharp"), "    ")
+	printComment(w, r.StructuredComment.NarrowToLanguage("csharp"), "    ")
 
 	// Open the class.
 	className := name
@@ -940,7 +940,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 			secretProps = append(secretProps, prop.Name)
 		}
 
-		printComment(w, prop.Comment, "        ")
+		printComment(w, prop.StructuredComment, "        ")
 		fmt.Fprintf(w, "        [Output(\"%s\")]\n", wireName)
 		fmt.Fprintf(w, "        public Output<%s> %s { get; private set; } = null!;\n", propertyType, propertyName)
 		fmt.Fprintf(w, "\n")
@@ -1172,7 +1172,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		}
 
 		// Emit the doc comment, if any.
-		printComment(w, fun.Comment, "        ")
+		printComment(w, fun.StructuredComment, "        ")
 
 		if fun.DeprecationMessage != "" {
 			fmt.Fprintf(w, "        [Obsolete(@\"%s\")]\n", strings.ReplaceAll(fun.DeprecationMessage, `"`, `""`))
@@ -1248,7 +1248,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 			}
 		}
 		if len(args) > 0 {
-			comment, escape := fun.Inputs.Comment, true
+			comment, escape := fun.Inputs.StructuredComment, true
 			if len(comment) == 0 {
 				comment, escape = schema.MakeMarkdownDescription(fmt.Sprintf(
 					"The set of arguments for the <see cref=\"%s.%s\"/> method.", className, methodName)), false
@@ -1272,7 +1272,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		if fun.Outputs != nil {
 			shouldLiftReturn := mod.liftSingleValueMethodReturns && len(fun.Outputs.Properties) == 1
 
-			comment, escape := fun.Inputs.Comment, true
+			comment, escape := fun.Inputs.StructuredComment, true
 			if len(comment) == 0 {
 				comment, escape =
 					schema.MakeMarkdownDescription(
@@ -1371,7 +1371,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 	fmt.Fprintf(w, "    {\n")
 
 	// Emit the doc comment, if any.
-	printComment(w, fun.Comment, "        ")
+	printComment(w, fun.StructuredComment, "        ")
 
 	// Emit the datasource method.
 	fmt.Fprintf(w, "        public static Task%s InvokeAsync(%sInvokeOptions? options = null)\n",
@@ -1452,7 +1452,7 @@ func (mod *modContext) genFunctionOutputVersion(w io.Writer, fun *schema.Functio
 	fmt.Fprintf(w, "\n")
 
 	// Emit the doc comment, if any.
-	printComment(w, fun.Comment, "        ")
+	printComment(w, fun.StructuredComment, "        ")
 	fmt.Fprintf(w, "        public static Output<%sResult> Invoke(%sInvokeOptions? options = null)\n",
 		className, outputArgsParamDef)
 	fmt.Fprintf(w, "            => global::Pulumi.Deployment.Instance.Invoke<%sResult>(\"%s\", %s, options.WithDefaults());\n",
@@ -1527,7 +1527,7 @@ func (mod *modContext) genEnum(w io.Writer, enum *schema.EnumType) error {
 	}
 
 	// Print documentation comment
-	printComment(w, enum.Comment, indent)
+	printComment(w, enum.StructuredComment, indent)
 
 	underlyingType := mod.typeString(enum.ElementType, "", false, false, false)
 	switch enum.ElementType {
@@ -1555,7 +1555,7 @@ func (mod *modContext) genEnum(w io.Writer, enum *schema.EnumType) error {
 
 		// Enum values
 		for _, e := range enum.Elements {
-			printComment(w, e.Comment, indent)
+			printComment(w, e.StructuredComment, indent)
 			printObsoleteAttribute(w, e.DeprecationMessage, indent)
 			fmt.Fprintf(w, "%[1]spublic static %[2]s %[3]s { get; } = new %[2]s(", indent, enumName, e.Name)
 			if enum.ElementType == schema.StringType {
@@ -1613,7 +1613,7 @@ func (mod *modContext) genEnum(w io.Writer, enum *schema.EnumType) error {
 		fmt.Fprintf(w, "%s{\n", indent)
 		for _, e := range enum.Elements {
 			indent := strings.Repeat(indent, 2)
-			printComment(w, e.Comment, indent)
+			printComment(w, e.StructuredComment, indent)
 			printObsoleteAttribute(w, e.DeprecationMessage, indent)
 			fmt.Fprintf(w, "%s%s = %v,\n", indent, e.Name, e.Value)
 		}
@@ -1642,7 +1642,7 @@ func (mod *modContext) genType(w io.Writer, obj *schema.ObjectType, propertyType
 	pt := &plainType{
 		mod:                   mod,
 		name:                  mod.typeName(obj, state, input, args),
-		comment:               obj.Comment,
+		comment:               obj.StructuredComment,
 		propertyTypeQualifier: propertyTypeQualifier,
 		properties:            obj.Properties,
 		state:                 state,
@@ -1777,7 +1777,7 @@ func (mod *modContext) genConfig(variables []*schema.Property) (string, error) {
 		}
 
 		fmt.Fprintf(w, "        private static readonly __Value<%[1]s> _%[2]s = new __Value<%[1]s>(() => %[3]s);\n", propertyType, p.Name, initializer)
-		printComment(w, p.Comment, "        ")
+		printComment(w, p.StructuredComment, "        ")
 		fmt.Fprintf(w, "        public static %s %s\n", propertyType, propertyName)
 		fmt.Fprintf(w, "        {\n")
 		fmt.Fprintf(w, "            get => _%s.Get();\n", p.Name)
@@ -1813,7 +1813,7 @@ func (mod *modContext) genConfig(variables []*schema.Property) (string, error) {
 					initializer = " = null!;"
 				}
 
-				printComment(w, prop.Comment, "            ")
+				printComment(w, prop.StructuredComment, "            ")
 				fmt.Fprintf(w, "                public %s %s { get; set; }%s\n", typ, name, initializer)
 			}
 

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -27,20 +27,26 @@ import (
 )
 
 var testPackageSpec = schema.PackageSpec{
-	Name:        "aws",
-	Version:     "0.0.1",
-	Description: "A fake provider package used for testing.",
+	Name:    "aws",
+	Version: "0.0.1",
+	Description: schema.DescriptionSpec{
+		Legacy: "A fake provider package used for testing.",
+	},
 	Meta: &schema.MetadataSpec{
 		ModuleFormat: "(.*)(?:/[^/]*)",
 	},
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: "The resource options object.",
-				Type:        "object",
+				Description: schema.DescriptionSpec{
+					Legacy: "The resource options object.",
+				},
+				Type: "object",
 				Properties: map[string]schema.PropertySpec{
 					"stringProp": {
-						Description: "A string prop.",
+						Description: schema.DescriptionSpec{
+							Legacy: "A string prop.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "string",
 						},

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -29,7 +29,7 @@ import (
 var testPackageSpec = schema.PackageSpec{
 	Name:    "aws",
 	Version: "0.0.1",
-	Description: schema.DescriptionSpec{
+	Description: &schema.DescriptionSpec{
 		Legacy: "A fake provider package used for testing.",
 	},
 	Meta: &schema.MetadataSpec{
@@ -38,13 +38,13 @@ var testPackageSpec = schema.PackageSpec{
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: schema.DescriptionSpec{
+				Description: &schema.DescriptionSpec{
 					Legacy: "The resource options object.",
 				},
 				Type: "object",
 				Properties: map[string]schema.PropertySpec{
 					"stringProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "A string prop.",
 						},
 						TypeSpec: schema.TypeSpec{

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1088,7 +1088,7 @@ func (pkg *pkgContext) genEnum(w io.Writer, enumType *schema.EnumType) error {
 	modPkg, ok := pkg.packages[mod]
 	contract.Assert(ok)
 
-	printCommentWithDeprecationMessage(w, enumType.Comment, "", false)
+	printCommentWithDeprecationMessage(w, enumType.StructuredComment, "", false)
 
 	elementArgsType := pkg.argsTypeImpl(enumType.ElementType)
 	elementGoType := pkg.typeString(enumType.ElementType)
@@ -1098,7 +1098,7 @@ func (pkg *pkgContext) genEnum(w io.Writer, enumType *schema.EnumType) error {
 
 	fmt.Fprintln(w, "const (")
 	for _, e := range enumType.Elements {
-		printCommentWithDeprecationMessage(w, e.Comment, e.DeprecationMessage, true)
+		printCommentWithDeprecationMessage(w, e.StructuredComment, e.DeprecationMessage, true)
 
 		var elementName = e.Name
 		if e.Name == "" {
@@ -1323,7 +1323,7 @@ func (pkg *pkgContext) genPlainType(w io.Writer, name string, comment schema.Des
 	printCommentWithDeprecationMessage(w, comment, deprecationMessage, false)
 	fmt.Fprintf(w, "type %s struct {\n", name)
 	for _, p := range properties {
-		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+		printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 		fmt.Fprintf(w, "\t%s %s `pulumi:\"%s\"`\n", pkg.fieldName(nil, p), pkg.typeString(codegen.ResolvedType(p.Type)), p.Name)
 	}
 	fmt.Fprintf(w, "}\n\n")
@@ -1449,10 +1449,10 @@ func (pkg *pkgContext) genInputTypes(w io.Writer, t *schema.ObjectType, details 
 func (pkg *pkgContext) genInputArgsStruct(w io.Writer, typeName string, t *schema.ObjectType) {
 	contract.Assert(t.IsInputShape())
 
-	printComment(w, t.Comment, false)
+	printComment(w, t.StructuredComment, false)
 	fmt.Fprintf(w, "type %s struct {\n", typeName)
 	for _, p := range t.Properties {
-		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+		printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 		fmt.Fprintf(w, "\t%s %s `pulumi:\"%s\"`\n", pkg.fieldName(nil, p), pkg.typeString(p.Type), p.Name)
 	}
 	fmt.Fprintf(w, "}\n\n")
@@ -1477,7 +1477,7 @@ func (pkg *pkgContext) genOutputTypes(w io.Writer, genArgs genOutputTypesArgs) {
 	}
 
 	if details.output {
-		printComment(w, t.Comment, false)
+		printComment(w, t.StructuredComment, false)
 		genOutputType(w,
 			name,             /* baseName */
 			name,             /* elementType */
@@ -1485,7 +1485,7 @@ func (pkg *pkgContext) genOutputTypes(w io.Writer, genArgs genOutputTypesArgs) {
 		)
 
 		for _, p := range t.Properties {
-			printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, false)
+			printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, false)
 			outputType, applyType := pkg.outputType(p.Type), pkg.typeString(p.Type)
 
 			propName := pkg.fieldName(nil, p)
@@ -1504,7 +1504,7 @@ func (pkg *pkgContext) genOutputTypes(w io.Writer, genArgs genOutputTypesArgs) {
 		genPtrOutput(w, name, name)
 
 		for _, p := range t.Properties {
-			printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, false)
+			printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, false)
 			optionalType := codegen.OptionalType(p)
 			outputType, applyType := pkg.outputType(optionalType), pkg.typeString(optionalType)
 			deref := ""
@@ -1633,7 +1633,7 @@ func (pkg *pkgContext) getDefaultValue(dv *schema.DefaultValue, t schema.Type) (
 func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateResourceContainerTypes bool) error {
 	name := disambiguatedResourceName(r, pkg)
 
-	printCommentWithDeprecationMessage(w, r.Comment, r.DeprecationMessage, false)
+	printCommentWithDeprecationMessage(w, r.StructuredComment, r.DeprecationMessage, false)
 	fmt.Fprintf(w, "type %s struct {\n", name)
 
 	switch {
@@ -1649,7 +1649,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	var secretInputProps []*schema.Property
 
 	for _, p := range r.Properties {
-		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+		printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 		fmt.Fprintf(w, "\t%s %s `pulumi:\"%s\"`\n", pkg.fieldName(r, p), pkg.outputType(p.Type), p.Name)
 
 		if p.Secret {
@@ -1831,7 +1831,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 		fmt.Fprintf(w, "type %sState struct {\n", cgstrings.Camel(name))
 		if r.StateInputs != nil {
 			for _, p := range r.StateInputs.Properties {
-				printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+				printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 				fmt.Fprintf(w, "\t%s %s `pulumi:\"%s\"`\n", pkg.fieldName(r, p), pkg.typeString(codegen.ResolvedType(codegen.OptionalType(p))), p.Name)
 			}
 		}
@@ -1840,7 +1840,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 		fmt.Fprintf(w, "type %sState struct {\n", name)
 		if r.StateInputs != nil {
 			for _, p := range r.StateInputs.Properties {
-				printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+				printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 				fmt.Fprintf(w, "\t%s %s\n", pkg.fieldName(r, p), pkg.inputType(p.Type))
 			}
 		}
@@ -1854,7 +1854,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	// Emit the args types.
 	fmt.Fprintf(w, "type %sArgs struct {\n", cgstrings.Camel(name))
 	for _, p := range r.InputProperties {
-		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+		printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 		fmt.Fprintf(w, "\t%s %s `pulumi:\"%s\"`\n", pkg.fieldName(r, p), pkg.typeString(codegen.ResolvedType(p.Type)), p.Name)
 	}
 	fmt.Fprintf(w, "}\n\n")
@@ -1872,7 +1872,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			})
 		}
 
-		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+		printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 		fmt.Fprintf(w, "\t%s %s\n", pkg.fieldName(r, p), pkg.typeString(typ))
 	}
 	fmt.Fprintf(w, "}\n\n")
@@ -1912,7 +1912,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			retty = fmt.Sprintf("(%s%sResultOutput, error)", name, methodName)
 		}
 		fmt.Fprintf(w, "\n")
-		printCommentWithDeprecationMessage(w, f.Comment, f.DeprecationMessage, false)
+		printCommentWithDeprecationMessage(w, f.StructuredComment, f.DeprecationMessage, false)
 		fmt.Fprintf(w, "func (r *%s) %s(%s) %s {\n", name, methodName, argsig, retty)
 
 		resultVar := "_"
@@ -1962,7 +1962,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			fmt.Fprintf(w, "\n")
 			fmt.Fprintf(w, "type %s%sArgs struct {\n", cgstrings.Camel(name), methodName)
 			for _, p := range args {
-				printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+				printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 				fmt.Fprintf(w, "\t%s %s `pulumi:\"%s\"`\n", pkg.fieldName(nil, p), pkg.typeString(codegen.ResolvedType(p.Type)),
 					p.Name)
 			}
@@ -1971,7 +1971,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			fmt.Fprintf(w, "// The set of arguments for the %s method of the %s resource.\n", methodName, name)
 			fmt.Fprintf(w, "type %s%sArgs struct {\n", name, methodName)
 			for _, p := range args {
-				printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, true)
+				printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, true)
 				fmt.Fprintf(w, "\t%s %s\n", pkg.fieldName(nil, p), pkg.typeString(p.Type))
 			}
 			fmt.Fprintf(w, "}\n\n")
@@ -1989,7 +1989,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			}
 
 			fmt.Fprintf(w, "\n")
-			pkg.genPlainType(w, fmt.Sprintf("%s%sResult", outputStructName, methodName), f.Outputs.Comment, "",
+			pkg.genPlainType(w, fmt.Sprintf("%s%sResult", outputStructName, methodName), f.Outputs.StructuredComment, "",
 				f.Outputs.Properties)
 
 			fmt.Fprintf(w, "\n")
@@ -2001,7 +2001,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 
 			for _, p := range f.Outputs.Properties {
 				fmt.Fprintf(w, "\n")
-				printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, false)
+				printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, false)
 				fmt.Fprintf(w, "func (o %s%sResultOutput) %s() %s {\n", outputStructName, methodName, Title(p.Name),
 					pkg.outputType(p.Type))
 				fmt.Fprintf(w, "\treturn o.ApplyT(func(v %s%sResult) %s { return v.%s }).(%s)\n", outputStructName, methodName,
@@ -2038,7 +2038,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 
 	// Emit chaining methods for the resource output type.
 	for _, p := range r.Properties {
-		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, false)
+		printCommentWithDeprecationMessage(w, p.StructuredComment, p.DeprecationMessage, false)
 		outputType := pkg.outputType(p.Type)
 
 		propName := pkg.fieldName(r, p)
@@ -2101,7 +2101,7 @@ func (pkg *pkgContext) genFunctionCodeFile(f *schema.Function) (string, error) {
 
 func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) error {
 	name := pkg.functionName(f)
-	printCommentWithDeprecationMessage(w, f.Comment, f.DeprecationMessage, false)
+	printCommentWithDeprecationMessage(w, f.StructuredComment, f.DeprecationMessage, false)
 
 	// Now, emit the function signature.
 	argsig := "ctx *pulumi.Context"
@@ -2165,7 +2165,7 @@ func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) error {
 	if f.Inputs != nil {
 		fmt.Fprintf(w, "\n")
 		fnInputsName := pkg.functionArgsTypeName(f)
-		pkg.genPlainType(w, fnInputsName, f.Inputs.Comment, "", f.Inputs.Properties)
+		pkg.genPlainType(w, fnInputsName, f.Inputs.StructuredComment, "", f.Inputs.Properties)
 		if codegen.IsProvideDefaultsFuncRequired(f.Inputs) && !pkg.disableObjectDefaults {
 			if err := pkg.genObjectDefaultFunc(w, fnInputsName, f.Inputs.Properties); err != nil {
 				return err
@@ -2175,7 +2175,7 @@ func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) error {
 	if f.Outputs != nil && len(f.Outputs.Properties) > 0 {
 		fmt.Fprintf(w, "\n")
 		fnOutputsName := pkg.functionResultTypeName(f)
-		pkg.genPlainType(w, fnOutputsName, f.Outputs.Comment, "", f.Outputs.Properties)
+		pkg.genPlainType(w, fnOutputsName, f.Outputs.StructuredComment, "", f.Outputs.Properties)
 		if codegen.IsProvideDefaultsFuncRequired(f.Outputs) && !pkg.disableObjectDefaults {
 			if err := pkg.genObjectDefaultFunc(w, fnOutputsName, f.Outputs.Properties); err != nil {
 				return err
@@ -2376,7 +2376,7 @@ func (pkg *pkgContext) genType(w io.Writer, obj *schema.ObjectType) error {
 	}
 
 	plainName := pkg.tokenToType(obj.Token)
-	pkg.genPlainType(w, plainName, obj.Comment, "", obj.Properties)
+	pkg.genPlainType(w, plainName, obj.StructuredComment, "", obj.Properties)
 	if !pkg.disableObjectDefaults {
 		if err := pkg.genObjectDefaultFunc(w, plainName, obj.Properties); err != nil {
 			return err
@@ -2879,7 +2879,7 @@ func (pkg *pkgContext) genConfig(w io.Writer, variables []*schema.Property) erro
 		}
 
 		printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, false)
-		configKey := fmt.Sprintf("\"%s:%s\"", pkg.pkg.Name(), cgstrings.Camel(p.Name))
+		configKey := fmt.Sprintf("\"%s:%s\"", pkg.pkg.Name, cgstrings.Camel(p.Name))
 
 		fmt.Fprintf(w, "func Get%s(ctx *pulumi.Context) %s {\n", Title(p.Name), getType)
 		if p.DefaultValue != nil {

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -844,6 +844,9 @@ func (pkg *pkgContext) toOutputMethod(t schema.Type) string {
 	return "To" + outputTypeName
 }
 
+// printComment filters examples for the Go languages and prepends double forward slash to each line in the given
+// comment. If indent is true, each line is indented with tab character. It returns the number of lines in the
+// resulting comment. It guarantees that each line is terminated with newline character.
 func printComment(w io.Writer, comment schema.Description, indent bool) int {
 	desc, err := comment.NarrowToLanguage("go").RenderToMarkdown(nil)
 	contract.IgnoreError(err)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -844,10 +844,7 @@ func (pkg *pkgContext) toOutputMethod(t schema.Type) string {
 	return "To" + outputTypeName
 }
 
-// printComment filters examples for the Go languages and prepends double forward slash to each line in the given
-// comment. If indent is true, each line is indented with tab character. It returns the number of lines in the
-// resulting comment. It guarantees that each line is terminated with newline character.
-func printComment(w io.Writer, comment string, indent bool) int {
+func printComment(w io.Writer, comment schema.Description, indent bool) int {
 	comment = codegen.FilterExamples(comment, "go")
 
 	lines := strings.Split(comment, "\n")
@@ -867,7 +864,8 @@ func printComment(w io.Writer, comment string, indent bool) int {
 	return len(lines)
 }
 
-func printCommentWithDeprecationMessage(w io.Writer, comment, deprecationMessage string, indent bool) {
+func printCommentWithDeprecationMessage(w io.Writer, comment schema.Description,
+	deprecationMessage string, indent bool) {
 	lines := printComment(w, comment, indent)
 	if deprecationMessage != "" {
 		if lines > 0 {

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -28,7 +28,7 @@ import (
 var testPackageSpec = schema.PackageSpec{
 	Name:    "aws",
 	Version: "0.0.1",
-	Description: schema.DescriptionSpec{
+	Description: &schema.DescriptionSpec{
 		Legacy: "A fake provider package used for testing.",
 	},
 	Meta: &schema.MetadataSpec{
@@ -37,13 +37,13 @@ var testPackageSpec = schema.PackageSpec{
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: schema.DescriptionSpec{
+				Description: &schema.DescriptionSpec{
 					Legacy: "The resource options object.",
 				},
 				Type: "object",
 				Properties: map[string]schema.PropertySpec{
 					"stringProp": {
-						Description: schema.DescriptionSpec{
+						Description: &schema.DescriptionSpec{
 							Legacy: "A string prop.",
 						},
 						TypeSpec: schema.TypeSpec{

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -26,20 +26,26 @@ import (
 )
 
 var testPackageSpec = schema.PackageSpec{
-	Name:        "aws",
-	Version:     "0.0.1",
-	Description: "A fake provider package used for testing.",
+	Name:    "aws",
+	Version: "0.0.1",
+	Description: schema.DescriptionSpec{
+		Legacy: "A fake provider package used for testing.",
+	},
 	Meta: &schema.MetadataSpec{
 		ModuleFormat: "(.*)(?:/[^/]*)",
 	},
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			ObjectTypeSpec: schema.ObjectTypeSpec{
-				Description: "The resource options object.",
-				Type:        "object",
+				Description: schema.DescriptionSpec{
+					Legacy: "The resource options object.",
+				},
+				Type: "object",
 				Properties: map[string]schema.PropertySpec{
 					"stringProp": {
-						Description: "A string prop.",
+						Description: schema.DescriptionSpec{
+							Legacy: "A string prop.",
+						},
 						TypeSpec: schema.TypeSpec{
 							Type: "string",
 						},

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -501,7 +501,8 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 		}
 
 		if readme == "" {
-			readme, err := mod.pkg.Description().NarrowToLanguage("python").RenderToMarkdown(nil)
+			var err error
+			readme, err = mod.pkg.Description().NarrowToLanguage("python").RenderToMarkdown(nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -262,6 +262,6 @@ Here \\\\N slashes should be escaped but not N
 """
 `
 	w := &bytes.Buffer{}
-	printComment(w, source, "")
+	printComment(w, schema.MakeMarkdownDescription(source), "")
 	assert.Equal(t, expected, w.String())
 }

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -236,21 +236,22 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 	}
 
 	pkg := &Package{
-		moduleFormat:        moduleFormatRegexp,
-		Name:                info.Name,
-		DisplayName:         info.DisplayName,
-		Version:             version,
-		Description:         description,
-		Keywords:            info.Keywords,
-		Homepage:            info.Homepage,
-		License:             info.License,
-		Attribution:         info.Attribution,
-		Repository:          info.Repository,
-		PluginDownloadURL:   info.PluginDownloadURL,
-		Publisher:           info.Publisher,
-		AllowedPackageNames: info.AllowedPackageNames,
-		LogoURL:             info.LogoURL,
-		Language:            language,
+		moduleFormat:          moduleFormatRegexp,
+		Name:                  info.Name,
+		DisplayName:           info.DisplayName,
+		Version:               version,
+		Description:           description.pretendLegacy(),
+		StructuredDescription: description,
+		Keywords:              info.Keywords,
+		Homepage:              info.Homepage,
+		License:               info.License,
+		Attribution:           info.Attribution,
+		Repository:            info.Repository,
+		PluginDownloadURL:     info.PluginDownloadURL,
+		Publisher:             info.Publisher,
+		AllowedPackageNames:   info.AllowedPackageNames,
+		LogoURL:               info.LogoURL,
+		Language:              language,
 	}
 
 	// We want to use the same loader instance for all referenced packages, so only instantiate the loader if the
@@ -1218,7 +1219,8 @@ func (t *types) bindProperties(path string, properties map[string]PropertySpec, 
 		}
 		p := &Property{
 			Name:                 name,
-			Comment:              description,
+			Comment:              description.pretendLegacy(),
+			StructuredComment:    description,
 			Type:                 t.newOptionalType(typ),
 			ConstValue:           cv,
 			DefaultValue:         dv,
@@ -1289,7 +1291,8 @@ func (t *types) bindObjectTypeDetails(path string, obj *ObjectType, token string
 	obj.Package = t.pkg
 	obj.PackageReference = t.externalPackage()
 	obj.Token = token
-	obj.Comment = description
+	obj.Comment = description.pretendLegacy()
+	obj.StructuredComment = description
 	obj.Language = language
 	obj.Properties = properties
 	obj.properties = propertyMap
@@ -1298,7 +1301,8 @@ func (t *types) bindObjectTypeDetails(path string, obj *ObjectType, token string
 	obj.InputShape.Package = t.pkg
 	obj.InputShape.PackageReference = t.externalPackage()
 	obj.InputShape.Token = token
-	obj.InputShape.Comment = description
+	obj.InputShape.Comment = description.pretendLegacy()
+	obj.InputShape.StructuredComment = description
 	obj.InputShape.Language = language
 	obj.InputShape.Properties = inputProperties
 	obj.InputShape.properties = inputPropertyMap
@@ -1352,7 +1356,8 @@ func (t *types) bindEnumType(token string, spec ComplexTypeSpec) (*EnumType, hcl
 
 		values[i] = &Enum{
 			Value:              value,
-			Comment:            description,
+			Comment:            description.pretendLegacy(),
+			StructuredComment:  description,
 			Name:               spec.Name,
 			DeprecationMessage: spec.DeprecationMessage,
 		}
@@ -1362,13 +1367,14 @@ func (t *types) bindEnumType(token string, spec ComplexTypeSpec) (*EnumType, hcl
 		diags = diags.Append(diag)
 	}
 	return &EnumType{
-		Package:          t.pkg,
-		PackageReference: t.externalPackage(),
-		Token:            token,
-		Elements:         values,
-		ElementType:      typ,
-		Comment:          description,
-		IsOverlay:        spec.IsOverlay,
+		Package:           t.pkg,
+		PackageReference:  t.externalPackage(),
+		Token:             token,
+		Elements:          values,
+		ElementType:       typ,
+		Comment:           description.pretendLegacy(),
+		StructuredComment: description,
+		IsOverlay:         spec.IsOverlay,
 	}, diags
 }
 
@@ -1563,7 +1569,8 @@ func (t *types) bindResourceDetails(path, token string, spec ResourceSpec, decl 
 		Package:            t.pkg,
 		PackageReference:   t.externalPackage(),
 		Token:              token,
-		Comment:            description,
+		Comment:            description.pretendLegacy(),
+		StructuredComment:  description,
 		InputProperties:    inputProperties,
 		Properties:         properties,
 		StateInputs:        stateInputs,
@@ -1688,7 +1695,8 @@ func (t *types) bindFunctionDef(token string) (*Function, hcl.Diagnostics, error
 		Package:            t.pkg,
 		PackageReference:   t.externalPackage(),
 		Token:              token,
-		Comment:            description,
+		Comment:            description.pretendLegacy(),
+		StructuredComment:  description,
 		Inputs:             inputs,
 		Outputs:            outputs,
 		DeprecationMessage: spec.DeprecationMessage,

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -494,7 +494,14 @@ func bindDescription(path string, spec DescriptionSpec) (Description, *hcl.Diagn
 		return nil, errorf(path, "cannot specify both legacy and structured")
 	}
 	if spec.Legacy != "" {
-		panic("parse the doc")
+		return Description{
+			DescriptionMarkdownNode{
+				descriptionNode: descriptionNode{
+					legacytxt: &spec.Legacy,
+				},
+				Text: spec.Legacy,
+			},
+		}, nil
 	}
 
 	desc := Description{}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -489,7 +489,10 @@ func bindHelpers(path string, errs *multierror.Error, obj map[string]interface{}
 // TODO: Cleanup into separate functions.
 //
 // We should have adding new node types as an explicit design goal here.
-func bindDescription(path string, spec DescriptionSpec) (Description, *hcl.Diagnostic) {
+func bindDescription(path string, spec *DescriptionSpec) (Description, *hcl.Diagnostic) {
+	if spec == nil {
+		return Description{}, nil
+	}
 	if spec.Legacy != "" && len(spec.Structured) != 0 {
 		return nil, errorf(path, "cannot specify both legacy and structured")
 	}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -542,8 +542,8 @@ func bindDescription(path string, spec DescriptionSpec) (Description, *hcl.Diagn
 					}, func(node map[string]interface{}) {
 						expectFields, castString := bindHelpers(path, &errs, node)
 						expectFields("raw-text")
-						v = DescriptionPlainNode{
-							Text: castString("raw-text"),
+						v = DescriptionMarkdownNode{
+							Text: "```\n" + castString("raw-text") + "\n```",
 						}
 					})
 					return v
@@ -552,12 +552,6 @@ func bindDescription(path string, spec DescriptionSpec) (Description, *hcl.Diagn
 					Leading:  bindTriviaNode("leading"),
 					Trailing: bindTriviaNode("trailing"),
 				}
-			}
-			if _, ok := node["raw-text"]; ok {
-				expectFields("raw-text")
-				desc = append(desc,
-					DescriptionPlainNode{Text: castString("raw-text")})
-				return
 			}
 			if _, ok := node["pcl"]; ok {
 				expectFields("pcl", "trivia")

--- a/pkg/codegen/schema/description.go
+++ b/pkg/codegen/schema/description.go
@@ -262,7 +262,7 @@ type descriptionNode struct {
 }
 
 func (d descriptionNode) isDescriptionNode()  {}
-func (d descriptionNode) legacyText() *string { return d.legacyText() }
+func (d descriptionNode) legacyText() *string { return d.legacytxt }
 
 func (d DescriptionMarkdownNode) isDescriptionTriviaField() {}
 func (d DescriptionMarkdownNode) asMarkdown() string {

--- a/pkg/codegen/schema/description.go
+++ b/pkg/codegen/schema/description.go
@@ -217,18 +217,18 @@ func MakeMarkdownDescription(s string) Description {
 
 // Implementation details for marshaling and unmarshaling
 
-func (d Description) marshal() (DescriptionSpec, error) {
+func (d Description) marshal() (*DescriptionSpec, error) {
 	if isLegacy, legacyText, otherNodes := d.checkLegacy(); isLegacy {
 		if len(otherNodes) != 0 {
-			return DescriptionSpec{}, fmt.Errorf("cannot mutate a legacy description")
+			return nil, fmt.Errorf("cannot mutate a legacy description")
 		}
-		return DescriptionSpec{Legacy: legacyText}, nil
+		return &DescriptionSpec{Legacy: legacyText}, nil
 	}
 	structured := make([]interface{}, len(d))
 	for i, node := range d {
 		structured[i] = node
 	}
-	return DescriptionSpec{Structured: structured}, nil
+	return &DescriptionSpec{Structured: structured}, nil
 }
 
 func (d Description) checkLegacy() (bool, string, []DescriptionNode) {

--- a/pkg/codegen/schema/description.go
+++ b/pkg/codegen/schema/description.go
@@ -107,6 +107,16 @@ func (d Description) RenderToMarkdown(convert PclConverter) (string, error) {
 	return rendered, nil
 }
 
+// A pest effort attempt at legacy behavor during the transition from `string` to
+// `Description`.
+func (d Description) pretendLegacy() string {
+	if legacy, s, _ := d.checkLegacy(); legacy {
+		return s
+	}
+	s, _ := d.RenderToMarkdown(nil)
+	return s
+}
+
 func LegacyFilterExamples(source []byte, node ast.Node, lang string) {
 	var c, next ast.Node
 	for c = node.FirstChild(); c != nil; c = next {

--- a/pkg/codegen/schema/description.go
+++ b/pkg/codegen/schema/description.go
@@ -125,3 +125,6 @@ type descriptionNode struct {
 
 func (d descriptionNode) isDescriptionNode()  {}
 func (d descriptionNode) legacyText() *string { return d.legacyText() }
+
+func (d DescriptionMarkdownNode) isDescriptionTriviaField() {}
+func (d DescriptionPlainNode) isDescriptionTriviaField()    {}

--- a/pkg/codegen/schema/description.go
+++ b/pkg/codegen/schema/description.go
@@ -1,0 +1,127 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+)
+
+// Description and node types
+
+type Description []DescriptionNode
+
+type DescriptionCodeNode struct {
+	descriptionNode
+	Trivia DescriptionTrivia
+	Code   map[string]DescriptionCodeElement
+}
+
+type DescriptionCodeElement struct {
+	Trivia DescriptionTrivia
+	Body   string
+}
+
+type DescriptionTrivia struct {
+	Leading  DescriptionTriviaField
+	Trailing DescriptionTriviaField
+}
+
+type DescriptionPlainNode struct {
+	descriptionNode
+	Text string
+}
+type DescriptionMarkdownNode struct {
+	descriptionNode
+	Text string
+}
+
+type DescriptionPclNode struct {
+	descriptionNode
+	Trivia DescriptionTrivia
+	Body   string
+}
+
+type DescriptionYamlNode struct {
+	descriptionNode
+	Trivia DescriptionTrivia
+	Body   string
+}
+
+type DescriptionNode interface {
+	isDescriptionNode()
+	legacyText() *string
+}
+
+type DescriptionTriviaField interface {
+	DescriptionNode
+	isDescriptionTriviaField()
+}
+
+// Helper functions for creating simple descriptions
+
+func MakeMarkdownDescription(s string) Description {
+	return Description{
+		DescriptionMarkdownNode{Text: s},
+	}
+}
+
+// Implementation details for marshaling and unmarshaling
+
+func (d Description) marshal() (DescriptionSpec, error) {
+	if isLegacy, legacyText, otherNodes := d.checkLegacy(); isLegacy {
+		if len(otherNodes) != 0 {
+			return DescriptionSpec{}, fmt.Errorf("cannot mutate a legacy description")
+		}
+		return DescriptionSpec{Legacy: legacyText}, nil
+	}
+	structured := make([]interface{}, len(d))
+	for i, node := range d {
+		structured[i] = node
+	}
+	return DescriptionSpec{Structured: structured}, nil
+}
+
+func (d Description) checkLegacy() (bool, string, []DescriptionNode) {
+	var text *string
+	var otherNodes []DescriptionNode
+
+	for i, node := range d {
+		if node.legacyText() != text {
+			if text == nil {
+				// We have hit a legacy node for the first time.
+				text = node.legacyText()
+				// All previous nodes don't match, so mark them as other.
+				otherNodes = d[:i]
+			} else {
+				otherNodes = append(otherNodes, node)
+			}
+		}
+	}
+
+	if text != nil {
+		return true, *text, otherNodes
+	}
+	return false, "", nil
+}
+
+type descriptionNode struct {
+	// A pointer to the text that the enclosing Description was derived from.
+	// legacyText is nil if the node is not from a legacy value.
+	// legacyText is compared with pointer equality.
+	legacytxt *string
+}
+
+func (d descriptionNode) isDescriptionNode()  {}
+func (d descriptionNode) legacyText() *string { return d.legacyText() }

--- a/pkg/codegen/schema/description.go
+++ b/pkg/codegen/schema/description.go
@@ -16,11 +16,142 @@ package schema
 
 import (
 	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pgavlin/goldmark/ast"
 )
 
 // Description and node types
 
 type Description []DescriptionNode
+
+type PclConverter func(body string) (map[string]DescriptionCodeElement, error)
+
+func (d Description) NarrowToLanguage(lang string) Description {
+	// TODO: Consider normalizing legacy earlier.
+	if legacy, s, _ := d.checkLegacy(); legacy {
+		source := []byte(s)
+		parsed := ParseDocs(source)
+		LegacyFilterExamples(source, parsed, lang)
+		return MakeMarkdownDescription(RenderDocsToString(source, parsed))
+	}
+	desc := make(Description, 0, len(d))
+	for _, d := range d {
+		if code, ok := d.(DescriptionCodeNode); ok {
+			if code.Code == nil || code.Code[lang].Body == "" {
+				continue
+			}
+			code.Code = map[string]DescriptionCodeElement{
+				lang: code.Code[lang],
+			}
+			desc = append(desc)
+		} else {
+			desc = append(desc, d)
+		}
+
+	}
+	return desc
+}
+
+func (d Description) RenderToMarkdown(convert PclConverter) (string, error) {
+	if legacy, d, _ := d.checkLegacy(); legacy {
+		return d, nil
+	}
+	var rendered string
+
+	renderCode := func(node DescriptionCodeNode) {
+		if node.Code == nil {
+			return
+		}
+		rendered += node.Trivia.Leading.asMarkdown()
+		rendered += "{{% " + ExamplesShortcode + " %}}\n"
+		for lang, block := range node.Code {
+			rendered += "\n" + block.Trivia.Leading.asMarkdown()
+			rendered += "{{% " + ExampleShortcode + " %}}\n"
+
+			rendered += "```" + lang
+			rendered += block.Body
+			rendered += "```\n"
+
+			rendered += "{{% /" + ExampleShortcode + " %}}"
+			rendered += block.Trivia.Trailing.asMarkdown() + "\n"
+		}
+		rendered += "{{% /" + ExamplesShortcode + " %}}"
+		rendered += node.Trivia.Trailing.asMarkdown()
+	}
+
+	var errs multierror.Error
+	for _, node := range d {
+		switch node := node.(type) {
+		case DescriptionMarkdownNode:
+			rendered += node.Text
+		case DescriptionCodeNode:
+			renderCode(node)
+		case DescriptionPclNode:
+			if convert == nil {
+				continue
+			}
+			code, err := convert(node.Body)
+			if err != nil {
+				errs.Errors = append(errs.Errors, err)
+			}
+
+			// We'll try to render what was returned, even if there was an error.
+			renderCode(DescriptionCodeNode{
+				descriptionNode: node.descriptionNode,
+				Trivia:          node.Trivia,
+				Code:            code,
+			})
+		}
+	}
+	return rendered, nil
+}
+
+func LegacyFilterExamples(source []byte, node ast.Node, lang string) {
+	var c, next ast.Node
+	for c = node.FirstChild(); c != nil; c = next {
+		LegacyFilterExamples(source, c, lang)
+
+		next = c.NextSibling()
+		switch c := c.(type) {
+		case *ast.FencedCodeBlock:
+			sourceLang := string(c.Language(source))
+			if sourceLang != lang && sourceLang != "sh" {
+				node.RemoveChild(node, c)
+			}
+		case *Shortcode:
+			switch string(c.Name) {
+			case ExampleShortcode:
+				hasCode := false
+				for gc := c.FirstChild(); gc != nil; gc = gc.NextSibling() {
+					if gc.Kind() == ast.KindFencedCodeBlock {
+						hasCode = true
+						break
+					}
+				}
+				if hasCode {
+					var grandchild, nextGrandchild ast.Node
+					for grandchild = c.FirstChild(); grandchild != nil; grandchild = nextGrandchild {
+						nextGrandchild = grandchild.NextSibling()
+						node.InsertBefore(node, c, grandchild)
+					}
+				}
+				node.RemoveChild(node, c)
+			case ExamplesShortcode:
+				if first := c.FirstChild(); first != nil {
+					first.SetBlankPreviousLines(c.HasBlankPreviousLines())
+				}
+
+				var grandchild, nextGrandchild ast.Node
+				for grandchild = c.FirstChild(); grandchild != nil; grandchild = nextGrandchild {
+					nextGrandchild = grandchild.NextSibling()
+					node.InsertBefore(node, c, grandchild)
+				}
+				node.RemoveChild(node, c)
+			}
+		}
+	}
+}
 
 type DescriptionCodeNode struct {
 	descriptionNode
@@ -38,10 +169,6 @@ type DescriptionTrivia struct {
 	Trailing DescriptionTriviaField
 }
 
-type DescriptionPlainNode struct {
-	descriptionNode
-	Text string
-}
 type DescriptionMarkdownNode struct {
 	descriptionNode
 	Text string
@@ -66,6 +193,7 @@ type DescriptionNode interface {
 
 type DescriptionTriviaField interface {
 	DescriptionNode
+	asMarkdown() string
 	isDescriptionTriviaField()
 }
 
@@ -127,4 +255,6 @@ func (d descriptionNode) isDescriptionNode()  {}
 func (d descriptionNode) legacyText() *string { return d.legacyText() }
 
 func (d DescriptionMarkdownNode) isDescriptionTriviaField() {}
-func (d DescriptionPlainNode) isDescriptionTriviaField()    {}
+func (d DescriptionMarkdownNode) asMarkdown() string {
+	return d.Text
+}

--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -5,11 +5,16 @@ import (
 )
 
 func newPulumiPackage() *Package {
+	md := func(s string) DescriptionSpec {
+		spec, err := MakeMarkdownDescription(s).marshal()
+		contract.AssertNoError(err)
+		return spec
+	}
 	spec := PackageSpec{
 		Name:        "pulumi",
 		DisplayName: "Pulumi",
 		Version:     "1.0.0",
-		Description: "mock pulumi package",
+		Description: md("mock pulumi package"),
 		Resources: map[string]ResourceSpec{
 			"pulumi:pulumi:StackReference": {
 				ObjectTypeSpec: ObjectTypeSpec{
@@ -28,7 +33,7 @@ func newPulumiPackage() *Package {
 		Provider: ResourceSpec{
 			InputProperties: map[string]PropertySpec{
 				"name": {
-					Description: "fully qualified name of stack, i.e. <organization>/<project>/<stack>",
+					Description: md("fully qualified name of stack, i.e. <organization>/<project>/<stack>"),
 					TypeSpec: TypeSpec{
 						Type: "string",
 					},

--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -5,7 +5,7 @@ import (
 )
 
 func newPulumiPackage() *Package {
-	md := func(s string) DescriptionSpec {
+	md := func(s string) *DescriptionSpec {
 		spec, err := MakeMarkdownDescription(s).marshal()
 		contract.AssertNoError(err)
 		return spec

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -21,8 +21,11 @@ type PackageReference interface {
 	// Version returns the package version.
 	Version() *semver.Version
 
+	// Depreciated in favor of StructuredDescription.
+	Description() string
+
 	// Description returns the packages description.
-	Description() Description
+	StructuredDescription() Description
 
 	// Types returns the package's types.
 	Types() PackageTypes
@@ -142,8 +145,12 @@ func (p packageDefRef) Version() *semver.Version {
 	return p.pkg.Version
 }
 
-func (p packageDefRef) Description() Description {
+func (p packageDefRef) Description() string {
 	return p.pkg.Description
+}
+
+func (p packageDefRef) StructuredDescription() Description {
+	return p.pkg.StructuredDescription
 }
 
 func (p packageDefRef) Types() PackageTypes {
@@ -326,7 +333,7 @@ func (p *PartialPackage) Version() *semver.Version {
 	return p.types.pkg.Version
 }
 
-func (p *PartialPackage) Description() Description {
+func (p *PartialPackage) Description() string {
 	p.m.Lock()
 	defer p.m.Unlock()
 
@@ -334,6 +341,16 @@ func (p *PartialPackage) Description() Description {
 		return p.def.Description
 	}
 	return p.types.pkg.Description
+}
+
+func (p *PartialPackage) StructuredDescription() Description {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if p.def != nil {
+		return p.def.StructuredDescription
+	}
+	return p.types.pkg.StructuredDescription
 }
 
 func (p *PartialPackage) Types() PackageTypes {

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -22,7 +22,7 @@ type PackageReference interface {
 	Version() *semver.Version
 
 	// Description returns the packages description.
-	Description() string
+	Description() Description
 
 	// Types returns the package's types.
 	Types() PackageTypes
@@ -142,7 +142,7 @@ func (p packageDefRef) Version() *semver.Version {
 	return p.pkg.Version
 }
 
-func (p packageDefRef) Description() string {
+func (p packageDefRef) Description() Description {
 	return p.pkg.Description
 }
 
@@ -326,7 +326,7 @@ func (p *PartialPackage) Version() *semver.Version {
 	return p.types.pkg.Version
 }
 
-func (p *PartialPackage) Description() string {
+func (p *PartialPackage) Description() Description {
 	p.m.Lock()
 	defer p.m.Unlock()
 

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -154,8 +154,10 @@ type EnumType struct {
 	PackageReference PackageReference
 	// Token is the type's Pulumi type token.
 	Token string
+	// Depreciated in favor of StructuredComment.
+	Comment string
 	// Comment is the description of the type, if any.
-	Comment Description
+	StructuredComment Description
 	// Elements are the predefined enum values.
 	Elements []*Enum
 	// ElementType is the underlying type for the enum.
@@ -170,8 +172,10 @@ type EnumType struct {
 type Enum struct {
 	// Value is the value of the enum.
 	Value interface{}
+	// Depreciated in favor of StructuredComment.
+	Comment string
 	// Comment is the description for the enum value.
-	Comment Description
+	StructuredComment Description
 	// Name for the enum.
 	Name string
 	// DeprecationMessage indicates whether or not the value is deprecated.
@@ -221,8 +225,10 @@ type ObjectType struct {
 	PackageReference PackageReference
 	// Token is the type's Pulumi type token.
 	Token string
+	// Depreciated in favor of StructuredComment.
+	Comment string
 	// Comment is the description of the type, if any.
-	Comment Description
+	StructuredComment Description
 	// Properties is the list of the type's properties.
 	Properties []*Property
 	// Language specifies additional language-specific data about the object type.
@@ -340,8 +346,10 @@ type DefaultValue struct {
 type Property struct {
 	// Name is the name of the property.
 	Name string
+	// Deprecated in favor of StructuredComment.
+	Comment string
 	// Comment is the description of the property, if any.
-	Comment Description
+	StructuredComment Description
 	// Type is the type of the property.
 	Type Type
 	// ConstValue is the constant value for the property, if any.
@@ -387,8 +395,10 @@ type Resource struct {
 	PackageReference PackageReference
 	// Token is the resource's Pulumi type token.
 	Token string
+	// Deprecated in favor of StructuredComment
+	Comment string
 	// Comment is the description of the resource, if any.
-	Comment Description
+	StructuredComment Description
 	// IsProvider is true if the resource is a provider resource.
 	IsProvider bool
 	// InputProperties is the list of the resource's input properties.
@@ -537,8 +547,10 @@ type Function struct {
 	PackageReference PackageReference
 	// Token is the function's Pulumi type token.
 	Token string
+	// Deprecated in favor of StructuredComment.
+	Comment string
 	// Comment is the description of the function, if any.
-	Comment Description
+	StructuredComment Description
 	// Inputs is the bag of input values for the function, if any.
 	Inputs *ObjectType
 	// Outputs is the bag of output values for the function, if any.
@@ -589,8 +601,10 @@ type Package struct {
 	DisplayName string
 	// Version is the version of the package.
 	Version *semver.Version
+	// Depreciated in favor of StructuredDescription
+	Description string
 	// Description is the description of the package.
-	Description Description
+	StructuredDescription Description
 	// Keywords is the list of keywords that are associated with the package, if any.
 	// Some reserved keywords can be specified as well that help with categorizing the
 	// package in the Pulumi registry. `category/<name>` and `kind/<type>` are the only
@@ -946,7 +960,7 @@ func (pkg *Package) MarshalSpec() (spec *PackageSpec, err error) {
 		metadata = &MetadataSpec{ModuleFormat: pkg.moduleFormat.String()}
 	}
 
-	pkgDescription, err := pkg.Description.marshal()
+	pkgDescription, err := pkg.StructuredDescription.marshal()
 	if err != nil {
 		return nil, err
 	}
@@ -1079,7 +1093,7 @@ func (pkg *Package) marshalObjectData(comment Description, properties []*Propert
 }
 
 func (pkg *Package) marshalObject(t *ObjectType, plain bool) (ComplexTypeSpec, error) {
-	data, err := pkg.marshalObjectData(t.Comment, t.Properties, t.Language, plain, t.IsOverlay)
+	data, err := pkg.marshalObjectData(t.StructuredComment, t.Properties, t.Language, plain, t.IsOverlay)
 	if err != nil {
 		return ComplexTypeSpec{}, err
 	}
@@ -1089,7 +1103,7 @@ func (pkg *Package) marshalObject(t *ObjectType, plain bool) (ComplexTypeSpec, e
 func (pkg *Package) marshalEnum(t *EnumType) (ComplexTypeSpec, error) {
 	values := make([]EnumValueSpec, len(t.Elements))
 	for i, el := range t.Elements {
-		desc, err := el.Comment.marshal()
+		desc, err := el.StructuredComment.marshal()
 		if err != nil {
 			return ComplexTypeSpec{}, err
 		}
@@ -1108,7 +1122,7 @@ func (pkg *Package) marshalEnum(t *EnumType) (ComplexTypeSpec, error) {
 }
 
 func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
-	object, err := pkg.marshalObjectData(r.Comment, r.Properties, r.Language, true, r.IsOverlay)
+	object, err := pkg.marshalObjectData(r.StructuredComment, r.Properties, r.Language, true, r.IsOverlay)
 	if err != nil {
 		return ResourceSpec{}, fmt.Errorf("marshaling properties: %w", err)
 	}
@@ -1180,7 +1194,7 @@ func (pkg *Package) marshalFunction(f *Function) (FunctionSpec, error) {
 		return FunctionSpec{}, err
 	}
 
-	desc, err := f.Comment.marshal()
+	desc, err := f.StructuredComment.marshal()
 	if err != nil {
 		return FunctionSpec{}, err
 	}
@@ -1233,7 +1247,7 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 			return nil, nil, fmt.Errorf("property '%v': %w", p.Name, err)
 		}
 
-		desc, err := p.Comment.marshal()
+		desc, err := p.StructuredComment.marshal()
 		if err != nil {
 			return nil, nil, fmt.Errorf("property '%v': %w", p.Name, err)
 		}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1452,11 +1452,11 @@ func (d DescriptionSpec) marshal(marshal func(interface{}) ([]byte, error)) func
 		if d.Legacy != "" && len(d.Structured) > 0 {
 			return nil, fmt.Errorf("cannot marshal multiple fields in a union")
 		}
-		if d.Legacy != "" {
-			return marshal(d.Legacy)
+		if len(d.Structured) > 0 {
+			return marshal(d.Structured)
 		}
 
-		return marshal(d.Structured)
+		return marshal(d.Legacy)
 	}
 }
 
@@ -1523,7 +1523,7 @@ type PropertySpec struct {
 	TypeSpec `yaml:",inline"`
 
 	// Description is the description of the property, if any.
-	Description DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
+	Description *DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
 	// Const is the constant value for the property, if any. The type of the value must be assignable to the type of
 	// the property.
 	Const interface{} `json:"const,omitempty" yaml:"const,omitempty"`
@@ -1548,7 +1548,7 @@ type PropertySpec struct {
 // ObjectTypeSpec is the serializable form of an object type.
 type ObjectTypeSpec struct {
 	// Description is the description of the type, if any.
-	Description DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
+	Description *DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
 	// Properties, if present, is a map from property name to PropertySpec that describes the type's properties.
 	Properties map[string]PropertySpec `json:"properties,omitempty" yaml:"properties,omitempty"`
 	// Type must be "object" if this is an object type, or the underlying type for an enum.
@@ -1579,7 +1579,7 @@ type EnumValueSpec struct {
 	// Name, if present, overrides the name of the enum value that would usually be derived from the value.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Description of the enum value.
-	Description DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
+	Description *DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
 	// Value is the enum value itself.
 	Value interface{} `json:"value" yaml:"value"`
 	// DeprecationMessage indicates whether or not the value is deprecated.
@@ -1623,7 +1623,7 @@ type ResourceSpec struct {
 // FunctionSpec is the serializable form of a function description.
 type FunctionSpec struct {
 	// Description is the description of the function, if any.
-	Description DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
+	Description *DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
 	// Inputs is the bag of input values for the function, if any.
 	Inputs *ObjectTypeSpec `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	// Outputs is the bag of output values for the function, if any.
@@ -1663,7 +1663,7 @@ type PackageInfoSpec struct {
 	// Version is the version of the package. The version must be valid semver.
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	// Description is the description of the package.
-	Description DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
+	Description *DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
 	// Keywords is the list of keywords that are associated with the package, if any.
 	// Some reserved keywords can be specified as well that help with categorizing the
 	// package in the Pulumi registry. `category/<name>` and `kind/<type>` are the only
@@ -1706,7 +1706,7 @@ type PackageSpec struct {
 	// Version is the version of the package. The version must be valid semver.
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	// Description is the description of the package.
-	Description DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
+	Description *DescriptionSpec `json:"description,omitempty" yaml:"description,omitempty"`
 	// Keywords is the list of keywords that are associated with the package, if any.
 	// Some reserved keywords can be specified as well that help with categorizing the
 	// package in the Pulumi registry. `category/<name>` and `kind/<type>` are the only

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1233,9 +1233,14 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 			return nil, nil, fmt.Errorf("property '%v': %w", p.Name, err)
 		}
 
+		desc, err := p.Comment.marshal()
+		if err != nil {
+			return nil, nil, fmt.Errorf("property '%v': %w", p.Name, err)
+		}
+
 		specs[p.Name] = PropertySpec{
 			TypeSpec:           pkg.marshalType(typ, plain),
-			Description:        p.Comment,
+			Description:        desc,
 			Const:              p.ConstValue,
 			Default:            defaultValue,
 			DefaultInfo:        defaultSpec,


### PR DESCRIPTION
Fixes #11338

This change is backwards compatible at the schema level, but not at the code level. Because of the circular dependency between pu/pu and pu/java, we need to merge multiple PRs to update the field type:

1. Merge this PR. Adding the bridge field and pointing pu/pu code to the bridge field. The original field is now depreciated.
2. Merge a similar PR in Java, pointing usage to the bridge field instead of the depreciated field.
3. Merge a PR to pu/pu that switches the type of the depreciated fields to `Description`, pointing consumers of `Structured*` fields to the old field. The old fields are no longer depreciated. Depreciate the bridge fields.
4. Merge a PR in Java, depending on the original fields (now with the new type). Don't depend on the bridged fields.
5. Merge a PR to pu/pu, removing the bridge fields. Add a changelog entry, indicating new behavior in the schema and that it should be universally preferred for new schemas.