### PR TITLE
fix(sdk/python): Allow for duplicate output values in python programs

### DIFF
--- a/changelog/pending/20221206--sdk-python--allows-for-duplicate-output-values-in-python.yaml
+++ b/changelog/pending/20221206--sdk-python--allows-for-duplicate-output-values-in-python.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Allows for duplicate output values in python

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -6,3 +6,4 @@
 .venv/
 venv/
 .coverage
+build/

--- a/sdk/python/lib/test/langhost/stack_output/__main__.py
+++ b/sdk/python/lib/test/langhost/stack_output/__main__.py
@@ -18,6 +18,9 @@ class TestClass:
         self.num = 1
         self._private = 2
 
+
+my_test_class_instance = TestClass()
+
 recursive = {"a": 1}
 recursive["b"] = 2
 recursive["c"] = recursive
@@ -34,3 +37,5 @@ pulumi.export("dict", {"a": 1})
 pulumi.export("output", pulumi.Output.from_input(1))
 pulumi.export("class", TestClass())
 pulumi.export("recursive", recursive)
+pulumi.export("duplicate_output_0", my_test_class_instance)
+pulumi.export("duplicate_output_1", my_test_class_instance)

--- a/sdk/python/lib/test/langhost/stack_output/test_stack_output.py
+++ b/sdk/python/lib/test/langhost/stack_output/test_stack_output.py
@@ -39,4 +39,6 @@ class StackOutputTest(LanghostTest):
             "output": 1.0,
             "class": {"num": 1.0},
             "recursive": {"a": 1.0, "b": 2.0},
+            "duplicate_output_0": {'num': 1.0},
+            "duplicate_output_1": {'num': 1.0},
         }, outputs)


### PR DESCRIPTION
I used the node SDK as inspiration for this change - there were a few things we were doing differently in python (specifically handling all cases in the outer layer of `massage` rather than allowing for more fine-grained control in a `massage_complex` function like in node.  We also take the stack concept from the node SDK to resolve the immediate issue of duplicate outputs.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11133 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
