### PR TITLE
all: gofmt -w -s

### DIFF
--- a/pkg/codegen/dotnet/gen_program_test/batch1/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test/batch1/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch1
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../dotnet") // chdir into codegen/dotnet
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
+	os.Chdir("../../../dotnet") // chdir into codegen/dotnet
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
 }

--- a/pkg/codegen/dotnet/gen_program_test/batch2/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test/batch2/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch2
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../dotnet") // chdir into codegen/dotnet
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
+	os.Chdir("../../../dotnet") // chdir into codegen/dotnet
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
 }

--- a/pkg/codegen/dotnet/gen_program_test/batch3/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test/batch3/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch3
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../dotnet") // chdir into codegen/dotnet
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
+	os.Chdir("../../../dotnet") // chdir into codegen/dotnet
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
 }

--- a/pkg/codegen/dotnet/gen_program_test/batch4/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test/batch4/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch4
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../dotnet") // chdir into codegen/dotnet
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
+	os.Chdir("../../../dotnet") // chdir into codegen/dotnet
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
 }

--- a/pkg/codegen/dotnet/gen_program_test/batch5/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test/batch5/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch5
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../dotnet") // chdir into codegen/dotnet
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
+	os.Chdir("../../../dotnet") // chdir into codegen/dotnet
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
 }

--- a/pkg/codegen/dotnet/gen_program_test/batch6/gen_program_test.go
+++ b/pkg/codegen/dotnet/gen_program_test/batch6/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch6
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../dotnet") // chdir into codegen/dotnet
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
+	os.Chdir("../../../dotnet") // chdir into codegen/dotnet
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
 }

--- a/pkg/codegen/go/gen_program_test/batch1/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch1/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch1
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../go") // chdir into codegen/go
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
+	os.Chdir("../../../go") // chdir into codegen/go
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
 }

--- a/pkg/codegen/go/gen_program_test/batch2/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch2/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch2
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../go") // chdir into codegen/go
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
+	os.Chdir("../../../go") // chdir into codegen/go
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
 }

--- a/pkg/codegen/go/gen_program_test/batch3/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch3/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch3
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../go") // chdir into codegen/go
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
+	os.Chdir("../../../go") // chdir into codegen/go
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
 }

--- a/pkg/codegen/go/gen_program_test/batch4/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch4/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch4
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../go") // chdir into codegen/go
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
+	os.Chdir("../../../go") // chdir into codegen/go
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
 }

--- a/pkg/codegen/go/gen_program_test/batch5/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch5/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch5
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../go") // chdir into codegen/go
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
+	os.Chdir("../../../go") // chdir into codegen/go
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
 }

--- a/pkg/codegen/go/gen_program_test/batch6/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test/batch6/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch6
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../go") // chdir into codegen/go
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
+	os.Chdir("../../../go") // chdir into codegen/go
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
 }

--- a/pkg/codegen/nodejs/gen_program_test/batch1/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test/batch1/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch1
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../nodejs") // chdir into codegen/nodejs
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
+	os.Chdir("../../../nodejs") // chdir into codegen/nodejs
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
 }

--- a/pkg/codegen/nodejs/gen_program_test/batch2/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test/batch2/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch2
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../nodejs") // chdir into codegen/nodejs
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
+	os.Chdir("../../../nodejs") // chdir into codegen/nodejs
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
 }

--- a/pkg/codegen/nodejs/gen_program_test/batch3/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test/batch3/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch3
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../nodejs") // chdir into codegen/nodejs
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
+	os.Chdir("../../../nodejs") // chdir into codegen/nodejs
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
 }

--- a/pkg/codegen/nodejs/gen_program_test/batch4/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test/batch4/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch4
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../nodejs") // chdir into codegen/nodejs
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
+	os.Chdir("../../../nodejs") // chdir into codegen/nodejs
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
 }

--- a/pkg/codegen/nodejs/gen_program_test/batch5/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test/batch5/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch5
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../nodejs") // chdir into codegen/nodejs
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
+	os.Chdir("../../../nodejs") // chdir into codegen/nodejs
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
 }

--- a/pkg/codegen/nodejs/gen_program_test/batch6/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test/batch6/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch6
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../nodejs") // chdir into codegen/nodejs
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
+	os.Chdir("../../../nodejs") // chdir into codegen/nodejs
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
 }

--- a/pkg/codegen/python/gen_program_test/batch1/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test/batch1/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch1
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../python") // chdir into codegen/python
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
+	os.Chdir("../../../python") // chdir into codegen/python
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(1, 6))
 }

--- a/pkg/codegen/python/gen_program_test/batch2/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test/batch2/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch2
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../python") // chdir into codegen/python
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
+	os.Chdir("../../../python") // chdir into codegen/python
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(2, 6))
 }

--- a/pkg/codegen/python/gen_program_test/batch3/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test/batch3/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch3
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../python") // chdir into codegen/python
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
+	os.Chdir("../../../python") // chdir into codegen/python
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(3, 6))
 }

--- a/pkg/codegen/python/gen_program_test/batch4/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test/batch4/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch4
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../python") // chdir into codegen/python
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
+	os.Chdir("../../../python") // chdir into codegen/python
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(4, 6))
 }

--- a/pkg/codegen/python/gen_program_test/batch5/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test/batch5/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch5
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../python") // chdir into codegen/python
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
+	os.Chdir("../../../python") // chdir into codegen/python
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(5, 6))
 }

--- a/pkg/codegen/python/gen_program_test/batch6/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test/batch6/gen_program_test.go
@@ -17,14 +17,14 @@
 package batch6
 
 import (
-  "os"
-  "testing"
+	"os"
+	"testing"
 
-  codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
-  "github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
+	codegen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/test"
 )
 
 func TestGenerateProgram(t *testing.T) {
-  os.Chdir("../../../python") // chdir into codegen/python
-  codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
+	os.Chdir("../../../python") // chdir into codegen/python
+	codegen.GenerateProgramBatchTest(t, test.ProgramTestBatch(6, 6))
 }


### PR DESCRIPTION
Runs `gofmt -w -s` on all files.

Command used to make this change:

    gofmt -w -s $(rg --files -g '*.go' | rg -v compilation_error)

Depends on #11821
Refs #10327
