### PR TITLE
golangci-lint: Opt into nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - nolintlint
     - nakedret
     - structcheck
     - unconvert
@@ -29,3 +30,10 @@ linters:
   disable:
     - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
     - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0
+
+linters-settings:
+  nolintlint:
+    # Some linter exclusions are added to generated or templated files
+    # pre-emptively.
+    # Don't complain about these.
+    allow-unused: true

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -739,7 +739,7 @@ func serveBrowserLoginServer(l net.Listener, expectedNonce string, destinationUR
 
 	mux := &http.ServeMux{}
 	mux.HandleFunc("/", handler)
-	contract.IgnoreError(http.Serve(l, mux)) //nolint gosec
+	contract.IgnoreError(http.Serve(l, mux)) //nolint:gosec
 }
 
 // CloudConsoleStackPath returns the stack path components for getting to a stack in the cloud console.  This path

--- a/pkg/cmd/pulumi/view-trace.go
+++ b/pkg/cmd/pulumi/view-trace.go
@@ -72,7 +72,7 @@ func newViewTraceCmd() *cobra.Command {
 			app.Store, app.Queryer = store, store
 
 			fmt.Printf("Displaying trace at %v\n", url)
-			return http.ListenAndServe(fmt.Sprintf(":%d", port), app) //nolint gosec
+			return http.ListenAndServe(fmt.Sprintf(":%d", port), app) //nolint:gosec
 		}),
 	}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -2094,7 +2094,7 @@ func (dctx *docGenContext) initialize(tool string, pkg *schema.Package) {
 			// Markdown fragments in the templates need to be rendered as-is,
 			// so that html/template package doesn't try to inject data into it,
 			// which will most certainly fail.
-			//nolint gosec
+			//nolint:gosec
 			return template.HTML(html)
 		},
 		"markdownify": func(html string) template.HTML {
@@ -2103,7 +2103,7 @@ func (dctx *docGenContext) initialize(tool string, pkg *schema.Package) {
 			if err := goldmark.Convert([]byte(html), &buf); err != nil {
 				glog.Fatalf("rendering Markdown: %v", err)
 			}
-			//nolint gosec
+			//nolint:gosec
 			return template.HTML(buf.String())
 		},
 	})

--- a/sdk/go/auto/example_test.go
+++ b/sdk/go/auto/example_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint
+//nolint
 package auto
 
 import (


### PR DESCRIPTION
This opts the project into [nolintlint],
which finds incorrect usages of the `//nolint` directive.
If used incorrectly, these can show up the project's API Reference,
which looks a bit shoddy.

   [nolintlint]: https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/README.md

Note that this configures the linter to ignore unused directives.
We have a bunch of those across the project,
and some of them are in generated or templated files.

In addition to enabling the linter,
this fixes a couple other nolint directives
that were missed in #11791.

Depends on #11791
Relates to #11785
