### PR TITLE
[sdk/nodejs] - Add support for custom naming of dynamic provider resource

### DIFF
--- a/changelog/pending/20230114--sdk-nodejs--add-support-for-custom-naming-of-dynamic-provider-resource.yaml
+++ b/changelog/pending/20230114--sdk-nodejs--add-support-for-custom-naming-of-dynamic-provider-resource.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Add support for custom naming of dynamic provider resource.

--- a/sdk/nodejs/dynamic/index.ts
+++ b/sdk/nodejs/dynamic/index.ts
@@ -199,15 +199,17 @@ export abstract class Resource extends resource.CustomResource {
      * @param props The arguments to use to populate the new resource. Must not define the reserved
      *              property "__provider".
      * @param opts A bag of options that control this resource's behavior.
+     * @param module The module of the resource.
+     * @param type The type of the resource.
      */
     constructor(provider: ResourceProvider, name: string, props: Inputs,
-                opts?: resource.CustomResourceOptions) {
+                opts?: resource.CustomResourceOptions, module?: string, type: string = "Resource") {
         const providerKey: string = "__provider";
         if (props[providerKey]) {
             throw new Error("A dynamic resource must not define the __provider key");
         }
         props[providerKey] = serializeProvider(provider);
 
-        super("pulumi-nodejs:dynamic:Resource", name, props, opts);
+        super(`pulumi-nodejs:dynamic${module ? `/${module}` : ""}:${type}`, name, props, opts);
     }
 }

--- a/tests/integration/dynamic/nodejs-resource-type-name/Pulumi.yaml
+++ b/tests/integration/dynamic/nodejs-resource-type-name/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nodejs_resource_type_name
+runtime: nodejs
+description: A simple Nodejs program that uses dynamic providers with custom resource type name.

--- a/tests/integration/dynamic/nodejs-resource-type-name/index.ts
+++ b/tests/integration/dynamic/nodejs-resource-type-name/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2016-2022, Pulumi Corporation.
+
+import * as pulumi from '@pulumi/pulumi'
+
+class CustomResource extends pulumi.dynamic.Resource {
+  constructor (name: string, opts?: pulumi.ResourceOptions) {
+    super(new DummyResourceProvider(), name, {}, opts, "custom-provider", "CustomResource")
+  }
+}
+
+class DummyResourceProvider implements pulumi.dynamic.ResourceProvider {
+  async create (props: any): Promise<pulumi.dynamic.CreateResult> {
+    return { id: "resource-id", outs: {} }
+  }
+}
+
+const resource = new CustomResource('resource-name')
+
+export const urn = resource.urn

--- a/tests/integration/dynamic/nodejs-resource-type-name/package.json
+++ b/tests/integration/dynamic/nodejs-resource-type-name/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nodejs-resource-type-name",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^4.5.4"
+  },
+  "peerDependencies": {
+    "@pulumi/pulumi": "latest"
+  }
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1297,3 +1297,17 @@ func TestDeletedWithNode(t *testing.T) {
 		Quick: true,
 	})
 }
+
+// Tests custom resource type name of dynamic provider.
+func TestCustomResourceTypeNameDynamicNode(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("dynamic", "nodejs-resource-type-name"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			urnOut := stack.Outputs["urn"].(string)
+			urn := resource.URN(urnOut)
+			typ := urn.Type().String()
+			assert.Equal(t, "pulumi-nodejs:dynamic/custom-provider:CustomResource", typ)
+		},
+	})
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11856 

Added two new optional constructor parameters to `pulumi.dynamic.Resource`, `module`, and `type`, which enables custom type naming of dynamic provider resources.

Based on the Python implementation from [here](https://github.com/pulumi/pulumi/pull/7633).

### Before
All dynamic provider resources would have the type `pulumi-nodejs:dynamic:Resource`

### After

Usage:
```ts
class CustomResource extends pulumi.dynamic.Resource {
  constructor (name: string, opts?: pulumi.ResourceOptions) {
    super(new DummyResourceProvider(), name, {}, opts, "custom-provider", "CustomResource")
  }
}
```
Output: `pulumi-nodejs:dynamic/custom-provider:CustomResource`



## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
