### PR TITLE
pkg: Fix unnecessary appends

### DIFF
--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -145,7 +145,6 @@ func Linearize(p *Program) []Node {
 //
 // The resultant program should be a shallow copy of the source with only the modified resource nodes copied.
 func MapProvidersAsResources(p *Program) {
-	nodes := make([]Node, 0, len(p.Nodes))
 	for _, n := range p.Nodes {
 		if r, ok := n.(*Resource); ok {
 			pkg, mod, name, _ := r.DecomposeToken()
@@ -154,8 +153,6 @@ func MapProvidersAsResources(p *Program) {
 				r.Token = name + "::Provider"
 			}
 		}
-
-		nodes = append(nodes, n)
 	}
 }
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2187,9 +2187,9 @@ func getRewritePath(pkg string, gopath string, depRoot string) string {
 		repoName := splitPkg[2]
 		basePath := splitPkg[len(splitPkg)-1]
 		if basePath == repoName {
-			depParts = append([]string{depRoot, repoName})
+			depParts = []string{depRoot, repoName}
 		} else {
-			depParts = append([]string{depRoot, repoName, basePath})
+			depParts = []string{depRoot, repoName, basePath}
 		}
 		return filepath.Join(depParts...)
 	}


### PR DESCRIPTION
Removes unnecessary appends in pkg.
There were two instances:

- append into a slice that's never used again
- append with nothing to append (`append([]{foo}) == []{foo}`)

Issue found by staticcheck:

```
testing/integration/program.go:2190:15: SA4021: x = append(y) is equivalent to x = y (staticcheck)
testing/integration/program.go:2192:15: SA4021: x = append(y) is equivalent to x = y (staticcheck)
codegen/pcl/utilities.go:158:11: SA4010: this result of append is never used, except maybe in other appends (staticcheck)
```

Refs #11808
