### PR TITLE
Fix test failure on Windows

### DIFF
--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,6 +117,11 @@ func TestGoModEdits(t *testing.T) {
 `), 0600)
 	require.NoError(t, err)
 
+	errNotExists := "no such file or directory"
+	if runtime.GOOS == "windows" {
+		errNotExists = "The system cannot find the path specified"
+	}
+
 	tests := []struct {
 		name          string
 		dep           string
@@ -130,7 +136,7 @@ func TestGoModEdits(t *testing.T) {
 		{
 			name:          "invalid-path-non-existent",
 			dep:           "../../../.tmp.non-existent-dir",
-			expectedError: "open ../../../.tmp.non-existent-dir/go.mod: no such file or directory",
+			expectedError: errNotExists,
 		},
 		{
 			name:          "invalid-path-bad-go-mod",


### PR DESCRIPTION
PR #11611 assumed a unix-y error message in one of the failure cases of the test `TestGoModEdits`. This case did not match on Windows:

```
=== FAIL: testing/integration TestGoModEdits/invalid-path-non-existent (0.00s)
    program_test.go:170: 
        	Error Trace:	C:\a\pulumi\pulumi\pkg\testing\integration\program_test.go:170
        	Error:      	Error "error reading go.mod at ../../../.tmp.non-existent-dir: open ..\\..\\..\\.tmp.non-existent-dir\\go.mod: The system cannot find the path specified." does not contain "open ../../../.tmp.non-existent-dir/go.mod: no such file or directory"
        	Test:       	TestGoModEdits/invalid-path-non-existent
    --- FAIL: TestGoModEdits/invalid-path-non-existent (0.00s)
```
