### PR TITLE
Fix generate flag for pcl convert

### DIFF
--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -178,6 +178,8 @@ func runConvert(
 		projectGenerator = yamlgen.GenerateProject
 	case "pulumi", "pcl":
 		if cmdutil.IsTruthy(os.Getenv("PULUMI_DEV")) {
+			// No plugin for PCL to install dependencies with
+			generateOnly = true
 			projectGenerator = pclGenerateProject
 			break
 		}
@@ -214,8 +216,6 @@ func runConvert(
 		}
 	} else if from == "pcl" {
 		if cmdutil.IsTruthy(os.Getenv("PULUMI_DEV")) {
-			// No plugin for PCL to generate with
-			generateOnly = true
 			proj, program, err = pclEject(cwd, loader)
 			if err != nil {
 				return result.FromError(fmt.Errorf("could not load pcl program: %w", err))


### PR DESCRIPTION
Had the setting of this flag to false on the "read pcl", but it actually needs to be set on the "write pcl" side. That is if we write out a PCL project, don't try to install dependencies on it.