### PR TITLE
Make the PluginMapper lazy

### DIFF
--- a/changelog/pending/20221213--cli--improve-performance-of-convert-to-not-try-and-load-so-many-provider-plugins.yaml
+++ b/changelog/pending/20221213--cli--improve-performance-of-convert-to-not-try-and-load-so-many-provider-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Improve performance of convert to not try and load so many provider plugins.

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -624,15 +624,9 @@ func (p *providerServer) Call(ctx context.Context, req *pulumirpc.CallRequest) (
 
 func (p *providerServer) GetMapping(ctx context.Context,
 	req *pulumirpc.GetMappingRequest) (*pulumirpc.GetMappingResponse, error) {
-	// TODO: We have to do a dance here where first we publish a version of pulumi with these RPC structures
-	// then add methods to terraform-bridge to implement this method as if it did exist, and then actually add
-	// the RPC method and uncomment out the code below. This is all because we currently build these in a loop
-	// (pulumi include terraform-bridge, which includes pulumi).
-	return &pulumirpc.GetMappingResponse{Data: nil, Provider: ""}, nil
-
-	//data, provider, err := p.provider.GetMapping(req.Key)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//return &pulumirpc.GetMappingResponse{Data: data, Provider: provider}, nil
+	data, provider, err := p.provider.GetMapping(req.Key)
+	if err != nil {
+		return nil, err
+	}
+	return &pulumirpc.GetMappingResponse{Data: data, Provider: provider}, nil
 }


### PR DESCRIPTION
What it says on the tin. Makes the PluginMapper lazy so for yaml we don't have to load every plugin in ~/.pulumi/plugins.

We don't load any provider plugins until we need to load an conversion mapping that we don't yet have.
Once we find the first provider that supplies a conversion mapping we stop looking for any more.

The only other improvement to make here that I think is possible is to shut down the providers after asking for their conversion mapping data. But that needs a rejig of how plugin.Host works, which is hard to do right now as it's a public api.