### PR TITLE
Fix executable checks for windows

### DIFF
--- a/changelog/pending/20221220--cli-plugin--fix-check-of-executable-bits-on-windows.yaml
+++ b/changelog/pending/20221220--cli-plugin--fix-check-of-executable-bits-on-windows.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Fix check of executable bits on Windows.

--- a/pkg/cmd/pulumi/package.go
+++ b/pkg/cmd/pulumi/package.go
@@ -20,6 +20,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/blang/semver"
@@ -109,6 +110,10 @@ func schemaFromSchemaSource(packageSource string) (*schema.Package, error) {
 	}
 
 	isExecutable := func(info fs.FileInfo) bool {
+		// Windows doesn't have executable bits to check
+		if runtime.GOOS == "windows" {
+			return !info.IsDir()
+		}
 		return info.Mode()&0111 != 0 && !info.IsDir()
 	}
 

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -233,7 +233,8 @@ func getFilePayload(file string, spec workspace.PluginSpec) (workspace.PluginCon
 		return nil, fmt.Errorf("seeking back in file %s: %w", source, err)
 	}
 	if !encoding.IsCompressed(compressHeader) {
-		if (stat.Mode() & 0100) == 0 {
+		// Windows doesn't have executable bits to check
+		if runtime.GOOS != "windows" && (stat.Mode()&0100) == 0 {
 			return nil, fmt.Errorf("%s is not executable", source)
 		}
 		return workspace.SingleFilePlugin(f, spec), nil


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes the checking of executable bits for plugins in Windows (which doesn't have executable bits).

Obligatory https://fasterthanli.me/articles/i-want-off-mr-golangs-wild-ride#simple-is-a-lie given I literally re-read this yesterday and then hit _this_ today.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
