### PR TITLE
Clean up use of pkg/errors in sdk/go/pulumi

### DIFF
--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -1,11 +1,11 @@
 package pulumi
 
 import (
+	"fmt"
 	"log"
 	"sync"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -109,7 +109,7 @@ func (m *mockMonitor) Invoke(ctx context.Context, in *pulumirpc.ResourceInvokeRe
 		urn := args["urn"].StringValue()
 		registeredResourceV, ok := m.resources.Load(urn)
 		if !ok {
-			return nil, errors.Errorf("unknown resource %s", urn)
+			return nil, fmt.Errorf("unknown resource %s", urn)
 		}
 		registeredResource := registeredResourceV.(resource.PropertyMap)
 		result, err := plugin.MarshalProperties(registeredResource, plugin.MarshalOptions{

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -387,7 +386,7 @@ func (module) Construct(ctx *Context, name, typ, urn string) (Resource, error) {
 		var instance testInstanceResource
 		return &instance, nil
 	default:
-		return nil, errors.Errorf("unknown resource type %s", typ)
+		return nil, fmt.Errorf("unknown resource type %s", typ)
 	}
 }
 
@@ -411,7 +410,7 @@ func TestRegisterResourceWithResourceReferences(t *testing.T) {
 			case "pkg:index:MyCustom":
 				return args.Name + "_id", args.Inputs, nil
 			default:
-				return "", nil, errors.Errorf("unknown resource %s", args.TypeToken)
+				return "", nil, fmt.Errorf("unknown resource %s", args.TypeToken)
 			}
 		},
 	}
@@ -470,7 +469,7 @@ func TestRemoteComponent(t *testing.T) {
 					"outprop": outprop,
 				}, nil
 			default:
-				return "", nil, errors.Errorf("unknown resource %s", args.TypeToken)
+				return "", nil, fmt.Errorf("unknown resource %s", args.TypeToken)
 			}
 		},
 	}
@@ -994,7 +993,7 @@ func TestResourceInput(t *testing.T) {
 					"outprop": resource.NewStringProperty("bar"),
 				}, nil
 			default:
-				return "", nil, errors.Errorf("unknown resource %s", args.TypeToken)
+				return "", nil, fmt.Errorf("unknown resource %s", args.TypeToken)
 			}
 
 		},


### PR DESCRIPTION
Continuing to replace "github.com/pkg/errors" with "errors", this handles everything in sdk/go/pulumi.