### PR TITLE
Don't use *schema.Package in python codegen

### DIFF
--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -76,7 +76,7 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input bool) string {
 	typeDetails := map[*schema.ObjectType]*typeDetails{}
 	mod := &modContext{
-		pkg:         pkg,
+		pkg:         pkg.Reference(),
 		mod:         moduleName,
 		typeDetails: typeDetails,
 	}
@@ -114,7 +114,7 @@ func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName stri
 		if info.LiftSingleValueMethodReturns && m.Function.Outputs != nil && len(m.Function.Outputs.Properties) == 1 {
 			typeDetails := map[*schema.ObjectType]*typeDetails{}
 			mod := &modContext{
-				pkg:         pkg,
+				pkg:         pkg.Reference(),
 				mod:         modName,
 				typeDetails: typeDetails,
 			}

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -237,9 +237,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				g.Fgenf(w, "%.v", expr.Args[0])
 				return
 			}
-			moduleNameOverrides := enum.(*schema.EnumType).Package.Language["python"].(PackageInfo).ModuleNameOverrides
+			var moduleNameOverrides map[string]string
+			if pkg, err := enum.(*schema.EnumType).PackageReference.Definition(); err == nil {
+				moduleNameOverrides = pkg.Language["python"].(PackageInfo).ModuleNameOverrides
+			}
 			pkg := strings.ReplaceAll(components[0], "-", "_")
-			if m := tokenToModule(to.Token, &schema.Package{}, moduleNameOverrides); m != "" {
+			if m := tokenToModule(to.Token, nil, moduleNameOverrides); m != "" {
 				pkg += "." + m
 			}
 			enumName := tokenToName(to.Token)

--- a/pkg/codegen/python/gen_resource_mappings.go
+++ b/pkg/codegen/python/gen_resource_mappings.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 	"sort"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 // Generates code to build and regsiter ResourceModule and
@@ -109,8 +111,8 @@ func collectResourceModuleInfos(mctx *modContext) []resourceModuleInfo {
 		}
 
 		if !res.IsProvider {
-			pkg := mctx.pkg.Name
-			mod := mctx.pkg.TokenToRuntimeModule(res.Token)
+			pkg := mctx.pkg.Name()
+			mod := schema.TokenToRuntimeModule(res.Token)
 			fqn := mctx.fullyQualifiedImportName()
 
 			rmi, found := byMod[mod]
@@ -169,7 +171,7 @@ func collectResourcePackageInfos(mctx *modContext) []resourcePackageInfo {
 		}
 
 		if res.IsProvider {
-			pkg := mctx.pkg.Name
+			pkg := mctx.pkg.Name()
 			token := res.Token
 			fqn := mctx.fullyQualifiedImportName()
 			class := "Provider"

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1507,6 +1507,7 @@ func (t *types) bindFunctionDef(token string) (*Function, hcl.Diagnostics, error
 
 	fn := &Function{
 		Package:            t.pkg,
+		PackageReference:   t.externalPackage(),
 		Token:              token,
 		Comment:            spec.Description,
 		Inputs:             inputs,

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -530,8 +530,11 @@ type Method struct {
 
 // Function describes a Pulumi function.
 type Function struct {
-	// Package is the package that defines the function.
+	// Package is the package that defines the function. Package will not be accurate for
+	// types loaded by reference. In that case, use PackageReference instead.
 	Package *Package
+	// PackageReference is the PackageReference that defines the function.
+	PackageReference PackageReference
 	// Token is the function's Pulumi type token.
 	Token string
 	// Comment is the description of the function, if any.
@@ -894,7 +897,7 @@ func (pkg *Package) TokenToModule(tok string) string {
 	}
 }
 
-func (pkg *Package) TokenToRuntimeModule(tok string) string {
+func TokenToRuntimeModule(tok string) string {
 	// token := pkg ":" module ":" member
 
 	components := strings.Split(tok, ":")
@@ -902,6 +905,10 @@ func (pkg *Package) TokenToRuntimeModule(tok string) string {
 		return ""
 	}
 	return components[1]
+}
+
+func (pkg *Package) TokenToRuntimeModule(tok string) string {
+	return TokenToRuntimeModule(tok)
 }
 
 func (pkg *Package) GetResource(token string) (*Resource, bool) {

--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -183,4 +184,25 @@ func (fs Fs) Add(path string, contents []byte) {
 	_, has := fs[path]
 	contract.Assertf(!has, "duplicate file: %s", path)
 	fs[path] = contents
+}
+
+// Check if two packages are the same.
+func PkgEquals(p1, p2 schema.PackageReference) bool {
+	if p1 == p2 {
+		return true
+	} else if p1 == nil || p2 == nil {
+		return false
+	}
+
+	if p1.Name() != p2.Name() {
+		return false
+	}
+
+	v1, v2 := p1.Version(), p2.Version()
+	if v1 == v2 {
+		return true
+	} else if v1 == nil || v2 == nil {
+		return false
+	}
+	return v1.Equals(*v2)
 }


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi/issues/9932

tldr: `Package` is not reliable when its used for an external package. We are transferring over to `PackageReference`, and will remove the `Package` field once all references to it have been removed.