### PR TITLE
backend/display/test: string(buffer.Bytes()) => buffer.String()

### DIFF
--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -90,8 +90,8 @@ func testDiffEvents(t *testing.T, path string, accept bool, truncateOutput bool)
 	<-doneChannel
 
 	if !accept {
-		assert.Equal(t, string(expectedStdout), string(stdout.Bytes()))
-		assert.Equal(t, string(expectedStderr), string(stderr.Bytes()))
+		assert.Equal(t, string(expectedStdout), stdout.String())
+		assert.Equal(t, string(expectedStderr), stderr.String())
 	} else {
 		err = os.WriteFile(path+".stdout.txt", stdout.Bytes(), 0600)
 		require.NoError(t, err)

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -61,8 +61,8 @@ func testProgressEvents(t *testing.T, path string, accept, interactive bool, wid
 	<-doneChannel
 
 	if !accept {
-		assert.Equal(t, string(expectedStdout), string(stdout.Bytes()))
-		assert.Equal(t, string(expectedStderr), string(stderr.Bytes()))
+		assert.Equal(t, string(expectedStdout), stdout.String())
+		assert.Equal(t, string(expectedStderr), stderr.String())
 	} else {
 		err = os.WriteFile(path+suffix+".stdout.txt", stdout.Bytes(), 0600)
 		require.NoError(t, err)


### PR DESCRIPTION
`bytes.Buffer` has a `String()` method
that is equivalent to `string(b.Bytes())`.
