### PR TITLE
sdk/resource/plugin: Don't print from test

### DIFF
--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -44,7 +44,7 @@ func TestAssetSerialize(t *testing.T) {
 	assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", asset.Hash)
 	assetProps, err := MarshalPropertyValue(pk, resource.NewAssetProperty(asset), MarshalOptions{})
 	assert.Nil(t, err)
-	fmt.Printf("%v\n", assetProps)
+	t.Logf("%v", assetProps)
 	assetValue, err := UnmarshalPropertyValue("", assetProps, MarshalOptions{})
 	assert.Nil(t, err)
 	assert.True(t, assetValue.IsAsset())


### PR DESCRIPTION
TestAssetSerialize prints to stdout from the test.
This seems like a leftover from debugging.

Drop that in favor of a t.Logf so that if the test fails,
the print is still available in the output.
