### PR TITLE
codgen/go/test: Replace ineffective sort

### DIFF
--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -211,13 +211,11 @@ func TestPackageNaming(t *testing.T) {
 			}
 			files, err := GeneratePackage("test", schema)
 			require.NoError(t, err)
-			ordering := make([]string, len(files))
-			var i int
+			ordering := make([]string, 0, len(files))
 			for k := range files {
-				ordering[i] = k
-				i++
+				ordering = append(ordering, k)
 			}
-			ordering = sort.StringSlice(ordering)
+			sort.Strings(ordering)
 			require.NotEmpty(t, files, "This test only works when files are generated")
 			for _, k := range ordering {
 				root := strings.Split(k, "/")[0]


### PR DESCRIPTION
`sort.StringSlice` is a type wrapper, not a function.

    type StringSlice []string

So `ordering = sort.StringSlice(ordering)` has no effect.

This replaces that with use of `sort.Strings`,
whic has the desired effect of sorting the slice in place.

Also drops the unnecesary index tracking to append into the slice
in favor of appends.

Issue caught by staticcheck:

```
codegen/go/gen_test.go:220:4: SA4029: sort.StringSlice is a type, not a function, and sort.StringSlice(ordering) doesn't sort your values; consider using sort.Strings instead (staticcheck)
```

Refs #11808
