### PR TITLE
Rotate cloud secrets provider

### DIFF
--- a/changelog/pending/20221206--cli--allow-rotating-the-encrpytion-key-for-cloud-secrets.yaml
+++ b/changelog/pending/20221206--cli--allow-rotating-the-encrpytion-key-for-cloud-secrets.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow rotating the encrpytion key for cloud secrets.

--- a/pkg/backend/filestate/crypto.go
+++ b/pkg/backend/filestate/crypto.go
@@ -23,7 +23,7 @@ import (
 )
 
 func NewPassphraseSecretsManager(stackName tokens.Name, configFile string,
-	rotatePassphraseSecretsProvider bool) (secrets.Manager, error) {
+	rotateSecretsProvider bool) (secrets.Manager, error) {
 	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
 	project, _, err := workspace.DetectProjectStackPath(stackName.Q())
@@ -36,16 +36,14 @@ func NewPassphraseSecretsManager(stackName tokens.Name, configFile string,
 		return nil, err
 	}
 
-	if rotatePassphraseSecretsProvider {
+	if rotateSecretsProvider {
 		info.EncryptionSalt = ""
 	}
 
 	// If there are any other secrets providers set in the config, remove them, as the passphrase
 	// provider deals only with EncryptionSalt, not EncryptedKey or SecretsProvider.
-	if info.EncryptedKey != "" || info.SecretsProvider != "" {
-		info.EncryptedKey = ""
-		info.SecretsProvider = ""
-	}
+	info.EncryptedKey = ""
+	info.SecretsProvider = ""
 
 	// If we have a salt, we can just use it.
 	if info.EncryptionSalt != "" {
@@ -53,7 +51,7 @@ func NewPassphraseSecretsManager(stackName tokens.Name, configFile string,
 	}
 
 	// Otherwise, prompt the user for a new passphrase.
-	salt, sm, err := passphrase.PromptForNewPassphrase(rotatePassphraseSecretsProvider)
+	salt, sm, err := passphrase.PromptForNewPassphrase(rotateSecretsProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -64,11 +64,11 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 
 		// nolint: goconst
 		if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
-			return newCloudSecretsManager(s.Ref().Name(), configFile, ps.SecretsProvider)
+			return newCloudSecretsManager(s.Ref().Name(), configFile, ps.SecretsProvider, false /* rotateSecretsProvider */)
 		}
 
 		if ps.EncryptionSalt != "" {
-			return filestate.NewPassphraseSecretsManager(s.Ref().Name(), configFile, false /* rotatePassphraseSecretsProvider */)
+			return filestate.NewPassphraseSecretsManager(s.Ref().Name(), configFile, false /* rotateSecretsProvider */)
 		}
 
 		return s.DefaultSecretManager(configFile)

--- a/pkg/cmd/pulumi/crypto_cloud_test.go
+++ b/pkg/cmd/pulumi/crypto_cloud_test.go
@@ -64,10 +64,10 @@ func TestSecretsProviderOverride(t *testing.T) {
 	t.Run("without override", func(t *testing.T) {
 		createTempFiles(t, files, func() {
 			opener.wantURL = "test://foo"
-			_, createSecretsManagerError := newCloudSecretsManager(stackName, stackConfigFileName, "test://foo")
+			_, createSecretsManagerError := newCloudSecretsManager(stackName, stackConfigFileName, "test://foo", false)
 			assert.Nil(t, createSecretsManagerError, "Creating the cloud secret manager should succeed")
 
-			_, createSecretsManagerError = newCloudSecretsManager(stackName, stackConfigFileName, "test://bar")
+			_, createSecretsManagerError = newCloudSecretsManager(stackName, stackConfigFileName, "test://bar", false)
 			msg := "newCloudSecretsManager with unexpected secretsProvider URL succeeded, expected an error"
 			assert.NotNil(t, createSecretsManagerError, msg)
 		})
@@ -82,9 +82,9 @@ func TestSecretsProviderOverride(t *testing.T) {
 			// Last argument here shouldn't matter anymore, since it gets overridden
 			// by the env var. Both calls should succeed.
 			msg := "creating the secrets manager should succeed regardless of secrets provider"
-			_, createSecretsManagerError := newCloudSecretsManager(stackName, stackConfigFileName, "test://foo")
+			_, createSecretsManagerError := newCloudSecretsManager(stackName, stackConfigFileName, "test://foo", false)
 			assert.Nil(t, createSecretsManagerError, msg)
-			_, createSecretsManagerError = newCloudSecretsManager(stackName, stackConfigFileName, "test://bar")
+			_, createSecretsManagerError = newCloudSecretsManager(stackName, stackConfigFileName, "test://bar", false)
 			assert.Nil(t, createSecretsManagerError, msg)
 		})
 	})

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -95,9 +95,14 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			}
 
 			secretsProvider := args[0]
-			rotatePassphraseProvider := secretsProvider == "passphrase"
+			rotateProvider :=
+				// If we're setting the secrets provider to the same provider then do a rotation.
+				secretsProvider == currentProjectStack.SecretsProvider ||
+					// passphrase doesn't get saved to stack state, so if we're changing to passphrase see if
+					// the current secrets provider is empty
+					((secretsProvider == "passphrase") && (currentProjectStack.SecretsProvider == ""))
 			// Create the new secrets provider and set to the currentStack
-			if err := createSecretsManager(ctx, currentStack, secretsProvider, rotatePassphraseProvider,
+			if err := createSecretsManager(ctx, currentStack, secretsProvider, rotateProvider,
 				false /*creatingStack*/); err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -161,7 +161,7 @@ func commandContext() context.Context {
 
 func createSecretsManager(
 	ctx context.Context, stack backend.Stack, secretsProvider string,
-	rotatePassphraseSecretsProvider, creatingStack bool) error {
+	rotateSecretsProvider, creatingStack bool) error {
 
 	// As part of creating the stack, we also need to configure the secrets provider for the stack.
 	// We need to do this configuration step for cases where we will be using with the passphrase
@@ -190,14 +190,15 @@ func createSecretsManager(
 	}
 
 	if secretsProvider == passphrase.Type {
-		if _, pharseErr := filestate.NewPassphraseSecretsManager(stack.Ref().Name(), configFile,
-			rotatePassphraseSecretsProvider); pharseErr != nil {
-			return pharseErr
+		if _, phraseErr := filestate.NewPassphraseSecretsManager(stack.Ref().Name(),
+			configFile, rotateSecretsProvider); phraseErr != nil {
+			return phraseErr
 		}
 	} else {
 		// All other non-default secrets providers are handled by the cloud secrets provider which
 		// uses a URL schema to identify the provider
-		if _, secretsErr := newCloudSecretsManager(stack.Ref().Name(), configFile, secretsProvider); secretsErr != nil {
+		if _, secretsErr := newCloudSecretsManager(stack.Ref().Name(),
+			configFile, secretsProvider, rotateSecretsProvider); secretsErr != nil {
 			return secretsErr
 		}
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Little thing I noticed while looking at secrets. We support the idea of rotating the passphrase secret provider (that is changing the key and assigning a new passphrase). Turns out this makes sense for the cloud secret provider as well where we generate a new symmetric key.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
