### PR TITLE
Add stack tag support for nodejs automation api sdk

### DIFF
--- a/changelog/pending/20230119--auto-nodejs--enable-programmatic-tagging-of-stacks-nodejs-only.yaml
+++ b/changelog/pending/20230119--auto-nodejs--enable-programmatic-tagging-of-stacks-nodejs-only.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Enable programmatic tagging of stacks (Nodejs only)

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -27,6 +27,7 @@ import { OutputMap, Stack } from "./stack";
 import * as localState from "../runtime/state";
 import { StackSettings, stackSettingsSerDeKeys } from "./stackSettings";
 import { Deployment, PluginInfo, PulumiFn, StackSummary, WhoAmIResult, Workspace } from "./workspace";
+import { TagMap } from "./tag";
 
 const SKIP_VERSION_CHECK_VAR = "PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK";
 
@@ -498,6 +499,45 @@ export class LocalWorkspace implements Workspace {
     async refreshConfig(stackName: string): Promise<ConfigMap> {
         await this.runPulumiCmd(["config", "refresh", "--force", "--stack", stackName]);
         return this.getAllConfig(stackName);
+    }
+    /**
+     * Returns the value associated with the specified stack name and key,
+     * scoped to the LocalWorkspace.
+     *
+     * @param stackName The stack to read tag metadata from.
+     * @param key The key to use for the tag lookup.
+     */
+    async getTag(stackName: string, key: string): Promise<string> {
+        const result = await this.runPulumiCmd(["stack", "tag", "get", key, "--stack", stackName]);
+        return result.stdout.trim();
+    }
+    /**
+     * Sets the specified key-value pair on the provided stack name.
+     *
+     * @param stackName The stack to operate on.
+     * @param key The tag key to set.
+     * @param value The tag value to set.
+     */
+    async setTag(stackName: string, key: string, value: string): Promise<void> {
+        await this.runPulumiCmd(["stack", "tag", "set", key, value, "--stack", stackName]);
+    }
+    /**
+     * Removes the specified key-value pair on the provided stack name.
+     *
+     * @param stackName The stack to operate on.
+     * @param key The tag key to remove.
+     */
+    async removeTag(stackName: string, key: string): Promise<void> {
+        await this.runPulumiCmd(["stack", "tag", "rm", key, "--stack", stackName]);
+    }
+    /**
+     * Returns the tag map for the specified tag name, scoped to the current LocalWorkspace.
+     *
+     * @param stackName The stack to read tag metadata from.
+     */
+    async listTags(stackName: string): Promise<TagMap> {
+        const result = await this.runPulumiCmd(["stack", "tag", "ls", "--json", "--stack", stackName]);
+        return JSON.parse(result.stdout);
     }
     /**
      * Returns the currently authenticated user.

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -29,6 +29,7 @@ import { EngineEvent, SummaryEvent } from "./events";
 import { LanguageServer, maxRPCMessageSize } from "./server";
 import { Deployment, PulumiFn, Workspace } from "./workspace";
 import { LocalWorkspace } from "./localWorkspace";
+import { TagMap } from "./tag";
 
 const langrpc = require("../proto/language_grpc_pb.js");
 
@@ -567,6 +568,37 @@ Event: ${line}\n${e.toString()}`);
      */
     async refreshConfig(): Promise<ConfigMap> {
         return this.workspace.refreshConfig(this.name);
+    }
+    /**
+     * Returns the tag value associated with specified key.
+     *
+     * @param key The key to use for the tag lookup.
+     */
+    async getTag(key: string): Promise<string> {
+        return this.workspace.getTag(this.name, key);
+    }
+    /**
+     * Sets a tag key-value pair on the Stack in the associated Workspace.
+     *
+     * @param key The tag key to set.
+     * @param value The tag value to set.
+     */
+    async setTag(key: string, value: string): Promise<void> {
+        await this.workspace.setTag(this.name, key, value);
+    }
+    /**
+     * Removes the specified tag key-value pair from the Stack in the associated Workspace.
+     *
+     * @param key The tag key to remove.
+     */
+    async removeTag(key: string): Promise<void> {
+        await this.workspace.removeTag(this.name, key);
+    }
+    /**
+     * Returns the full tag map associated with the stack in the Workspace.
+     */
+    async listTags(): Promise<TagMap> {
+        return this.workspace.listTags(this.name);
     }
     /**
      * Gets the current set of Stack outputs from the last Stack.up().

--- a/sdk/nodejs/automation/tag.ts
+++ b/sdk/nodejs/automation/tag.ts
@@ -1,0 +1,18 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * TagMap is a key-value map of tag metadata associated with a stack.
+ */
+export type TagMap = { [key: string]: string };

--- a/sdk/nodejs/automation/workspace.ts
+++ b/sdk/nodejs/automation/workspace.ts
@@ -16,6 +16,7 @@ import { ConfigMap, ConfigValue } from "./config";
 import { ProjectSettings } from "./projectSettings";
 import { OutputMap } from "./stack";
 import { StackSettings } from "./stackSettings";
+import { TagMap } from "./tag";
 
 /**
  * Workspace is the execution context containing a single Pulumi project, a program, and multiple stacks.
@@ -140,6 +141,35 @@ export interface Workspace {
      * @param stackName The stack to refresh
      */
     refreshConfig(stackName: string): Promise<ConfigMap>;
+    /**
+     * Returns the value associated with the specified stack name and key,
+     * scoped to the Workspace.
+     *
+     * @param stackName The stack to read tag metadata from.
+     * @param key The key to use for the tag lookup.
+     */
+    getTag(stackName: string, key: string): Promise<string>;
+    /**
+     * Sets the specified key-value pair on the provided stack name.
+     *
+     * @param stackName The stack to operate on.
+     * @param key The tag key to set.
+     * @param value The tag value to set.
+     */
+    setTag(stackName: string, key: string, value: string): Promise<void>;
+    /**
+     * Removes the specified key-value pair on the provided stack name.
+     *
+     * @param stackName The stack to operate on.
+     * @param key The tag key to remove.
+     */
+    removeTag(stackName: string, key: string): Promise<void>;
+    /**
+     * Returns the tag map for the specified tag name, scoped to the current Workspace.
+     *
+     * @param stackName The stack to read tag metadata from.
+     */
+    listTags(stackName: string): Promise<TagMap>;
     /**
      * Returns the currently authenticated user.
      */


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds stack tag management support to the **nodejs** automation api sdk (https://github.com/pulumi/pulumi/issues/5681).

Before I move on to other language/runtime SDKs, I'd like to get a quick sanity check on this nodejs implementation, since they will follow a similar pattern 👍 . There is no changelog for now; this won't be merged as-is. Thank you! 🙏😄 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes: https://github.com/pulumi/pulumi/issues/5681

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- ~~[ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change~~
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] ~~Yes, there are changes in this PR that warrants bumping the Pulumi Service API version~~
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
