### PR TITLE
go.mod: Raise to 'go 1.18'

### DIFF
--- a/changelog/pending/20230107--pkg--pkg-raise-go-directive-to-1-18.yaml
+++ b/changelog/pending/20230107--pkg--pkg-raise-go-directive-to-1-18.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg
+  description: Raise 'go' directive to 1.18.

--- a/changelog/pending/20230107--sdk-go--sdk-raise-go-directive-to-1-18.yaml
+++ b/changelog/pending/20230107--sdk-go--sdk-raise-go-directive-to-1-18.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Raise 'go' directive to 1.18.

--- a/developer-docs/go.mod
+++ b/developer-docs/go.mod
@@ -1,5 +1,5 @@
 module github.com/pulumi/pulumi/developer-docs
 
-go 1.16
+go 1.18
 
 require github.com/santhosh-tekuri/jsonschema/v5 v5.0.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/pkg/v3
 
-go 1.17
+go 1.18
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/v3
 
-go 1.17
+go 1.18
 
 replace golang.org/x/text => golang.org/x/text v0.3.6
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.5.0


### PR DESCRIPTION
Raise the 'go' directive for top-level Go modules to 1.18.
This is the minimum version of Go required by Pulumi.
Raising this directive allows us to use language features like generics
in the codbase.

Resolves #11798

Note that this includes two changelog entries: one for sdk, one for pkg
