### PR TITLE
test/integration: defer close after successful open

### DIFF
--- a/tests/integration/appdash_test.go
+++ b/tests/integration/appdash_test.go
@@ -14,11 +14,10 @@ func ReadMemoryStoreFromFile(file string) (*appdash.MemoryStore, error) {
 	store := appdash.NewMemoryStore()
 
 	traceFile, err := os.Open(file)
-	defer traceFile.Close()
-
 	if err != nil {
 		return nil, err
 	}
+	defer traceFile.Close()
 
 	_, err = store.ReadFrom(traceFile)
 	if err != nil {


### PR DESCRIPTION
The pattern,

    f, err := os.Open(..)
    defer f.Close()
    if err != nil { return }

Isn't quite right because the contract
for functions that return err, unless otherwise specified,
is that if `err != nil`, then the other results are invalid.

So if `os.Open` fails, the `f` should be considered invalid,
and we should not defer close on it because that could panic.
[`os.File.Close` guards against this][1],
but it's still preferable to defer the close after the error check.

    f, err := os.Open(..)
    if err != nil { return }
    defer f.Close()

  [1]: https://cs.opensource.google/go/go/+/refs/tags/go1.19.5:src/os/file_posix.go;l=21

Issue caught by staticcheck:

```
integration/appdash_test.go:17:2: SA5001: should check returned error before deferring traceFile.Close() (staticcheck)
```

Refs #11808
