### PR TITLE
Add config to logical-name-pp test

### DIFF
--- a/pkg/codegen/testing/test/testdata/logical-name-pp/dotnet/logical-name.cs
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/dotnet/logical-name.cs
@@ -4,7 +4,12 @@ using Random = Pulumi.Random;
 
 return await Deployment.RunAsync(() => 
 {
-    var resourceLexicalName = new Random.RandomPet("aA-Alpha_alpha.🤯⁉️");
+    var config = new Config();
+    var configLexicalName = config.Require("cC-Charlie_charlie.😃⁉️");
+    var resourceLexicalName = new Random.RandomPet("aA-Alpha_alpha.🤯⁉️", new()
+    {
+        Prefix = configLexicalName,
+    });
 
     return new Dictionary<string, object?>
     {

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/go/logical-name.go
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/go/logical-name.go
@@ -3,11 +3,16 @@ package main
 import (
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		resourceLexicalName, err := random.NewRandomPet(ctx, "aA-Alpha_alpha.🤯⁉️", nil)
+		cfg := config.New(ctx, "")
+		configLexicalName := cfg.Require("cC-Charlie_charlie.😃⁉️")
+		resourceLexicalName, err := random.NewRandomPet(ctx, "aA-Alpha_alpha.🤯⁉️", &random.RandomPetArgs{
+			Prefix: pulumi.String(configLexicalName),
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/logical-name.pp
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/logical-name.pp
@@ -1,6 +1,12 @@
+config configLexicalName string {
+  __logicalName = "cC-Charlie_charlie.😃⁉️"
+}
+
 resource resourceLexicalName "random:index/randomPet:RandomPet" {
   // not necessarily a valid logical name, just testing that it passes through to codegen unmodified
   __logicalName = "aA-Alpha_alpha.🤯⁉️"
+
+  prefix = configLexicalName
 }
 
 output outputLexicalName {

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/nodejs/logical-name.ts
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/nodejs/logical-name.ts
@@ -2,7 +2,9 @@ import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 
 export = async () => {
-    const resourceLexicalName = new random.RandomPet("aA-Alpha_alpha.🤯⁉️", {});
+    const config = new pulumi.Config();
+    const configLexicalName = config.require("cC-Charlie_charlie.😃⁉️");
+    const resourceLexicalName = new random.RandomPet("aA-Alpha_alpha.🤯⁉️", {prefix: configLexicalName});
     const outputLexicalName = resourceLexicalName.id;
     return {
         "bB-Beta_beta.💜⁉": outputLexicalName,

--- a/pkg/codegen/testing/test/testdata/logical-name-pp/python/logical-name.py
+++ b/pkg/codegen/testing/test/testdata/logical-name-pp/python/logical-name.py
@@ -1,5 +1,7 @@
 import pulumi
 import pulumi_random as random
 
-resource_lexical_name = random.RandomPet("aA-Alpha_alpha.🤯⁉️")
+config = pulumi.Config()
+config_lexical_name = config.require("cC-Charlie_charlie.😃⁉️")
+resource_lexical_name = random.RandomPet("aA-Alpha_alpha.🤯⁉️", prefix=config_lexical_name)
 pulumi.export("bB-Beta_beta.💜⁉", resource_lexical_name.id)


### PR DESCRIPTION
PCL config can also have a logical name but that wasn't covered in the logical name test. Small test addition to cover that.