### PR TITLE
Fix incorrect pointers for array of objects [go/codegen]

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -49,6 +49,10 @@ type generator struct {
 	configCreated       bool
 	externalCache       *Cache
 
+	// inGenTupleConExprListArgs indicates that a the generator is processing an args list within a TupleConExpression.
+	inGenTupleConExprListArgs bool
+	isPtrArg                  bool
+
 	// User-configurable options
 	assignResourcesToVariables bool // Assign resource to a new variable instead of _.
 }

--- a/pkg/codegen/testing/test/testdata/aws-optionals-pp/go/aws-optionals.go
+++ b/pkg/codegen/testing/test/testdata/aws-optionals-pp/go/aws-optionals.go
@@ -9,7 +9,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		policyDocument, err := iam.GetPolicyDocument(ctx, &iam.GetPolicyDocumentArgs{
 			Statements: []iam.GetPolicyDocumentStatement{
-				iam.GetPolicyDocumentStatement{
+				{
 					Sid: pulumi.StringRef("1"),
 					Actions: []string{
 						"s3:ListAllMyBuckets",

--- a/pkg/codegen/testing/test/testdata/aws-webserver-pp/go/aws-webserver.go
+++ b/pkg/codegen/testing/test/testdata/aws-webserver-pp/go/aws-webserver.go
@@ -27,7 +27,7 @@ func main() {
 		}
 		ami, err := aws.GetAmi(ctx, &aws.GetAmiArgs{
 			Filters: []aws.GetAmiFilter{
-				aws.GetAmiFilter{
+				{
 					Name: "name",
 					Values: []string{
 						"amzn-ami-hvm-*-x86_64-ebs",

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
@@ -36,6 +36,26 @@ return await Deployment.RunAsync(() =>
                         },
                     },
                 },
+                new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
+                {
+                    Name = "nginx2",
+                    Image = "nginx:1.14-alpine",
+                    Ports = new[]
+                    {
+                        new Kubernetes.Types.Inputs.Core.V1.ContainerPortArgs
+                        {
+                            ContainerPortValue = 80,
+                        },
+                    },
+                    Resources = new Kubernetes.Types.Inputs.Core.V1.ResourceRequirementsArgs
+                    {
+                        Limits = 
+                        {
+                            { "memory", "20Mi" },
+                            { "cpu", "0.2" },
+                        },
+                    },
+                },
             },
         },
     });

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
@@ -16,16 +16,31 @@ func main() {
 			},
 			Spec: &corev1.PodSpecArgs{
 				Containers: []corev1.ContainerArgs{
-					&corev1.ContainerArgs{
+					{
 						Name:  pulumi.String("nginx"),
 						Image: pulumi.String("nginx:1.14-alpine"),
 						Ports: corev1.ContainerPortArray{
-							&corev1.ContainerPortArgs{
+							{
 								ContainerPort: pulumi.Int(80),
 							},
 						},
-						Resources: &corev1.ResourceRequirementsArgs{
-							Limits: pulumi.StringMap{
+						Resources: {
+							Limits: {
+								"memory": pulumi.String("20Mi"),
+								"cpu":    pulumi.String("0.2"),
+							},
+						},
+					},
+					{
+						Name:  pulumi.String("nginx2"),
+						Image: pulumi.String("nginx:1.14-alpine"),
+						Ports: corev1.ContainerPortArray{
+							{
+								ContainerPort: pulumi.Int(80),
+							},
+						},
+						Resources: {
+							Limits: {
 								"memory": pulumi.String("20Mi"),
 								"cpu":    pulumi.String("0.2"),
 							},

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/kubernetes-pod.pp
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/kubernetes-pod.pp
@@ -16,6 +16,17 @@ resource bar "kubernetes:core/v1:Pod" {
                         cpu = 0.2
                     }
                 }
+            },
+            {
+                name = "nginx2"
+                image = "nginx:1.14-alpine"
+                ports = [{ containerPort = 80 }]
+                resources = {
+                    limits = {
+                        memory = "20Mi"
+                        cpu = 0.2
+                    }
+                }
             }
         ]
     }

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/nodejs/kubernetes-pod.ts
@@ -8,19 +8,34 @@ const bar = new kubernetes.core.v1.Pod("bar", {
         name: "bar",
     },
     spec: {
-        containers: [{
-            name: "nginx",
-            image: "nginx:1.14-alpine",
-            ports: [{
-                containerPort: 80,
-            }],
-            resources: {
-                limits: {
-                    memory: "20Mi",
-                    cpu: "0.2",
+        containers: [
+            {
+                name: "nginx",
+                image: "nginx:1.14-alpine",
+                ports: [{
+                    containerPort: 80,
+                }],
+                resources: {
+                    limits: {
+                        memory: "20Mi",
+                        cpu: "0.2",
+                    },
                 },
             },
-        }],
+            {
+                name: "nginx2",
+                image: "nginx:1.14-alpine",
+                ports: [{
+                    containerPort: 80,
+                }],
+                resources: {
+                    limits: {
+                        memory: "20Mi",
+                        cpu: "0.2",
+                    },
+                },
+            },
+        ],
     },
 });
 const kind = bar.kind;

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
@@ -8,18 +8,33 @@ bar = kubernetes.core.v1.Pod("bar",
         name="bar",
     ),
     spec=kubernetes.core.v1.PodSpecArgs(
-        containers=[kubernetes.core.v1.ContainerArgs(
-            name="nginx",
-            image="nginx:1.14-alpine",
-            ports=[kubernetes.core.v1.ContainerPortArgs(
-                container_port=80,
-            )],
-            resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                limits={
-                    "memory": "20Mi",
-                    "cpu": "0.2",
-                },
+        containers=[
+            kubernetes.core.v1.ContainerArgs(
+                name="nginx",
+                image="nginx:1.14-alpine",
+                ports=[kubernetes.core.v1.ContainerPortArgs(
+                    container_port=80,
+                )],
+                resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                    limits={
+                        "memory": "20Mi",
+                        "cpu": "0.2",
+                    },
+                ),
             ),
-        )],
+            kubernetes.core.v1.ContainerArgs(
+                name="nginx2",
+                image="nginx:1.14-alpine",
+                ports=[kubernetes.core.v1.ContainerPortArgs(
+                    container_port=80,
+                )],
+                resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                    limits={
+                        "memory": "20Mi",
+                        "cpu": "0.2",
+                    },
+                ),
+            ),
+        ],
     ))
 kind = bar.kind


### PR DESCRIPTION
Fixes #11663
Fix incorrect pointer argument codegen when objects are nested inside an array whose type is not a pointer.

Example:
`&s3.BucketLoggingArgs` is valid here
```
bucket, err := s3.NewBucket(ctx, "bucket", &s3.BucketArgs{
			Loggings: s3.BucketLoggingArray{
				&s3.BucketLoggingArgs{
					TargetBucket: logs.Bucket,
				},
			},
		})

```
but `&ec2.SubnetSpecArgs{}` is invalid here:
```
SubnetSpecs: []ec2.SubnetSpecArgs{
				&ec2.SubnetSpecArgs{
					Type:     ec2.SubnetTypePublic,
					CidrMask: 22,
				},
				&ec2.SubnetSpecArgs{
					Type:     ec2.SubnetTypePrivate,
					CidrMask: 20,
				},
			},
```
Instead, it should be: 
```
SubnetSpecs: []ec2.SubnetSpecArgs{
				{
					Type:     ec2.SubnetTypePublic,
					CidrMask: 22,
				},
				{
					Type:     ec2.SubnetTypePrivate,
					CidrMask: 20,
				},
			},
```

