### PR TITLE
crypto/ssh/terminal is deprecated

### DIFF
--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -26,9 +26,8 @@ import (
 	"strings"
 
 	zxcvbn "github.com/nbutton23/zxcvbn-go"
-
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -528,7 +527,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			switch {
 			case len(args) == 2:
 				value = args[1]
-			case !terminal.IsTerminal(int(os.Stdin.Fd())):
+			case !term.IsTerminal(int(os.Stdin.Fd())):
 				b, readerr := io.ReadAll(os.Stdin)
 				if readerr != nil {
 					return readerr

--- a/pkg/cmd/pulumi/terminal.go
+++ b/pkg/cmd/pulumi/terminal.go
@@ -15,9 +15,7 @@
 // Terminal detection utilities.
 package main
 
-import (
-	"golang.org/x/crypto/ssh/terminal"
-)
+import "golang.org/x/term"
 
 type optimalPageSizeOpts struct {
 	nopts          int
@@ -30,7 +28,7 @@ func optimalPageSize(opts optimalPageSizeOpts) int {
 	pageSize := 15
 	if opts.terminalHeight != 0 {
 		pageSize = opts.terminalHeight
-	} else if _, height, err := terminal.GetSize(0); err == nil {
+	} else if _, height, err := term.GetSize(0); err == nil {
 		pageSize = height
 	}
 	if pageSize > opts.nopts {

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/zclconf/go-cty v1.12.1
 	gocloud.dev v0.27.0
 	gocloud.dev/secrets/hashivault v0.27.0
-	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503
+	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503 // indirect
 	golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/rivo/uniseg"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
 )
@@ -59,8 +59,8 @@ func InteractiveTerminal() bool {
 	// if we're piping in stdin, we're clearly not interactive, as there's no way for a user to
 	// provide input.  If we're piping stdout, we also can't be interactive as there's no way for
 	// users to see prompts to interact with them.
-	return terminal.IsTerminal(int(os.Stdin.Fd())) &&
-		terminal.IsTerminal(int(os.Stdout.Fd()))
+	return term.IsTerminal(int(os.Stdin.Fd())) &&
+		term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // ReadConsole reads the console with the given prompt text.

--- a/sdk/go/common/util/cmdutil/console_password.go
+++ b/sdk/go/common/util/cmdutil/console_password.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // ReadConsoleNoEcho reads from the console without echoing.  This is useful for reading passwords.
@@ -27,7 +27,7 @@ func ReadConsoleNoEcho(prompt string) (string, error) {
 	// error when it tries to disable local echo.
 	//
 	// In this case, just read normally
-	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return ReadConsole(prompt)
 	}
 
@@ -35,7 +35,7 @@ func ReadConsoleNoEcho(prompt string) (string, error) {
 		fmt.Print(prompt + ": ")
 	}
 
-	b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	b, err := term.ReadPassword(int(os.Stdin.Fd()))
 
 	fmt.Println() // echo a newline, since the user's keypress did not generate one
 


### PR DESCRIPTION
golang.org/x/crypto/ssh/terminal is deprecated.
golang.org/x/term is a near drop-in replacement for it.

In service to #11808
