### PR TITLE
cli/update: Move experimental option to bottom

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -158,15 +158,15 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 
 		choices := []string{string(yes), string(no)}
 
-		// If we have a new plan but didn't start with a plan we can prompt to use the new plan.
-		// If we're in experimental mode we don't add this because "yes" will also use the plan
-		if plan != nil && opts.Engine.Plan == nil && !opts.Engine.Experimental {
-			choices = append([]string{string(yesPlan)}, choices...)
-		}
-
 		// For non-previews, we can also offer a detailed summary.
 		if !opts.SkipPreview {
 			choices = append(choices, string(details))
+		}
+
+		// If we have a new plan but didn't start with a plan we can prompt to use the new plan.
+		// If we're in experimental mode we don't add this because "yes" will also use the plan
+		if plan != nil && opts.Engine.Plan == nil && !opts.Engine.Experimental {
+			choices = append(choices, string(yesPlan))
 		}
 
 		var previewWarning string


### PR DESCRIPTION
For the options presented in the 'Do you want to perform this update?'
dialog, move the experimental option to the bottom.

Before:

```
Do you want to perform this update?  [Use arrows to move, type to filter]
  [experimental] yes, using Update Plans (https://pulumi.com/updateplans)
  yes
> no
  details
```

Now:

```
Do you want to perform this update?  [Use arrows to move, type to filter]
  yes
> no
  details
  [experimental] yes, using Update Plans (https://pulumi.com/updateplans)
```

Fixes #11800
