### PR TITLE
golangci-lint: Drop deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ run:
 linters:
   enable-all: false
   enable:
-    - deadcode
     - errcheck
     - goconst
     - gofmt
@@ -23,9 +22,8 @@ linters:
     - misspell
     - nolintlint
     - nakedret
-    - structcheck
     - unconvert
-    - varcheck
+    - unused
     - paralleltest
   disable:
     - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0


### PR DESCRIPTION
golangci-lint constantly prints this message:

```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```

Drop these linters and enable the 'unused' linter.

Depends on #11823
