### PR TITLE
feat: Add ctx.RunningWithMocks()

### DIFF
--- a/changelog/pending/20230105--sdk-go--allows-users-to-discover-if-their-program-is-being-run-with-a-mock-monitor.yaml
+++ b/changelog/pending/20230105--sdk-go--allows-users-to-discover-if-their-program-is-being-run-with-a-mock-monitor.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Allows users to discover if their program is being run with a mock monitor

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -219,6 +219,12 @@ func (ctx *Context) Parallel() int { return ctx.info.Parallel }
 // DryRun is true when evaluating a program for purposes of planning, instead of performing a true deployment.
 func (ctx *Context) DryRun() bool { return ctx.info.DryRun }
 
+// RunningWithMocks is true if the program is running using a Mock monitor instead of a real Pulumi engine.
+func (ctx *Context) RunningWithMocks() bool {
+	_, isMockMonitor := ctx.monitor.(*mockMonitor)
+	return isMockMonitor
+}
+
 // GetConfig returns the config value, as a string, and a bool indicating whether it exists or not.
 func (ctx *Context) GetConfig(key string) (string, bool) {
 	v, ok := ctx.info.Config[key]

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -58,6 +58,7 @@ func TestRunningUnderMocks(t *testing.T) {
 	t.Parallel()
 
 	t.Run("With mocks", func(t *testing.T) {
+		t.Parallel()
 		testCtx := &Context{
 			monitor: &mockMonitor{},
 		}
@@ -65,6 +66,7 @@ func TestRunningUnderMocks(t *testing.T) {
 	})
 
 	t.Run("Without mocks", func(t *testing.T) {
+		t.Parallel()
 		testCtx := &Context{
 			monitor: nil,
 		}

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 // The test is extracted from a panic using pulumi-docker and minified
@@ -51,6 +52,24 @@ func TestLoggingFromApplyCausesNoPanics(t *testing.T) {
 		}, WithMocks("project", "stack", mocks))
 		assert.NoError(t, err)
 	}
+}
+
+func TestRunningUnderMocks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("With mocks", func(t *testing.T) {
+		testCtx := &Context{
+			monitor: &mockMonitor{},
+		}
+		assert.True(t, testCtx.RunningWithMocks())
+	})
+
+	t.Run("Without mocks", func(t *testing.T) {
+		testCtx := &Context{
+			monitor: nil,
+		}
+		assert.False(t, testCtx.RunningWithMocks())
+	})
 }
 
 // An extended version of `TestLoggingFromApplyCausesNoPanics`, more


### PR DESCRIPTION
# Description

It is often desirable to detect running Pulumi programs under mocks in the same situations where it would be interesting to know if they were executing as a dry run. This commit adds a mechanism to find out (in Go).

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version