### PR TITLE
Pass `--remote-git-commit` to remote deployment

### DIFF
--- a/changelog/pending/20230224--auto-dotnet-go-nodejs-python--fix-support-for-specifying-a-git-commit-for-remote-workspaces.yaml
+++ b/changelog/pending/20230224--auto-dotnet-go-nodejs-python--fix-support-for-specifying-a-git-commit-for-remote-workspaces.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/dotnet,go,nodejs,python
+  description: Fix support for specifying a git commit for remote workspaces

--- a/pkg/cmd/pulumi/util_remote.go
+++ b/pkg/cmd/pulumi/util_remote.go
@@ -321,6 +321,7 @@ func runDeployment(ctx context.Context, opts display.Options, operation apitype.
 			Git: &apitype.SourceContextGit{
 				RepoURL: url,
 				Branch:  args.gitBranch,
+				Commit:  args.gitCommit,
 				RepoDir: args.gitRepoDir,
 				GitAuth: gitAuth,
 			},


### PR DESCRIPTION
This was being parsed from CLI flags, but seemingly not passed into the Deployment.

Not 100% sure how/where to add test coverage for this.
