### PR TITLE
[sdk/gen] Avoid generating Result types for functions with empty outputs

### DIFF
--- a/changelog/pending/20221208--sdkgen-dotnet-go-nodejs-python--do-not-generate-result-types-for-functions-with-empty-outputs.yaml
+++ b/changelog/pending/20221208--sdkgen-dotnet-go-nodejs-python--do-not-generate-result-types-for-functions-with-empty-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/dotnet,go,nodejs,python
+  description: Do not generate Result types for functions with empty outputs

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1341,7 +1341,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 	fmt.Fprintf(w, "{\n")
 
 	var typeParameter string
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		typeParameter = fmt.Sprintf("<%sResult>", className)
 	}
 
@@ -1404,7 +1404,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 		return err
 	}
 
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		fmt.Fprintf(w, "\n")
 
 		res := &plainType{

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2104,7 +2104,7 @@ func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) error {
 		argsig = fmt.Sprintf("%s, args *%sArgs", argsig, name)
 	}
 	var retty string
-	if f.Outputs == nil {
+	if f.Outputs == nil || len(f.Outputs.Properties) == 0 {
 		retty = "error"
 	} else {
 		retty = fmt.Sprintf("(*%sResult, error)", name)
@@ -2123,7 +2123,7 @@ func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) error {
 
 	// Now simply invoke the runtime function with the arguments.
 	var outputsType string
-	if f.Outputs == nil {
+	if f.Outputs == nil || len(f.Outputs.Properties) == 0 {
 		outputsType = "struct{}"
 	} else {
 		outputsType = name + "Result"
@@ -2134,7 +2134,7 @@ func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) error {
 	fmt.Fprintf(w, "\tvar rv %s\n", outputsType)
 	fmt.Fprintf(w, "\terr := ctx.Invoke(\"%s\", %s, &rv, opts...)\n", f.Token, inputsVar)
 
-	if f.Outputs == nil {
+	if f.Outputs == nil || len(f.Outputs.Properties) == 0 {
 		fmt.Fprintf(w, "\treturn err\n")
 	} else {
 		// Check the error before proceeding.
@@ -2164,7 +2164,7 @@ func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) error {
 			}
 		}
 	}
-	if f.Outputs != nil {
+	if f.Outputs != nil && len(f.Outputs.Properties) > 0 {
 		fmt.Fprintf(w, "\n")
 		fnOutputsName := pkg.functionResultTypeName(f)
 		pkg.genPlainType(w, fnOutputsName, f.Outputs.Comment, "", f.Outputs.Properties)

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1142,7 +1142,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) (functionF
 		}
 		info.functionArgsInterfaceName = argsInterfaceName
 	}
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		fmt.Fprintf(w, "\n")
 		resultInterfaceName := title(name) + "Result"
 		if err := mod.genPlainType(w, resultInterfaceName, fun.Outputs.Comment, fun.Outputs.Properties, false, true, 0); err != nil {
@@ -1166,7 +1166,7 @@ func functionArgsOptional(fun *schema.Function) bool {
 }
 
 func functionReturnType(fun *schema.Function) string {
-	if fun.Outputs == nil {
+	if fun.Outputs == nil || len(fun.Outputs.Properties) == 0 {
 		return "void"
 	}
 	return title(tokenToFunctionName(fun.Token)) + "Result"

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -357,27 +357,52 @@ func genStandardHeader(w io.Writer, tool string) {
 	fmt.Fprintf(w, "# *** Do not edit by hand unless you're certain you know what you are doing! ***\n\n")
 }
 
+func typingImports() []string {
+	return []string{
+		"Any",
+		"Mapping",
+		"Optional",
+		"Sequence",
+		"Union",
+		"overload",
+	}
+}
+
+func (mod *modContext) generateCommonImports(w io.Writer, imports imports, typingImports []string) {
+	rel, err := filepath.Rel(mod.mod, "")
+	contract.Assert(err == nil)
+	relRoot := path.Dir(rel)
+	relImport := relPathToRelImport(relRoot)
+
+	fmt.Fprintf(w, "import copy\n")
+	fmt.Fprintf(w, "import warnings\n")
+	fmt.Fprintf(w, "import pulumi\n")
+	fmt.Fprintf(w, "import pulumi.runtime\n")
+	fmt.Fprintf(w, "from typing import %s\n", strings.Join(typingImports, ", "))
+	fmt.Fprintf(w, "from %s import _utilities\n", relImport)
+	for _, imp := range imports.strings() {
+		fmt.Fprintf(w, "%s\n", imp)
+	}
+	fmt.Fprintf(w, "\n")
+}
+
 func (mod *modContext) genHeader(w io.Writer, needsSDK bool, imports imports) {
 	genStandardHeader(w, mod.tool)
 
 	// If needed, emit the standard Pulumi SDK import statement.
 	if needsSDK {
-		rel, err := filepath.Rel(mod.mod, "")
-		contract.Assert(err == nil)
-		relRoot := path.Dir(rel)
-		relImport := relPathToRelImport(relRoot)
-
-		fmt.Fprintf(w, "import copy\n")
-		fmt.Fprintf(w, "import warnings\n")
-		fmt.Fprintf(w, "import pulumi\n")
-		fmt.Fprintf(w, "import pulumi.runtime\n")
-		fmt.Fprintf(w, "from typing import Any, Mapping, Optional, Sequence, Union, overload\n")
-		fmt.Fprintf(w, "from %s import _utilities\n", relImport)
-		for _, imp := range imports.strings() {
-			fmt.Fprintf(w, "%s\n", imp)
-		}
-		fmt.Fprintf(w, "\n")
+		typings := typingImports()
+		mod.generateCommonImports(w, imports, typings)
 	}
+}
+
+func (mod *modContext) genFunctionHeader(w io.Writer, function *schema.Function, imports imports) {
+	genStandardHeader(w, mod.tool)
+	typings := typingImports()
+	if function.Outputs == nil || len(function.Outputs.Properties) == 0 {
+		typings = append(typings, "Awaitable")
+	}
+	mod.generateCommonImports(w, imports, typings)
 }
 
 func relPathToRelImport(relPath string) string {
@@ -1671,17 +1696,17 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 		mod.collectImports(fun.Outputs.Properties, imports, false)
 	}
 
-	mod.genHeader(w, true /*needsSDK*/, imports)
+	mod.genFunctionHeader(w, fun, imports)
 
 	var baseName, awaitableName string
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		baseName, awaitableName = awaitableTypeNames(fun.Outputs.Token)
 	}
 	name := PyName(tokenToName(fun.Token))
 
 	// Export only the symbols we want exported.
 	fmt.Fprintf(w, "__all__ = [\n")
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		fmt.Fprintf(w, "    '%s',\n", baseName)
 		fmt.Fprintf(w, "    '%s',\n", awaitableName)
 	}
@@ -1699,9 +1724,11 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	// If there is a return type, emit it.
 	retTypeName := ""
 	var rets []*schema.Property
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		retTypeName, rets = mod.genAwaitableType(w, fun.Outputs), fun.Outputs.Properties
 		fmt.Fprintf(w, "\n\n")
+	} else {
+		retTypeName = "Awaitable[None]"
 	}
 
 	var args []*schema.Property
@@ -1725,7 +1752,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 
 	// Now simply invoke the runtime function with the arguments.
 	var typ string
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		// Pass along the private output_type we generated, so any nested outputs classes are instantiated by
 		// the call to invoke.
 		typ = fmt.Sprintf(", typ=%s", baseName)
@@ -1734,7 +1761,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	fmt.Fprintf(w, "\n")
 
 	// And copy the results to an object, if there are indeed any expected returns.
-	if fun.Outputs != nil {
+	if fun.Outputs != nil && len(fun.Outputs.Properties) > 0 {
 		fmt.Fprintf(w, "    return %s(", retTypeName)
 		for i, ret := range rets {
 			if i > 0 {

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -558,7 +558,7 @@ func (fun *Function) NeedsOutputVersion() bool {
 	// support them and return `Task`, but there are no such
 	// functions in `pulumi-azure-native` or `pulumi-aws` so we
 	// omit to simplify.
-	if fun.Outputs == nil {
+	if fun.Outputs == nil || len(fun.Outputs.Properties) == 0 {
 		return false
 	}
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithemptyoutputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithemptyoutputs/_index.md
@@ -19,11 +19,6 @@ n/a
 
 ## Using funcWithEmptyOutputs {#using}
 
-Two invocation forms are available. The direct form accepts plain
-arguments and either blocks until the result value is available, or
-returns a Promise-wrapped result. The output form accepts
-Input-wrapped arguments and returns an Output-wrapped result.
-
 <div>
 <pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser>
 </div>
@@ -34,8 +29,6 @@ Input-wrapped arguments and returns an Output-wrapped result.
 <div class="highlight"
 ><pre class="chroma"><code class="language-typescript" data-lang="typescript"
 ><span class="k">function </span>funcWithEmptyOutputs<span class="p">(</span><span class="nx">args</span><span class="p">:</span> <span class="nx">FuncWithEmptyOutputsArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#InvokeOptions">InvokeOptions</a></span><span class="p">): Promise&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>></span
-><span class="k">
-function </span>funcWithEmptyOutputsOutput<span class="p">(</span><span class="nx">args</span><span class="p">:</span> <span class="nx">FuncWithEmptyOutputsOutputArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#InvokeOptions">InvokeOptions</a></span><span class="p">): Output&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>></span
 ></code></pre></div>
 </pulumi-choosable>
 </div>
@@ -46,9 +39,6 @@ function </span>funcWithEmptyOutputsOutput<span class="p">(</span><span class="n
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"
 ><span class="k">def </span>func_with_empty_outputs<span class="p">(</span><span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithEmptyOutputsResult</span
-><span class="k">
-def </span>func_with_empty_outputs_output<span class="p">(</span><span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                            <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithEmptyOutputsResult]</span
 ></code></pre></div>
 </pulumi-choosable>
 </div>
@@ -58,8 +48,6 @@ def </span>func_with_empty_outputs_output<span class="p">(</span><span class="nx
 <pulumi-choosable type="language" values="go">
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"
 ><span class="k">func </span>FuncWithEmptyOutputs<span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">args</span><span class="p"> *</span><span class="nx">FuncWithEmptyOutputsArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#InvokeOption">InvokeOption</a></span><span class="p">) (*<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>, error)</span
-><span class="k">
-func </span>FuncWithEmptyOutputsOutput<span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">args</span><span class="p"> *</span><span class="nx">FuncWithEmptyOutputsOutputArgs</span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi?tab=doc#InvokeOption">InvokeOption</a></span><span class="p">) FuncWithEmptyOutputsResultOutput</span
 ></code></pre></div>
 
 &gt; Note: This function is named `FuncWithEmptyOutputs` in the Go SDK.
@@ -72,8 +60,7 @@ func </span>FuncWithEmptyOutputsOutput<span class="p">(</span><span class="nx">c
 <pulumi-choosable type="language" values="csharp">
 <div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static class </span><span class="nx">FuncWithEmptyOutputs </span><span class="p">
 {</span><span class="k">
-    public static </span>Task&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>> <span class="p">InvokeAsync(</span><span class="nx">FuncWithEmptyOutputsArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="k">
-    public static </span>Output&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>> <span class="p">Invoke(</span><span class="nx">FuncWithEmptyOutputsInvokeArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="p">
+    public static </span>Task&lt;<span class="nx"><a href="#result">FuncWithEmptyOutputsResult</a></span>> <span class="p">InvokeAsync(</span><span class="nx">FuncWithEmptyOutputsArgs</span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.InvokeOptions.html">InvokeOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span><span class="p">
 }</span></code></pre></div>
 </pulumi-choosable>
 </div>

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithEmptyOutputs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithEmptyOutputs.cs
@@ -14,14 +14,8 @@ namespace Pulumi.Mypkg
         /// <summary>
         /// n/a
         /// </summary>
-        public static Task<FuncWithEmptyOutputsResult> InvokeAsync(FuncWithEmptyOutputsArgs args, InvokeOptions? options = null)
-            => global::Pulumi.Deployment.Instance.InvokeAsync<FuncWithEmptyOutputsResult>("mypkg::funcWithEmptyOutputs", args ?? new FuncWithEmptyOutputsArgs(), options.WithDefaults());
-
-        /// <summary>
-        /// n/a
-        /// </summary>
-        public static Output<FuncWithEmptyOutputsResult> Invoke(FuncWithEmptyOutputsInvokeArgs args, InvokeOptions? options = null)
-            => global::Pulumi.Deployment.Instance.Invoke<FuncWithEmptyOutputsResult>("mypkg::funcWithEmptyOutputs", args ?? new FuncWithEmptyOutputsInvokeArgs(), options.WithDefaults());
+        public static Task InvokeAsync(FuncWithEmptyOutputsArgs args, InvokeOptions? options = null)
+            => global::Pulumi.Deployment.Instance.InvokeAsync("mypkg::funcWithEmptyOutputs", args ?? new FuncWithEmptyOutputsArgs(), options.WithDefaults());
     }
 
 
@@ -37,29 +31,5 @@ namespace Pulumi.Mypkg
         {
         }
         public static new FuncWithEmptyOutputsArgs Empty => new FuncWithEmptyOutputsArgs();
-    }
-
-    public sealed class FuncWithEmptyOutputsInvokeArgs : global::Pulumi.InvokeArgs
-    {
-        /// <summary>
-        /// The Name of the FeatureGroup.
-        /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
-
-        public FuncWithEmptyOutputsInvokeArgs()
-        {
-        }
-        public static new FuncWithEmptyOutputsInvokeArgs Empty => new FuncWithEmptyOutputsInvokeArgs();
-    }
-
-
-    [OutputType]
-    public sealed class FuncWithEmptyOutputsResult
-    {
-        [OutputConstructor]
-        private FuncWithEmptyOutputsResult()
-        {
-        }
     }
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithEmptyOutputs.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithEmptyOutputs.go
@@ -4,66 +4,17 @@
 package mypkg
 
 import (
-	"context"
-	"reflect"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // n/a
-func FuncWithEmptyOutputs(ctx *pulumi.Context, args *FuncWithEmptyOutputsArgs, opts ...pulumi.InvokeOption) (*FuncWithEmptyOutputsResult, error) {
-	var rv FuncWithEmptyOutputsResult
+func FuncWithEmptyOutputs(ctx *pulumi.Context, args *FuncWithEmptyOutputsArgs, opts ...pulumi.InvokeOption) error {
+	var rv struct{}
 	err := ctx.Invoke("mypkg::funcWithEmptyOutputs", args, &rv, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &rv, nil
+	return err
 }
 
 type FuncWithEmptyOutputsArgs struct {
 	// The Name of the FeatureGroup.
 	Name string `pulumi:"name"`
-}
-
-type FuncWithEmptyOutputsResult struct {
-}
-
-func FuncWithEmptyOutputsOutput(ctx *pulumi.Context, args FuncWithEmptyOutputsOutputArgs, opts ...pulumi.InvokeOption) FuncWithEmptyOutputsResultOutput {
-	return pulumi.ToOutputWithContext(context.Background(), args).
-		ApplyT(func(v interface{}) (FuncWithEmptyOutputsResult, error) {
-			args := v.(FuncWithEmptyOutputsArgs)
-			r, err := FuncWithEmptyOutputs(ctx, &args, opts...)
-			var s FuncWithEmptyOutputsResult
-			if r != nil {
-				s = *r
-			}
-			return s, err
-		}).(FuncWithEmptyOutputsResultOutput)
-}
-
-type FuncWithEmptyOutputsOutputArgs struct {
-	// The Name of the FeatureGroup.
-	Name pulumi.StringInput `pulumi:"name"`
-}
-
-func (FuncWithEmptyOutputsOutputArgs) ElementType() reflect.Type {
-	return reflect.TypeOf((*FuncWithEmptyOutputsArgs)(nil)).Elem()
-}
-
-type FuncWithEmptyOutputsResultOutput struct{ *pulumi.OutputState }
-
-func (FuncWithEmptyOutputsResultOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*FuncWithEmptyOutputsResult)(nil)).Elem()
-}
-
-func (o FuncWithEmptyOutputsResultOutput) ToFuncWithEmptyOutputsResultOutput() FuncWithEmptyOutputsResultOutput {
-	return o
-}
-
-func (o FuncWithEmptyOutputsResultOutput) ToFuncWithEmptyOutputsResultOutputWithContext(ctx context.Context) FuncWithEmptyOutputsResultOutput {
-	return o
-}
-
-func init() {
-	pulumi.RegisterOutputType(FuncWithEmptyOutputsResultOutput{})
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithEmptyOutputs.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithEmptyOutputs.ts
@@ -7,7 +7,7 @@ import * as utilities from "./utilities";
 /**
  * n/a
  */
-export function funcWithEmptyOutputs(args: FuncWithEmptyOutputsArgs, opts?: pulumi.InvokeOptions): Promise<FuncWithEmptyOutputsResult> {
+export function funcWithEmptyOutputs(args: FuncWithEmptyOutputsArgs, opts?: pulumi.InvokeOptions): Promise<void> {
 
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invoke("mypkg::funcWithEmptyOutputs", {
@@ -20,20 +20,4 @@ export interface FuncWithEmptyOutputsArgs {
      * The Name of the FeatureGroup.
      */
     name: string;
-}
-
-export interface FuncWithEmptyOutputsResult {
-}
-/**
- * n/a
- */
-export function funcWithEmptyOutputsOutput(args: FuncWithEmptyOutputsOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<FuncWithEmptyOutputsResult> {
-    return pulumi.output(args).apply((a: any) => funcWithEmptyOutputs(a, opts))
-}
-
-export interface FuncWithEmptyOutputsOutputArgs {
-    /**
-     * The Name of the FeatureGroup.
-     */
-    name: pulumi.Input<string>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/index.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/index.ts
@@ -24,10 +24,9 @@ export const funcWithDictParam: typeof import("./funcWithDictParam").funcWithDic
 export const funcWithDictParamOutput: typeof import("./funcWithDictParam").funcWithDictParamOutput = null as any;
 utilities.lazyLoad(exports, ["funcWithDictParam","funcWithDictParamOutput"], () => require("./funcWithDictParam"));
 
-export { FuncWithEmptyOutputsArgs, FuncWithEmptyOutputsResult, FuncWithEmptyOutputsOutputArgs } from "./funcWithEmptyOutputs";
+export { FuncWithEmptyOutputsArgs } from "./funcWithEmptyOutputs";
 export const funcWithEmptyOutputs: typeof import("./funcWithEmptyOutputs").funcWithEmptyOutputs = null as any;
-export const funcWithEmptyOutputsOutput: typeof import("./funcWithEmptyOutputs").funcWithEmptyOutputsOutput = null as any;
-utilities.lazyLoad(exports, ["funcWithEmptyOutputs","funcWithEmptyOutputsOutput"], () => require("./funcWithEmptyOutputs"));
+utilities.lazyLoad(exports, ["funcWithEmptyOutputs"], () => require("./funcWithEmptyOutputs"));
 
 export { FuncWithListParamArgs, FuncWithListParamResult, FuncWithListParamOutputArgs } from "./funcWithListParam";
 export const funcWithListParam: typeof import("./funcWithListParam").funcWithListParam = null as any;

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_const_input.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_const_input.py
@@ -6,7 +6,7 @@ import copy
 import warnings
 import pulumi
 import pulumi.runtime
-from typing import Any, Mapping, Optional, Sequence, Union, overload
+from typing import Any, Mapping, Optional, Sequence, Union, overload, Awaitable
 from . import _utilities
 
 __all__ = [
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 def func_with_const_input(plain_input: Optional[str] = None,
-                          opts: Optional[pulumi.InvokeOptions] = None):
+                          opts: Optional[pulumi.InvokeOptions] = None) -> Awaitable[None]:
     """
     Codegen demo with const inputs
     """

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
@@ -6,31 +6,15 @@ import copy
 import warnings
 import pulumi
 import pulumi.runtime
-from typing import Any, Mapping, Optional, Sequence, Union, overload
+from typing import Any, Mapping, Optional, Sequence, Union, overload, Awaitable
 from . import _utilities
 
 __all__ = [
-    'FuncWithEmptyOutputsResult',
-    'AwaitableFuncWithEmptyOutputsResult',
     'func_with_empty_outputs',
-    'func_with_empty_outputs_output',
 ]
 
-@pulumi.output_type
-class FuncWithEmptyOutputsResult:
-    def __init__(__self__):
-        pass
-
-class AwaitableFuncWithEmptyOutputsResult(FuncWithEmptyOutputsResult):
-    # pylint: disable=using-constant-test
-    def __await__(self):
-        if False:
-            yield self
-        return FuncWithEmptyOutputsResult()
-
-
 def func_with_empty_outputs(name: Optional[str] = None,
-                            opts: Optional[pulumi.InvokeOptions] = None) -> AwaitableFuncWithEmptyOutputsResult:
+                            opts: Optional[pulumi.InvokeOptions] = None) -> Awaitable[None]:
     """
     n/a
 
@@ -40,18 +24,5 @@ def func_with_empty_outputs(name: Optional[str] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke('mypkg::funcWithEmptyOutputs', __args__, opts=opts, typ=FuncWithEmptyOutputsResult).value
+    __ret__ = pulumi.runtime.invoke('mypkg::funcWithEmptyOutputs', __args__, opts=opts).value
 
-    return AwaitableFuncWithEmptyOutputsResult()
-
-
-@_utilities.lift_output_func(func_with_empty_outputs)
-def func_with_empty_outputs_output(name: Optional[pulumi.Input[str]] = None,
-                                   opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithEmptyOutputsResult]:
-    """
-    n/a
-
-
-    :param str name: The Name of the FeatureGroup.
-    """
-    ...

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/example_func.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/pulumi_my8110/example_func.py
@@ -6,7 +6,7 @@ import copy
 import warnings
 import pulumi
 import pulumi.runtime
-from typing import Any, Mapping, Optional, Sequence, Union, overload
+from typing import Any, Mapping, Optional, Sequence, Union, overload, Awaitable
 from . import _utilities
 from ._enums import *
 
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 def example_func(enums: Optional[Sequence[Union[str, 'MyEnum']]] = None,
-                 opts: Optional[pulumi.InvokeOptions] = None):
+                 opts: Optional[pulumi.InvokeOptions] = None) -> Awaitable[None]:
     """
     Use this data source to access information about an existing resource.
     """

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/do_foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/do_foo.py
@@ -6,7 +6,7 @@ import copy
 import warnings
 import pulumi
 import pulumi.runtime
-from typing import Any, Mapping, Optional, Sequence, Union, overload
+from typing import Any, Mapping, Optional, Sequence, Union, overload, Awaitable
 from . import _utilities
 from ._inputs import *
 
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 def do_foo(foo: Optional[pulumi.InputType['Foo']] = None,
-           opts: Optional[pulumi.InvokeOptions] = None):
+           opts: Optional[pulumi.InvokeOptions] = None) -> Awaitable[None]:
     """
     Use this data source to access information about an existing resource.
     """


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Part of #11418 where we shouldn't generate result types for function invokes that have no properties. 

This is a separate PR to showcase the exact changes required to improve the situation and reduce the diff from #11418

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
