### PR TITLE
ProgramTest provider record-and-replay prototype

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -81,7 +81,7 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 		}
 	}
 
-	if replayFile := os.Getenv("PULUMI_REPLAY_GRPC"); replayFile != "" {
+	if replayFile := env.ReplayGRPC.Value(); replayFile != "" {
 		i, err := interceptors.NewReplayInterceptor(interceptors.ReplayInterceptorOptions{
 			LogFile: replayFile,
 			Mutex:   ctx.DebugTraceMutex,

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -82,13 +82,18 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 	}
 
 	if replayFile := os.Getenv("PULUMI_REPLAY_GRPC"); replayFile != "" {
-		i, err := interceptors.NewReplayInterceptor(interceptors.ReplayInterceptorOptions{})
+		i, err := interceptors.NewReplayInterceptor(interceptors.ReplayInterceptorOptions{
+			LogFile: replayFile,
+			Mutex:   ctx.DebugTraceMutex,
+		})
 		if err != nil {
 			return "", "", nil, err
 		}
 		oldOptions := ctx.DialOptions
 		ctx.DialOptions = func(metadata interface{}) []grpc.DialOption {
-			more := i.DialOptions()
+			more := i.DialOptions(interceptors.LogOptions{
+				Metadata: metadata,
+			})
 			return append(oldOptions(metadata), more...)
 		}
 	}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	cryptorand "crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec
 	sha256 "crypto/sha256"
 	"encoding/hex"
 	"encoding/json"

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2487,7 +2487,7 @@ func withRecordReplaySetup(pt *ProgramTester, name string, cmd []string) *Progra
 		return pt
 	}
 
-	// Compute hash of name, cmd, wd to unqiuely identify a Pulumi command.
+	// Compute hash of name, cmd, wd to uniquely identify a Pulumi command.
 	var hash string
 	{
 		var buf bytes.Buffer

--- a/pkg/util/rpcdebug/interceptor_replay.go
+++ b/pkg/util/rpcdebug/interceptor_replay.go
@@ -15,26 +15,140 @@
 package rpcdebug
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
+	"strings"
+	"sync"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-type ReplayInterceptorOptions struct{}
-
-type ReplayInterceptor struct{}
-
-func NewReplayInterceptor(opts ReplayInterceptorOptions) (*ReplayInterceptor, error) {
-	return &ReplayInterceptor{}, nil
+type ReplayInterceptorOptions struct {
+	LogFile string
+	Mutex   *sync.Mutex
 }
 
-func (i *ReplayInterceptor) ClientInterceptor() grpc.UnaryClientInterceptor {
+type ReplayInterceptor struct {
+	entries []debugInterceptorLogEntry
+	mutex   *sync.Mutex
+}
+
+func NewReplayInterceptor(opts ReplayInterceptorOptions) (*ReplayInterceptor, error) {
+	if opts.Mutex == nil {
+		return nil, fmt.Errorf("Mutex option is required")
+	}
+	if opts.LogFile == "" {
+		return nil, fmt.Errorf("LogFile option is required")
+	}
+	f, err := os.Open(opts.LogFile)
+	if err != nil {
+		return nil, err
+	}
+	defer contract.IgnoreClose(f)
+	entries := []debugInterceptorLogEntry{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry debugInterceptorLogEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return &ReplayInterceptor{
+		entries: entries,
+		mutex:   opts.Mutex,
+	}, nil
+}
+
+func (i *ReplayInterceptor) ClientInterceptor(opts LogOptions) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{},
 		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, gopts ...grpc.CallOption) error {
-		panic(fmt.Sprintf("ReplayInterceptor caught client call %v", reflect.TypeOf(reply)))
+
+		if strings.HasPrefix(method, "/pulumirpc.ResourceProvider") {
+			reqJ, err := transcode(req)
+			if err != nil {
+				panic(fmt.Errorf("ReplayInterceptor failed to transcode: %w", err))
+			}
+
+			found, _, entry := i.popEntry(method, reqJ, opts.Metadata)
+			if !found {
+				return status.Errorf(codes.FailedPrecondition,
+					"Cannot find matching logs of a call with method=%q reqJ=%s metadata=%v",
+					method, reqJ, opts.Metadata)
+			}
+
+			if i.isUnimplemented(entry) {
+				return status.Errorf(codes.Unimplemented, "%s Unimplemented", method)
+			}
+
+			if err := transcodeBack(entry.Response, reply); err != nil {
+				return status.Errorf(codes.FailedPrecondition,
+					"ReplayInterceptor failed to transcodeBack from %q (%d bytes): %w",
+					entry.Response, len(entry.Response), err)
+			}
+
+			return nil
+		}
+
+		return invoker(ctx, method, req, reply, cc, gopts...)
 	}
+}
+
+func (*ReplayInterceptor) isUnimplemented(entry debugInterceptorLogEntry) bool {
+	for _, e := range entry.Errors {
+		if strings.Contains(strings.ToLower(e), "unimplemented") {
+			return true
+		}
+	}
+	return false
+}
+
+func (i *ReplayInterceptor) popEntry(method string, req json.RawMessage, meta interface{}) (bool, int, debugInterceptorLogEntry) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	ok, index, e := i.findEntry(method, req, meta)
+	if ok {
+		i.removeEntry(index)
+	}
+	return ok, index, e
+}
+
+func (i *ReplayInterceptor) removeEntry(index int) {
+	i.entries = append(i.entries[0:index], i.entries[index+1:]...)
+}
+
+func (i *ReplayInterceptor) findEntry(method string, req json.RawMessage, metadata interface{}) (bool, int, debugInterceptorLogEntry) {
+	ref := debugInterceptorLogEntry{Method: method, Request: req, Metadata: metadata}
+	for k, e := range i.entries {
+		if i.entriesMatch(e, ref) {
+			return true, k, e
+		}
+	}
+	return false, 0, debugInterceptorLogEntry{}
+}
+
+func (*ReplayInterceptor) entriesMatch(a, b debugInterceptorLogEntry) bool {
+	if a.Method != b.Method {
+		return false
+	}
+	if !bytes.Equal(a.Request, b.Request) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Metadata, b.Metadata) {
+		return false
+	}
+	return true
 }
 
 func (i *ReplayInterceptor) StreamClientInterceptor() grpc.StreamClientInterceptor {
@@ -44,9 +158,9 @@ func (i *ReplayInterceptor) StreamClientInterceptor() grpc.StreamClientIntercept
 	}
 }
 
-func (i *ReplayInterceptor) DialOptions() []grpc.DialOption {
+func (i *ReplayInterceptor) DialOptions(opts LogOptions) []grpc.DialOption {
 	return []grpc.DialOption{
-		grpc.WithChainUnaryInterceptor(i.ClientInterceptor()),
+		grpc.WithChainUnaryInterceptor(i.ClientInterceptor(opts)),
 		grpc.WithChainStreamInterceptor(i.StreamClientInterceptor()),
 	}
 }

--- a/pkg/util/rpcdebug/interceptor_replay.go
+++ b/pkg/util/rpcdebug/interceptor_replay.go
@@ -37,6 +37,7 @@ type ReplayInterceptorOptions struct {
 }
 
 type ReplayInterceptor struct {
+	logFile string
 	entries []debugInterceptorLogEntry
 	mutex   *sync.Mutex
 }
@@ -66,6 +67,7 @@ func NewReplayInterceptor(opts ReplayInterceptorOptions) (*ReplayInterceptor, er
 		return nil, err
 	}
 	return &ReplayInterceptor{
+		logFile: opts.LogFile,
 		entries: entries,
 		mutex:   opts.Mutex,
 	}, nil
@@ -84,8 +86,8 @@ func (i *ReplayInterceptor) ClientInterceptor(opts LogOptions) grpc.UnaryClientI
 			found, _, entry := i.popEntry(method, reqJ, opts.Metadata)
 			if !found {
 				return status.Errorf(codes.FailedPrecondition,
-					"Cannot find matching logs of a call with method=%q reqJ=%s metadata=%v",
-					method, reqJ, opts.Metadata)
+					"No matching logs of a call with method=%q req=%s metadata=%v in %q",
+					method, reqJ, opts.Metadata, i.logFile)
 			}
 
 			if i.isUnimplemented(entry) {

--- a/pkg/util/rpcdebug/interceptor_replay.go
+++ b/pkg/util/rpcdebug/interceptor_replay.go
@@ -1,0 +1,52 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcdebug
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"google.golang.org/grpc"
+)
+
+type ReplayInterceptorOptions struct{}
+
+type ReplayInterceptor struct{}
+
+func NewReplayInterceptor(opts ReplayInterceptorOptions) (*ReplayInterceptor, error) {
+	return &ReplayInterceptor{}, nil
+}
+
+func (i *ReplayInterceptor) ClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{},
+		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, gopts ...grpc.CallOption) error {
+		panic(fmt.Sprintf("ReplayInterceptor caught client call %v", reflect.TypeOf(reply)))
+	}
+}
+
+func (i *ReplayInterceptor) StreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string,
+		streamer grpc.Streamer, gopts ...grpc.CallOption) (grpc.ClientStream, error) {
+		panic("ReplayInterceptor caught client stream call")
+	}
+}
+
+func (i *ReplayInterceptor) DialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(i.ClientInterceptor()),
+		grpc.WithChainStreamInterceptor(i.StreamClientInterceptor()),
+	}
+}

