### PR TITLE
Make sure output state deps is only accessed under a lock

### DIFF
--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -256,9 +256,10 @@ func (o *OutputState) await(ctx context.Context) (interface{}, bool, bool, []Res
 			}
 			o.cond.Wait()
 		}
+		odeps := o.deps
 		o.cond.L.Unlock()
 
-		deps = mergeDependencies(deps, o.deps)
+		deps = mergeDependencies(deps, odeps)
 		known = known && o.known
 		secret = secret || o.secret
 		if !o.known || o.err != nil {
@@ -282,6 +283,10 @@ func (o *OutputState) getState() *OutputState {
 }
 
 func newOutputState(join *workGroup, elementType reflect.Type, deps ...Resource) *OutputState {
+	if deps == nil && len(deps) != 0 {
+		panic(fmt.Sprintf("data race detected - please report to https://github.com/pulumi/pulumi/issues: deps is nil with len %d", len(deps)))
+	}
+
 	if join != nil {
 		join.Add(1)
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Related to https://github.com/pulumi/pulumi/issues/11727 though that might have possibly been fixed on master already, as the last known failing version is  3.43.1

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
