### PR TITLE
sdk/go/generate: Replace incorrect TrimRight with TrimSuffix

### DIFF
--- a/sdk/go/pulumi/generate/main.go
+++ b/sdk/go/pulumi/generate/main.go
@@ -339,13 +339,7 @@ func main() {
 			log.Fatalf("code generation failed: %v", err.Error())
 		}
 
-		parts := strings.Split(t.Name(), "-")
-		filename := strings.TrimRight(parts[len(parts)-1], ".template")
-		parts[len(parts)-1] = filename
-
-		paths := append([]string{pwd}, parts...)
-
-		fullname := filepath.Join(paths...)
+		fullname := filepath.Join(pwd, templateFilePath(t.Name()))
 		f, err := os.Create(fullname)
 		if err != nil {
 			log.Fatalf("failed to create %v: %v", fullname, err)
@@ -370,4 +364,23 @@ func main() {
 			log.Fatalf("failed to gofmt %v: %v", fullname, err)
 		}
 	}
+}
+
+// Determines the relative file path for a templated file
+// given the name of the template.
+//
+// Dashes in template names are converted to directory separators
+// and the .template suffix is removed.
+//
+// For example:
+//
+//	foo-bar.go.template      => foo/bar.go
+//	bar.go.template          => bar.go
+//	fizz-buz-bar.go.template => fizz/buz/bar.go
+func templateFilePath(name string) string {
+	parts := strings.Split(name, "-")
+	filename := strings.TrimSuffix(parts[len(parts)-1], ".template")
+	parts[len(parts)-1] = filename
+	return filepath.Join(parts...)
+
 }

--- a/sdk/go/pulumi/generate/main_test.go
+++ b/sdk/go/pulumi/generate/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplateFilePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		give string
+		want string
+	}{
+		{"foo-bar.go.template", "foo/bar.go"},
+		{"bar.go.template", "bar.go"},
+		{"fizz-buz-bar.go.template", "fizz/buz/bar.go"},
+		{"foo-bar.tmpl.template", "foo/bar.tmpl"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.give, func(t *testing.T) {
+			t.Parallel()
+
+			got := templateFilePath(tt.give)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Code in go/pulumi/generate that determines the destination file path
based on the name of the template
incorrectly used TrimRight instead of TrimSuffix.

TrimRight removes all instances
of *any* of the provided characters (referred to as the cutset)
from the provided string
instead of removing just a fixed suffix.
So if we tried to generate say, a .tmpl file,
it would have stripped that from the destination file path too.

This switches to TrimSuffix, which is what was intended here,
and adds a test to verify the desired behavior.

Issue caught by staticcheck:

```
go/pulumi/generate/main.go:343:54: SA1024: cutset contains duplicate characters (staticcheck)
```

Refs #11808
