### PR TITLE
Check for optional/ Ptr types within Unions [go/programgen]

### DIFF
--- a/changelog/pending/20221212--programgen-go--Check-for-optional-Ptr-types-within-Union-types.yaml
+++ b/changelog/pending/20221212--programgen-go--Check-for-optional-Ptr-types-within-Union-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/go
+  description: Check for optional/ Ptr types within Union types. This fixes a bug in Go programgen where optional outputs are not returned as pointers.

--- a/pkg/codegen/testing/test/testdata/aws-s3-logging-pp/go/aws-s3-logging.go
+++ b/pkg/codegen/testing/test/testdata/aws-s3-logging-pp/go/aws-s3-logging.go
@@ -21,9 +21,9 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("targetBucket", bucket.Loggings.ApplyT(func(loggings []s3.BucketLogging) (string, error) {
-			return loggings[0].TargetBucket, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("targetBucket", bucket.Loggings.ApplyT(func(loggings []s3.BucketLogging) (*string, error) {
+			return &loggings[0].TargetBucket, nil
+		}).(pulumi.StringPtrOutput))
 		return nil
 	})
 }

--- a/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
+++ b/pkg/codegen/testing/test/testdata/synthetic-resource-properties-pp/go/synthetic-resource-properties.go
@@ -16,9 +16,9 @@ func main() {
 		ctx.Export("foo", rt.Res1.ApplyT(func(res1 *resourceproperties.Res1) (resourceproperties.Obj2, error) {
 			return res1.Obj1.Res2.Obj2, nil
 		}).(resourceproperties.Obj2Output))
-		ctx.Export("complex", rt.Res1.ApplyT(func(res1 *resourceproperties.Res1) (float64, error) {
-			return res1.Obj1.Res2.Obj2.Answer, nil
-		}).(pulumi.Float64Output))
+		ctx.Export("complex", rt.Res1.ApplyT(func(res1 *resourceproperties.Res1) (*float64, error) {
+			return &res1.Obj1.Res2.Obj2.Answer, nil
+		}).(pulumi.Float64PtrOutput))
 		return nil
 	})
 }


### PR DESCRIPTION
Fixes #11496 
This fixes a bug in Go programgen where optional outputs are not returned as pointers (example in ticket)
