### PR TITLE
Add some basic tests for Output.Format

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
@@ -642,7 +642,7 @@ namespace Pulumi.Tests.Core
             public Task JsonSerializeBasic()
                 => RunInNormal(async () =>
                 {
-                    var o1 = CreateOutput(new int[]{ 0, 1} , true);
+                    var o1 = CreateOutput(new int[]{ 0, 1}, true);
                     var o2 = Output.JsonSerialize(o1);
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.True(data.IsKnown);
@@ -753,6 +753,29 @@ namespace Pulumi.Tests.Core
                 Assert.Contains(resource, data.Resources);
                 Assert.Equal("[0,1]", data.Value);
             }
+
+            [Fact]
+            public Task FormatBasic()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, true);
+                    var o2 = Output.Format($"{o1}");
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.False(data.IsSecret);
+                    Assert.Equal("0", data.Value);
+                });
+
+            [Fact]
+            public Task FormatBraceSyntax()
+                => RunInNormal(async () =>
+                {
+                    var o2 = Output.Format($"{{ pip pip");
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.False(data.IsSecret);
+                    Assert.Equal("{ pip pip", data.Value);
+                });
         }
     }
 }


### PR DESCRIPTION
Couple of tests for Output.Format, prompted by looking into https://github.com/pulumi/pulumi/issues/11623 and seeing that we seem to have zero tests for this method right now.