### PR TITLE
sdk/plugin: Delete unused tracingToFile field

### DIFF
--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -298,7 +298,6 @@ func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
 	args := buildPluginArguments(pluginArgumentOptions{
 		pluginArgs:      pluginArgs,
 		tracingEndpoint: cmdutil.TracingEndpoint,
-		tracingToFile:   cmdutil.TracingToFile,
 		logFlow:         logging.LogFlow,
 		logToStderr:     logging.LogToStderr,
 		verbose:         logging.Verbose,
@@ -411,10 +410,10 @@ func execPlugin(ctx *Context, bin, prefix string, kind workspace.PluginKind,
 }
 
 type pluginArgumentOptions struct {
-	pluginArgs                          []string
-	tracingEndpoint                     string
-	tracingToFile, logFlow, logToStderr bool
-	verbose                             int
+	pluginArgs           []string
+	tracingEndpoint      string
+	logFlow, logToStderr bool
+	verbose              int
 }
 
 func buildPluginArguments(opts pluginArgumentOptions) []string {


### PR DESCRIPTION
The unused tracingToFile on pluginArgumentOptions
caused a reference to cmdutil.TracingToFile
which has been deprecated.

Issue caught by staticcheck:

```
go/common/resource/plugin/plugin.go:301:20: SA1019: cmdutil.TracingToFile is deprecated: Even in this case TracingEndpoint will now have the tcp:// scheme and will point to a proxy server that will append traces to the user-specified file. Plugins should respect TracingEndpoint and ignore TracingToFile. (staticcheck)
```

Refs #11808
