### PR TITLE
Revv capability API to V2

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1768,7 +1768,7 @@ func (c httpstateBackendClient) GetStackResourceOutputs(
 // Represents feature-detected capabilities of the service the backend is connected to.
 type capabilities struct {
 	// If non-nil, indicates that delta checkpoint updates are supported.
-	deltaCheckpointUpdates *apitype.DeltaCheckpointUploadsConfigV1
+	deltaCheckpointUpdates *apitype.DeltaCheckpointUploadsConfigV2
 }
 
 // Builds a lazy wrapper around doDetectCapabilities.
@@ -1814,13 +1814,15 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 	var parsed capabilities
 	for _, entry := range wireLevel {
 		switch entry.Capability {
-		case apitype.DeltaCheckpointUploads:
-			var cap apitype.DeltaCheckpointUploadsConfigV1
-			if err := json.Unmarshal(entry.Configuration, &cap); err != nil {
-				msg := "decoding DeltaCheckpointUploadsConfigV1 returned %w"
-				return capabilities{}, fmt.Errorf(msg, err)
+		case apitype.DeltaCheckpointUploadsV2:
+			if entry.Version == 2 {
+				var cap apitype.DeltaCheckpointUploadsConfigV2
+				if err := json.Unmarshal(entry.Configuration, &cap); err != nil {
+					msg := "decoding DeltaCheckpointUploadsConfigV2 returned %w"
+					return capabilities{}, fmt.Errorf(msg, err)
+				}
+				parsed.deltaCheckpointUpdates = &cap
 			}
-			parsed.deltaCheckpointUpdates = &cap
 		default:
 			continue
 		}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1814,6 +1814,15 @@ func decodeCapabilities(wireLevel []apitype.APICapabilityConfig) (capabilities, 
 	var parsed capabilities
 	for _, entry := range wireLevel {
 		switch entry.Capability {
+		case apitype.DeltaCheckpointUploads:
+			var cap apitype.DeltaCheckpointUploadsConfigV1
+			if err := json.Unmarshal(entry.Configuration, &cap); err != nil {
+				msg := "decoding DeltaCheckpointUploadsConfig returned %w"
+				return capabilities{}, fmt.Errorf(msg, err)
+			}
+			parsed.deltaCheckpointUpdates = &apitype.DeltaCheckpointUploadsConfigV2{
+				CheckpointCutoffSizeBytes: cap.CheckpointCutoffSizeBytes,
+			}
 		case apitype.DeltaCheckpointUploadsV2:
 			if entry.Version == 2 {
 				var cap apitype.DeltaCheckpointUploadsConfigV2

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -22,7 +22,7 @@ type APICapability string
 
 const (
 	// Deprecated. Use DeltaCheckpointUploadsV2.
-	//DeltaCheckpointUploads APICapability = "delta-checkpoint-uploads"
+	DeltaCheckpointUploads APICapability = "delta-checkpoint-uploads"
 
 	// DeltaCheckpointUploads is the feature that enables the CLI to upload checkpoints
 	// via the PatchUpdateCheckpointDeltaRequest API to save on network bytes.
@@ -30,9 +30,9 @@ const (
 )
 
 // Deprecated. Use DeltaCheckpointUploadsConfigV2.
-// type DeltaCheckpointUploadsConfigV1 struct {
-// 	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
-// }
+type DeltaCheckpointUploadsConfigV1 struct {
+	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
+}
 
 type DeltaCheckpointUploadsConfigV2 struct {
 	// CheckpointCutoffSizeBytes defines the size of a checkpoint file, in bytes,

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -21,12 +21,20 @@ import "encoding/json"
 type APICapability string
 
 const (
+	// Deprecated. Use DeltaCheckpointUploadsV2.
+	//DeltaCheckpointUploads APICapability = "delta-checkpoint-uploads"
+
 	// DeltaCheckpointUploads is the feature that enables the CLI to upload checkpoints
 	// via the PatchUpdateCheckpointDeltaRequest API to save on network bytes.
-	DeltaCheckpointUploads APICapability = "delta-checkpoint-uploads"
+	DeltaCheckpointUploadsV2 APICapability = "delta-checkpoint-uploads-v2"
 )
 
-type DeltaCheckpointUploadsConfigV1 struct {
+// Deprecated. Use DeltaCheckpointUploadsConfigV2.
+// type DeltaCheckpointUploadsConfigV1 struct {
+// 	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
+// }
+
+type DeltaCheckpointUploadsConfigV2 struct {
 	// CheckpointCutoffSizeBytes defines the size of a checkpoint file, in bytes,
 	// at which the CLI should cutover to using delta checkpoint uploads.
 	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
