### PR TITLE
Add JSONUnmarshal to go sdk

### DIFF
--- a/changelog/pending/20221229--sdk-go--add-output-jsonunmarshal-using-encoding-json.yaml
+++ b/changelog/pending/20221229--sdk-go--add-output-jsonunmarshal-using-encoding-json.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Add JSONUnmarshal to go sdk.

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -632,6 +632,24 @@ func JSONMarshalWithContext(ctx context.Context, v interface{}) StringOutput {
 	}).(StringOutput)
 }
 
+// JSONUnmarshal uses "encoding/json".Unmarshal to deserialize the given Input JSON string into a value.
+func JSONUnmarshal(data StringInput) AnyOutput {
+	return JSONUnmarshalWithContext(context.Background(), data)
+}
+
+// JSONUnmarshalWithContext uses "encoding/json".Unmarshal to deserialize the given Input JSON string into a value.
+func JSONUnmarshalWithContext(ctx context.Context, data StringInput) AnyOutput {
+	o := ToOutputWithContext(ctx, data)
+	return o.ApplyTWithContext(ctx, func(_ context.Context, data string) (interface{}, error) {
+		var v interface{}
+		err := json.Unmarshal([]byte(data), &v)
+		if err != nil {
+			return nil, err
+		}
+		return v, nil
+	}).(AnyOutput)
+}
+
 func gatherJoins(v interface{}) workGroups {
 	if v == nil {
 		return nil

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -1128,3 +1128,23 @@ func TestJSONMarshalNested(t *testing.T) {
 	assert.Nil(t, deps)
 	assert.Nil(t, v)
 }
+
+func TestJSONUnmarshalBasic(t *testing.T) {
+	t.Parallel()
+
+	out, resolve, _ := NewOutput()
+	go func() {
+		resolve("[0, 1]")
+	}()
+	str := out.ApplyT(func(str interface{}) (string, error) {
+		return str.(string), nil
+	}).(StringOutput)
+	json := JSONUnmarshal(str)
+	v, known, secret, deps, err := await(json)
+	assert.Nil(t, err)
+	assert.True(t, known)
+	assert.False(t, secret)
+	assert.Nil(t, deps)
+	assert.NotNil(t, v)
+	assert.Equal(t, []interface{}{0.0, 1.0}, v.([]interface{}))
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Partner method to JSONMarshal.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
