### PR TITLE
ci/lint: Use latest golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -20,8 +20,7 @@ env:
 
 jobs:
   golangci:
-    # See https://github.com/pulumi/pulumi/issues/9280 for why this is set to v1.44
-    container: golangci/golangci-lint:v1.47.3
+    container: golangci/golangci-lint:latest
     name: Lint Go
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Now that all code is gofmt compliant (#11822),
we can upgrade to the latest golangci-lint.

We should be able to re-enable staticcheck
some time after this lands.

Refs #10327
Refs #9280

