### PR TITLE
Fix panic in mapper support for map[string]*string

### DIFF
--- a/sdk/go/common/util/mapper/mapper_decode.go
+++ b/sdk/go/common/util/mapper/mapper_decode.go
@@ -151,16 +151,19 @@ func (md *mapper) adjustValueForAssignment(val reflect.Value,
 			// A simple conversion exists to make this right.
 			val = val.Convert(to)
 		} else if to.Kind() == reflect.Ptr && val.Type().AssignableTo(to.Elem()) {
-			// If the target is a pointer, turn the target into a pointer.  If it's not addressable, make a copy.
-			if val.CanAddr() {
-				val = val.Addr()
+			// Here the destination type (to) is a pointer to a type that accepts val.
+			var adjusted reflect.Value // var adjusted *toElem
+			if val.CanAddr() && val.Addr().Type().AssignableTo(to) {
+				// If taking the address of val makes this right, do it.
+				adjusted = val.Addr() // adjusted = &val
 			} else {
-				slot := reflect.New(val.Type().Elem())
-				copy := reflect.ValueOf(val.Interface())
-				contract.Assert(copy.CanAddr())
-				slot.Set(copy)
-				val = slot
+				// Otherwise create a fresh pointer of the desired type and point it to val.
+				adjusted = reflect.New(to.Elem()) // adjusted = new(toElem)
+				adjusted.Elem().Set(val)          // *adjusted = val
 			}
+			// In either case, the loop condition should be sastisfied at this point.
+			contract.Assert(adjusted.Type().AssignableTo(to))
+			return adjusted, nil
 		} else if val.Kind() == reflect.Interface {
 			// It could be that the source is an interface{} with the right element type (or the right element type
 			// through a series of successive conversions); go ahead and give it a try.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

`map[string]*string` does not turn around through mapper, causing a panic.

```go
go test -run TestReproduceMapStringPointerTurnaroundIssue                                                                                                  ~/code/pulumi/sdk/go/common/util/mapper
--- FAIL: TestReproduceMapStringPointerTurnaroundIssue (0.00s)
    mapper_test.go:608: encodedMap: map[args:map[key:value]]
panic: reflect: Elem of invalid type string [recovered]
        panic: reflect: Elem of invalid type string

goroutine 20 [running]:
testing.tRunner.func1.2({0x11cb480, 0xc0000992b0})
        /nix/store/0c30lcag5r6ahw3qj0x7lkshpry4yqwl-go-1.19/share/go/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
        /nix/store/0c30lcag5r6ahw3qj0x7lkshpry4yqwl-go-1.19/share/go/src/testing/testing.go:1399 +0x39f
panic({0x11cb480, 0xc0000992b0})
        /nix/store/0c30lcag5r6ahw3qj0x7lkshpry4yqwl-go-1.19/share/go/src/runtime/panic.go:884 +0x212
reflect.(*rtype).Elem(0x11d1500?)
        /nix/store/0c30lcag5r6ahw3qj0x7lkshpry4yqwl-go-1.19/share/go/src/reflect/type.go:972 +0x134
github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper.(*mapper).adjustValueForAssignment(0xc0000a2240, {0x11d1500?, 0xc000099290?, 0x98?}, {0x126b940?, 0x11c6160}, {0x126b940?, 0x11dd060}, {0xc0000a4a80, 0xf})
        /Users/t0yv0/code/pulumi/sdk/go/common/util/mapper/mapper_decode.go:158 +0x2ea
github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper.(*mapper).adjustValueForAssignment(0xc0000a2240, {0x11d5c20?, 0xc00009d470?, 0x11de1e0?}, {0x126b940?, 0x11d5680}, {0x126b940?, 0x11dd060}, {0x11c0b24, 0x4})
        /Users/t0yv0/code/pulumi/sdk/go/common/util/mapper/mapper_decode.go:204 +0x1a15
github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper.(*mapper).DecodeValue(0xc0000a2240, 0xc0000a0060?, {0x126b940?, 0x11dd060}, {0x11c0b24, 0x4}, {0xc0000aac80?, 0xc0000a0060?}, 0x1)
        /Users/t0yv0/code/pulumi/sdk/go/common/util/mapper/mapper_decode.go:117 +0x8ee
github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper.(*mapper).Decode(0xc0000a2240, 0xc0000a8380?, {0x11c36a0?, 0xc0000a0060?})
        /Users/t0yv0/code/pulumi/sdk/go/common/util/mapper/mapper_decode.go:55 +0x8db
github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper.TestReproduceMapStringPointerTurnaroundIssue.func2(0xc000083520?)
        /Users/t0yv0/code/pulumi/sdk/go/common/util/mapper/mapper_test.go:592 +0xe9
github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper.TestReproduceMapStringPointerTurnaroundIssue(0xc000083520)
        /Users/t0yv0/code/pulumi/sdk/go/common/util/mapper/mapper_test.go:610 +0x11f
testing.tRunner(0xc000083520, 0x1231f88)
        /nix/store/0c30lcag5r6ahw3qj0x7lkshpry4yqwl-go-1.19/share/go/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
        /nix/store/0c30lcag5r6ahw3qj0x7lkshpry4yqwl-go-1.19/share/go/src/testing/testing.go:1493 +0x35f
exit status 2
FAIL    github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper   0.674s
```


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
