### PR TITLE
Move SecretsProvider to pkg/secrets

### DIFF
--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -110,7 +110,7 @@ func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
 // if there have been no deployments performed on this checkpoint.
 func DeserializeCheckpoint(
 	ctx context.Context,
-	secretsProvider SecretsProvider,
+	secretsProvider secrets.Provider,
 	chkpoint *apitype.CheckpointV3) (*deploy.Snapshot, error) {
 	contract.Require(chkpoint != nil, "chkpoint")
 	if chkpoint.Latest != nil {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -167,7 +167,7 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets 
 func DeserializeUntypedDeployment(
 	ctx context.Context,
 	deployment *apitype.UntypedDeployment,
-	secretsProv SecretsProvider) (*deploy.Snapshot, error) {
+	secretsProv secrets.Provider) (*deploy.Snapshot, error) {
 
 	contract.Require(deployment != nil, "deployment")
 	switch {
@@ -207,7 +207,7 @@ func DeserializeUntypedDeployment(
 func DeserializeDeploymentV3(
 	ctx context.Context,
 	deployment apitype.DeploymentV3,
-	secretsProv SecretsProvider) (*deploy.Snapshot, error) {
+	secretsProv secrets.Provider) (*deploy.Snapshot, error) {
 
 	// Unpack the versions.
 	manifest, err := deploy.DeserializeManifest(deployment.Manifest)

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -29,13 +29,7 @@ import (
 )
 
 // DefaultSecretsProvider is the default SecretsProvider to use when deserializing deployments.
-var DefaultSecretsProvider SecretsProvider = &defaultSecretsProvider{}
-
-// SecretsProvider allows for the creation of secrets managers based on a well-known type name.
-type SecretsProvider interface {
-	// OfType returns a secrets manager for the given type, initialized with its previous state.
-	OfType(ty string, state json.RawMessage) (secrets.Manager, error)
-}
+var DefaultSecretsProvider secrets.Provider = &defaultSecretsProvider{}
 
 // defaultSecretsProvider implements the secrets.ManagerProviderFactory interface. Essentially
 // it is the global location where new secrets managers can be registered for use when

--- a/pkg/secrets/provider.go
+++ b/pkg/secrets/provider.go
@@ -1,0 +1,25 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"encoding/json"
+)
+
+// Provider allows for the creation of secrets managers based on a well-known type name.
+type Provider interface {
+	// OfType returns a secrets manager for the given type, initialized with its previous state.
+	OfType(ty string, state json.RawMessage) (Manager, error)
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Trying to push DefaultSecretsProvider up past the backends resulted in a module loop between pkg/resource/stack and pkg/resource/deploy. This places SecretProvider in the secrets module to avoid that.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A Just moving interface declaration 
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - N/A Internal code changes
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version - No
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
