### PR TITLE
pkg/codegen: Add types for typeTokenKind values

### DIFF
--- a/pkg/codegen/testing/tstypes/tstypes.go
+++ b/pkg/codegen/testing/tstypes/tstypes.go
@@ -155,12 +155,12 @@ type typeTokenKind string
 
 const (
 	openParen  typeTokenKind = "("
-	closeParen               = ")"
-	openMap                  = "{[key: string]: "
-	closeMap                 = "}"
-	identifier               = "x"
-	array                    = "[]"
-	union                    = " | "
+	closeParen typeTokenKind = ")"
+	openMap    typeTokenKind = "{[key: string]: "
+	closeMap   typeTokenKind = "}"
+	identifier typeTokenKind = "x"
+	array      typeTokenKind = "[]"
+	union      typeTokenKind = " | "
 )
 
 type typeToken struct {


### PR DESCRIPTION
string constants don't behave like iota.
With,

    type something string
    const (
        foo something = "foo"
        bar           = "bar"
    )

Only `foo` will have the type `something`.
`bar` will be an untyped string literal.

The type is copied over only when there's no rhs, e.g.

    type something int
    const (
        foo something = iota
        bar
    )

This adds types for constants
that were intended to have the type `typeTokenKind`.

Issue found by staticcheck:

```
codegen/testing/tstypes/tstypes.go:157:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
```

Refs #11808
