### PR TITLE
sdk/context/test: Explicitly sleep for 10 nanoseconds

### DIFF
--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -90,7 +90,7 @@ func NewLoggingTestResource(
 	}
 
 	resource.TestOutput = input.ToStringOutput().ApplyT(func(inputValue string) (string, error) {
-		time.Sleep(10)
+		time.Sleep(10 * time.Nanosecond)
 		err := ctx.Log.Debug("Zzz", &LogArgs{})
 		assert.NoError(t, err)
 		return inputValue, nil


### PR DESCRIPTION
`time.Sleep(10)` is perceived as a bug because there's no unit.
If the author was coming from another programming language
they could have meant milliseconds or seconds (unlikely).

Make the nanosecond unit explicit.

Issue caught by staticcheck:

```
go/pulumi/context_test.go:93:14: SA1004: sleeping for 10 nanoseconds is probably a bug; be explicit if it isn't (staticcheck)
```

Refs #7661
Refs #11808

---

I'm not sure if this was actually intended to be nanoseconds.
The test still passes with milliseconds and microseconds,
although with milliseconds
it takes a lot longer because of the many iterations.

CC @t0yv0, in case you remember the unit you wanted here.
