### PR TITLE
Pretty recursive types

### DIFF
--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -45,23 +44,13 @@ func ExprNotConvertible(destType Type, expr Expression) *hcl.Diagnostic {
 	if len(why) != 0 {
 		return errorf(expr.SyntaxNode().Range(), why[0].Summary)
 	}
-	var e, d fmt.Stringer = expr.Type(), destType
-	if env.PrettyPrintPCL.Value() {
-		e = expr.Type().Pretty()
-		d = destType.Pretty()
-	}
 	return errorf(expr.SyntaxNode().Range(), "cannot assign expression of type %s to location of type %s: ",
-		e, d)
+		expr.Type().Pretty(), destType.Pretty())
 }
 
 func typeNotConvertible(dest, src Type) *hcl.Diagnostic {
-	var s, d fmt.Stringer = src, dest
-	if env.PrettyPrintPCL.Value() {
-		s = src.Pretty()
-		d = dest.Pretty()
-	}
 	return &hcl.Diagnostic{Severity: hcl.DiagError, Summary: fmt.Sprintf("cannot assign value of type %s to type %s",
-		s, d)}
+		src.Pretty(), dest.Pretty())}
 }
 
 func tuplesHaveDifferentLengths(dest, src *TupleType) *hcl.Diagnostic {

--- a/pkg/codegen/hcl2/model/type_enum.go
+++ b/pkg/codegen/hcl2/model/type_enum.go
@@ -84,10 +84,10 @@ func (t *EnumType) Pretty() pretty.Formatter {
 			NewConstType(ctyTypeToType(c.Type(), false), c).Pretty(),
 		)
 	}
-	return pretty.Wrap{
+	return &pretty.Wrap{
 		Prefix:  "enum(",
 		Postfix: ")",
-		Value: pretty.List{
+		Value: &pretty.List{
 			Separator: " | ",
 			Elements:  types,
 		},

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -41,7 +41,7 @@ func (*ListType) SyntaxNode() hclsyntax.Node {
 }
 
 func (t *ListType) Pretty() pretty.Formatter {
-	return pretty.Wrap{
+	return &pretty.Wrap{
 		Prefix:  "list(",
 		Postfix: ")",
 		Value:   t.ElementType.Pretty(),

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -36,7 +36,7 @@ func NewMapType(elementType Type) *MapType {
 }
 
 func (t *MapType) Pretty() pretty.Formatter {
-	return pretty.Wrap{
+	return &pretty.Wrap{
 		Prefix:  "map(",
 		Value:   t.ElementType.Pretty(),
 		Postfix: ")",

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -55,7 +55,7 @@ func (t *ObjectType) Pretty() pretty.Formatter {
 	for k, v := range t.Properties {
 		m[k] = v.Pretty()
 	}
-	return pretty.Object{Properties: m}
+	return &pretty.Object{Properties: m}
 }
 
 // Traverse attempts to traverse the optional type with the given traverser. The result type of

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -41,7 +41,7 @@ func (*OutputType) SyntaxNode() hclsyntax.Node {
 }
 
 func (t *OutputType) Pretty() pretty.Formatter {
-	return pretty.Wrap{
+	return &pretty.Wrap{
 		Prefix:  "output(",
 		Value:   t.ElementType.Pretty(),
 		Postfix: ")",

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -42,7 +42,7 @@ func (*PromiseType) SyntaxNode() hclsyntax.Node {
 }
 
 func (t *PromiseType) Pretty() pretty.Formatter {
-	return pretty.Wrap{
+	return &pretty.Wrap{
 		Prefix:  "promise(",
 		Value:   t.ElementType.Pretty(),
 		Postfix: ")",

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -100,7 +100,7 @@ func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}
 }
 
 func (t *SetType) Pretty() pretty.Formatter {
-	return pretty.Wrap{
+	return &pretty.Wrap{
 		Prefix:  "set(",
 		Value:   t.ElementType.Pretty(),
 		Postfix: ")",

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -46,9 +46,9 @@ func (t *TupleType) Pretty() pretty.Formatter {
 	for i, el := range t.ElementTypes {
 		elements[i] = el.Pretty()
 	}
-	return pretty.Wrap{
+	return &pretty.Wrap{
 		Prefix: "(",
-		Value: pretty.List{
+		Value: &pretty.List{
 			AdjoinSeparator: true,
 			Separator:       ", ",
 			Elements:        elements,

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -116,12 +116,12 @@ func (t *UnionType) Pretty() pretty.Formatter {
 		}
 		elements = append(elements, el.Pretty())
 	}
-	var v pretty.Formatter = pretty.List{
+	var v pretty.Formatter = &pretty.List{
 		Separator: " | ",
 		Elements:  elements,
 	}
 	if isOptional {
-		v = pretty.Wrap{
+		v = &pretty.Wrap{
 			Value:           v,
 			Postfix:         "?",
 			PostfixSameline: true,

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -68,5 +68,3 @@ fail without a --force parameter.`)
 
 var DebugGRPC = env.String("DEBUG_GRPC", `Enables debug tracing of Pulumi gRPC internals.
 The variable should be set to the log file to which gRPC debug traces will be sent.`)
-
-var PrettyPrintPCL = env.Bool("PRETTY_PRINT_PCL", "Print PCL type errors across multiple lines")


### PR DESCRIPTION
Re-enable pretty printing of types in the default case. 

Pretty printing by default was disabled as a quick solution for https://github.com/pulumi/pulumi-gcp/pull/963. This PR has been manually tested against `pulumi-gcp`.

This PR adds 3 behaviors to the `pretty.Formatter` type.

1. A inner string method that accommodates state.
2. A visit function that allows pre-processing to discover recursive
types and apply tags to them.
3. A hash function that allows structural hashing on recursive types. This hash function is memoized by the `tagGenerator` during traversal.

Together, this allows pretty-printing recursive types, regardless of
the pointers are. This allows `(0x1)Object{ key: *0x1 }` to be the same
as `(0x1)Object{ key: (0x2)Object{ key: *0x1 }}`.




