### PR TITLE
Bundle NodeJS runtime

### DIFF
--- a/changelog/pending/20221214--sdk-nodejs--bundle-nodejs-runtimey.yaml
+++ b/changelog/pending/20221214--sdk-nodejs--bundle-nodejs-runtimey.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: The NodeJS language runtime is now distributed as bundled JavaScript. This makes bundling of Pulumi programs somewhat less challenging, and might result in a slight performance improvement in certain circumstances.

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -32,6 +32,8 @@ lint:: ensure
 
 build_package:: ensure
 	yarn run tsc
+	npx esbuild --bundle --tree-shaking=true --minify --format=cjs --allow-overwrite --platform=node --define:window=global --target=node14 --outdir=bundled_dist index.ts
+	cp bundled_dist/index.js bin/robbies_vendor.js
 	cp tests/runtime/jsClosureCases_8.js bin/tests/runtime
 	cp tests/runtime/jsClosureCases_10_4.js bin/tests/runtime
 	mkdir -p bin/tests/automation/data/

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -32,7 +32,7 @@ lint:: ensure
 
 build_package:: ensure
 	yarn run tsc
-	npx esbuild --bundle --tree-shaking=true --minify --format=cjs --allow-overwrite --platform=node --define:window=global --target=node14 --outdir=bundled_dist index.ts
+	npx esbuild --bundle --tree-shaking=true --minify --format=cjs --allow-overwrite --platform=node --define:window=global --target=node14 --outdir=bundled_dist cmd/run/index.ts
 	cp bundled_dist/index.js bin/robbies_vendor.js
 	cp tests/runtime/jsClosureCases_8.js bin/tests/runtime
 	cp tests/runtime/jsClosureCases_10_4.js bin/tests/runtime

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -24,7 +24,7 @@ GO_TEST_FAST = $(PYTHON) ../../scripts/go-test.py $(GO_TEST_FAST_FLAGS)
 
 ensure:: yarn.ensure node.ensure .ensure.phony
 .ensure.phony: package.json
-	yarn install --frozen-lockfile
+	yarn install
 	@touch .ensure.phony
 
 lint:: ensure

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import execa from "execa";
-
 import { createCommandError } from "./errors";
 
 /** @internal */

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -546,8 +546,6 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 		runPath = defaultRunPath
 	}
 
-	fmt.Printf("Using run path: %s\n", runPath)
-
 	runPath, err = locateModule(ctx, runPath, nodeBin)
 	if err != nil {
 		cmdutil.ExitError(

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -63,7 +63,7 @@ import (
 const (
 	// The path to the "run" program which will spawn the rest of the language host. This may be overridden with
 	// PULUMI_LANGUAGE_NODEJS_RUN_PATH, which we do in some testing cases.
-	defaultRunPath = "@pulumi/pulumi/cmd/run"
+	defaultRunPath = "@pulumi/pulumi/robbies_vendor"
 
 	// The runtime expects the config object to be saved to this environment variable.
 	pulumiConfigVar = "PULUMI_CONFIG"
@@ -545,6 +545,8 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 	if runPath == "" {
 		runPath = defaultRunPath
 	}
+
+	fmt.Printf("Using run path: %s\n", runPath)
 
 	runPath, err = locateModule(ctx, runPath, nodeBin)
 	if err != nil {

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -520,7 +520,7 @@ export function output<T>(val: Input<T>): Output<Unwrap<T>>;
 export function output<T>(val: Input<T> | undefined): Output<Unwrap<T | undefined>>;
 export function output<T>(val: Input<T | undefined>): Output<Unwrap<T | undefined>> {
     const ov = outputRec(val);
-    return Output.isInstance<Unwrap<T>>(ov) ? ov : createSimpleOutput(ov);
+    return (Output.isInstance<Unwrap<T>>(ov) ? ov : createSimpleOutput(ov)) as any;
 }
 
 /**

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -46,6 +46,7 @@
         "@types/split2": "^2.1.6",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
+        "esbuild": "0.16.5",
         "eslint": "^7.32.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.23.4",

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "strict": true,
         "outDir": "bin",
         "target": "es2016",
         "module": "commonjs",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

WIP PR for bundling the NodeJS runtime with ESBuild.
I need to clean up the code still before it's ready to merge.

I was able to bundle a Pulumi program (_i.e._ a user program) using:

```bash
$ yarn install
$ esbuild --bundle --tree-shaking=true --minify --format=cjs --platform=node --define:window=global --define:self=global --target=node14 index.ts --outfile=index.js
```

Then, I could delete every package from `@node_modules` except `@pulumi/pulumi` (because the runtime still lives in there!), and execute my bundled, minified Pulumi program.

<!--
This PR pushes us closer toward allowing users to bundle their Pulumi programs.
Without this PR, users need to install `@pulumi/pulumi` and all of its dependencies in `node_modules`, even if they're using a bundler. With this PR, users can install just `@pulumi/pulumi`, since all of the dependencies 
-->

Fixes https://github.com/pulumi/pulumi/issues/10210

## Why ESBuild

I would have rather used SWC since I believe it's the future, but ESBuild has a few appealing benefits.

* It's a lot easier to setup than SWC.
* It has a Go API, so if we decide to minify and bundle providers, we might just want to do that from within NodeJS codegen.
* I recently uncovered that code generated by SWC is not as performant as code generated by TSC. At least, I wasn't able to get the same performance. It's possible I was missing a toggle or two.

## Performance

Performance numbers are inconsistent. They range from 2% improvement to 14% improvement on cold cache. Warm cache produces virtually no improvement (since bundling is ultimately a way to reduce the number of disk reads).

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
