### PR TITLE
fix(testing): Adds cached python venvs for integration tests

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -64,6 +64,7 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   # Release builds use the service, PR checks and snapshots will use the local backend if possible.
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
+  PULUMI_TEST_PYTHON_SHARED_VENV: "true"
   PYTHON: python
   GO_TEST_PARALLELISM: 8
   GO_TEST_PKG_PARALLELISM: 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
     "go.buildTags": "all",
     "go.testTimeout": "1h",
+    "go.testEnvVars": {
+        "PULUMI_TEST_PYTHON_SHARED_VENV": "true",
+    },
     "gopls": {
         // A couple of modules get copied as part of builds and this confuse gopls as it sees the module name twice, just ignore the copy in the build folders.
         "build.directoryFilters": [

--- a/changelog/pending/20221205--pkg-testing--optionally-caches-python-venvs-for-testing.yaml
+++ b/changelog/pending/20221205--pkg-testing--optionally-caches-python-venvs-for-testing.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pkg/testing
+  description: Optionally caches python venvs for testing

--- a/tests/integration/integration_python_smoke_test.go
+++ b/tests/integration/integration_python_smoke_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/python"
 )
 
+func boolPointer(b bool) *bool {
+	return &b
+}
+
 // TestEmptyPython simply tests that we can run an empty Python project.
 func TestEmptyPython(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -83,6 +87,7 @@ func TestDynamicPython(t *testing.T) {
 				assert.Equal(t, randomVal, stack.Outputs["random_val"].(string))
 			},
 		}},
+		UseSharedVirtualEnv: boolPointer(false),
 	})
 }
 
@@ -144,7 +149,8 @@ func optsForConstructPython(t *testing.T, expectedResourceCount int, localProvid
 		Secrets: map[string]string{
 			"secret": "this super secret is encrypted",
 		},
-		Quick: true,
+		Quick:               true,
+		UseSharedVirtualEnv: boolPointer(false),
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {


### PR DESCRIPTION
The cache key is based on hashing the contents of "requirements.txt" for each python test.  This should result in unchanged test results among tests sharing venvs, and maintains environment isolation across requirement sets

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11485 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
