### PR TITLE
Don't return half-nil fat ptrs from `SyntaxNode()`

### DIFF
--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -344,6 +344,9 @@ type BinaryOpExpression struct {
 
 // SyntaxNode returns the syntax node associated with the binary operation.
 func (x *BinaryOpExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -468,6 +471,9 @@ type ConditionalExpression struct {
 
 // SyntaxNode returns the syntax node associated with the conditional expression.
 func (x *ConditionalExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -723,6 +729,9 @@ type ForExpression struct {
 
 // SyntaxNode returns the syntax node associated with the for expression.
 func (x *ForExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -1002,6 +1011,9 @@ type FunctionCallExpression struct {
 
 // SyntaxNode returns the syntax node associated with the function call expression.
 func (x *FunctionCallExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -1143,6 +1155,9 @@ type IndexExpression struct {
 
 // SyntaxNode returns the syntax node associated with the index expression.
 func (x *IndexExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -1331,6 +1346,9 @@ type LiteralValueExpression struct {
 
 // SyntaxNode returns the syntax node associated with the literal value expression.
 func (x *LiteralValueExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -1468,6 +1486,9 @@ type ObjectConsExpression struct {
 
 // SyntaxNode returns the syntax node associated with the object construction expression.
 func (x *ObjectConsExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -1746,6 +1767,9 @@ type RelativeTraversalExpression struct {
 
 // SyntaxNode returns the syntax node associated with the relative traversal expression.
 func (x *RelativeTraversalExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -1872,6 +1896,9 @@ type ScopeTraversalExpression struct {
 
 // SyntaxNode returns the syntax node associated with the scope traversal expression.
 func (x *ScopeTraversalExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -2014,6 +2041,9 @@ type SplatExpression struct {
 
 // SyntaxNode returns the syntax node associated with the splat expression.
 func (x *SplatExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -2169,6 +2199,9 @@ type TemplateExpression struct {
 
 // SyntaxNode returns the syntax node associated with the template expression.
 func (x *TemplateExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -2274,6 +2307,9 @@ type TemplateJoinExpression struct {
 
 // SyntaxNode returns the syntax node associated with the template join expression.
 func (x *TemplateJoinExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -2355,6 +2391,9 @@ type TupleConsExpression struct {
 
 // SyntaxNode returns the syntax node associated with the tuple construction expression.
 func (x *TupleConsExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 
@@ -2489,6 +2528,9 @@ type UnaryOpExpression struct {
 
 // SyntaxNode returns the syntax node associated with the unary operation.
 func (x *UnaryOpExpression) SyntaxNode() hclsyntax.Node {
+	if x.Syntax == nil {
+		return syntax.None
+	}
 	return x.Syntax
 }
 

--- a/pkg/codegen/pcl/rewrite_convert.go
+++ b/pkg/codegen/pcl/rewrite_convert.go
@@ -45,6 +45,9 @@ func sameSchemaTypes(xt, yt model.Type) bool {
 // rewriteConversions implements the core of RewriteConversions. It returns the rewritten expression and true if the
 // type of the expression may have changed.
 func rewriteConversions(x model.Expression, to model.Type, diags *hcl.Diagnostics) (model.Expression, bool) {
+	if x == nil {
+		return nil, false
+	}
 	// If rewriting an operand changed its type and the type of the expression depends on the type of that operand, the
 	// expression must be typechecked in order to update its type.
 	var typecheck bool


### PR DESCRIPTION
Passing a typed `nil` through a interface conversion, such as a `*hclsyntax.UnaryOpExpr` through a `hclsyntax.Node` interface will result in a half-nil fat pointer with the value part `nil`. Since most of programgen assumes that `(model.Expression).SyntaxNode().Range()` is valid, a `syntax.None` is passed instead of a `nil`.