### PR TITLE
ci: Fix extraneous alpha draft releases

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -71,7 +71,7 @@ jobs:
 
   prepare-release:
     name: prepare
-    if: |
+    if: >- # No newlines or trailing newline.
       ${{
         github.event.pull_request.head.repo.full_name == github.repository
         && contains(github.event.pull_request.labels.*.name, 'ci/test')


### PR DESCRIPTION
The [PR workflow to update Pulumi YAML to 1.0.4](https://github.com/pulumi/pulumi/actions/runs/3642973677) shows that it created a draft release, and this has been the case for all contributors' PRs.

This fixes the extra alpha releases created as a result of pull requests. The job "prepare-release" shouldn't run unless the ci/test label is set, indicating an intent to evaluate the full CI pipeline.
