### PR TITLE
nodejs runtime closure error fix - identifier 'exports' has already been declared 

### DIFF
--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -207,7 +207,7 @@ function serializeJavaScriptText(
             if (valEntry.module !== undefined) {
                 if(!emittedRequires.has(keyEntry.json)) {
                     emittedRequires.add(keyEntry.json);
-                    functionText += `const ${keyEntry.json} = require("${valEntry.module}");\n`;
+                    functionText += `var ${keyEntry.json} = require("${valEntry.module}");\n`;
                 }
                 delete capturedValues[keyEntry.json];
             }


### PR DESCRIPTION
# Description

(temporary) fixes error in emittedRequires for 
- keyEntry.json = "exports"
- keyEntry.module = "@pulumi/pulumi/output.js"
 
```
    SyntaxError: Identifier 'exports' has already been declared: :91
    const exports = require("@pulumi/pulumi/output.js");
```
the is a change from const to var in Pull Request. It would be better to rename "exports" to another unreserved word. 
