### PR TITLE
pkg: Drop unnecessary printfs

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1624,7 +1624,7 @@ func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.Stack
 	}
 	id := resp.ID
 
-	fmt.Printf(opts.Color.Colorize(colors.SpecHeadline + "Preparing deployment..." + colors.Reset + "\n\n"))
+	fmt.Print(opts.Color.Colorize(colors.SpecHeadline + "Preparing deployment..." + colors.Reset + "\n\n"))
 
 	if !opts.SuppressPermalink && !opts.JSONDisplay && resp.ConsoleURL != "" {
 		fmt.Printf(opts.Color.Colorize(
@@ -1641,7 +1641,7 @@ func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.Stack
 
 		for _, l := range logs.Lines {
 			if l.Header != "" {
-				fmt.Printf(opts.Color.Colorize(
+				fmt.Print(opts.Color.Colorize(
 					"\n" + colors.SpecHeadline + l.Header + ":" + colors.Reset + "\n"))
 
 				// If we see it's a Pulumi operation, rather than outputting the deployment logs,

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2257,7 +2257,7 @@ func ${fn}Output(ctx *pulumi.Context, args ${fn}OutputArgs, opts ...pulumi.Invok
 
 	code = strings.ReplaceAll(code, "${fn}", originalName)
 	code = strings.ReplaceAll(code, "${outputType}", resultTypeName)
-	fmt.Fprintf(w, code)
+	fmt.Fprint(w, code)
 
 	pkg.genInputArgsStruct(w, name+"Args", f.Inputs.InputShape)
 
@@ -2285,7 +2285,7 @@ func init() {
 
 `
 	initCode = strings.ReplaceAll(initCode, "${outputType}", resultTypeName)
-	fmt.Fprintf(w, initCode)
+	fmt.Fprint(w, initCode)
 }
 
 type objectProperty struct {

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1085,8 +1085,8 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 	typesString := types.String()
 	if typesString != "" {
 		fmt.Fprintf(w, "\nexport namespace %s {\n", name)
-		fmt.Fprintf(w, typesString)
-		fmt.Fprintf(w, "}\n")
+		fmt.Fprint(w, typesString)
+		fmt.Fprint(w, "}\n")
 		info.methodsNamespaceName = name
 	}
 	return info, nil

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -433,7 +433,7 @@ func relPathToRelImport(relPath string) string {
 func (mod *modContext) genUtilitiesFile() ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	genStandardHeader(buffer, mod.tool)
-	fmt.Fprintf(buffer, utilitiesFile)
+	fmt.Fprint(buffer, utilitiesFile)
 	optionalURL := "None"
 	pkg, err := mod.pkg.Definition()
 	if err != nil {
@@ -1858,7 +1858,7 @@ func (mod *modContext) genFunDef(w io.Writer, name, retTypeName string, args []*
 	if len(args) > 0 {
 		indent = strings.Repeat(" ", len(def))
 	}
-	fmt.Fprintf(w, def)
+	fmt.Fprint(w, def)
 	for i, arg := range args {
 		var ind string
 		if i != 0 {


### PR DESCRIPTION
A couple places in pkg/ use Printf without any arguments.
These cases can use the input strings as-is instead.

This changes switches them to the Print variant.

Issues found by staticcheck:

    backend/httpstate/backend.go:1627:2: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
    backend/httpstate/backend.go:1644:5: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
    codegen/go/gen.go:2260:2: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
    codegen/nodejs/gen.go:1088:3: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
    codegen/python/gen.go:1861:2: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
    codegen/python/gen.go:436:2: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)


Refs #11808
