### PR TITLE
chore: manually run release steps for 3.50.0

### DIFF
--- a/.github/workflows/release-tmp-workaround-3.50.0.yml
+++ b/.github/workflows/release-tmp-workaround-3.50.0.yml
@@ -1,0 +1,167 @@
+name: Release Actions (3.50.0 workaround)
+
+on:
+  pull_request:
+
+permissions:
+  # To create a PR
+  contents: write
+  pull-requests: write
+
+
+env:
+  PULUMI_VERSION: "3.50.0"
+  GITHUB_REF: v3.50.0
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  PULUMI_TEST_OWNER: "moolumi"
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+jobs:
+  pr:
+    # Relies on the Go SDK being published to update pkg
+    name: PR
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/manual-release-actions') }}
+    uses: ./.github/workflows/release-pr.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      ref: v3.50.0
+      version: "3.50.0"
+      release-notes: |
+        ## 3.50.0 (2022-12-19)
+
+        We're approaching the end of 2022, and this is the final minor release scheduled for the year! 🎸
+        Thank you very much to our wonderful community for your many contributions! ❤️
+
+        ### Features
+
+        - [auto/{go,nodejs,python}] Adds SkipInstallDependencies option for Remote Workspaces
+          [#11674](https://github.com/pulumi/pulumi/pull/11674)
+
+        - [ci] GitHub release artifacts are now signed using [cosign](https://github.com/sigstore/cosign) and signatures are uploaded to the [Rekor transparency log](https://rekor.tlog.dev/).
+          [#11310](https://github.com/pulumi/pulumi/pull/11310)
+
+        - [cli] Adds a flag that allows user to set the node label as the resource name instead of full URN in the stack graph
+          [#11383](https://github.com/pulumi/pulumi/pull/11383)
+
+        - [cli] pulumi destroy --remove will now delete the stack config file
+          [#11394](https://github.com/pulumi/pulumi/pull/11394)
+
+        - [cli] Allow rotating the encrpytion key for cloud secrets.
+          [#11554](https://github.com/pulumi/pulumi/pull/11554)
+
+        - [cli/{config,new,package}] Preserve comments on editing of project and config files.
+          [#11456](https://github.com/pulumi/pulumi/pull/11456)
+
+        - [sdk/dotnet] Add Output.JsonSerialize using System.Text.Json.
+          [#11556](https://github.com/pulumi/pulumi/pull/11556)
+
+        - [sdk/go] Add JSONMarshal to go sdk.
+          [#11609](https://github.com/pulumi/pulumi/pull/11609)
+
+        - [sdkgen/{dotnet,nodejs}] Initial implementation of simplified invokes for dotnet and nodejs.
+          [#11418](https://github.com/pulumi/pulumi/pull/11418)
+
+        - [sdk/nodejs] Delegates alias computation to engine for Node SDK
+          [#11206](https://github.com/pulumi/pulumi/pull/11206)
+
+        - [sdk/nodejs] Emit closure requires in global scope for improved cold start on Lambda
+          [#11481](https://github.com/pulumi/pulumi/pull/11481)
+
+        - [sdk/nodejs] Add output jsonStringify using JSON.stringify.
+          [#11605](https://github.com/pulumi/pulumi/pull/11605)
+
+        - [sdk/python] Add json_dumps to python sdk.
+          [#11607](https://github.com/pulumi/pulumi/pull/11607)
+
+
+        ### Bug Fixes
+
+        - [backend/service] Fixes out-of-memory issues when using PULUMI_OPTIMIZED_CHECKPOINT_PATCH protocol
+          [#11666](https://github.com/pulumi/pulumi/pull/11666)
+
+        - [cli] Improve performance of convert to not try and load so many provider plugins.
+          [#11639](https://github.com/pulumi/pulumi/pull/11639)
+
+        - [programgen] Don't panic on some empty objects
+          [#11660](https://github.com/pulumi/pulumi/pull/11660)
+
+        - [cli/display] Fixes negative durations on update display.
+          [#11631](https://github.com/pulumi/pulumi/pull/11631)
+
+        - [programgen/go] Check for optional/ Ptr types within Union types. This fixes a bug in Go programgen where optional outputs are not returned as pointers.
+          [#11635](https://github.com/pulumi/pulumi/pull/11635)
+
+        - [sdkgen/{dotnet,go,nodejs,python}] Do not generate Result types for functions with empty outputs
+          [#11596](https://github.com/pulumi/pulumi/pull/11596)
+
+        - [sdk/python] Fix a deadlock on provider-side error with automation api
+          [#11595](https://github.com/pulumi/pulumi/pull/11595)
+
+        - [sdkgen/{dotnet,nodejs}] Fix imports when a component is using another component from the same schema as a property
+          [#11606](https://github.com/pulumi/pulumi/pull/11606)
+          [#11467](https://github.com/pulumi/pulumi/pull/11467)
+
+        - [sdkgen/go] Illegal cast in resource constructors when secret-wrapping input arguments.
+          [#11673](https://github.com/pulumi/pulumi/pull/11673)
+
+
+        ### Miscellaneous
+
+        - [sdk/nodejs] Remove function serialization code for out of suppport NodeJS versions.
+          [#11551](https://github.com/pulumi/pulumi/pull/11551)
+          queue-merge: true
+          run-dispatch-commands: true
+          version-set: {
+          "dotnet": "6.0.x",
+          "go": "1.18.x",
+          "nodejs": "14.x",
+          "python": "3.9.x"
+        }
+
+      queue-merge: false
+    secrets: inherit
+
+  dispatch:
+    name: ${{ matrix.job.name }}
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/manual-release-actions') }}
+    needs: [pr]
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - name: Templates Smoke Test
+            run-command: pulumictl dispatch -r pulumi/templates -c trigger-cron "${PULUMI_VERSION}"
+          - name: Update Templates Version
+            run-command: pulumictl dispatch -r pulumi/templates -c update-templates "${PULUMI_VERSION}"
+          - name: Examples Templates Version
+            run-command: pulumictl dispatch -r pulumi/examples -c smoke-test-cli "${PULUMI_VERSION}"
+          - name: Chocolatey Update
+            run-command: pulumictl create choco-deploy "${PULUMI_VERSION}"
+          - name: Winget Update
+            run-command: pulumictl winget-deploy
+          - name: Build Package Docs
+            run-command: pulumictl create cli-docs-build "${PULUMI_VERSION}"
+          - name: Homebrew
+            run-command: pulumictl create homebrew-bump "${PULUMI_VERSION}" "$(git rev-parse HEAD)"
+          - name: Docker containers
+            run-command: pulumictl dispatch -r pulumi/pulumi-docker-containers -c release-build "${PULUMI_VERSION}"
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          ref: v3.50.0
+      - name: Install Pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.7.1
+        with:
+          repo: pulumi/pulumictl
+          tag: v0.0.32
+          cache: enable
+      - name: Repository Dispatch
+        run: ${{ matrix.job.run-command }}


### PR DESCRIPTION
The 3.50.0 release had an issue with running the `pr` and `dispatch` steps due to the dotnet SDK job being run - that step is now run by the pulumi/pulumi-dotnet repository. 

The `pr` and `dispatch` steps are included here with manually configured inputs.

The steps in this pull request workflow should not run unless a label is added and after review. To validate this, the PR will be updated 3 times:

1. This initial PR push with all steps commented out except the "test" job, to verify that the `if` condition works.

2. A second force push with the steps uncommented, for ease of review.

3. After approval, the label `ci/manual-release-actions` will be added to the PR, the PR will be amended with `--no-edit` to change the time stamp, and force pushed to apply the operations.