### PR TITLE
Add JSONMarshal to go sdk

### DIFF
--- a/changelog/pending/20221209--sdk-go--add-jsonmarshal-to-go-sdk.yaml
+++ b/changelog/pending/20221209--sdk-go--add-jsonmarshal-to-go-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Add JSONMarshal to go sdk.

--- a/sdk/go/pulumi/generate/templates/types_builtins.go.template
+++ b/sdk/go/pulumi/generate/templates/types_builtins.go.template
@@ -19,6 +19,7 @@ package pulumi
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 )
 
@@ -55,6 +56,7 @@ func {{.Name}}FromPtr(v *{{.ElemElementType}}) {{.Name}}Input {
 }
 {{end}}
 {{if .DefineInputMethods}}
+
 // ElementType returns the element type of this Input ({{.ElementType}}).
 func ({{.InputType}}) ElementType() reflect.Type {
 	return {{.Name | Unexported}}Type
@@ -91,6 +93,10 @@ func (in {{.InputType}}) To{{.Name}}PtrOutputWithContext(ctx context.Context) {{
 {{end}}
 // {{.Name}}Output is an Output that returns {{.ElementType}} values.
 type {{.Name}}Output struct { *OutputState }
+
+func ({{.Name}}Output) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ({{.ElementType}}).
 func ({{.Name}}Output) ElementType() reflect.Type {

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -17,6 +17,7 @@ package pulumi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -602,6 +603,23 @@ func AllWithContext(ctx context.Context, inputs ...interface{}) ArrayOutput {
 	return ToOutputWithContext(ctx, inputs).(ArrayOutput)
 }
 
+// JSONMarshal uses "encoding/json".Marshal to serialize the given Output value into a JSON string.
+func JSONMarshal(v interface{}) StringOutput {
+	return JSONMarshalWithContext(context.Background(), v)
+}
+
+// JSONMarshalWithContext uses "encoding/json".Marshal to serialize the given Output value into a JSON string.
+func JSONMarshalWithContext(ctx context.Context, v interface{}) StringOutput {
+	o := ToOutputWithContext(ctx, v)
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v interface{}) (string, error) {
+		json, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(json), nil
+	}).(StringOutput)
+}
+
 func gatherJoins(v interface{}) workGroups {
 	if v == nil {
 		return nil
@@ -1065,6 +1083,10 @@ func anyWithContext(ctx context.Context, join *workGroup, v interface{}) AnyOutp
 
 type AnyOutput struct{ *OutputState }
 
+func (AnyOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 func (AnyOutput) ElementType() reflect.Type {
 	return anyType
 }
@@ -1129,6 +1151,10 @@ func convert(v interface{}, to reflect.Type) interface{} {
 // TODO: ResourceOutput and the init() should probably be code generated.
 type ResourceOutput struct{ *OutputState }
 
+func (ResourceOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (Resource).
 func (ResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Resource)(nil)).Elem()
@@ -1191,6 +1217,10 @@ func (in ResourceArray) ToResourceArrayOutputWithContext(ctx context.Context) Re
 
 // ResourceArrayOutput is an Output that returns []Resource values.
 type ResourceArrayOutput struct{ *OutputState }
+
+func (ResourceArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]Resource).
 func (ResourceArrayOutput) ElementType() reflect.Type {

--- a/sdk/go/pulumi/types_builtins.go
+++ b/sdk/go/pulumi/types_builtins.go
@@ -19,6 +19,7 @@ package pulumi
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 )
 
@@ -55,6 +56,10 @@ func (in *archive) ToAssetOrArchiveOutputWithContext(ctx context.Context) AssetO
 
 // ArchiveOutput is an Output that returns Archive values.
 type ArchiveOutput struct{ *OutputState }
+
+func (ArchiveOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output (Archive).
 func (ArchiveOutput) ElementType() reflect.Type {
@@ -107,6 +112,10 @@ func (in ArchiveArray) ToArchiveArrayOutputWithContext(ctx context.Context) Arch
 
 // ArchiveArrayOutput is an Output that returns []Archive values.
 type ArchiveArrayOutput struct{ *OutputState }
+
+func (ArchiveArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]Archive).
 func (ArchiveArrayOutput) ElementType() reflect.Type {
@@ -180,6 +189,10 @@ func (in ArchiveMap) ToArchiveMapOutputWithContext(ctx context.Context) ArchiveM
 // ArchiveMapOutput is an Output that returns map[string]Archive values.
 type ArchiveMapOutput struct{ *OutputState }
 
+func (ArchiveMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]Archive).
 func (ArchiveMapOutput) ElementType() reflect.Type {
 	return archiveMapType
@@ -245,6 +258,10 @@ func (in ArchiveArrayMap) ToArchiveArrayMapOutputWithContext(ctx context.Context
 // ArchiveArrayMapOutput is an Output that returns map[string][]Archive values.
 type ArchiveArrayMapOutput struct{ *OutputState }
 
+func (ArchiveArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]Archive).
 func (ArchiveArrayMapOutput) ElementType() reflect.Type {
 	return archiveArrayMapType
@@ -309,6 +326,10 @@ func (in ArchiveMapArray) ToArchiveMapArrayOutputWithContext(ctx context.Context
 
 // ArchiveMapArrayOutput is an Output that returns []map[string]Archive values.
 type ArchiveMapArrayOutput struct{ *OutputState }
+
+func (ArchiveMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]Archive).
 func (ArchiveMapArrayOutput) ElementType() reflect.Type {
@@ -382,6 +403,10 @@ func (in ArchiveMapMap) ToArchiveMapMapOutputWithContext(ctx context.Context) Ar
 // ArchiveMapMapOutput is an Output that returns map[string]map[string]Archive values.
 type ArchiveMapMapOutput struct{ *OutputState }
 
+func (ArchiveMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]Archive).
 func (ArchiveMapMapOutput) ElementType() reflect.Type {
 	return archiveMapMapType
@@ -446,6 +471,10 @@ func (in ArchiveArrayArray) ToArchiveArrayArrayOutputWithContext(ctx context.Con
 
 // ArchiveArrayArrayOutput is an Output that returns [][]Archive values.
 type ArchiveArrayArrayOutput struct{ *OutputState }
+
+func (ArchiveArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]Archive).
 func (ArchiveArrayArrayOutput) ElementType() reflect.Type {
@@ -524,6 +553,10 @@ func (in *asset) ToAssetOrArchiveOutputWithContext(ctx context.Context) AssetOrA
 // AssetOutput is an Output that returns Asset values.
 type AssetOutput struct{ *OutputState }
 
+func (AssetOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (Asset).
 func (AssetOutput) ElementType() reflect.Type {
 	return assetType
@@ -575,6 +608,10 @@ func (in AssetArray) ToAssetArrayOutputWithContext(ctx context.Context) AssetArr
 
 // AssetArrayOutput is an Output that returns []Asset values.
 type AssetArrayOutput struct{ *OutputState }
+
+func (AssetArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]Asset).
 func (AssetArrayOutput) ElementType() reflect.Type {
@@ -648,6 +685,10 @@ func (in AssetMap) ToAssetMapOutputWithContext(ctx context.Context) AssetMapOutp
 // AssetMapOutput is an Output that returns map[string]Asset values.
 type AssetMapOutput struct{ *OutputState }
 
+func (AssetMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]Asset).
 func (AssetMapOutput) ElementType() reflect.Type {
 	return assetMapType
@@ -713,6 +754,10 @@ func (in AssetArrayMap) ToAssetArrayMapOutputWithContext(ctx context.Context) As
 // AssetArrayMapOutput is an Output that returns map[string][]Asset values.
 type AssetArrayMapOutput struct{ *OutputState }
 
+func (AssetArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]Asset).
 func (AssetArrayMapOutput) ElementType() reflect.Type {
 	return assetArrayMapType
@@ -777,6 +822,10 @@ func (in AssetMapArray) ToAssetMapArrayOutputWithContext(ctx context.Context) As
 
 // AssetMapArrayOutput is an Output that returns []map[string]Asset values.
 type AssetMapArrayOutput struct{ *OutputState }
+
+func (AssetMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]Asset).
 func (AssetMapArrayOutput) ElementType() reflect.Type {
@@ -850,6 +899,10 @@ func (in AssetMapMap) ToAssetMapMapOutputWithContext(ctx context.Context) AssetM
 // AssetMapMapOutput is an Output that returns map[string]map[string]Asset values.
 type AssetMapMapOutput struct{ *OutputState }
 
+func (AssetMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]Asset).
 func (AssetMapMapOutput) ElementType() reflect.Type {
 	return assetMapMapType
@@ -915,6 +968,10 @@ func (in AssetArrayArray) ToAssetArrayArrayOutputWithContext(ctx context.Context
 // AssetArrayArrayOutput is an Output that returns [][]Asset values.
 type AssetArrayArrayOutput struct{ *OutputState }
 
+func (AssetArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output ([][]Asset).
 func (AssetArrayArrayOutput) ElementType() reflect.Type {
 	return assetArrayArrayType
@@ -971,6 +1028,10 @@ type AssetOrArchiveInput interface {
 // AssetOrArchiveOutput is an Output that returns AssetOrArchive values.
 type AssetOrArchiveOutput struct{ *OutputState }
 
+func (AssetOrArchiveOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (AssetOrArchive).
 func (AssetOrArchiveOutput) ElementType() reflect.Type {
 	return assetOrArchiveType
@@ -1012,6 +1073,10 @@ func (in AssetOrArchiveArray) ToAssetOrArchiveArrayOutputWithContext(ctx context
 
 // AssetOrArchiveArrayOutput is an Output that returns []AssetOrArchive values.
 type AssetOrArchiveArrayOutput struct{ *OutputState }
+
+func (AssetOrArchiveArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]AssetOrArchive).
 func (AssetOrArchiveArrayOutput) ElementType() reflect.Type {
@@ -1069,6 +1134,10 @@ func (in AssetOrArchiveMap) ToAssetOrArchiveMapOutputWithContext(ctx context.Con
 // AssetOrArchiveMapOutput is an Output that returns map[string]AssetOrArchive values.
 type AssetOrArchiveMapOutput struct{ *OutputState }
 
+func (AssetOrArchiveMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]AssetOrArchive).
 func (AssetOrArchiveMapOutput) ElementType() reflect.Type {
 	return assetOrArchiveMapType
@@ -1118,6 +1187,10 @@ func (in AssetOrArchiveArrayMap) ToAssetOrArchiveArrayMapOutputWithContext(ctx c
 // AssetOrArchiveArrayMapOutput is an Output that returns map[string][]AssetOrArchive values.
 type AssetOrArchiveArrayMapOutput struct{ *OutputState }
 
+func (AssetOrArchiveArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]AssetOrArchive).
 func (AssetOrArchiveArrayMapOutput) ElementType() reflect.Type {
 	return assetOrArchiveArrayMapType
@@ -1166,6 +1239,10 @@ func (in AssetOrArchiveMapArray) ToAssetOrArchiveMapArrayOutputWithContext(ctx c
 
 // AssetOrArchiveMapArrayOutput is an Output that returns []map[string]AssetOrArchive values.
 type AssetOrArchiveMapArrayOutput struct{ *OutputState }
+
+func (AssetOrArchiveMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]AssetOrArchive).
 func (AssetOrArchiveMapArrayOutput) ElementType() reflect.Type {
@@ -1223,6 +1300,10 @@ func (in AssetOrArchiveMapMap) ToAssetOrArchiveMapMapOutputWithContext(ctx conte
 // AssetOrArchiveMapMapOutput is an Output that returns map[string]map[string]AssetOrArchive values.
 type AssetOrArchiveMapMapOutput struct{ *OutputState }
 
+func (AssetOrArchiveMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]AssetOrArchive).
 func (AssetOrArchiveMapMapOutput) ElementType() reflect.Type {
 	return assetOrArchiveMapMapType
@@ -1271,6 +1352,10 @@ func (in AssetOrArchiveArrayArray) ToAssetOrArchiveArrayArrayOutputWithContext(c
 
 // AssetOrArchiveArrayArrayOutput is an Output that returns [][]AssetOrArchive values.
 type AssetOrArchiveArrayArrayOutput struct{ *OutputState }
+
+func (AssetOrArchiveArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]AssetOrArchive).
 func (AssetOrArchiveArrayArrayOutput) ElementType() reflect.Type {
@@ -1339,6 +1424,10 @@ func (in Bool) ToBoolPtrOutputWithContext(ctx context.Context) BoolPtrOutput {
 // BoolOutput is an Output that returns bool values.
 type BoolOutput struct{ *OutputState }
 
+func (BoolOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (bool).
 func (BoolOutput) ElementType() reflect.Type {
 	return boolType
@@ -1401,6 +1490,10 @@ func (in *boolPtr) ToBoolPtrOutputWithContext(ctx context.Context) BoolPtrOutput
 // BoolPtrOutput is an Output that returns *bool values.
 type BoolPtrOutput struct{ *OutputState }
 
+func (BoolPtrOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (*bool).
 func (BoolPtrOutput) ElementType() reflect.Type {
 	return boolPtrType
@@ -1453,6 +1546,10 @@ func (in BoolArray) ToBoolArrayOutputWithContext(ctx context.Context) BoolArrayO
 
 // BoolArrayOutput is an Output that returns []bool values.
 type BoolArrayOutput struct{ *OutputState }
+
+func (BoolArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]bool).
 func (BoolArrayOutput) ElementType() reflect.Type {
@@ -1526,6 +1623,10 @@ func (in BoolMap) ToBoolMapOutputWithContext(ctx context.Context) BoolMapOutput 
 // BoolMapOutput is an Output that returns map[string]bool values.
 type BoolMapOutput struct{ *OutputState }
 
+func (BoolMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]bool).
 func (BoolMapOutput) ElementType() reflect.Type {
 	return boolMapType
@@ -1591,6 +1692,10 @@ func (in BoolArrayMap) ToBoolArrayMapOutputWithContext(ctx context.Context) Bool
 // BoolArrayMapOutput is an Output that returns map[string][]bool values.
 type BoolArrayMapOutput struct{ *OutputState }
 
+func (BoolArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]bool).
 func (BoolArrayMapOutput) ElementType() reflect.Type {
 	return boolArrayMapType
@@ -1655,6 +1760,10 @@ func (in BoolMapArray) ToBoolMapArrayOutputWithContext(ctx context.Context) Bool
 
 // BoolMapArrayOutput is an Output that returns []map[string]bool values.
 type BoolMapArrayOutput struct{ *OutputState }
+
+func (BoolMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]bool).
 func (BoolMapArrayOutput) ElementType() reflect.Type {
@@ -1728,6 +1837,10 @@ func (in BoolMapMap) ToBoolMapMapOutputWithContext(ctx context.Context) BoolMapM
 // BoolMapMapOutput is an Output that returns map[string]map[string]bool values.
 type BoolMapMapOutput struct{ *OutputState }
 
+func (BoolMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]bool).
 func (BoolMapMapOutput) ElementType() reflect.Type {
 	return boolMapMapType
@@ -1792,6 +1905,10 @@ func (in BoolArrayArray) ToBoolArrayArrayOutputWithContext(ctx context.Context) 
 
 // BoolArrayArrayOutput is an Output that returns [][]bool values.
 type BoolArrayArrayOutput struct{ *OutputState }
+
+func (BoolArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]bool).
 func (BoolArrayArrayOutput) ElementType() reflect.Type {
@@ -1876,6 +1993,10 @@ func (in Float64) ToFloat64PtrOutputWithContext(ctx context.Context) Float64PtrO
 // Float64Output is an Output that returns float64 values.
 type Float64Output struct{ *OutputState }
 
+func (Float64Output) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (float64).
 func (Float64Output) ElementType() reflect.Type {
 	return float64Type
@@ -1938,6 +2059,10 @@ func (in *float64Ptr) ToFloat64PtrOutputWithContext(ctx context.Context) Float64
 // Float64PtrOutput is an Output that returns *float64 values.
 type Float64PtrOutput struct{ *OutputState }
 
+func (Float64PtrOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (*float64).
 func (Float64PtrOutput) ElementType() reflect.Type {
 	return float64PtrType
@@ -1990,6 +2115,10 @@ func (in Float64Array) ToFloat64ArrayOutputWithContext(ctx context.Context) Floa
 
 // Float64ArrayOutput is an Output that returns []float64 values.
 type Float64ArrayOutput struct{ *OutputState }
+
+func (Float64ArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]float64).
 func (Float64ArrayOutput) ElementType() reflect.Type {
@@ -2063,6 +2192,10 @@ func (in Float64Map) ToFloat64MapOutputWithContext(ctx context.Context) Float64M
 // Float64MapOutput is an Output that returns map[string]float64 values.
 type Float64MapOutput struct{ *OutputState }
 
+func (Float64MapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]float64).
 func (Float64MapOutput) ElementType() reflect.Type {
 	return float64MapType
@@ -2128,6 +2261,10 @@ func (in Float64ArrayMap) ToFloat64ArrayMapOutputWithContext(ctx context.Context
 // Float64ArrayMapOutput is an Output that returns map[string][]float64 values.
 type Float64ArrayMapOutput struct{ *OutputState }
 
+func (Float64ArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]float64).
 func (Float64ArrayMapOutput) ElementType() reflect.Type {
 	return float64ArrayMapType
@@ -2192,6 +2329,10 @@ func (in Float64MapArray) ToFloat64MapArrayOutputWithContext(ctx context.Context
 
 // Float64MapArrayOutput is an Output that returns []map[string]float64 values.
 type Float64MapArrayOutput struct{ *OutputState }
+
+func (Float64MapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]float64).
 func (Float64MapArrayOutput) ElementType() reflect.Type {
@@ -2265,6 +2406,10 @@ func (in Float64MapMap) ToFloat64MapMapOutputWithContext(ctx context.Context) Fl
 // Float64MapMapOutput is an Output that returns map[string]map[string]float64 values.
 type Float64MapMapOutput struct{ *OutputState }
 
+func (Float64MapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]float64).
 func (Float64MapMapOutput) ElementType() reflect.Type {
 	return float64MapMapType
@@ -2329,6 +2474,10 @@ func (in Float64ArrayArray) ToFloat64ArrayArrayOutputWithContext(ctx context.Con
 
 // Float64ArrayArrayOutput is an Output that returns [][]float64 values.
 type Float64ArrayArrayOutput struct{ *OutputState }
+
+func (Float64ArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]float64).
 func (Float64ArrayArrayOutput) ElementType() reflect.Type {
@@ -2418,6 +2567,10 @@ func (in ID) ToIDPtrOutputWithContext(ctx context.Context) IDPtrOutput {
 // IDOutput is an Output that returns ID values.
 type IDOutput struct{ *OutputState }
 
+func (IDOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (ID).
 func (IDOutput) ElementType() reflect.Type {
 	return idType
@@ -2490,6 +2643,10 @@ func (in *idPtr) ToIDPtrOutputWithContext(ctx context.Context) IDPtrOutput {
 // IDPtrOutput is an Output that returns *ID values.
 type IDPtrOutput struct{ *OutputState }
 
+func (IDPtrOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (*ID).
 func (IDPtrOutput) ElementType() reflect.Type {
 	return iDPtrType
@@ -2542,6 +2699,10 @@ func (in IDArray) ToIDArrayOutputWithContext(ctx context.Context) IDArrayOutput 
 
 // IDArrayOutput is an Output that returns []ID values.
 type IDArrayOutput struct{ *OutputState }
+
+func (IDArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]ID).
 func (IDArrayOutput) ElementType() reflect.Type {
@@ -2615,6 +2776,10 @@ func (in IDMap) ToIDMapOutputWithContext(ctx context.Context) IDMapOutput {
 // IDMapOutput is an Output that returns map[string]ID values.
 type IDMapOutput struct{ *OutputState }
 
+func (IDMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]ID).
 func (IDMapOutput) ElementType() reflect.Type {
 	return iDMapType
@@ -2680,6 +2845,10 @@ func (in IDArrayMap) ToIDArrayMapOutputWithContext(ctx context.Context) IDArrayM
 // IDArrayMapOutput is an Output that returns map[string][]ID values.
 type IDArrayMapOutput struct{ *OutputState }
 
+func (IDArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]ID).
 func (IDArrayMapOutput) ElementType() reflect.Type {
 	return iDArrayMapType
@@ -2744,6 +2913,10 @@ func (in IDMapArray) ToIDMapArrayOutputWithContext(ctx context.Context) IDMapArr
 
 // IDMapArrayOutput is an Output that returns []map[string]ID values.
 type IDMapArrayOutput struct{ *OutputState }
+
+func (IDMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]ID).
 func (IDMapArrayOutput) ElementType() reflect.Type {
@@ -2817,6 +2990,10 @@ func (in IDMapMap) ToIDMapMapOutputWithContext(ctx context.Context) IDMapMapOutp
 // IDMapMapOutput is an Output that returns map[string]map[string]ID values.
 type IDMapMapOutput struct{ *OutputState }
 
+func (IDMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]ID).
 func (IDMapMapOutput) ElementType() reflect.Type {
 	return iDMapMapType
@@ -2881,6 +3058,10 @@ func (in IDArrayArray) ToIDArrayArrayOutputWithContext(ctx context.Context) IDAr
 
 // IDArrayArrayOutput is an Output that returns [][]ID values.
 type IDArrayArrayOutput struct{ *OutputState }
+
+func (IDArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]ID).
 func (IDArrayArrayOutput) ElementType() reflect.Type {
@@ -2954,6 +3135,10 @@ func (in Array) ToArrayOutputWithContext(ctx context.Context) ArrayOutput {
 // ArrayOutput is an Output that returns []interface{} values.
 type ArrayOutput struct{ *OutputState }
 
+func (ArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output ([]interface{}).
 func (ArrayOutput) ElementType() reflect.Type {
 	return arrayType
@@ -3026,6 +3211,10 @@ func (in Map) ToMapOutputWithContext(ctx context.Context) MapOutput {
 // MapOutput is an Output that returns map[string]interface{} values.
 type MapOutput struct{ *OutputState }
 
+func (MapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]interface{}).
 func (MapOutput) ElementType() reflect.Type {
 	return mapType
@@ -3091,6 +3280,10 @@ func (in ArrayMap) ToArrayMapOutputWithContext(ctx context.Context) ArrayMapOutp
 // ArrayMapOutput is an Output that returns map[string][]interface{} values.
 type ArrayMapOutput struct{ *OutputState }
 
+func (ArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]interface{}).
 func (ArrayMapOutput) ElementType() reflect.Type {
 	return arrayMapType
@@ -3155,6 +3348,10 @@ func (in MapArray) ToMapArrayOutputWithContext(ctx context.Context) MapArrayOutp
 
 // MapArrayOutput is an Output that returns []map[string]interface{} values.
 type MapArrayOutput struct{ *OutputState }
+
+func (MapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]interface{}).
 func (MapArrayOutput) ElementType() reflect.Type {
@@ -3228,6 +3425,10 @@ func (in MapMap) ToMapMapOutputWithContext(ctx context.Context) MapMapOutput {
 // MapMapOutput is an Output that returns map[string]map[string]interface{} values.
 type MapMapOutput struct{ *OutputState }
 
+func (MapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]interface{}).
 func (MapMapOutput) ElementType() reflect.Type {
 	return mapMapType
@@ -3292,6 +3493,10 @@ func (in ArrayArray) ToArrayArrayOutputWithContext(ctx context.Context) ArrayArr
 
 // ArrayArrayOutput is an Output that returns [][]interface{} values.
 type ArrayArrayOutput struct{ *OutputState }
+
+func (ArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]interface{}).
 func (ArrayArrayOutput) ElementType() reflect.Type {
@@ -3364,6 +3569,10 @@ func (in ArrayArrayMap) ToArrayArrayMapOutputWithContext(ctx context.Context) Ar
 
 // ArrayArrayMapOutput is an Output that returns map[string][][]interface{} values.
 type ArrayArrayMapOutput struct{ *OutputState }
+
+func (ArrayArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output (map[string][][]interface{}).
 func (ArrayArrayMapOutput) ElementType() reflect.Type {
@@ -3441,6 +3650,10 @@ func (in Int) ToIntPtrOutputWithContext(ctx context.Context) IntPtrOutput {
 // IntOutput is an Output that returns int values.
 type IntOutput struct{ *OutputState }
 
+func (IntOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (int).
 func (IntOutput) ElementType() reflect.Type {
 	return intType
@@ -3503,6 +3716,10 @@ func (in *intPtr) ToIntPtrOutputWithContext(ctx context.Context) IntPtrOutput {
 // IntPtrOutput is an Output that returns *int values.
 type IntPtrOutput struct{ *OutputState }
 
+func (IntPtrOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (*int).
 func (IntPtrOutput) ElementType() reflect.Type {
 	return intPtrType
@@ -3555,6 +3772,10 @@ func (in IntArray) ToIntArrayOutputWithContext(ctx context.Context) IntArrayOutp
 
 // IntArrayOutput is an Output that returns []int values.
 type IntArrayOutput struct{ *OutputState }
+
+func (IntArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]int).
 func (IntArrayOutput) ElementType() reflect.Type {
@@ -3628,6 +3849,10 @@ func (in IntMap) ToIntMapOutputWithContext(ctx context.Context) IntMapOutput {
 // IntMapOutput is an Output that returns map[string]int values.
 type IntMapOutput struct{ *OutputState }
 
+func (IntMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]int).
 func (IntMapOutput) ElementType() reflect.Type {
 	return intMapType
@@ -3693,6 +3918,10 @@ func (in IntArrayMap) ToIntArrayMapOutputWithContext(ctx context.Context) IntArr
 // IntArrayMapOutput is an Output that returns map[string][]int values.
 type IntArrayMapOutput struct{ *OutputState }
 
+func (IntArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]int).
 func (IntArrayMapOutput) ElementType() reflect.Type {
 	return intArrayMapType
@@ -3757,6 +3986,10 @@ func (in IntMapArray) ToIntMapArrayOutputWithContext(ctx context.Context) IntMap
 
 // IntMapArrayOutput is an Output that returns []map[string]int values.
 type IntMapArrayOutput struct{ *OutputState }
+
+func (IntMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]int).
 func (IntMapArrayOutput) ElementType() reflect.Type {
@@ -3830,6 +4063,10 @@ func (in IntMapMap) ToIntMapMapOutputWithContext(ctx context.Context) IntMapMapO
 // IntMapMapOutput is an Output that returns map[string]map[string]int values.
 type IntMapMapOutput struct{ *OutputState }
 
+func (IntMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]int).
 func (IntMapMapOutput) ElementType() reflect.Type {
 	return intMapMapType
@@ -3894,6 +4131,10 @@ func (in IntArrayArray) ToIntArrayArrayOutputWithContext(ctx context.Context) In
 
 // IntArrayArrayOutput is an Output that returns [][]int values.
 type IntArrayArrayOutput struct{ *OutputState }
+
+func (IntArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]int).
 func (IntArrayArrayOutput) ElementType() reflect.Type {
@@ -3978,6 +4219,10 @@ func (in String) ToStringPtrOutputWithContext(ctx context.Context) StringPtrOutp
 // StringOutput is an Output that returns string values.
 type StringOutput struct{ *OutputState }
 
+func (StringOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (string).
 func (StringOutput) ElementType() reflect.Type {
 	return stringType
@@ -4040,6 +4285,10 @@ func (in *stringPtr) ToStringPtrOutputWithContext(ctx context.Context) StringPtr
 // StringPtrOutput is an Output that returns *string values.
 type StringPtrOutput struct{ *OutputState }
 
+func (StringPtrOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (*string).
 func (StringPtrOutput) ElementType() reflect.Type {
 	return stringPtrType
@@ -4092,6 +4341,10 @@ func (in StringArray) ToStringArrayOutputWithContext(ctx context.Context) String
 
 // StringArrayOutput is an Output that returns []string values.
 type StringArrayOutput struct{ *OutputState }
+
+func (StringArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]string).
 func (StringArrayOutput) ElementType() reflect.Type {
@@ -4165,6 +4418,10 @@ func (in StringMap) ToStringMapOutputWithContext(ctx context.Context) StringMapO
 // StringMapOutput is an Output that returns map[string]string values.
 type StringMapOutput struct{ *OutputState }
 
+func (StringMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]string).
 func (StringMapOutput) ElementType() reflect.Type {
 	return stringMapType
@@ -4230,6 +4487,10 @@ func (in StringArrayMap) ToStringArrayMapOutputWithContext(ctx context.Context) 
 // StringArrayMapOutput is an Output that returns map[string][]string values.
 type StringArrayMapOutput struct{ *OutputState }
 
+func (StringArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]string).
 func (StringArrayMapOutput) ElementType() reflect.Type {
 	return stringArrayMapType
@@ -4294,6 +4555,10 @@ func (in StringMapArray) ToStringMapArrayOutputWithContext(ctx context.Context) 
 
 // StringMapArrayOutput is an Output that returns []map[string]string values.
 type StringMapArrayOutput struct{ *OutputState }
+
+func (StringMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]string).
 func (StringMapArrayOutput) ElementType() reflect.Type {
@@ -4367,6 +4632,10 @@ func (in StringMapMap) ToStringMapMapOutputWithContext(ctx context.Context) Stri
 // StringMapMapOutput is an Output that returns map[string]map[string]string values.
 type StringMapMapOutput struct{ *OutputState }
 
+func (StringMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]string).
 func (StringMapMapOutput) ElementType() reflect.Type {
 	return stringMapMapType
@@ -4431,6 +4700,10 @@ func (in StringArrayArray) ToStringArrayArrayOutputWithContext(ctx context.Conte
 
 // StringArrayArrayOutput is an Output that returns [][]string values.
 type StringArrayArrayOutput struct{ *OutputState }
+
+func (StringArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]string).
 func (StringArrayArrayOutput) ElementType() reflect.Type {
@@ -4520,6 +4793,10 @@ func (in URN) ToURNPtrOutputWithContext(ctx context.Context) URNPtrOutput {
 // URNOutput is an Output that returns URN values.
 type URNOutput struct{ *OutputState }
 
+func (URNOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (URN).
 func (URNOutput) ElementType() reflect.Type {
 	return urnType
@@ -4592,6 +4869,10 @@ func (in *urnPtr) ToURNPtrOutputWithContext(ctx context.Context) URNPtrOutput {
 // URNPtrOutput is an Output that returns *URN values.
 type URNPtrOutput struct{ *OutputState }
 
+func (URNPtrOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (*URN).
 func (URNPtrOutput) ElementType() reflect.Type {
 	return uRNPtrType
@@ -4644,6 +4925,10 @@ func (in URNArray) ToURNArrayOutputWithContext(ctx context.Context) URNArrayOutp
 
 // URNArrayOutput is an Output that returns []URN values.
 type URNArrayOutput struct{ *OutputState }
+
+func (URNArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]URN).
 func (URNArrayOutput) ElementType() reflect.Type {
@@ -4717,6 +5002,10 @@ func (in URNMap) ToURNMapOutputWithContext(ctx context.Context) URNMapOutput {
 // URNMapOutput is an Output that returns map[string]URN values.
 type URNMapOutput struct{ *OutputState }
 
+func (URNMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]URN).
 func (URNMapOutput) ElementType() reflect.Type {
 	return uRNMapType
@@ -4782,6 +5071,10 @@ func (in URNArrayMap) ToURNArrayMapOutputWithContext(ctx context.Context) URNArr
 // URNArrayMapOutput is an Output that returns map[string][]URN values.
 type URNArrayMapOutput struct{ *OutputState }
 
+func (URNArrayMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string][]URN).
 func (URNArrayMapOutput) ElementType() reflect.Type {
 	return uRNArrayMapType
@@ -4846,6 +5139,10 @@ func (in URNMapArray) ToURNMapArrayOutputWithContext(ctx context.Context) URNMap
 
 // URNMapArrayOutput is an Output that returns []map[string]URN values.
 type URNMapArrayOutput struct{ *OutputState }
+
+func (URNMapArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([]map[string]URN).
 func (URNMapArrayOutput) ElementType() reflect.Type {
@@ -4919,6 +5216,10 @@ func (in URNMapMap) ToURNMapMapOutputWithContext(ctx context.Context) URNMapMapO
 // URNMapMapOutput is an Output that returns map[string]map[string]URN values.
 type URNMapMapOutput struct{ *OutputState }
 
+func (URNMapMapOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
+
 // ElementType returns the element type of this Output (map[string]map[string]URN).
 func (URNMapMapOutput) ElementType() reflect.Type {
 	return uRNMapMapType
@@ -4983,6 +5284,10 @@ func (in URNArrayArray) ToURNArrayArrayOutputWithContext(ctx context.Context) UR
 
 // URNArrayArrayOutput is an Output that returns [][]URN values.
 type URNArrayArrayOutput struct{ *OutputState }
+
+func (URNArrayArrayOutput) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("Outputs can not be marshaled to JSON")
+}
 
 // ElementType returns the element type of this Output ([][]URN).
 func (URNArrayArrayOutput) ElementType() reflect.Type {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This is not as useful for Go as it is for other languages, but it's consistent and it saves an Apply call.

Ideally we would handle nested Output types during marshalling, but to do that correctly we need some way to get access to per-call-to-JSONMarshal flags to note if we see any unknowns, or secrets.

Go just doesn't (AFAIK) have any way to support doing that.

So we do the next best thing which is we at least error that nested Outputs can't be marshalled. Note that the `Output` interface doesn't embed the `Marshal` interface because there _may_ be users who have wrote their own `Output` types and that would be a breaking change.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
