### PR TITLE
Revert "Update Pulumi codegen to net6.0"

### DIFF
--- a/changelog/pending/20221206--sdk-dotnet--drop-support-for-net-core-3-1.yaml
+++ b/changelog/pending/20221206--sdk-dotnet--drop-support-for-net-core-3-1.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: sdk/dotnet
-  description: Drop support for .NET Core 3.1.

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -132,7 +132,7 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
     <RepositoryUrl>{{.Package.Repository}}</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-azure-native</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/external-enum/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/external-enum/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Other.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Other.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/sdk/go/auto/test/errors/compilation_error/dotnet/dotnet.csproj
+++ b/sdk/go/auto/test/errors/compilation_error/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/go/auto/test/errors/runtime_error/dotnet/adsfsdf.csproj
+++ b/sdk/go/auto/test/errors/runtime_error/dotnet/adsfsdf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/python/lib/test/automation/errors/compilation_error/dotnet/dotnet.csproj
+++ b/sdk/python/lib/test/automation/errors/compilation_error/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/python/lib/test/automation/errors/runtime_error/dotnet/adsfsdf.csproj
+++ b/sdk/python/lib/test/automation/errors/runtime_error/dotnet/adsfsdf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Reverts pulumi/pulumi#11543

After discussing with @danielrbradley the providers ecosystem is not ready for releasing this yet, as auto-merge workflows will blow up providers CI. Tracking merging pre-requisites first in https://github.com/pulumi/home/issues/2531 which will unblock this.