### PR TITLE
Fix PCL binding of options.range = number

### DIFF
--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -305,6 +305,8 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 					diags := rangeExpr.Typecheck(false)
 					contract.Assert(len(diags) == 0)
 
+					rangeValue = model.IntType
+
 					node.VariableType = rangeExpr.Type()
 				default:
 					rk, rv, diags := model.GetCollectionTypes(typ, rng.Range())

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -110,7 +110,6 @@ var PulumiPulumiProgramTests = []ProgramTest{
 	{
 		Directory:   "simple-range",
 		Description: "Simple range as int expression translation",
-		BindOptions: []pcl.BindOption{pcl.AllowMissingVariables},
 	},
 	{
 		Directory:   "azure-native",

--- a/pkg/codegen/testing/test/testdata/simple-range-pp/dotnet/simple-range.cs
+++ b/pkg/codegen/testing/test/testdata/simple-range-pp/dotnet/simple-range.cs
@@ -1,20 +1,24 @@
 using System.Collections.Generic;
 using Pulumi;
-using Aws = Pulumi.Aws;
+using Random = Pulumi.Random;
 
 return await Deployment.RunAsync(() => 
 {
-    var bucket = new List<Aws.S3.Bucket>();
-    for (var rangeIndex = 0; rangeIndex < 10; rangeIndex++)
+    var numbers = new List<Random.RandomInteger>();
+    for (var rangeIndex = 0; rangeIndex < 2; rangeIndex++)
     {
         var range = new { Value = rangeIndex };
-        bucket.Add(new Aws.S3.Bucket($"bucket-{range.Value}", new()
+        numbers.Add(new Random.RandomInteger($"numbers-{range.Value}", new()
         {
-            Website = new Aws.S3.Inputs.BucketWebsiteArgs
-            {
-                IndexDocument = $"index-{range.Value}.html",
-            },
+            Min = 1,
+            Max = range.Value,
+            Seed = $"seed{range.Value}",
         }));
     }
+    return new Dictionary<string, object?>
+    {
+        ["first"] = numbers[0].Id,
+        ["second"] = numbers[1].Id,
+    };
 });
 

--- a/pkg/codegen/testing/test/testdata/simple-range-pp/go/simple-range.go
+++ b/pkg/codegen/testing/test/testdata/simple-range-pp/go/simple-range.go
@@ -3,26 +3,28 @@ package main
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		var bucket []*s3.Bucket
-		for index := 0; index < 10; index++ {
+		var numbers []*random.RandomInteger
+		for index := 0; index < 2; index++ {
 			key0 := index
 			val0 := index
-			__res, err := s3.NewBucket(ctx, fmt.Sprintf("bucket-%v", key0), &s3.BucketArgs{
-				Website: &s3.BucketWebsiteArgs{
-					IndexDocument: pulumi.String(fmt.Sprintf("index-%v.html", val0)),
-				},
+			__res, err := random.NewRandomInteger(ctx, fmt.Sprintf("numbers-%v", key0), &random.RandomIntegerArgs{
+				Min:  pulumi.Int(1),
+				Max:  pulumi.Int(val0),
+				Seed: pulumi.String(fmt.Sprintf("seed%v", val0)),
 			})
 			if err != nil {
 				return err
 			}
-			bucket = append(bucket, __res)
+			numbers = append(numbers, __res)
 		}
+		ctx.Export("first", numbers[0].ID())
+		ctx.Export("second", numbers[1].ID())
 		return nil
 	})
 }

--- a/pkg/codegen/testing/test/testdata/simple-range-pp/nodejs/simple-range.ts
+++ b/pkg/codegen/testing/test/testdata/simple-range-pp/nodejs/simple-range.ts
@@ -1,9 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
-import * as aws from "@pulumi/aws";
+import * as random from "@pulumi/random";
 
-const bucket: aws.s3.Bucket[] = [];
-for (const range = {value: 0}; range.value < 10; range.value++) {
-    bucket.push(new aws.s3.Bucket(`bucket-${range.value}`, {website: {
-        indexDocument: `index-${range.value}.html`,
-    }}));
+const numbers: random.RandomInteger[] = [];
+for (const range = {value: 0}; range.value < 2; range.value++) {
+    numbers.push(new random.RandomInteger(`numbers-${range.value}`, {
+        min: 1,
+        max: range.value,
+        seed: `seed${range.value}`,
+    }));
 }
+export const first = numbers[0].id;
+export const second = numbers[1].id;

--- a/pkg/codegen/testing/test/testdata/simple-range-pp/python/simple-range.py
+++ b/pkg/codegen/testing/test/testdata/simple-range-pp/python/simple-range.py
@@ -1,8 +1,11 @@
 import pulumi
-import pulumi_aws as aws
+import pulumi_random as random
 
-bucket = []
-for range in [{"value": i} for i in range(0, 10)]:
-    bucket.append(aws.s3.Bucket(f"bucket-{range['value']}", website=aws.s3.BucketWebsiteArgs(
-        index_document=f"index-{range['value']}.html",
-    )))
+numbers = []
+for range in [{"value": i} for i in range(0, 2)]:
+    numbers.append(random.RandomInteger(f"numbers-{range['value']}",
+        min=1,
+        max=range["value"],
+        seed=f"seed{range['value']}"))
+pulumi.export("first", numbers[0].id)
+pulumi.export("second", numbers[1].id)

--- a/pkg/codegen/testing/test/testdata/simple-range-pp/simple-range.pp
+++ b/pkg/codegen/testing/test/testdata/simple-range-pp/simple-range.pp
@@ -1,8 +1,12 @@
-resource bucket "aws:s3:Bucket" {
+resource numbers "random:index/randomInteger:RandomInteger" {
 	options {
-	    range = 10
+		range = 2
 	}
-	website = {
-		indexDocument = "index-${range.value}.html"
-	}
+
+	min = 1
+	max = range.value
+	seed = "seed${range.value}"
 }
+
+output first { value = numbers[0].id }
+output second { value = numbers[1].id }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes the binding issue with `options { range = number }`.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
