### PR TITLE
deploytest/ResourceMonitor: Don't drop deps

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.3
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	google.golang.org/protobuf v1.28.1
 )
 
 require (
@@ -240,7 +241,6 @@ require (
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	lukechampine.com/frand v1.4.2 // indirect

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -384,11 +384,12 @@ func (rm *ResourceMonitor) Call(tok tokens.ModuleMember, inputs resource.Propert
 
 	// unmarshal return deps
 	deps := make(map[resource.PropertyKey][]resource.URN)
-	for _, p := range resp.ReturnDependencies {
+	for k, p := range resp.ReturnDependencies {
 		var urns []resource.URN
 		for _, urn := range p.Urns {
 			urns = append(urns, resource.URN(urn))
 		}
+		deps[resource.PropertyKey(k)] = urns
 	}
 
 	return outs, deps, nil, nil

--- a/pkg/resource/deploy/deploytest/resourcemonitor_test.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor_test.go
@@ -1,0 +1,72 @@
+package deploytest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Verifies that ReturnDependencies in a ResourceMonitor.Call
+// are propagated back to the caller.
+func TestResourceMonitor_Call_deps(t *testing.T) {
+	t.Parallel()
+
+	client := stubResourceMonitorClient{
+		// ResourceMonitorClient is unset
+		// so this will panic if an unexpected method is called.
+		CallFunc: func(req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
+			res, err := structpb.NewStruct(map[string]interface{}{
+				"k3": "value3",
+				"k4": "value4",
+			})
+			require.NoError(t, err)
+
+			return &pulumirpc.CallResponse{
+				Return: res,
+				ReturnDependencies: map[string]*pulumirpc.CallResponse_ReturnDependencies{
+					"foo": {Urns: []string{"urn1", "urn2"}},
+					"bar": {Urns: []string{"urn3", "urn4"}},
+				},
+			}, nil
+		},
+	}
+
+	_, deps, _, err := NewResourceMonitor(&client).Call(
+		"org/proj/stack:module:member",
+		resource.NewPropertyMapFromMap(map[string]interface{}{
+			"k1": "value1",
+			"k2": "value2",
+		}),
+		"provider", "1.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, map[resource.PropertyKey][]resource.URN{
+		"foo": {"urn1", "urn2"},
+		"bar": {"urn3", "urn4"},
+	}, deps)
+}
+
+// stubResourceMonitorClient is a ResourceMonitorClient
+// that can stub out specific functions.
+type stubResourceMonitorClient struct {
+	pulumirpc.ResourceMonitorClient
+
+	CallFunc func(req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error)
+}
+
+func (cl *stubResourceMonitorClient) Call(
+	ctx context.Context,
+	req *pulumirpc.CallRequest,
+	opts ...grpc.CallOption,
+) (*pulumirpc.CallResponse, error) {
+	if cl.CallFunc != nil {
+		return cl.CallFunc(req)
+	}
+	return cl.ResourceMonitorClient.Call(ctx, req, opts...)
+}


### PR DESCRIPTION
Another step towards #11808.

ResourceMonitor.Call calls ResourceMonitorClient.Call
and converts the output into a few different results.

During the conversion, it builds a `map[PropertyKey][]URN`,
but it never fills that map with values,
and instead always returns the empty map.

This was caught by staticcheck:

```
resource/deploy/deploytest/resourcemonitor.go:390:11: SA4010: this result of append is never used, except maybe in other appends (staticcheck)
```
