### PR TITLE
pkg/codegen/docs: Fix data race in tests

### DIFF
--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -48,18 +48,14 @@ var (
 			},
 		},
 	}
-
-	// testPackageSpec represents a fake package spec for a Provider used for testing.
-	testPackageSpec schema.PackageSpec
 )
 
-func initTestPackageSpec(t *testing.T) {
-	t.Helper()
-
+// newTestPackageSpec returns a new fake package spec for a Provider used for testing.
+func newTestPackageSpec() schema.PackageSpec {
 	pythonMapCase := map[string]schema.RawMessage{
 		"python": schema.RawMessage(`{"mapCase":false}`),
 	}
-	testPackageSpec = schema.PackageSpec{
+	return schema.PackageSpec{
 		Name:        providerPackage,
 		Version:     "0.0.1",
 		Description: "A fake provider package used for testing.",
@@ -376,7 +372,7 @@ func TestFunctionHeaders(t *testing.T) {
 	t.Parallel()
 
 	dctx := newDocGenContext()
-	initTestPackageSpec(t)
+	testPackageSpec := newTestPackageSpec()
 
 	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "importing spec")
@@ -428,7 +424,7 @@ func TestResourceDocHeader(t *testing.T) {
 	t.Parallel()
 
 	dctx := newDocGenContext()
-	initTestPackageSpec(t)
+	testPackageSpec := newTestPackageSpec()
 
 	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "importing spec")
@@ -482,7 +478,7 @@ func TestResourceDocHeader(t *testing.T) {
 func TestExamplesProcessing(t *testing.T) {
 	t.Parallel()
 
-	initTestPackageSpec(t)
+	testPackageSpec := newTestPackageSpec()
 	dctx := newDocGenContext()
 
 	description := testPackageSpec.Resources["prov:module/resource:Resource"].Description

--- a/pkg/codegen/docs/package_tree_test.go
+++ b/pkg/codegen/docs/package_tree_test.go
@@ -26,7 +26,7 @@ func TestGeneratePackageTree(t *testing.T) {
 	t.Parallel()
 
 	dctx := newDocGenContext()
-	initTestPackageSpec(t)
+	testPackageSpec := newTestPackageSpec()
 
 	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "importing spec")


### PR DESCRIPTION
Tests in pkg/codegen/docs all run in parallel,
but many of them call initTestPackageSpec,
which modifies the global testPackageSpec variable.
So these tests end up stomping on each other.
`go test -race` fails in this directory.

To address the data race,
this change deletes the global variable entirely,
and replaces initTestPackageSpec with newTestPackageSpec.
newTestPackageSpec returns a new copy of the package spec
which the tests can use individually.

Resolves #11790
