### PR TITLE
Remove Dotnet from release step of GH workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ on:
         # Example provided for illustration, this value is derived by scripts/get-job-matrix.py build
         default: |
           {
-            "dotnet": "6.0.x",
             "go": "1.18.x",
             "nodejs": "14.x",
             "python": "3.9.x"
@@ -57,7 +56,6 @@ env:
   PULUMI_TEST_OWNER: "moolumi"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
 jobs:
@@ -67,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["nodejs", "python", "dotnet", "go"]
+        language: ["nodejs", "python", "go"]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -83,12 +81,6 @@ jobs:
         if: ${{ matrix.language == 'python' }}
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet twine
-      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-        if: ${{ matrix.language == 'dotnet' }}
-        uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
-        with:
-          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
-          dotnet-quality: ga
       - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
         if: ${{ matrix.language == 'nodejs' }}
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ on:
         # Example provided for illustration, this value is derived by scripts/get-job-matrix.py build
         default: |
           {
+            "dotnet": "6.0.x",
             "go": "1.18.x",
             "nodejs": "14.x",
             "python": "3.9.x"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Now that dotnet has been exfiltrated to https://github.com/pulumi/pulumi-dotnet we do not release it as part of the release workflow. The release step errors since the dotnet artifacts are no longer uploaded to GitHub as part of the release bundle.

Is there an easy way to test this change?

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
