### PR TITLE
cli/new: Ignore VCS directories

### DIFF
--- a/changelog/pending/20230107--cli-new--allow-running-inside-new-git-repositories.yaml
+++ b/changelog/pending/20230107--cli-new--allow-running-inside-new-git-repositories.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/new
+  description: Allow running inside new VCS repositories.

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -506,6 +506,14 @@ func newNewCmd() *cobra.Command {
 	return cmd
 }
 
+// File or directory names that are considered invisible
+// when considering whether a directory is empty.
+var invisibleDirEntries = map[string]struct{}{
+	".git": {},
+	".hg":  {},
+	".bzr": {},
+}
+
 // errorIfNotEmptyDirectory returns an error if path is not empty.
 func errorIfNotEmptyDirectory(path string) error {
 	infos, err := os.ReadDir(path)
@@ -513,7 +521,16 @@ func errorIfNotEmptyDirectory(path string) error {
 		return err
 	}
 
-	if len(infos) > 0 {
+	var nonEmpty bool
+	for _, info := range infos {
+		if _, ignore := invisibleDirEntries[info.Name()]; ignore {
+			continue
+		}
+		nonEmpty = true
+		break
+	}
+
+	if nonEmpty {
 		return fmt.Errorf("%s is not empty; "+
 			"rerun in an empty directory, pass the path to an empty directory to --dir, or use --force", path)
 	}


### PR DESCRIPTION
# Description

The following set of operations currently fail with the CLI.

    git init
    pulumi new

This is because `pulumi new` refuses to run inside
non-empty directories.

This changes `pulumi new` to ignore .git, .hg, and .bzr
files/directories when considering whether a directory is empty.

Resolves #11789

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
