### PR TITLE
Lift DefaultSecretsProvider out of DeserializeCheckpoint

### DIFF
--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -149,7 +149,7 @@ func (b *localBackend) getStack(
 	}
 
 	// Materialize an actual snapshot object.
-	snapshot, err := stack.DeserializeCheckpoint(ctx, chk)
+	snapshot, err := stack.DeserializeCheckpoint(ctx, stack.DefaultSecretsProvider, chk)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/operations/resources_test.go
+++ b/pkg/operations/resources_test.go
@@ -33,7 +33,7 @@ func getPulumiResources(t *testing.T, path string) *Resource {
 	assert.NoError(t, err)
 	err = json.Unmarshal(byts, &checkpoint)
 	assert.NoError(t, err)
-	snapshot, err := stack.DeserializeCheckpoint(ctx, &checkpoint)
+	snapshot, err := stack.DeserializeCheckpoint(ctx, stack.DefaultSecretsProvider, &checkpoint)
 	assert.NoError(t, err)
 	resources := NewResourceTree(snapshot.Resources)
 	return resources

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -110,10 +110,11 @@ func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
 // if there have been no deployments performed on this checkpoint.
 func DeserializeCheckpoint(
 	ctx context.Context,
+	secretsProvider SecretsProvider,
 	chkpoint *apitype.CheckpointV3) (*deploy.Snapshot, error) {
 	contract.Require(chkpoint != nil, "chkpoint")
 	if chkpoint.Latest != nil {
-		return DeserializeDeploymentV3(ctx, *chkpoint.Latest, DefaultSecretsProvider)
+		return DeserializeDeploymentV3(ctx, *chkpoint.Latest, secretsProvider)
 	}
 
 	return nil, nil


### PR DESCRIPTION
SerializeCheckpoint takes the `secrets.Manager` to use as a parameter.
DeserializeCheckpoint was hardcoded to always use the `DefaultSecretsProvider`, this changes it to take it to also take it as a parameter, and lifts the setting of `DefaultSecretsProvider` up to filestate.

Later changes will work out how to lift `DefaultSecretsProvider` out of filestate and httpstate.