### PR TITLE
fix negative stopwatch times

### DIFF
--- a/changelog/pending/20221212--cli-display--fixes-negative-durations-on-update-display.yaml
+++ b/changelog/pending/20221212--cli-display--fixes-negative-durations-on-update-display.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fixes negative durations on update display.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -862,6 +862,9 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 		// and time elapsed.
 		display.opStopwatch.start[step.URN] = time.Now()
 
+		// Clear out potential event end timings for prior operations on the same resource.
+		delete(display.opStopwatch.end, step.URN)
+
 		row.SetStep(step)
 	} else if event.Type == engine.ResourceOutputsEvent {
 		isRefresh := display.getStepOp(row.Step()) == deploy.OpRefresh


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11188 

This PR fixes negative times showing up on the update display. This was caused by operations that did not emit a resource output event using the end time for the previous operation if it existed. This change clears the old end time if it exists.

~TODO~
- [x] write test
- [x] find and implement fix
- [x] write changelog entry

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
