### PR TITLE
Preallocate slices of known size.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ run:
 linters:
   enable-all: false
   enable:
+    - prealloc
     - deadcode
     - errcheck
     - goconst

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1033,7 +1033,7 @@ func (t *types) bindProperties(path string, properties map[string]PropertySpec, 
 
 	// Bind property types and constant or default values.
 	propertyMap := map[string]*Property{}
-	var result []*Property
+	var result = make([]*Property, 0, len(properties))
 	for name, spec := range properties {
 		propertyPath := path + "/" + name
 		// NOTE: The correct determination for if we should bind an input is:
@@ -1372,7 +1372,7 @@ func (t *types) bindResourceDetails(path, token string, spec ResourceSpec, decl 
 		stateInputs = si.InputShape
 	}
 
-	var aliases []*Alias
+	var aliases = make([]*Alias, 0, spec.Aliases)
 	for _, a := range spec.Aliases {
 		aliases = append(aliases, &Alias{Name: a.Name, Project: a.Project, Type: a.Type})
 	}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -27,7 +27,7 @@ func NewHostWithProviders(schemaDirectoryPath string, providers ...SchemaProvide
 		}, deploytest.WithPath(schemaDirectoryPath))
 	}
 
-	var pluginLoaders []*deploytest.PluginLoader
+	var pluginLoaders = make([]*deploytest.PluginLoader, 0, len(providers))
 
 	for _, v := range providers {
 		pluginLoaders = append(pluginLoaders, mockProvider(tokens.Package(v.name), v.version))

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -98,7 +98,7 @@ func (p pluginSet) Deduplicate() pluginSet {
 
 // Values returns a slice of all of the plugins contained within this set.
 func (p pluginSet) Values() []workspace.PluginSpec {
-	var plugins []workspace.PluginSpec
+	var plugins = make([]workspace.PluginSpec, 0, len(p))
 	for _, value := range p {
 		plugins = append(plugins, value)
 	}

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -185,7 +185,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 	//
 	// NOTE: what if the configuration for an existing default provider has changed? If it has, we should diff it and
 	// replace it appropriately or we should not use the ambient config at all.
-	var defaultProviderRequests []providers.ProviderRequest
+	var defaultProviderRequests = make([]providers.ProviderRequest, 0, len(i.deployments.imports))
 	defaultProviders := map[resource.URN]struct{}{}
 	for _, imp := range i.deployment.imports {
 		if imp.Provider != "" {

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -66,7 +66,7 @@ func (c *serviceCrypter) DecryptValue(ctx context.Context, cipherstring string) 
 }
 
 func (c *serviceCrypter) BulkDecrypt(ctx context.Context, secrets []string) (map[string]string, error) {
-	var secretsToDecrypt [][]byte
+	var secretsToDecrypt = make([][]byte, 0, len(secrets))
 	for _, val := range secrets {
 		ciphertext, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {


### PR DESCRIPTION
Enable the "prealloc" lint, which identifies locations where slices have a known size, and can be preallocated, instead of allocated and reallocated when the length exceeds capacity.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] **N/A: Linter refactor** have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] **N/A: No changelog required.**I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
