### PR TITLE
all: Drop ioutil

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"runtime"
@@ -380,7 +379,7 @@ func readBody(resp *http.Response) ([]byte, error) {
 	defer contract.IgnoreClose(resp.Body)
 	if !ok {
 		// No header implies that there's no additional encoding on this response.
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	}
 
 	if len(contentEncoding) > 1 {
@@ -402,7 +401,7 @@ func readBody(resp *http.Response) ([]byte, error) {
 			return nil, fmt.Errorf("reading gzip-compressed body: %w", err)
 		}
 
-		return ioutil.ReadAll(reader)
+		return io.ReadAll(reader)
 	default:
 		return nil, fmt.Errorf("unrecognized encoding %s", contentEncoding[0])
 	}

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -247,13 +246,13 @@ func (pack *cloudPolicyPack) Remove(ctx context.Context, op backend.PolicyPackOp
 const packageDir = "package"
 
 func installRequiredPolicy(ctx context.Context, finalDir string, tgz io.ReadCloser) error {
-	// If part of the directory tree is missing, ioutil.TempDir will return an error, so make sure
+	// If part of the directory tree is missing, os.MkdirTemp will return an error, so make sure
 	// the path we're going to create the temporary folder in actually exists.
 	if err := os.MkdirAll(filepath.Dir(finalDir), 0700); err != nil {
 		return fmt.Errorf("creating plugin root: %w", err)
 	}
 
-	tempDir, err := ioutil.TempDir(filepath.Dir(finalDir), fmt.Sprintf("%s.tmp", filepath.Base(finalDir)))
+	tempDir, err := os.MkdirTemp(filepath.Dir(finalDir), fmt.Sprintf("%s.tmp", filepath.Base(finalDir)))
 	if err != nil {
 		return fmt.Errorf("creating plugin directory %s: %w", tempDir, err)
 	}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -145,7 +144,7 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 				reader, err := gzip.NewReader(req.Body)
 				assert.NoError(t, err)
 				defer reader.Close()
-				rbytes, err := ioutil.ReadAll(reader)
+				rbytes, err := io.ReadAll(reader)
 				assert.NoError(t, err)
 				_, err = rw.Write([]byte(message))
 				assert.NoError(t, err)

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"sort"
@@ -529,7 +529,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			case len(args) == 2:
 				value = args[1]
 			case !terminal.IsTerminal(int(os.Stdin.Fd())):
-				b, readerr := ioutil.ReadAll(os.Stdin)
+				b, readerr := io.ReadAll(os.Stdin)
 				if readerr != nil {
 					return readerr
 				}

--- a/pkg/cmd/pulumi/convert.go
+++ b/pkg/cmd/pulumi/convert.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -109,7 +108,7 @@ func pclGenerateProject(directory string, project workspace.Project, p *pcl.Prog
 	// We don't write out the Pulumi.yaml for PCL, just the .pp files.
 	for file, source := range p.Source() {
 		outputFile := path.Join(directory, file)
-		err := ioutil.WriteFile(outputFile, []byte(source), 0600)
+		err := os.WriteFile(outputFile, []byte(source), 0600)
 		if err != nil {
 			return fmt.Errorf("could not write output program: %w", err)
 		}

--- a/pkg/cmd/pulumi/gen_markdown.go
+++ b/pkg/cmd/pulumi/gen_markdown.go
@@ -17,7 +17,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -72,7 +72,7 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 			// Now loop through each generated file and replace the `## <command>` line, since
 			// we're already adding the name of the command as a title in the front matter.
 			for _, file := range files {
-				b, err := ioutil.ReadFile(file)
+				b, err := os.ReadFile(file)
 				if err != nil {
 					return err
 				}
@@ -81,7 +81,7 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 				// We do this because we're already including the command as the front matter title.
 				result := replaceH2Pattern.ReplaceAllString(string(b), "")
 
-				if err := ioutil.WriteFile(file, []byte(result), 0600); err != nil {
+				if err := os.WriteFile(file, []byte(result), 0600); err != nil {
 					return err
 				}
 			}

--- a/pkg/cmd/pulumi/new_smoke_test.go
+++ b/pkg/cmd/pulumi/new_smoke_test.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +43,7 @@ func chdir(t *testing.T, dir string) {
 func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -68,7 +67,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 func TestCreatingStackWithPromptedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir)
@@ -91,7 +90,7 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 func TestCreatingProjectWithDefaultName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 	defaultProjectName := filepath.Base(tempdir)
@@ -123,7 +122,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
 
-	fileStateDir, _ := ioutil.TempDir("", "local-state-dir")
+	fileStateDir, _ := os.MkdirTemp("", "local-state-dir")
 	defer os.RemoveAll(fileStateDir)
 
 	// Now override to local filesystem backend
@@ -132,7 +131,7 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	t.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
 
 	backendInstance = nil
-	tempdir, _ := ioutil.TempDir("", "test-env-local")
+	tempdir, _ := os.MkdirTemp("", "test-env-local")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 	defaultProjectName := filepath.Base(tempdir)

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +30,7 @@ import (
 func TestFailInInteractiveWithoutYes(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -52,7 +51,7 @@ func TestFailInInteractiveWithoutYes(t *testing.T) {
 func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -78,7 +77,7 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -103,7 +102,7 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -131,7 +130,7 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir) + "test"
@@ -159,7 +158,7 @@ func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 func TestCreatingProjectWithPromptedName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 	uniqueProjectName := filepath.Base(tempdir) + "test"
@@ -184,7 +183,7 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -212,7 +211,7 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -238,7 +237,7 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -270,7 +269,7 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -300,7 +299,7 @@ func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -330,7 +329,7 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
-	tempdir, _ := ioutil.TempDir("", "test-env")
+	tempdir, _ := os.MkdirTemp("", "test-env")
 	defer os.RemoveAll(tempdir)
 	chdir(t, tempdir)
 
@@ -367,7 +366,7 @@ func TestInvalidTemplateName(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	t.Run("NoTemplateSpecified", func(t *testing.T) {
-		tempdir, _ := ioutil.TempDir("", "test-env")
+		tempdir, _ := os.MkdirTemp("", "test-env")
 		defer os.RemoveAll(tempdir)
 		chdir(t, tempdir)
 
@@ -385,7 +384,7 @@ func TestInvalidTemplateName(t *testing.T) {
 	})
 
 	t.Run("RemoteTemplateNotFound", func(t *testing.T) {
-		tempdir, _ := ioutil.TempDir("", "test-env")
+		tempdir, _ := os.MkdirTemp("", "test-env")
 		defer os.RemoveAll(tempdir)
 		chdir(t, tempdir)
 
@@ -406,7 +405,7 @@ func TestInvalidTemplateName(t *testing.T) {
 	})
 
 	t.Run("LocalTemplateNotFound", func(t *testing.T) {
-		tempdir, _ := ioutil.TempDir("", "test-env")
+		tempdir, _ := os.MkdirTemp("", "test-env")
 		defer os.RemoveAll(tempdir)
 		chdir(t, tempdir)
 

--- a/pkg/cmd/pulumi/schema_check.go
+++ b/pkg/cmd/pulumi/schema_check.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -54,7 +54,7 @@ func newSchemaCheckCommand() *cobra.Command {
 				}
 				reader = f
 			}
-			schemaBytes, err := ioutil.ReadAll(reader)
+			schemaBytes, err := io.ReadAll(reader)
 			if err != nil {
 				return fmt.Errorf("failed to read schema: %w", err)
 			}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 
@@ -236,7 +235,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Create temp directory for the "virtual workspace".
-		temp, err := ioutil.TempDir("", "pulumi-up-")
+		temp, err := os.MkdirTemp("", "pulumi-up-")
 		if err != nil {
 			return result.FromError(err)
 		}

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -2109,7 +2108,7 @@ func getLogo(pkg *schema.Package) ([]byte, error) {
 	}
 	defer contract.IgnoreClose(resp.Body)
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func computePropertyNames(props []*schema.Property, names map[*schema.Property]string) {

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -229,7 +229,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 
 	for filename, data := range files {
 		outPath := path.Join(directory, filename)
-		err := ioutil.WriteFile(outPath, data, 0600)
+		err := os.WriteFile(outPath, data, 0600)
 		if err != nil {
 			return fmt.Errorf("could not write output program: %w", err)
 		}

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	gofmt "go/format"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -252,7 +252,7 @@ require (
 
 	for filename, data := range files {
 		outPath := path.Join(directory, filename)
-		err := ioutil.WriteFile(outPath, data, 0600)
+		err := os.WriteFile(outPath, data, 0600)
 		if err != nil {
 			return fmt.Errorf("could not write output program: %w", err)
 		}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1192,13 +1192,13 @@ var functionPackages = map[string][]string{
 	"join":             {"strings"},
 	"mimeType":         {"mime", "path"},
 	"readDir":          {"os"},
-	"readFile":         {"io/ioutil"},
-	"filebase64":       {"io/ioutil", "encoding/base64"},
+	"readFile":         {"os"},
+	"filebase64":       {"encoding/base64", "os"},
 	"toBase64":         {"encoding/base64"},
 	"fromBase64":       {"encoding/base64"},
 	"toJSON":           {"encoding/json"},
 	"sha1":             {"fmt", "crypto/sha1"},
-	"filebase64sha256": {"fmt", "io/ioutil", "crypto/sha256"},
+	"filebase64sha256": {"fmt", "crypto/sha256", "os"},
 	"cwd":              {"os"},
 }
 

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -2,7 +2,7 @@ package gen
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 
 	"path/filepath"
 	"testing"
@@ -96,7 +96,7 @@ func TestCollectImports(t *testing.T) {
 
 func newTestGenerator(t *testing.T, testFile string) *generator {
 	path := filepath.Join(testdataPath, testFile)
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	require.NoErrorf(t, err, "could not read %v: %v", path, err)
 
 	parser := syntax.NewParser()

--- a/pkg/codegen/go/gen_program_utils.go
+++ b/pkg/codegen/go/gen_program_utils.go
@@ -63,7 +63,7 @@ func getHelperMethodIfNeeded(functionName string) (string, bool) {
 	switch functionName {
 	case "readFile":
 		return `func readFileOrPanic(path string) pulumi.StringPtrInput {
-				data, err := ioutil.ReadFile(path)
+				data, err := os.ReadFile(path)
 				if err != nil {
 					panic(err.Error())
 				}
@@ -71,7 +71,7 @@ func getHelperMethodIfNeeded(functionName string) (string, bool) {
 			}`, true
 	case "filebase64":
 		return `func filebase64OrPanic(path string) pulumi.StringPtrInput {
-					if fileData, err := ioutil.ReadFile(path); err == nil {
+					if fileData, err := os.ReadFile(path); err == nil {
 						return pulumi.String(base64.StdEncoding.EncodeToString(fileData[:]))
 					} else {
 						panic(err.Error())
@@ -79,7 +79,7 @@ func getHelperMethodIfNeeded(functionName string) (string, bool) {
 				}`, true
 	case "filebase64sha256":
 		return `func filebase64sha256OrPanic(path string) pulumi.StringPtrInput {
-					if fileData, err := ioutil.ReadFile(path); err == nil {
+					if fileData, err := os.ReadFile(path); err == nil {
 						hashedData := sha256.Sum256([]byte(fileData))
 						return pulumi.String(base64.StdEncoding.EncodeToString(hashedData[:]))
 					} else {

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -149,7 +149,7 @@ func TestGenerateTypeNames(t *testing.T) {
 
 func readSchemaFile(file string) *schema.Package {
 	// Read in, decode, and import the schema.
-	schemaBytes, err := ioutil.ReadFile(filepath.Join("..", "testing", "test", "testdata", file))
+	schemaBytes, err := os.ReadFile(filepath.Join("..", "testing", "test", "testdata", file))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/codegen/hcl2/syntax/comments_test.go
+++ b/pkg/codegen/hcl2/syntax/comments_test.go
@@ -2,7 +2,7 @@ package syntax
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -214,7 +214,7 @@ func (v *validator) Exit(n hclsyntax.Node) hcl.Diagnostics {
 func TestComments(t *testing.T) {
 	t.Parallel()
 
-	contents, err := ioutil.ReadFile("./testdata/comments_all.hcl")
+	contents, err := os.ReadFile("./testdata/comments_all.hcl")
 	if err != nil {
 		t.Fatalf("failed to read test data: %v", err)
 	}

--- a/pkg/codegen/hcl2/syntax/parser.go
+++ b/pkg/codegen/hcl2/syntax/parser.go
@@ -16,7 +16,6 @@ package syntax
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -45,7 +44,7 @@ func NewParser() *Parser {
 // ParseFile attempts to parse the contents of the given io.Reader as HCL2. If parsing fails, any diagnostics generated
 // will be added to the parser's diagnostics.
 func (p *Parser) ParseFile(r io.Reader, filename string) error {
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/codegen/importer/language_test.go
+++ b/pkg/codegen/importer/language_test.go
@@ -17,7 +17,6 @@ package importer
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
@@ -50,7 +49,7 @@ func TestGenerateLanguageDefinition(t *testing.T) {
 			}
 
 			var actualState *resource.State
-			err = GenerateLanguageDefinitions(ioutil.Discard, loader, func(_ io.Writer, p *pcl.Program) error {
+			err = GenerateLanguageDefinitions(io.Discard, loader, func(_ io.Writer, p *pcl.Program) error {
 				if !assert.Len(t, p.Nodes, 1) {
 					t.Fatal()
 				}

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -242,7 +242,7 @@ func GenerateProject(directory string, project workspace.Project, program *pcl.P
 
 	for filename, data := range files {
 		outPath := path.Join(directory, filename)
-		err := ioutil.WriteFile(outPath, data, 0600)
+		err := os.WriteFile(outPath, data, 0600)
 		if err != nil {
 			return fmt.Errorf("could not write output program: %w", err)
 		}

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -2,7 +2,6 @@ package pcl_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,7 +54,7 @@ func TestBindProgram(t *testing.T) {
 				t.Parallel()
 
 				path := filepath.Join(folderPath, fileName)
-				contents, err := ioutil.ReadFile(path)
+				contents, err := os.ReadFile(path)
 				require.NoErrorf(t, err, "could not read %v", path)
 
 				parser := syntax.NewParser()

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -128,7 +128,7 @@ venv/`)
 
 	for filename, data := range files {
 		outPath := path.Join(directory, filename)
-		err := ioutil.WriteFile(outPath, data, 0600)
+		err := os.WriteFile(outPath, data, 0600)
 		if err != nil {
 			return fmt.Errorf("could not write output program: %w", err)
 		}

--- a/pkg/codegen/report/report.go
+++ b/pkg/codegen/report/report.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -241,6 +240,6 @@ func (r *reporter) defaultExport(dir string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, data, 0600)
+	return os.WriteFile(path, data, 0600)
 
 }

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -137,7 +136,7 @@ func TestParseAndRenderDocs(t *testing.T) {
 			t.Parallel()
 
 			path := filepath.Join(testdataPath, f.Name())
-			contents, err := ioutil.ReadFile(path)
+			contents, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("could not read %v: %v", path, err)
 			}

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -17,8 +17,8 @@ package schema
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -31,7 +31,7 @@ import (
 
 func readSchemaFile(file string) (pkgSpec PackageSpec) {
 	// Read in, decode, and import the schema.
-	schemaBytes, err := ioutil.ReadFile(filepath.Join("..", "testing", "test", "testdata", file))
+	schemaBytes, err := os.ReadFile(filepath.Join("..", "testing", "test", "testdata", file))
 	if err != nil {
 		panic(err)
 	}
@@ -202,7 +202,7 @@ func TestImportResourceRef(t *testing.T) {
 			t.Parallel()
 
 			// Read in, decode, and import the schema.
-			schemaBytes, err := ioutil.ReadFile(
+			schemaBytes, err := os.ReadFile(
 				filepath.Join("..", "testing", "test", "testdata", tt.schemaFile))
 			assert.NoError(t, err)
 

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -41,7 +40,7 @@ type GenPkgSignature func(string, *schema.Package, map[string][]byte) (map[strin
 // GeneratePackageFilesFromSchema loads a schema and generates files using the provided GeneratePackage function.
 func GeneratePackageFilesFromSchema(schemaPath string, genPackageFunc GenPkgSignature) (map[string][]byte, error) {
 	// Read in, decode, and import the schema.
-	schemaBytes, err := ioutil.ReadFile(schemaPath)
+	schemaBytes, err := os.ReadFile(schemaPath)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,7 @@ func GeneratePackageFilesFromSchema(schemaPath string, genPackageFunc GenPkgSign
 func LoadFiles(dir, lang string, files []string) (map[string][]byte, error) {
 	result := map[string][]byte{}
 	for _, file := range files {
-		fileBytes, err := ioutil.ReadFile(filepath.Join(dir, lang, file))
+		fileBytes, err := os.ReadFile(filepath.Join(dir, lang, file))
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +109,7 @@ func LoadBaseline(dir, lang string) (map[string][]byte, error) {
 	files := make(map[string][]byte)
 
 	for _, f := range cm.EmittedFiles {
-		bytes, err := ioutil.ReadFile(filepath.Join(dir, lang, f))
+		bytes, err := os.ReadFile(filepath.Join(dir, lang, f))
 		if err != nil {
 			return nil, fmt.Errorf("Failed to load file %s referenced in codegen-manifest.json: %w", f, err)
 		}
@@ -125,7 +124,7 @@ type codegenManifest struct {
 }
 
 func (cm *codegenManifest) load(dir string) error {
-	bytes, err := ioutil.ReadFile(filepath.Join(dir, "codegen-manifest.json"))
+	bytes, err := os.ReadFile(filepath.Join(dir, "codegen-manifest.json"))
 	if err != nil {
 		return err
 	}
@@ -143,7 +142,7 @@ func (cm *codegenManifest) save(dir string) error {
 		return err
 	}
 	data := buf.Bytes()
-	return ioutil.WriteFile(filepath.Join(dir, "codegen-manifest.json"), data, 0600)
+	return os.WriteFile(filepath.Join(dir, "codegen-manifest.json"), data, 0600)
 }
 
 // ValidateFileEquality compares maps of files for equality.
@@ -239,7 +238,7 @@ func CopyExtraFiles(t *testing.T, dir, lang string) {
 		}
 		destPath := filepath.Join(codeDir, relPath)
 
-		bytes, err := ioutil.ReadFile(path)
+		bytes, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -259,7 +258,7 @@ func writeFileEnsuringDir(path string, bytes []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, bytes, 0600)
+	return os.WriteFile(path, bytes, 0600)
 }
 
 // CheckAllFilesGenerated ensures that the set of expected and actual files generated
@@ -305,7 +304,7 @@ func ValidateFileTransformer(
 	actualBytes := buf.Bytes()
 
 	if os.Getenv("PULUMI_ACCEPT") != "" {
-		err := ioutil.WriteFile(expectedOutputFile, actualBytes, 0600)
+		err := os.WriteFile(expectedOutputFile, actualBytes, 0600)
 		if err != nil {
 			t.Error(err)
 			return
@@ -314,7 +313,7 @@ func ValidateFileTransformer(
 
 	actual := map[string][]byte{expectedOutputFile: actualBytes}
 
-	expectedBytes, err := ioutil.ReadFile(expectedOutputFile)
+	expectedBytes, err := os.ReadFile(expectedOutputFile)
 	if err != nil {
 		t.Error(err)
 		return

--- a/pkg/codegen/testing/test/testdata/read-file-func-pp/go/read-file-func.go
+++ b/pkg/codegen/testing/test/testdata/read-file-func-pp/go/read-file-func.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func readFileOrPanic(path string) pulumi.StringPtrInput {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/operations/resources_test.go
+++ b/pkg/operations/resources_test.go
@@ -17,7 +17,7 @@ package operations
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,7 @@ import (
 func getPulumiResources(t *testing.T, path string) *Resource {
 	ctx := context.Background()
 	var checkpoint apitype.CheckpointV3
-	byts, err := ioutil.ReadFile(path)
+	byts, err := os.ReadFile(path)
 	assert.NoError(t, err)
 	err = json.Unmarshal(byts, &checkpoint)
 	assert.NoError(t, err)

--- a/pkg/resource/analyzer/config.go
+++ b/pkg/resource/analyzer/config.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -29,7 +29,7 @@ import (
 
 // LoadPolicyPackConfigFromFile loads the JSON config from a file.
 func LoadPolicyPackConfigFromFile(file string) (map[string]plugin.AnalyzerPolicyConfig, error) {
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -15,7 +15,7 @@
 package provider
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -39,7 +39,7 @@ type HostClient struct {
 func NewHostClient(addr string) (*HostClient, error) {
 	// Provider client is sensitive to GRPC info logging to stdout, so ensure they are dropped.
 	// See https://github.com/pulumi/pulumi/issues/7156
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 	conn, err := grpc.Dial(
 		addr,
 		grpc.WithInsecure(),

--- a/pkg/resource/stack/checkpoint_test.go
+++ b/pkg/resource/stack/checkpoint_test.go
@@ -15,7 +15,7 @@
 package stack
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
@@ -25,7 +25,7 @@ import (
 func TestLoadV0Checkpoint(t *testing.T) {
 	t.Parallel()
 
-	bytes, err := ioutil.ReadFile("testdata/checkpoint-v0.json")
+	bytes, err := os.ReadFile("testdata/checkpoint-v0.json")
 	assert.NoError(t, err)
 
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
@@ -37,7 +37,7 @@ func TestLoadV0Checkpoint(t *testing.T) {
 func TestLoadV1Checkpoint(t *testing.T) {
 	t.Parallel()
 
-	bytes, err := ioutil.ReadFile("testdata/checkpoint-v1.json")
+	bytes, err := os.ReadFile("testdata/checkpoint-v1.json")
 	assert.NoError(t, err)
 
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)
@@ -49,7 +49,7 @@ func TestLoadV1Checkpoint(t *testing.T) {
 func TestLoadV3Checkpoint(t *testing.T) {
 	t.Parallel()
 
-	bytes, err := ioutil.ReadFile("testdata/checkpoint-v3.json")
+	bytes, err := os.ReadFile("testdata/checkpoint-v3.json")
 	assert.NoError(t, err)
 
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strings"
 
@@ -76,7 +75,7 @@ func init() {
 		default:
 			return jsonschema.LoadURL(s)
 		}
-		return ioutil.NopCloser(strings.NewReader(schema)), nil
+		return io.NopCloser(strings.NewReader(schema)), nil
 	}
 	deploymentSchema = compiler.MustCompile(apitype.DeploymentSchemaID)
 	resourceSchema = compiler.MustCompile(apitype.ResourceSchemaID)

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -247,7 +247,7 @@ func TestMapCrypter(t *testing.T) {
 
 	ctx := context.Background()
 
-	bytes, err := ioutil.ReadFile("testdata/checkpoint-secrets.json")
+	bytes, err := os.ReadFile("testdata/checkpoint-secrets.json")
 	require.NoError(t, err)
 
 	chk, err := UnmarshalVersionedCheckpointToLatestCheckpoint(encoding.JSON, bytes)

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -154,7 +154,7 @@ func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, 
 		Project: s.Project,
 		Stack:   s.Stack,
 	}
-	c := client.NewClient(s.URL, token, diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{
+	c := client.NewClient(s.URL, token, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 		Color: colors.Never}))
 
 	return &serviceSecretsManager{

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1436,7 +1435,7 @@ func (pt *ProgramTester) exportImport(dir string) error {
 	}
 
 	if f := pt.opts.ExportStateValidator; f != nil {
-		bytes, err := ioutil.ReadFile(filepath.Join(dir, "stack.json"))
+		bytes, err := os.ReadFile(filepath.Join(dir, "stack.json"))
 		if err != nil {
 			pt.t.Logf("Failed to read stack.json: %s", err.Error())
 			return err
@@ -1557,7 +1556,7 @@ func (pt *ProgramTester) testEdit(dir string, i int, edit EditDir) error {
 		}
 	} else {
 		// Create a new temporary directory
-		newDir, err := ioutil.TempDir("", pt.opts.StackName+"-")
+		newDir, err := os.MkdirTemp("", pt.opts.StackName+"-")
 		if err != nil {
 			return fmt.Errorf("Couldn't create new temporary directory: %w", err)
 		}
@@ -1663,7 +1662,7 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 	stackName := pt.opts.GetStackName()
 
 	// Create a temporary file name for the stack export
-	tempDir, err := ioutil.TempDir("", string(stackName))
+	tempDir, err := os.MkdirTemp("", string(stackName))
 	if err != nil {
 		return err
 	}
@@ -1798,7 +1797,7 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 		tmpdir = targetDir
 		projdir = targetDir
 	} else {
-		targetDir, tempErr := ioutil.TempDir("", stackName+"-")
+		targetDir, tempErr := os.MkdirTemp("", stackName+"-")
 		if tempErr != nil {
 			return "", "", fmt.Errorf("Couldn't create temporary directory: %w", tempErr)
 		}
@@ -1866,7 +1865,7 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 		return "", "", fmt.Errorf("error marshalling project %q: %w", projfile, err)
 	}
 
-	if err := ioutil.WriteFile(projfile, bytes, 0600); err != nil {
+	if err := os.WriteFile(projfile, bytes, 0600); err != nil {
 		return "", "", fmt.Errorf("error writing project: %w", err)
 	}
 
@@ -1894,7 +1893,7 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 				"@pulumi/pulumi": "latest"
 			}
 		}`
-		if err := ioutil.WriteFile(filepath.Join(projdir, "package.json"), []byte(packageJSON), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(projdir, "package.json"), []byte(packageJSON), 0600); err != nil {
 			return "", "", err
 		}
 		if err := pt.runYarnCommand("yarn-link", []string{"link", "@pulumi/pulumi"}, projdir); err != nil {

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,7 +51,7 @@ func TestRunCommandLog(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(matches))
 
-	output, err := ioutil.ReadFile(matches[0])
+	output, err := os.ReadFile(matches[0])
 	assert.Nil(t, err)
 	assert.Equal(t, "output from node\n", string(output))
 }

--- a/pkg/testing/integration/pulumi.go
+++ b/pkg/testing/integration/pulumi.go
@@ -16,7 +16,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -34,7 +33,7 @@ func CreateBasicPulumiRepo(e *testing.Environment) {
 	contents := "name: pulumi-test\ndescription: a test\nruntime: nodejs\n"
 	filePath := fmt.Sprintf("%s.yaml", workspace.ProjectFile)
 	filePath = path.Join(e.CWD, filePath)
-	err := ioutil.WriteFile(filePath, []byte(contents), os.ModePerm)
+	err := os.WriteFile(filePath, []byte(contents), os.ModePerm)
 	assert.NoError(e, err, "writing %s file", filePath)
 }
 
@@ -44,7 +43,7 @@ func CreateBasicPulumiRepo(e *testing.Environment) {
 func CreatePulumiRepo(e *testing.Environment, projectFileContent string) {
 	e.RunCommand("git", "init")
 	filePath := path.Join(e.CWD, fmt.Sprintf("%s.yaml", workspace.ProjectFile))
-	err := ioutil.WriteFile(filePath, []byte(projectFileContent), os.ModePerm)
+	err := os.WriteFile(filePath, []byte(projectFileContent), os.ModePerm)
 	assert.NoError(e, err, "writing %s file", filePath)
 }
 

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -17,7 +17,6 @@ package integration
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -56,12 +55,12 @@ func DecodeMapString(val string) (map[string]string, error) {
 
 // ReplaceInFile does a find and replace for a given string within a file.
 func ReplaceInFile(old, new, path string) error {
-	rawContents, err := ioutil.ReadFile(path)
+	rawContents, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	newContents := strings.Replace(string(rawContents), old, new, -1)
-	return ioutil.WriteFile(path, []byte(newContents), os.ModePerm)
+	return os.WriteFile(path, []byte(newContents), os.ModePerm)
 }
 
 // getCmdBin returns the binary named bin in location loc or, if it hasn't yet been initialized, will lazily
@@ -100,7 +99,7 @@ func writeCommandOutput(commandName, runDir string, output []byte) (string, erro
 
 	logFile := filepath.Join(logFileDir, commandName+uniqueSuffix()+".log")
 
-	if err := ioutil.WriteFile(logFile, output, 0600); err != nil {
+	if err := os.WriteFile(logFile, output, 0600); err != nil {
 		return "", fmt.Errorf("Failed to write '%s': %w", logFile, err)
 	}
 
@@ -236,7 +235,7 @@ func AssertHTTPResultWithRetry(
 	}
 	// Read the body
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if !assert.NoError(t, err) {
 		return false
 	}

--- a/pkg/util/testutil/testdiagsink.go
+++ b/pkg/util/testutil/testdiagsink.go
@@ -15,7 +15,7 @@
 package testutil
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -31,7 +31,7 @@ type TestDiagSink struct {
 func NewTestDiagSink(pwd string) *TestDiagSink {
 	return &TestDiagSink{
 		Pwd: pwd,
-		sink: diag.DefaultSink(ioutil.Discard, ioutil.Discard, diag.FormatOptions{
+		sink: diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 			Color: colors.Never,
 			Pwd:   pwd,
 		}),

--- a/sdk/go/auto/example_test.go
+++ b/sdk/go/auto/example_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -957,7 +956,7 @@ func ExampleStack_Destroy_streamingProgress() {
 	// select an existing stack to destroy
 	stack, _ := SelectStackLocalSource(ctx, stackName, filepath.Join(".", "program"))
 	// create a temp file that we can tail during while our program runs
-	tmp, _ := ioutil.TempFile(os.TempDir(), "")
+	tmp, _ := os.CreateTemp(os.TempDir(), "")
 	// optdestroy.ProgressStreams allows us to stream incremental output to stdout, a file to tail, etc.
 	// this gives us incremental status over time
 	progressStreams := []io.Writer{os.Stdout, tmp}
@@ -981,7 +980,7 @@ func ExampleStack_Up_streamingProgress() {
 	// create a new stack to update
 	stack, _ := NewStackLocalSource(ctx, stackName, filepath.Join(".", "program"))
 	// create a temp file that we can tail during while our program runs
-	tmp, _ := ioutil.TempFile(os.TempDir(), "")
+	tmp, _ := os.CreateTemp(os.TempDir(), "")
 	// optup.ProgressStreams allows us to stream incremental output to stdout, a file to tail, etc.
 	// this gives us incremental status over time
 	progressStreams := []io.Writer{os.Stdout, tmp}
@@ -1011,7 +1010,7 @@ func ExampleStack_Refresh_streamingProgress() {
 	// select an existing stack and refresh the resources under management
 	stack, _ := SelectStackLocalSource(ctx, stackName, filepath.Join(".", "program"))
 	// create a temp file that we can tail during while our program runs
-	tmp, _ := ioutil.TempFile(os.TempDir(), "")
+	tmp, _ := os.CreateTemp(os.TempDir(), "")
 	// optrefresh.ProgressStreams allows us to stream incremental output to stdout, a file to tail, etc.
 	// this gives us incremental status over time
 	progressStreams := []io.Writer{os.Stdout, tmp}

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -474,7 +473,7 @@ func (l *LocalWorkspace) ExportStack(ctx context.Context, stackName string) (api
 // ImportStack imports the specified deployment state into a pre-existing stack.
 // This can be combined with ExportStack to edit a stack's state (such as recovery from failed deployments).
 func (l *LocalWorkspace) ImportStack(ctx context.Context, stackName string, state apitype.UntypedDeployment) error {
-	f, err := ioutil.TempFile(os.TempDir(), "")
+	f, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return errors.Wrap(err, "could not import stack. failed to allocate temp file")
 	}
@@ -629,7 +628,7 @@ func NewLocalWorkspace(ctx context.Context, opts ...LocalWorkspaceOption) (Works
 	if lwOpts.WorkDir != "" {
 		workDir = lwOpts.WorkDir
 	} else {
-		dir, err := ioutil.TempDir("", "pulumi_auto")
+		dir, err := os.MkdirTemp("", "pulumi_auto")
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to create tmp directory for workspace")
 		}

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -100,7 +100,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1223,7 +1222,7 @@ func watchFile(path string, receivers []chan<- events.EngineEvent) (*fileWatcher
 }
 
 func tailLogs(command string, receivers []chan<- events.EngineEvent) (*fileWatcher, error) {
-	logDir, err := ioutil.TempDir("", fmt.Sprintf("automation-logs-%s-", command))
+	logDir, err := os.MkdirTemp("", fmt.Sprintf("automation-logs-%s-", command))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create logdir")
 	}

--- a/sdk/go/common/encoding/marshal.go
+++ b/sdk/go/common/encoding/marshal.go
@@ -19,7 +19,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/yamlutil"
@@ -155,7 +155,7 @@ func (m *gzipMarshaller) Unmarshal(data []byte, v interface{}) error {
 		return err
 	}
 	defer reader.Close()
-	inflated, err := ioutil.ReadAll(reader)
+	inflated, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -69,7 +68,7 @@ func (plugin *PulumiPluginJSON) JSON() ([]byte, error) {
 }
 
 func LoadPulumiPluginJSON(path string) (*PulumiPluginJSON, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		// Deliberately not wrapping the error here so that os.IsNotExist checks can be used to determine
 		// if the file could not be opened due to it not existing.

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -68,7 +67,7 @@ func WriteYarnRCForTest(root string) error {
 	// https://github.com/yarnpkg/yarn/issues/683
 	// Also add --network-concurrency 1 since we've been seeing
 	// https://github.com/yarnpkg/yarn/issues/4563 as well
-	return ioutil.WriteFile(
+	return os.WriteFile(
 		filepath.Join(root, ".yarnrc"),
 		[]byte("--mutex network\n--network-concurrency 1\n"), 0600)
 }
@@ -90,7 +89,7 @@ func NewGoEnvironment(t *testing.T) *Environment {
 
 // NewEnvironment returns a new Environment object, located in a temp directory.
 func NewEnvironment(t *testing.T) *Environment {
-	root, err := ioutil.TempDir("", "test-env")
+	root, err := os.MkdirTemp("", "test-env")
 	assert.NoError(t, err, "creating temp directory")
 	assert.NoError(t, WriteYarnRCForTest(root), "writing .yarnrc file")
 

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -20,7 +20,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -149,7 +148,7 @@ func archiveContents(t *testing.T, prefixPathInsideTar, path string, files ...fi
 			return nil, err
 		}
 
-		err = ioutil.WriteFile(filepath.Join(dir, name), file.contents, 0600)
+		err = os.WriteFile(filepath.Join(dir, name), file.contents, 0600)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/util/fsutil/copy.go
+++ b/sdk/go/common/util/fsutil/copy.go
@@ -15,7 +15,6 @@
 package fsutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -48,7 +47,7 @@ func CopyFile(dst string, src string, excl map[string]bool) error {
 		}
 	} else if info.Mode().IsRegular() {
 		// Copy files by reading and rewriting their contents.  Skip symlinks and other special files.
-		data, err := ioutil.ReadFile(src)
+		data, err := os.ReadFile(src)
 		if err != nil {
 			return err
 		}
@@ -56,7 +55,7 @@ func CopyFile(dst string, src string, excl map[string]bool) error {
 		if err = os.MkdirAll(dstdir, 0700); err != nil {
 			return err
 		}
-		if err = ioutil.WriteFile(dst, data, info.Mode()); err != nil {
+		if err = os.WriteFile(dst, data, info.Mode()); err != nil {
 			return err
 		}
 	}

--- a/sdk/go/common/util/httputil/http_test.go
+++ b/sdk/go/common/util/httputil/http_test.go
@@ -16,7 +16,7 @@ package httputil
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -66,7 +66,7 @@ func TestRetryPostHTTP2(t *testing.T) {
 
 		// Check that the body's content length matches the sent data.
 		defer r.Body.Close()
-		content, err := ioutil.ReadAll(r.Body)
+		content, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, strconv.Itoa(len(content)), r.Header.Get("Content-Length"))
 

--- a/sdk/go/common/util/rpcutil/writer_test.go
+++ b/sdk/go/common/util/rpcutil/writer_test.go
@@ -17,7 +17,7 @@ package rpcutil
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -77,11 +77,11 @@ func TestWriter_NoTerminal(t *testing.T) {
 	err = closer.Close()
 	assert.NoError(t, err)
 
-	outBytes, err := ioutil.ReadAll(&server.stdout)
+	outBytes, err := io.ReadAll(&server.stdout)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("hello"), outBytes)
 
-	errBytes, err := ioutil.ReadAll(&server.stderr)
+	errBytes, err := io.ReadAll(&server.stderr)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("world"), errBytes)
 }
@@ -132,13 +132,13 @@ func TestWriter_Terminal(t *testing.T) {
 		err = closer.Close()
 		assert.NoError(t, err)
 
-		outBytes, err := ioutil.ReadAll(&server.stdout)
+		outBytes, err := io.ReadAll(&server.stdout)
 		assert.NoError(t, err)
 		// echo adds an extra \n at the end, and line discipline will cause \n to come back as \r\n
 		expected := strings.Replace(text+"\n", "\n", "\r\n", -1)
 		assert.Equal(t, []byte(expected), outBytes)
 
-		errBytes, err := ioutil.ReadAll(&server.stderr)
+		errBytes, err := io.ReadAll(&server.stderr)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte{}, errBytes)
 	} else {
@@ -154,11 +154,11 @@ func TestWriter_Terminal(t *testing.T) {
 		err = closer.Close()
 		assert.NoError(t, err)
 
-		outBytes, err := ioutil.ReadAll(&server.stdout)
+		outBytes, err := io.ReadAll(&server.stdout)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("hello"), outBytes)
 
-		errBytes, err := ioutil.ReadAll(&server.stderr)
+		errBytes, err := io.ReadAll(&server.stderr)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("world"), errBytes)
 	}

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -17,7 +17,6 @@ package workspace
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -273,7 +272,7 @@ func GetPulumiConfig() (PulumiConfig, error) {
 		return PulumiConfig{}, err
 	}
 
-	c, err := ioutil.ReadFile(configFile)
+	c, err := os.ReadFile(configFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return PulumiConfig{}, nil
@@ -302,7 +301,7 @@ func StorePulumiConfig(config PulumiConfig) error {
 
 	// Use a temporary file and atomic os.Rename to ensure the file contents are
 	// updated atomically to ensure concurrent `pulumi` CLI operations are safe.
-	tempConfigFile, err := ioutil.TempFile(filepath.Dir(configFile), "config-*.json")
+	tempConfigFile, err := os.CreateTemp(filepath.Dir(configFile), "config-*.json")
 	if err != nil {
 		return err
 	}

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -16,7 +16,6 @@ package workspace
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -49,9 +48,9 @@ var policyPackProjectSingleton = &policyPackProjectLoader{
 	internal: map[string]*PolicyPackProject{},
 }
 
-// readFileStripUTF8BOM wraps ioutil.ReadFile and also strips the UTF-8 Byte-order Mark (BOM) if present.
+// readFileStripUTF8BOM wraps os.ReadFile and also strips the UTF-8 Byte-order Mark (BOM) if present.
 func readFileStripUTF8BOM(path string) ([]byte, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // In the tests below we use temporary directories and then expect DetectProjectAndPath to return a path to
-// that directory. However DetectProjectAndPath will do symlink resolution, while ioutil.TempDir normally does
+// that directory. However DetectProjectAndPath will do symlink resolution, while t.TempDir() normally does
 // not. This can lead to asserts especially on macos where TmpDir will have returned /var/folders/XX, but
 // after sym link resolution that is /private/var/folders/XX.
 func mkTempDir(t *testing.T) string {

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -78,7 +77,7 @@ func prepareTestPluginTGZ(t *testing.T, files map[string][]byte) io.ReadCloser {
 
 	tgz, err := createTGZ(files)
 	require.NoError(t, err)
-	return ioutil.NopCloser(bytes.NewReader(tgz))
+	return io.NopCloser(bytes.NewReader(tgz))
 }
 
 func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadCloser, PluginSpec) {
@@ -186,7 +185,7 @@ func TestInstallNoDeps(t *testing.T) {
 
 	pluginInfo := assertPluginInstalled(t, dir, plugin)
 
-	b, err := ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
+	b, err := os.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 	require.NoError(t, err)
 	assert.Equal(t, content, b)
 
@@ -204,7 +203,7 @@ func TestReinstall(t *testing.T) {
 
 	pluginInfo := assertPluginInstalled(t, dir, plugin)
 
-	b, err := ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
+	b, err := os.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 	require.NoError(t, err)
 	assert.Equal(t, content, b)
 
@@ -215,7 +214,7 @@ func TestReinstall(t *testing.T) {
 
 	pluginInfo = assertPluginInstalled(t, dir, plugin)
 
-	b, err = ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
+	b, err = os.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 	require.NoError(t, err)
 	assert.Equal(t, content, b)
 
@@ -231,7 +230,7 @@ func TestConcurrentInstalls(t *testing.T) {
 	assertSuccess := func() PluginInfo {
 		pluginInfo := assertPluginInstalled(t, dir, plugin)
 
-		b, err := ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
+		b, err := os.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 		assert.NoError(t, err)
 		assert.Equal(t, content, b)
 
@@ -263,16 +262,16 @@ func TestInstallCleansOldFiles(t *testing.T) {
 	dir, tarball, plugin := prepareTestDir(t, nil)
 
 	// Leftover temp dirs.
-	tempDir1, err := ioutil.TempDir(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	tempDir1, err := os.MkdirTemp(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
 	assert.NoError(t, err)
-	tempDir2, err := ioutil.TempDir(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	tempDir2, err := os.MkdirTemp(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
 	assert.NoError(t, err)
-	tempDir3, err := ioutil.TempDir(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	tempDir3, err := os.MkdirTemp(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
 	assert.NoError(t, err)
 
 	// Leftover partial file.
 	partialPath := filepath.Join(dir, plugin.Dir()+".partial")
-	err = ioutil.WriteFile(partialPath, nil, 0600)
+	err = os.WriteFile(partialPath, nil, 0600)
 	assert.NoError(t, err)
 
 	err = plugin.Install(tarball, false)
@@ -296,7 +295,7 @@ func TestGetPluginsSkipsPartial(t *testing.T) {
 	err := plugin.Install(tarball, false)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(dir, plugin.Dir()+".partial"), nil, 0600)
+	err = os.WriteFile(filepath.Join(dir, plugin.Dir()+".partial"), nil, 0600)
 	assert.NoError(t, err)
 
 	assert.False(t, HasPlugin(plugin))

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -322,7 +322,7 @@ func TestPluginDownload(t *testing.T) {
 		}
 		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.NoError(t, err)
-		readBytes, err := ioutil.ReadAll(r)
+		readBytes, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
@@ -349,7 +349,7 @@ func TestPluginDownload(t *testing.T) {
 		}
 		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.NoError(t, err)
-		readBytes, err := ioutil.ReadAll(r)
+		readBytes, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
@@ -373,7 +373,7 @@ func TestPluginDownload(t *testing.T) {
 		}
 		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.NoError(t, err)
-		readBytes, err := ioutil.ReadAll(r)
+		readBytes, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
@@ -416,7 +416,7 @@ func TestPluginDownload(t *testing.T) {
 		}
 		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.NoError(t, err)
-		readBytes, err := ioutil.ReadAll(r)
+		readBytes, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
@@ -464,7 +464,7 @@ func TestPluginDownload(t *testing.T) {
 		}
 		r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 		assert.NoError(t, err)
-		readBytes, err := ioutil.ReadAll(r)
+		readBytes, err := io.ReadAll(r)
 		assert.NoError(t, err)
 		assert.Equal(t, int(l), len(readBytes))
 		assert.Equal(t, expectedBytes, readBytes)
@@ -512,7 +512,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.NoError(t, err)
 			r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 			assert.NoError(t, err)
-			readBytes, err := ioutil.ReadAll(r)
+			readBytes, err := io.ReadAll(r)
 			assert.Error(t, err, "invalid checksum, expected 00, actual "+chksum)
 			assert.Equal(t, int(l), len(readBytes))
 			assert.Equal(t, expectedBytes, readBytes)
@@ -535,7 +535,7 @@ func TestPluginDownload(t *testing.T) {
 			assert.NoError(t, err)
 			r, l, err := source.Download(*spec.Version, "darwin", "amd64", getHTTPResponse)
 			assert.NoError(t, err)
-			readBytes, err := ioutil.ReadAll(r)
+			readBytes, err := io.ReadAll(r)
 			assert.NoError(t, err)
 			assert.Equal(t, int(l), len(readBytes))
 			assert.Equal(t, expectedBytes, readBytes)
@@ -816,7 +816,7 @@ func TestUnmarshalProjectWithProviderList(t *testing.T) {
 	pyaml := filepath.Join(tempdir, "Pulumi.yaml")
 
 	//write to pyaml
-	err := ioutil.WriteFile(pyaml, []byte(`name: test-yaml
+	err := os.WriteFile(pyaml, []byte(`name: test-yaml
 runtime: yaml
 description: "Test Pulumi YAML"
 plugins:

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -154,10 +153,10 @@ func TestProjectLoadJSON(t *testing.T) {
 	t.Parallel()
 
 	writeAndLoad := func(str string) (*Project, error) {
-		tmp, err := ioutil.TempFile("", "*.json")
+		tmp, err := os.CreateTemp("", "*.json")
 		assert.NoError(t, err)
 		path := tmp.Name()
-		err = ioutil.WriteFile(path, []byte(str), 0600)
+		err = os.WriteFile(path, []byte(str), 0600)
 		assert.NoError(t, err)
 		return LoadProject(path)
 	}
@@ -221,20 +220,20 @@ func deleteFile(t *testing.T, file *os.File) {
 }
 
 func loadProjectFromText(t *testing.T, content string) (*Project, error) {
-	tmp, err := ioutil.TempFile("", "*.yaml")
+	tmp, err := os.CreateTemp("", "*.yaml")
 	assert.NoError(t, err)
 	path := tmp.Name()
-	err = ioutil.WriteFile(path, []byte(content), 0600)
+	err = os.WriteFile(path, []byte(content), 0600)
 	assert.NoError(t, err)
 	defer deleteFile(t, tmp)
 	return LoadProject(path)
 }
 
 func loadProjectStackFromText(t *testing.T, project *Project, content string) (*ProjectStack, error) {
-	tmp, err := ioutil.TempFile("", "*.yaml")
+	tmp, err := os.CreateTemp("", "*.yaml")
 	assert.NoError(t, err)
 	path := tmp.Name()
-	err = ioutil.WriteFile(path, []byte(content), 0600)
+	err = os.WriteFile(path, []byte(content), 0600)
 	assert.NoError(t, err)
 	defer deleteFile(t, tmp)
 	return LoadProjectStack(project, path)

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -17,7 +17,6 @@ package workspace
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -302,7 +301,7 @@ func retrieveURLTemplates(rawurl string, offline bool, templateKind TemplateKind
 
 	// Create a temp dir.
 	var temp string
-	if temp, err = ioutil.TempDir("", "pulumi-template-"); err != nil {
+	if temp, err = os.MkdirTemp("", "pulumi-template-"); err != nil {
 		return TemplateRepository{}, err
 	}
 
@@ -509,7 +508,7 @@ func CopyTemplateFiles(
 			}
 
 			// Read the source file.
-			b, err := ioutil.ReadFile(source)
+			b, err := os.ReadFile(source)
 			if err != nil {
 				return err
 			}

--- a/sdk/go/common/workspace/workspace.go
+++ b/sdk/go/common/workspace/workspace.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,7 +144,7 @@ func (pw *projectWorkspace) Save() error {
 
 // atomicWriteFile provides a rename based atomic write through a temporary file.
 func atomicWriteFile(path string, b []byte) error {
-	tmp, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path))
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create temporary file %s", path)
 	}
@@ -169,7 +168,7 @@ func atomicWriteFile(path string, b []byte) error {
 func (pw *projectWorkspace) readSettings() error {
 	settingsPath := pw.settingsPath()
 
-	b, err := ioutil.ReadFile(settingsPath)
+	b, err := os.ReadFile(settingsPath)
 	if err != nil && os.IsNotExist(err) {
 		// not an error to not have an existing settings file.
 		pw.settings = &Settings{}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -33,7 +33,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -294,7 +293,7 @@ func getPluginsFromDir(
 			plugins = append(plugins, more...)
 		} else if inNodeModules && name == "package.json" {
 			// if a package.json file within a node_modules package, parse it, and see if it's a source of plugins.
-			b, err := ioutil.ReadFile(curr)
+			b, err := os.ReadFile(curr)
 			if err != nil {
 				allErrors = multierror.Append(allErrors, fmt.Errorf("reading package.json %s: %w", curr, err))
 				continue
@@ -951,7 +950,7 @@ func (host *nodeLanguageHost) GetProgramDependencies(
 		return nil, fmt.Errorf("could not get node dependency data: %w", err)
 	}
 	if !req.TransitiveDependencies {
-		file, err := ioutil.ReadFile(packageFile)
+		file, err := os.ReadFile(packageFile)
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("could not find %s. "+
 				"Please include this in your report and run "+

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_unix.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_unix.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
@@ -32,7 +31,7 @@ import (
 // files that we can communicate over.  Slightly complex as this involves extra cleanup steps to
 // ensure they're cleaned up when we're done.
 func createPipes() (pipes, error) {
-	dir, err := ioutil.TempDir("", "pulumi-node-pipes")
+	dir, err := os.MkdirTemp("", "pulumi-node-pipes")
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ func Pack(ctx context.Context, dir string, stderr io.Writer) ([]byte, error) {
 
 	defer os.Remove(packfile)
 
-	packTarball, err := ioutil.ReadFile(packfile)
+	packTarball, err := os.ReadFile(packfile)
 	if err != nil {
 		return nil, fmt.Errorf("%s pack completed successfully but the packed .tgz file was not generated", bin)
 	}

--- a/sdk/nodejs/npm/npm_test.go
+++ b/sdk/nodejs/npm/npm_test.go
@@ -16,7 +16,6 @@ package npm
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,7 +71,7 @@ func testInstall(t *testing.T, expectedBin string, production bool) {
 	        "@pulumi/pulumi": "latest"
 	    }
 	}`)
-	assert.NoError(t, ioutil.WriteFile(packageJSONFilename, packageJSON, 0600))
+	assert.NoError(t, os.WriteFile(packageJSONFilename, packageJSON, 0600))
 
 	// Install dependencies, passing nil for stdout and stderr, which connects
 	// them to the file descriptor for the null device (os.DevNull).

--- a/sdk/python/python_test.go
+++ b/sdk/python/python_test.go
@@ -17,7 +17,6 @@ package python
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -104,7 +103,7 @@ func TestRunningPipInVirtualEnvironment(t *testing.T) {
 
 	// Create a requirements.txt file in the temp directory.
 	requirementsFile := filepath.Join(tempdir, "requirements.txt")
-	assert.NoError(t, ioutil.WriteFile(requirementsFile, []byte("pulumi==2.0.0\n"), 0600))
+	assert.NoError(t, os.WriteFile(requirementsFile, []byte("pulumi==2.0.0\n"), 0600))
 
 	// Create a command to run pip from the virtual environment.
 	pipCmd := VirtualEnvCommand(venvDir, "python", "-m", "pip", "install", "-r", "requirements.txt")

--- a/tests/integration/integration_python_smoke_test.go
+++ b/tests/integration/integration_python_smoke_test.go
@@ -18,7 +18,7 @@ package ints
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -216,7 +216,7 @@ func TestAutomaticVenvCreation(t *testing.T) {
 		// replace "virtualenv: venv" with "virtualenv: ${venvPath}" in Pulumi.yaml
 		pulumiYaml := filepath.Join(e.RootPath, "Pulumi.yaml")
 
-		oldYaml, err := ioutil.ReadFile(pulumiYaml)
+		oldYaml, err := os.ReadFile(pulumiYaml)
 		if err != nil {
 			t.Error(err)
 			return
@@ -225,7 +225,7 @@ func TestAutomaticVenvCreation(t *testing.T) {
 			"virtualenv: venv",
 			fmt.Sprintf("virtualenv: >-\n      %s", venvPath)))
 
-		if err := ioutil.WriteFile(pulumiYaml, newYaml, 0644); err != nil {
+		if err := os.WriteFile(pulumiYaml, newYaml, 0644); err != nil {
 			t.Error(err)
 			return
 		}

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -245,7 +244,7 @@ func TestStackCommands(t *testing.T) {
 
 				stackFile := path.Join(e.RootPath, "stack.json")
 				e.RunCommand("pulumi", "stack", "export", "--file", "stack.json")
-				stackJSON, err := ioutil.ReadFile(stackFile)
+				stackJSON, err := os.ReadFile(stackFile)
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
@@ -259,7 +258,7 @@ func TestStackCommands(t *testing.T) {
 				deployment.Version = deploymentVersion
 				bytes, err := json.Marshal(deployment)
 				assert.NoError(t, err)
-				err = ioutil.WriteFile(stackFile, bytes, os.FileMode(os.O_CREATE))
+				err = os.WriteFile(stackFile, bytes, os.FileMode(os.O_CREATE))
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
@@ -295,7 +294,7 @@ func TestStackCommands(t *testing.T) {
 		// becomes invalid.
 		stackFile := path.Join(e.RootPath, "stack.json")
 		e.RunCommand("pulumi", "stack", "export", "--file", "stack.json")
-		stackJSON, err := ioutil.ReadFile(stackFile)
+		stackJSON, err := os.ReadFile(stackFile)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -331,7 +330,7 @@ func TestStackCommands(t *testing.T) {
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		err = ioutil.WriteFile(stackFile, bytes, os.FileMode(os.O_CREATE))
+		err = os.WriteFile(stackFile, bytes, os.FileMode(os.O_CREATE))
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}


### PR DESCRIPTION
Stop using io/ioutil across the entire repository.
The io/ioutil package was deprecated in Go 1.16 (2021-02)
with replacements provided in other packages.
Specifically:

    ioutil.Discard   => io.Discard
    ioutil.NopCloser => io.NopCloser
    ioutil.ReadAll   => io.ReadAll
    ioutil.ReadFile  => os.ReadFile
    ioutil.TempDir   => os.MkdirTemp
    ioutil.TempFile  => os.CreateTemp
    ioutil.WriteFile => os.WriteFile

This change switches all of these entities
across the repository.

Following this change,
the only references to ioutil are in schema files:

    % rg -l ioutil
    pkg/codegen/testing/test/testdata/aws-4.26.0.json
    pkg/codegen/testing/test/testdata/aws-4.36.0.json
    pkg/codegen/testing/test/testdata/aws-4.37.1.json
    pkg/codegen/testing/test/testdata/aws-5.4.0.json
    pkg/codegen/testing/test/testdata/aws-5.16.2.json

The bulk of this change was generated automatically
with manual touch ups afterwards.

Specifically, the template and the template input
had to be updated manually.
