### PR TITLE
Fix illegal cast in resource constructors when secret-wrapping input arguments.

### DIFF
--- a/changelog/pending/20221217--sdkgen-go--illegal-cast-in-resource-constructors-when-secret-wrapping-input-arguments.yaml
+++ b/changelog/pending/20221217--sdkgen-go--illegal-cast-in-resource-constructors-when-secret-wrapping-input-arguments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/go
+  description: Illegal cast in resource constructors when secret-wrapping input arguments.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1763,7 +1763,8 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	// Setup secrets
 	for _, p := range secretInputProps {
 		fmt.Fprintf(w, "\tif args.%s != nil {\n", pkg.fieldName(r, p))
-		fmt.Fprintf(w, "\t\targs.%[1]s = pulumi.ToSecret(args.%[1]s).(%[2]s)\n", pkg.fieldName(r, p), pkg.outputType(p.Type))
+
+		fmt.Fprintf(w, "\t\targs.%[1]s = pulumi.ToSecret(args.%[1]s).(%[2]s)\n", pkg.fieldName(r, p), pkg.typeString(p.Type))
 		fmt.Fprintf(w, "\t}\n")
 	}
 	if len(secretProps) > 0 {

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
@@ -24,7 +24,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Baz != nil {
-		args.Baz = pulumi.ToSecret(args.Baz).(pulumi.StringPtrOutput)
+		args.Baz = pulumi.ToSecret(args.Baz).(pulumi.StringPtrInput)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"baz",

--- a/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
@@ -24,7 +24,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Bar != nil {
-		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrOutput)
+		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrInput)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"bar",

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/provider.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/provider.go
@@ -26,7 +26,7 @@ func NewProvider(ctx *pulumi.Context,
 		args.FavoriteColor = pulumi.StringPtr(getEnvOrDefault("", nil, "FAVE_COLOR").(string))
 	}
 	if args.SecretSandwiches != nil {
-		args.SecretSandwiches = pulumi.ToSecret(args.SecretSandwiches).(config.SandwichArrayOutput)
+		args.SecretSandwiches = pulumi.ToSecret(args.SecretSandwiches).(config.SandwichArrayInput)
 	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:configstation", name, args, &resource, opts...)

--- a/pkg/codegen/testing/test/testdata/secrets/go/mypkg/resource.go
+++ b/pkg/codegen/testing/test/testdata/secrets/go/mypkg/resource.go
@@ -48,22 +48,22 @@ func NewResource(ctx *pulumi.Context,
 		return nil, errors.New("invalid value for required argument 'FooMap'")
 	}
 	if args.Config != nil {
-		args.Config = pulumi.ToSecret(args.Config).(ConfigOutput)
+		args.Config = pulumi.ToSecret(args.Config).(ConfigInput)
 	}
 	if args.ConfigArray != nil {
-		args.ConfigArray = pulumi.ToSecret(args.ConfigArray).(ConfigArrayOutput)
+		args.ConfigArray = pulumi.ToSecret(args.ConfigArray).(ConfigArrayInput)
 	}
 	if args.ConfigMap != nil {
-		args.ConfigMap = pulumi.ToSecret(args.ConfigMap).(ConfigMapOutput)
+		args.ConfigMap = pulumi.ToSecret(args.ConfigMap).(ConfigMapInput)
 	}
 	if args.Foo != nil {
-		args.Foo = pulumi.ToSecret(args.Foo).(pulumi.StringOutput)
+		args.Foo = pulumi.ToSecret(args.Foo).(pulumi.StringInput)
 	}
 	if args.FooArray != nil {
-		args.FooArray = pulumi.ToSecret(args.FooArray).(pulumi.StringArrayOutput)
+		args.FooArray = pulumi.ToSecret(args.FooArray).(pulumi.StringArrayInput)
 	}
 	if args.FooMap != nil {
-		args.FooMap = pulumi.ToSecret(args.FooMap).(pulumi.StringMapOutput)
+		args.FooMap = pulumi.ToSecret(args.FooMap).(pulumi.StringMapInput)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"config",

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
@@ -25,7 +25,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Bar != nil {
-		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrOutput)
+		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrInput)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"bar",

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
@@ -24,7 +24,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Bar != nil {
-		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrOutput)
+		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrInput)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"bar",


### PR DESCRIPTION
Fixes #11664 after new SDK gen. Will require an update to pulumi-aws using this branch or a new release.

Codegen for wrapping input properties as secrets performed an incorrect cast, as seen in Pulumi's AWS classic SDK.

Using the sample program and the resource constructor described in #11664 as our test case, from `pulumi-aws/sdk/v5/go/aws/secretmanager/secretVersion.go`:

```go
      func NewSecretVersion(ctx *pulumi.Context,
        name string, args *SecretVersionArgs, opts ...pulumi.ResourceOption) (*SecretVersion, error)
        if args == nil {
          return nil, errors.New("missing one or more required arguments")
        }

        if args.SecretId == nil {
          return nil, errors.New("invalid value for required argument 'SecretId'")
        }
        if args.SecretBinary != nil {
82:        args.SecretBinary = pulumi.ToSecret(args.SecretBinary).(pulumi.StringPtrOutput)
        }
        if args.SecretString != nil {
85:        args.SecretString = pulumi.ToSecret(args.SecretString).(pulumi.StringPtrOutput)
        }
```

`args.SecretBinary` is of type `pulumi.StringPtrInput` and `pulumi.ToSecret` returns `pulumi.Output` returns its input as an Output-wrapped value marked secret.

As `StringPtrInput` is an interface accepting multiple input types, the return value would be either `pulumi.StringOutput` `pulumi.StringPtrOutput`. These are both concrete types, and casting to the incorrect one would panic.

Fortunately we can cast back to the input type, as verified by building the new codegen and testing the Pulumi program in #11664.

The new codegen below converts an input type `T` to `pulumi.Output`, then casts back to `T`.

```go
      func NewSecretVersion(ctx *pulumi.Context,
        // ...
        if args.SecretBinary != nil {
82:             args.SecretBinary = pulumi.ToSecret(args.SecretBinary).(pulumi.StringPtrInput)
        }
        if args.SecretString != nil {
85:             args.SecretString = pulumi.ToSecret(args.SecretString).(pulumi.StringPtrInput)
        }
```
