### PR TITLE
Make pretty-printing conditional

### DIFF
--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -44,13 +45,23 @@ func ExprNotConvertible(destType Type, expr Expression) *hcl.Diagnostic {
 	if len(why) != 0 {
 		return errorf(expr.SyntaxNode().Range(), why[0].Summary)
 	}
+	var e, d fmt.Stringer = expr.Type(), destType
+	if env.PrettyPrintPCL.Value() {
+		e = expr.Type().Pretty()
+		d = destType.Pretty()
+	}
 	return errorf(expr.SyntaxNode().Range(), "cannot assign expression of type %s to location of type %s: ",
-		expr.Type().Pretty(), destType.Pretty())
+		e, d)
 }
 
 func typeNotConvertible(dest, src Type) *hcl.Diagnostic {
+	var s, d fmt.Stringer = src, dest
+	if env.PrettyPrintPCL.Value() {
+		s = src.Pretty()
+		d = dest.Pretty()
+	}
 	return &hcl.Diagnostic{Severity: hcl.DiagError, Summary: fmt.Sprintf("cannot assign value of type %s to type %s",
-		src.Pretty(), dest.Pretty())}
+		s, d)}
 }
 
 func tuplesHaveDifferentLengths(dest, src *TupleType) *hcl.Diagnostic {

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -68,3 +68,5 @@ fail without a --force parameter.`)
 
 var DebugGRPC = env.String("DEBUG_GRPC", `Enables debug tracing of Pulumi gRPC internals.
 The variable should be set to the log file to which gRPC debug traces will be sent.`)
+
+var PrettyPrintPCL = env.Bool("PRETTY_PRINT_PCL", "Print PCL type errors across multiple lines")


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/11722


The aim is to remove this flag after the `pretty` library can provably handle recursive types.
Related to #11676