### PR TITLE
ci: Remove page file tweak for Windows

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -125,14 +125,6 @@ jobs:
         if: ${{ inputs.enable-coverage && runner.os != 'Windows' }}
         run: |
           echo "PULUMI_TEST_COVERAGE_PATH=$(pwd)/coverage" >> "$GITHUB_ENV"
-      # See: https://github.com/actions/virtual-environments/issues/2642#issuecomment-774988591
-      - name: Configure Windows pagefile
-        uses: aaronfriel/action-configure-pagefile@v2.0-beta.1
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          minimum-size: 4GB
-          maximum-size: 4GB
-          disk-root: "D:"
       - name: Configure Go Cache Key
         env:
           CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"


### PR DESCRIPTION
The step to [configure the pagefile on Windows](https://github.com/pulumi/pulumi/actions/runs/3624853251/jobs/6112393713) began failing due to an update to the underlying runner image. Given that this is blocking CI, we'll remove the step for now.

Either #11532 or #11471 should address performance of integration tests and reliability and obviate the need for this step.