### PR TITLE
Don't use `*schema.Package` in nodejs codegen

### DIFF
--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -77,7 +77,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 	}
 
 	modCtx := &modContext{
-		pkg: pkg,
+		pkg: pkg.Reference(),
 		mod: moduleName,
 	}
 	typeName := modCtx.typeString(t, input, nil)
@@ -114,7 +114,7 @@ func (d DocLanguageHelper) GetMethodResultName(pkg *schema.Package, modName stri
 	if info, ok := pkg.Language["nodejs"].(NodePackageInfo); ok {
 		if info.LiftSingleValueMethodReturns && m.Function.Outputs != nil && len(m.Function.Outputs.Properties) == 1 {
 			modCtx := &modContext{
-				pkg: pkg,
+				pkg: pkg.Reference(),
 				mod: modName,
 			}
 			return modCtx.typeString(m.Function.Outputs.Properties[0].Type, false, nil)

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -309,11 +309,15 @@ func enumName(enum *model.EnumType) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("Could not get associated enum")
 	}
-	if name := e.(*schema.EnumType).Package.Language["nodejs"].(NodePackageInfo).PackageName; name != "" {
+	def, err := e.(*schema.EnumType).PackageReference.Definition()
+	if err != nil {
+		return "", err
+	}
+	if name := def.Language["nodejs"].(NodePackageInfo).PackageName; name != "" {
 		pkg = name
 	}
 	if mod := components[1]; mod != "" && mod != "index" {
-		if pkg := e.(*schema.EnumType).Package; pkg != nil {
+		if pkg := e.(*schema.EnumType).PackageReference; pkg != nil {
 			mod = moduleName(mod, pkg)
 		}
 		pkg += "." + mod


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi/issues/9932
Builds on https://github.com/pulumi/pulumi/pull/11578

tldr: Package is not reliable when its used for an external package. We are transferring over to PackageReference, and will remove the Package field once all references to it have been removed.