### PR TITLE
Fix undeclared err codegen bug

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -816,9 +816,6 @@ func (g *generator) genLocalVariable(w io.Writer, v *pcl.LocalVariable) {
 			assignment = "="
 		}
 	}
-	if name == "_" {
-		assignment = "="
-	}
 	switch expr := expr.(type) {
 	case *model.FunctionCallExpression:
 		switch expr.Name {


### PR DESCRIPTION
Fixes #11584 .

This fixes a codegen bug where `=` was always being used when generating a local variable with no assignment (assigning to `_`), which is incorrect if an error is also being assigned to for the first time (`_, err := ...`).