### PR TITLE
testing: Allow plugin testing users to define their own plugin sets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ get_schemas: \
 			schema-eks!0.37.1           \
 			schema-eks!0.40.0           \
 			schema-docker!3.1.0         \
+			schema-docker!4.0.0-alpha.0 \
 			schema-awsx!1.0.0-beta.5    \
 			schema-aws-native!0.13.0    \
 			schema-google-native!0.18.2


### PR DESCRIPTION
Updating Pulumi YAML to address pulumi/pulumi-yaml#421 and pulumi/pulumi-yaml#422, requires testing against the Docker v4.0.0-alpha.0 schema. That required updating this repo, and using Go workspaces/module replacement to allow the deploytest plugin loader to find the prerelease schema.

This change allows Pulumi YAML to define its own set of required plugins, decoupling the two repos and preventing the catch-22 here.

Because this repo will need to support the new example being authored which will serve as a test of #421 and #422, this also adds Docker v4.0.0-alpha.0 as a schema.