### PR TITLE
Add JSON as an experimental program-gen convert target

### DIFF
--- a/changelog/pending/20230102--programgen--adds-json-as-an-experimental-program-gen-convert-target.yaml
+++ b/changelog/pending/20230102--programgen--adds-json-as-an-experimental-program-gen-convert-target.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen
+  description: Adds JSON as an experimental program-gen convert target

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	jsongen "github.com/pulumi/pulumi/pkg/v3/codegen/json"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
@@ -178,6 +179,14 @@ func runConvert(
 		projectGenerator = javagen.GenerateProject
 	case "yaml": // nolint: goconst
 		projectGenerator = yamlgen.GenerateProject
+	case "json": // nolint: goconst
+		if e.GetBool(env.Experimental) || e.GetBool(env.Dev) {
+			generateOnly = true
+			projectGenerator = jsongen.GenerateProject
+			break
+		}
+
+		fallthrough
 	case "pulumi", "pcl":
 		if e.GetBool(env.Dev) {
 			// No plugin for PCL to install dependencies with

--- a/pkg/codegen/json/README.md
+++ b/pkg/codegen/json/README.md
@@ -1,0 +1,114 @@
+# PCL to JSON (experimental)
+
+This directory contains a PCL to JSON code generator which converts a PCL program into a JSON format that represents the Abstract Syntax Tree (AST) of the program. This JSON can be used by external tools to perform analysis or conversion of PCL programs to target languages without needing to build a specialized PCL parser. The JSON format is not intended to be human readable, but rather to be easily parsed by external tools.
+
+## Usage
+Execute `pulumi convert` against a Pulumi YAML program in experimental mode:
+```
+PULUMI_EXPERIMENTAL=1 pulumi convert --language json --out json
+```
+
+Note that Pulumi already type checks the program before converting it to JSON. If the program contains errors, the conversion will fail.
+
+## Format
+
+See [pcl-json-schema.json](./pcl-json-schema.json) for the full JSON schema specifications of the output format.
+
+A PCL program is converted into a JSON object with a field called `nodes` which is an array of the nodes of the program:
+```json
+{
+    "nodes": [...],
+    "plugins": [...]
+}
+```
+The `plugins` are references to the used resource plugins and are of the following shape:
+```json
+{
+    "name": "string",
+    "version": "string"
+}
+```
+Then each `node` can be one of the following:
+
+`Resource` of the following shape:
+```json
+{
+    "type": "Resource",
+    "name": "string",
+    "token": "string",
+    "logicalName": "string",
+    "inputs": {
+        "string": <expression>
+    },
+    "options": {
+        ["dependsOn"]: <expression>,
+        ["ignoreChanges"]: <string array>,
+        ["provider"]: <expression>,
+        ["protect"]: <boolean>,
+        ["parent"]: <expression>,
+        ["version"]: <expression>,
+    }
+}
+```
+`LocalVariable` of the following shape
+```json
+{
+    "type": "LocalVariable",
+    "name": "string",
+    "logicalName": "string",
+    "value": <expression>
+}
+```
+`OutputVariable` of the following shape
+```json
+{
+    "type": "OutputVariable",
+    "name": "string",
+    "logicalName": "string",
+    "value": <expression>
+}
+```
+`ConfigVariable` of the following shape
+```json
+{
+    "type": "ConfigVariable",
+    "name": "string",
+    "logicalName": "string",
+    "configType": "<string | number | int | boolean | unknown>",
+    "defaultValue": <expression>
+}
+```
+Where each `<expression>` is a JSON object that represents an expression. The shape of the expression depends on the type of expression. Here are examples of these expressions:
+
+`LiteralValueExpression:`
+```json
+{
+    "type": "LiteralValueExpression",
+    "value": "string | number | boolean"
+}
+```
+`ObjectConstExpression`: 
+```json
+{
+    "type": "ObjectConstExpression",
+    "properties": {
+        "string": <expression>
+    }
+}
+```
+`TupleConsExpression`: 
+```json
+{
+    "type": "TupleConsExpression",
+    "items": [<expression>, ...]
+}
+```
+`FunctionCallExpression`: 
+```json
+{
+    "type": "FunctionCallExpression",
+    "name": "string",
+    "args": [<expression>, ...]
+}
+```
+etc. See [pcl-json-schema.json](./pcl-json-schema.json) for the full list of expression types.

--- a/pkg/codegen/json/gen_program.go
+++ b/pkg/codegen/json/gen_program.go
@@ -1,0 +1,408 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func transformTraversal(traversal hcl.Traversal) []interface{} {
+	result := make([]interface{}, 0)
+	for _, part := range traversal {
+		switch part := part.(type) {
+		case hcl.TraverseAttr:
+			result = append(result, map[string]interface{}{
+				"type": "TraverseAttr",
+				"name": part.Name,
+			})
+		case hcl.TraverseIndex:
+			index, _ := part.Key.AsBigFloat().Int64()
+			result = append(result, map[string]interface{}{
+				"type": "TraverseIndex",
+				"key":  index,
+			})
+		case hcl.TraverseRoot:
+			result = append(result, map[string]interface{}{
+				"type": "TraverseRoot",
+				"name": part.Name,
+			})
+
+		case hcl.TraverseSplat:
+			result = append(result, map[string]interface{}{
+				"type": "TraverseSplat",
+				"each": transformTraversal(part.Each),
+			})
+		}
+	}
+
+	return result
+}
+
+func tranformFunctionParameters(parameters []*model.Variable) []string {
+	result := make([]string, len(parameters))
+	for i, parameter := range parameters {
+		result[i] = parameter.Name
+	}
+	return result
+}
+
+func formatOperation(operation *hclsyntax.Operation) string {
+	switch operation {
+	case hclsyntax.OpAdd:
+		return "Add"
+	case hclsyntax.OpDivide:
+		return "Divide"
+	case hclsyntax.OpEqual:
+		return "Equal"
+	case hclsyntax.OpGreaterThan:
+		return "GreaterThan"
+	case hclsyntax.OpGreaterThanOrEqual:
+		return "GreaterThanOrEqual"
+	case hclsyntax.OpLessThan:
+		return "LessThan"
+	case hclsyntax.OpLessThanOrEqual:
+		return "LessThanOrEqual"
+	case hclsyntax.OpLogicalAnd:
+		return "LogicalAnd"
+	case hclsyntax.OpLogicalOr:
+		return "LogicalOr"
+	case hclsyntax.OpModulo:
+		return "Modulo"
+	case hclsyntax.OpMultiply:
+		return "Multiply"
+	case hclsyntax.OpNotEqual:
+		return "NotEqual"
+	case hclsyntax.OpSubtract:
+		return "Subtract"
+	}
+
+	return ""
+}
+
+func transformExpression(expr model.Expression) map[string]interface{} {
+	switch expr.(type) {
+	case *model.LiteralValueExpression:
+		literalExpr := expr.(*model.LiteralValueExpression)
+		var value interface{}
+		switch literalExpr.Value.Type() {
+		case cty.Bool:
+			value = literalExpr.Value.True()
+		case cty.Number:
+			number, _ := literalExpr.Value.AsBigFloat().Float64()
+			value = number
+		case cty.String:
+			value = literalExpr.Value.AsString()
+		default:
+			value = nil
+		}
+
+		return map[string]interface{}{
+			"type":  "LiteralValueExpression",
+			"value": value,
+		}
+
+	case *model.TemplateExpression:
+		templateExpression := expr.(*model.TemplateExpression)
+		if len(templateExpression.Parts) == 1 {
+			return transformExpression(templateExpression.Parts[0])
+		}
+
+		parts := make([]interface{}, len(templateExpression.Parts))
+		for i, part := range templateExpression.Parts {
+			parts[i] = transformExpression(part)
+		}
+		return map[string]interface{}{
+			"type":  "TemplateExpression",
+			"parts": parts,
+		}
+
+	case *model.IndexExpression:
+		indexExpr := expr.(*model.IndexExpression)
+		return map[string]interface{}{
+			"type":       "IndexExpression",
+			"collection": transformExpression(indexExpr.Collection),
+			"key":        transformExpression(indexExpr.Key),
+		}
+
+	case *model.ObjectConsExpression:
+		objectExpr := expr.(*model.ObjectConsExpression)
+		properties := make(map[string]interface{})
+		for _, item := range objectExpr.Items {
+			if lit, ok := item.Key.(*model.LiteralValueExpression); ok {
+				propertyKey := lit.Value.AsString()
+				properties[propertyKey] = transformExpression(item.Value)
+			}
+		}
+		return map[string]interface{}{
+			"type":       "ObjectConsExpression",
+			"properties": properties,
+		}
+
+	case *model.TupleConsExpression:
+		tupleExpr := expr.(*model.TupleConsExpression)
+		items := make([]interface{}, len(tupleExpr.Expressions))
+		for i, item := range tupleExpr.Expressions {
+			items[i] = transformExpression(item)
+		}
+		return map[string]interface{}{
+			"type":  "TupleConsExpression",
+			"items": items,
+		}
+
+	case *model.FunctionCallExpression:
+		funcExpr := expr.(*model.FunctionCallExpression)
+		args := make([]interface{}, len(funcExpr.Args))
+		for i, arg := range funcExpr.Args {
+			args[i] = transformExpression(arg)
+		}
+		return map[string]interface{}{
+			"type": "FunctionCallExpression",
+			"name": funcExpr.Name,
+			"args": args,
+		}
+
+	case *model.RelativeTraversalExpression:
+		traversalExpr := expr.(*model.RelativeTraversalExpression)
+		return map[string]interface{}{
+			"type":      "RelativeTraversalExpression",
+			"source":    transformExpression(traversalExpr.Source),
+			"traversal": transformTraversal(traversalExpr.Traversal),
+		}
+
+	case *model.ScopeTraversalExpression:
+		traversalExpr := expr.(*model.ScopeTraversalExpression)
+		return map[string]interface{}{
+			"type":      "ScopeTraversalExpression",
+			"rootName":  traversalExpr.RootName,
+			"traversal": transformTraversal(traversalExpr.Traversal),
+		}
+
+	case *model.AnonymousFunctionExpression:
+		funcExpr := expr.(*model.AnonymousFunctionExpression)
+		return map[string]interface{}{
+			"type":       "AnonymousFunctionExpression",
+			"parameters": tranformFunctionParameters(funcExpr.Parameters),
+			"body":       transformExpression(funcExpr.Body),
+		}
+
+	case *model.ConditionalExpression:
+		condExpr := expr.(*model.ConditionalExpression)
+		return map[string]interface{}{
+			"type":      "ConditionalExpression",
+			"condition": transformExpression(condExpr.Condition),
+			"trueExpr":  transformExpression(condExpr.TrueResult),
+			"falseExpr": transformExpression(condExpr.FalseResult),
+		}
+
+	case *model.BinaryOpExpression:
+		binaryExpr := expr.(*model.BinaryOpExpression)
+		return map[string]interface{}{
+			"type":      "BinaryOpExpression",
+			"operation": formatOperation(binaryExpr.Operation),
+			"left":      transformExpression(binaryExpr.LeftOperand),
+			"right":     transformExpression(binaryExpr.RightOperand),
+		}
+
+	case *model.UnaryOpExpression:
+		unaryExpr := expr.(*model.UnaryOpExpression)
+		return map[string]interface{}{
+			"type":      "UnaryOpExpression",
+			"operation": formatOperation(unaryExpr.Operation),
+			"operand":   transformExpression(unaryExpr.Operand),
+		}
+
+	default:
+		return nil
+	}
+}
+
+func transformResourceOptions(options *pcl.ResourceOptions) map[string]interface{} {
+	optionsJSON := make(map[string]interface{})
+	if options.DependsOn != nil {
+		optionsJSON["dependsOn"] = transformExpression(options.DependsOn)
+	}
+	if options.IgnoreChanges != nil {
+		optionsJSON["ignoreChanges"] = transformExpression(options.IgnoreChanges)
+	}
+	if options.Parent != nil {
+		optionsJSON["parent"] = transformExpression(options.Parent)
+	}
+	if options.Protect != nil {
+		optionsJSON["protect"] = transformExpression(options.Protect)
+	}
+	if options.Provider != nil {
+		optionsJSON["provider"] = transformExpression(options.Provider)
+	}
+	if options.Version != nil {
+		optionsJSON["version"] = transformExpression(options.Version)
+	}
+	return optionsJSON
+}
+
+func transformResource(resource *pcl.Resource) map[string]interface{} {
+	resourceJSON := make(map[string]interface{})
+	resourceJSON["type"] = "Resource"
+	resourceJSON["name"] = resource.Name()
+	resourceJSON["token"] = resource.Token
+	resourceJSON["logicalName"] = resource.LogicalName()
+	inputs := make(map[string]interface{})
+	for _, attr := range resource.Inputs {
+		inputs[attr.Name] = transformExpression(attr.Value)
+	}
+	resourceJSON["inputs"] = inputs
+	if resource.Options != nil {
+		resourceJSON["options"] = transformResourceOptions(resource.Options)
+	}
+
+	return resourceJSON
+}
+
+func transformLocalVariable(variable *pcl.LocalVariable) map[string]interface{} {
+	variableJSON := make(map[string]interface{})
+	variableJSON["type"] = "LocalVariable"
+	variableJSON["name"] = variable.Name()
+	variableJSON["logicalName"] = variable.LogicalName()
+	variableJSON["value"] = transformExpression(variable.Definition.Value)
+	return variableJSON
+}
+
+func transformOutput(output *pcl.OutputVariable) map[string]interface{} {
+	outputJSON := make(map[string]interface{})
+	outputJSON["type"] = "OutputVariable"
+	outputJSON["name"] = output.Name()
+	outputJSON["logicalName"] = output.LogicalName()
+	outputJSON["value"] = transformExpression(output.Value)
+	return outputJSON
+}
+
+func transformConfigVariable(variable *pcl.ConfigVariable) map[string]interface{} {
+	variableJSON := make(map[string]interface{})
+	variableJSON["type"] = "ConfigVariable"
+	variableJSON["defaultValue"] = transformExpression(variable.DefaultValue)
+	variableJSON["name"] = variable.Name()
+	variableJSON["logicalName"] = variable.LogicalName()
+	switch variable.Type() {
+	case model.StringType:
+		variableJSON["configType"] = "string"
+	case model.NumberType:
+		variableJSON["configType"] = "number"
+	case model.IntType:
+		variableJSON["configType"] = "int"
+	case model.BoolType:
+		variableJSON["configType"] = "bool"
+	default:
+		variableJSON["configType"] = "unknown"
+	}
+
+	return variableJSON
+}
+
+func transformProgram(program *pcl.Program) map[string]interface{} {
+	programJSON := make(map[string]interface{})
+	nodes := make([]interface{}, 0, len(program.Nodes))
+	plugins := make([]interface{}, 0, len(program.Packages()))
+	for _, node := range program.Nodes {
+		switch node := node.(type) {
+		case *pcl.Resource:
+			transformedResource := transformResource(node)
+			nodes = append(nodes, transformedResource)
+		case *pcl.OutputVariable:
+			transformedOutput := transformOutput(node)
+			nodes = append(nodes, transformedOutput)
+		case *pcl.LocalVariable:
+			tranformedVariable := transformLocalVariable(node)
+			nodes = append(nodes, tranformedVariable)
+		case *pcl.ConfigVariable:
+			tranformedVariable := transformConfigVariable(node)
+			nodes = append(nodes, tranformedVariable)
+		}
+	}
+
+	for _, pkg := range program.Packages() {
+		pluginRef := map[string]interface{}{
+			"name":    pkg.Name,
+			"version": pkg.Version.String(),
+		}
+
+		plugins = append(plugins, pluginRef)
+	}
+
+	programJSON["nodes"] = nodes
+	programJSON["plugins"] = plugins
+	return programJSON
+}
+
+//go:embed pcl-json-schema.json
+var pclJSONSchema string
+
+func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {
+	files := make(map[string][]byte)
+	diagnostics := hcl.Diagnostics{}
+	programJSON := transformProgram(program)
+	schemaCompiler := jsonschema.NewCompiler()
+	schemaCompiler.LoadURL = func(_ string) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(pclJSONSchema)), nil
+	}
+
+	schema := schemaCompiler.MustCompile("blob://pcl-json-schema.json")
+
+	err := schema.Validate(programJSON)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("generated PCL program as JSON did not conform to the schema: %w", err)
+	}
+
+	programBytes, err := json.MarshalIndent(programJSON, "", "  ")
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not marshal program to JSON: %w", err)
+	}
+
+	files["program.json"] = programBytes
+	return files, diagnostics, nil
+}
+
+func GenerateProject(directory string, project workspace.Project, program *pcl.Program) error {
+	files, diagnostics, err := GenerateProgram(program)
+	if err != nil {
+		return err
+	}
+	if diagnostics.HasErrors() {
+		return diagnostics
+	}
+
+	for filename, data := range files {
+		outPath := path.Join(directory, filename)
+		err := ioutil.WriteFile(outPath, data, 0600)
+		if err != nil {
+			return fmt.Errorf("could not write output program: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/codegen/json/pcl-json-schema.json
+++ b/pkg/codegen/json/pcl-json-schema.json
@@ -1,0 +1,524 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/product.schema.json",
+    "title": "PclJsonProgram",
+    "description": "A PCL program definition",
+    "type": "object",
+    "required": ["nodes", "plugins"],
+    "properties": {
+        "nodes": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/Node"
+            }
+        },
+        "plugins": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/PluginReference"
+            }
+        }
+    },
+    "$defs": {
+        "Node": {
+            "oneOf": [
+                { "$ref": "#/$defs/Resource" },
+                { "$ref": "#/$defs/LocalVariable" },
+                { "$ref": "#/$defs/ConfigVariable" },
+                { "$ref": "#/$defs/OutputVariable" }
+            ]
+        },
+
+        "PluginReference": {
+            "description": "Describes a plugin reference",
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+
+        "Resource": {
+            "description": "Describes a resource declaration",
+            "type": "object",
+            "required": ["type", "name", "logicalName", "token", "inputs"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "Resource"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "logicalName": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                },
+                "inputs": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/Expression"
+                    }
+                },
+                "options": {
+                    "$ref": "#/$defs/ResourceOptions"
+                }
+            }
+        },
+
+        "ResourceOptions": {
+            "description": "Describes the custom resource options",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dependsOn": {
+                    "$ref": "#/$defs/Expression"
+                },
+                "protect": {
+                    "type": "boolean"
+                },
+                "parent": {
+                    "$ref": "#/$defs/Expression"
+                },
+                "ignoreChanges": {
+                    "$ref": "#/$defs/Expression"
+                },
+                "provider": {
+                    "$ref": "#/$defs/Expression"
+                },
+                "version": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "LocalVariable": {
+            "description": "Describes a local variable declaration",
+            "type": "object",
+            "required": ["type", "name", "logicalName", "value"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "LocalVariable"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "logicalName": {
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "ConfigVariable": {
+            "description": "Describes a config variable declaration",
+            "type": "object",
+            "required": ["type", "name", "logicalName", "configType"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ConfigVariable"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "logicalName": {
+                    "type": "string"
+                },
+                "configType": {
+                    "type": "string",
+                    "enum": ["string", "number", "int", "bool", "unknown"]
+                },
+                "defaultValue": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "OutputVariable": {
+            "description": "Describes an output declaration",
+            "type": "object",
+            "required": ["type", "name", "logicalName", "value"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "OutputVariable"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "logicalName": {
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "Expression": {
+            "oneOf": [
+                { "$ref": "#/$defs/LiteralValueExpression" },
+                { "$ref": "#/$defs/TemplateExpression" },
+                { "$ref": "#/$defs/IndexExpression" },
+                { "$ref": "#/$defs/ObjectConsExpression" },
+                { "$ref": "#/$defs/TupleConsExpression" },
+                { "$ref": "#/$defs/FunctionCallExpression" },
+                { "$ref": "#/$defs/RelativeTraversalExpression" },
+                { "$ref": "#/$defs/ScopeTraversalExpression" },
+                { "$ref": "#/$defs/AnonymousFunctionExpression" },
+                { "$ref": "#/$defs/ConditionalExpression" },
+                { "$ref": "#/$defs/BinaryOpExpression" },
+                { "$ref": "#/$defs/UnaryOpExpression" }
+            ]
+        },
+
+        "LiteralValueExpression": {
+            "type": "object",
+            "required": ["type", "value"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "LiteralValueExpression"
+                },
+
+                "value": {
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "number" },
+                        { "type": "boolean" }
+                    ]
+                }
+            }
+        },
+
+        "TemplateExpression": {
+            "type": "object",
+            "required": ["type", "parts"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "TemplateExpression"
+                },
+
+                "parts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Expression"
+                    }
+                }
+            }
+        },
+
+        "IndexExpression": {
+            "type": "object",
+            "required": ["type", "collection", "key"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "IndexExpression"
+                },
+
+                "collection": {
+                    "$ref": "#/$defs/Expression"
+                },
+
+                "key": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "ObjectConsExpression": {
+            "type": "object",
+            "required": ["type", "properties"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ObjectConsExpression"
+                },
+
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/Expression"
+                    }
+                }
+            }
+        },
+
+        "TupleConsExpression": {
+            "type": "object",
+            "required": ["type", "items"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "TupleConsExpression"
+                },
+
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Expression"
+                    }
+                }
+            }
+        },
+
+        "FunctionCallExpression": {
+            "type": "object",
+            "required": ["type", "name", "args"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "FunctionCallExpression"
+                },
+
+                "name": {
+                    "type": "string"
+                },
+
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Expression"
+                    }
+                }
+            }
+        },
+
+        "RelativeTraversalExpression": {
+            "type": "object",
+            "required": ["type", "source", "traversal"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "RelativeTraversalExpression"
+                },
+
+                "source": {
+                    "$ref": "#/$defs/Expression"
+                },
+
+                "traversal": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/$defs/Traversal"
+                    }
+                }
+            }
+        },
+
+        "ScopeTraversalExpression": {
+            "type": "object",
+            "required": ["type", "rootName", "traversal"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ScopeTraversalExpression"
+                },
+
+                "rootName": {
+                    "type": "string"
+                },
+
+                "traversal": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/$defs/Traversal"
+                    }
+                }
+            }
+        },
+
+        "AnonymousFunctionExpression": {
+            "type": "object",
+            "required": ["type", "body", "parameters"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "AnonymousFunctionExpression"
+                },
+
+                "body": {
+                    "$ref": "#/$defs/Expression"
+                },
+
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+
+        "ConditionalExpression": {
+            "type": "object",
+            "required": ["type", "condition", "trueExpr", "falseExpr"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ConditionalExpression"
+                },
+
+                "condition": {
+                    "$ref": "#/$defs/Expression"
+                },
+
+                "trueExpr": {
+                    "$ref": "#/$defs/Expression"
+                },
+
+                "falseExpr": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "BinaryOpExpression": {
+            "type": "object",
+            "required": ["type", "operation", "left", "right"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "BinaryOpExpression"
+                },
+
+                "operation": {
+                    "type": "string"
+                },
+
+                "left": {
+                    "$ref": "#/$defs/Expression"
+                },
+
+                "right": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "UnaryOpExpression": {
+            "type": "object",
+            "required": ["type", "operation", "operand"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "UnaryOpExpression"
+                },
+
+                "operation": {
+                    "type": "string"
+                },
+
+                "operand": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "Traversal": {
+            "oneOf": [
+                { "$ref": "#/$defs/TraverseAttr" },
+                { "$ref": "#/$defs/TraverseIndex" },
+                { "$ref": "#/$defs/TraverseRoot" },
+                { "$ref": "#/$defs/TraverseSplat" }
+            ]
+        },
+
+        "TraverseAttr": {
+            "type": "object",
+            "required": ["type", "name"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "TraverseAttr"
+                },
+
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+
+        "TraverseIndex": {
+            "type": "object",
+            "required": ["type", "index"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "TraverseIndex"
+                },
+
+                "index": {
+                    "$ref": "#/$defs/Expression"
+                }
+            }
+        },
+
+        "TraverseRoot": {
+            "type": "object",
+            "required": ["type", "name"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "TraverseRoot"
+                },
+
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+
+        "TraverseSplat": {
+            "type": "object",
+            "required": ["type", "each"],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "TraverseSplat"
+                },
+
+                "each": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Traversal"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

### Description

As part of my hackathon project, I've added a JSON as a program-gen target from PCL so that it can be used from external tools without needing them to write a PCL parser from scratch! Implemented as an experimental feature:

```
PULUMI_EXPERIMENTAL=1 pulumi convert --language json --out json
```


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
