### PR TITLE
sdk/resource/ProviderServer: Fix potential panic at Configure

### DIFF
--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -230,6 +230,7 @@ func (p *providerServer) Configure(ctx context.Context,
 		}
 		inputs = args
 	} else {
+		inputs = make(resource.PropertyMap)
 		for k, v := range req.GetVariables() {
 			key, err := config.ParseKey(k)
 			if err != nil {

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -1,0 +1,56 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Validate that Configure can read inputs from variables instead of args.
+func TestProviderServer_Configure_variables(t *testing.T) {
+	t.Parallel()
+
+	provider := stubProvider{
+		ConfigureFunc: func(pm resource.PropertyMap) error {
+			assert.Equal(t, map[string]interface{}{
+				"foo": "bar",
+				"baz": 42.0,
+				"qux": map[string]interface{}{
+					"a": "str",
+					"b": true,
+				},
+			}, pm.Mappable())
+			return nil
+		},
+	}
+	srv := NewProviderServer(&provider)
+
+	ctx := context.Background()
+	_, err := srv.Configure(ctx, &pulumirpc.ConfigureRequest{
+		Variables: map[string]string{
+			"ns:foo": `"bar"`,
+			"ns:baz": "42",
+			"ns:qux": `{"a": "str", "b": true}`,
+		},
+	})
+	require.NoError(t, err)
+}
+
+// stubProvider is a Provider implementation
+// with support for stubbing out specific methods.
+type stubProvider struct {
+	Provider
+
+	ConfigureFunc func(resource.PropertyMap) error
+}
+
+func (p *stubProvider) Configure(inputs resource.PropertyMap) error {
+	if p.ConfigureFunc != nil {
+		return p.ConfigureFunc(inputs)
+	}
+	return p.Provider.Configure(inputs)
+}


### PR DESCRIPTION
If `GetArgs()` is empty, the inputs map isn't initialized
before the loop starts filling it.
Adding entries to a nil map will cause a panic.

Fix the potential panic and add a failing test.

Issue caught by staticcheck.

```
go/common/resource/plugin/provider_server.go:245:4: SA5000: assignment to nil map (staticcheck)
```

Refs #11808
