### PR TITLE
testing/integration: Fix failure without GOPATH

### DIFF
--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -97,11 +97,11 @@ func TestDepRootCalc(t *testing.T) {
 func TestGoModEdits(t *testing.T) {
 	t.Parallel()
 
-	depRoot := os.Getenv("PULUMI_GO_DEP_ROOT")
-	gopath, err := GoPath()
-	require.NoError(t, err)
-
 	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	depRoot := filepath.Clean(filepath.Join(cwd, "../../../.."))
+
+	gopath, err := GoPath()
 	require.NoError(t, err)
 
 	// Were we to commit this go.mod file, `make tidy` would fail, and we should keep the complexity


### PR DESCRIPTION
TestGoModEdits requires that one of the following conditions
be true for the test to pass:

- pulumi/pulumi is checked out at $GOPATH/src/github.com/pulumi/pulumi
- PULUMI_GO_DEP_ROOT is set to the directory where it's checked out

With wide usage of Go modules,
we're less likely to have folks working under GOPATH.

As for PULUMI_GO_DEP_ROOT, it makes sense for the generic utility:
Being able to specify where the dependency is checked out
is useful on a per-project basis,
but it makes less sense for this test.
This test is specifically checking the values inside the sdk/go.mod
and the path for that is always fixed.

This change modifies TestGoModEdits to pass
no matter where the repository is checked out
-- as long as it's called "pulumi".
It does so by hard-coding the position of the repository root
relative to the test directory.

This *feels* slightly icky because depRoot refers to the directory
that contains the "pulumi" directory,
but I think that this is less likely to break and easier to fix,
versus looking for a go.mod file
as the project structure evolves over time.