### PR TITLE
Fix a TypeError in Output.from_input

### DIFF
--- a/changelog/pending/20230113--sdk-python--fix-a-typeerror-in-output-from_input.yaml
+++ b/changelog/pending/20230113--sdk-python--fix-a-typeerror-in-output-from_input.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix a TypeError in Output.from_input.

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -197,6 +197,15 @@ class OutputFromInputTests(unittest.TestCase):
         self.assertIsInstance(x_val.nested, OutputFromInputTests.NestedArgs)
         self.assertEqual(x_val.nested.hello, "world")
 
+    @pulumi.input_type
+    class EmptyArgs: pass
+
+    @pulumi_test
+    async def test_unwrap_empty_input_type(self):
+        x = Output.from_input(OutputFromInputTests.EmptyArgs())
+        x_val = cast(OutputFromInputTests.EmptyArgs, await x.future())
+        self.assertIsInstance(x_val, OutputFromInputTests.EmptyArgs)
+
 class Obj:
     def __init__(self, x: str):
         self.x = x


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes a TypeError in Output.from_input when passing in an empty input type.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