--- a/pkg/util/rpcdebug/interceptor_replay.go
+++ b/pkg/util/rpcdebug/interceptor_replay.go
@@ -96,8 +96,8 @@ func (i *ReplayInterceptor) ClientInterceptor(opts LogOptions) grpc.UnaryClientI
 
 			if err := transcodeBack(entry.Response, reply); err != nil {
 				return status.Errorf(codes.FailedPrecondition,
-					"ReplayInterceptor failed to transcodeBack from %q (%d bytes): %w",
-					entry.Response, len(entry.Response), err)
+					"ReplayInterceptor failed to transcodeBack from %q (%d bytes): %s",
+					entry.Response, len(entry.Response), err.Error())
 			}
 
 			return nil

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -68,3 +68,5 @@ fail without a --force parameter.`)
 
 var DebugGRPC = env.String("DEBUG_GRPC", `Enables debug tracing of Pulumi gRPC internals.
 The variable should be set to the log file to which gRPC debug traces will be sent.`)
+
+var ReplayGRPC = env.String("REPLAY_GRPC", `Exprimental providers auto-mocking by replaying DEBUG_GRPC logs.`)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Sketches out a possible way to implement provider record-and-replay feature on top of ProgramTest. In record mode, interactions with resource providers (and therefore the cloud) are logged to files. In replay mode, Pulumi runs against mock providers that use pre-recorded conversations to answer queries. This speeds up testing Pulumi programs by taking the cloud out of the equation, with a few known limitations:

- testing in replay mode removes resources providers from the system under test

- replay fails to mock provider interactions if the program is modified or sufficiently non-deterministic 

Fixes # (issue)

Demonstration: https://github.com/pulumi/pulumi-java/pull/929

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
