### PR TITLE
ApplyT, ApplyTWithContext: De-dupe validation

### DIFF
--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -1147,3 +1147,132 @@ func TestJSONUnmarshalBasic(t *testing.T) {
 	assert.NotNil(t, v)
 	assert.Equal(t, []interface{}{0.0, 1.0}, v.([]interface{}))
 }
+
+func TestApplier_Call(t *testing.T) {
+	t.Parallel()
+
+	stringType := reflect.TypeOf("")
+
+	t.Run("minimal", func(t *testing.T) {
+		t.Parallel()
+
+		ap, err := newApplier(func(s string) int {
+			assert.Equal(t, "hello", s)
+			return 42
+		}, stringType)
+		require.NoError(t, err)
+
+		o, err := ap.Call(context.Background(), reflect.ValueOf("hello"))
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), o.Int())
+	})
+
+	t.Run("context", func(t *testing.T) {
+		t.Parallel()
+
+		giveCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ap, err := newApplier(func(ctx context.Context, s string) int {
+			// == check because we want an exact reference match,
+			// not a deep equals.
+			assert.True(t, ctx == giveCtx, "context must match")
+			assert.Equal(t, "hello", s)
+			return 42
+		}, stringType)
+		require.NoError(t, err)
+
+		o, err := ap.Call(giveCtx, reflect.ValueOf("hello"))
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), o.Int())
+	})
+
+	t.Run("error/success", func(t *testing.T) {
+		t.Parallel()
+
+		ap, err := newApplier(func(string) (int, error) {
+			return 42, nil
+		}, stringType)
+		require.NoError(t, err)
+
+		o, err := ap.Call(context.Background(), reflect.ValueOf("hello"))
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), o.Int())
+	})
+
+	t.Run("error/failure", func(t *testing.T) {
+		t.Parallel()
+
+		giveErr := errors.New("great sadness")
+
+		ap, err := newApplier(func(string) (int, error) {
+			return 0, giveErr
+		}, stringType)
+		require.NoError(t, err)
+
+		_, err = ap.Call(context.Background(), reflect.ValueOf("hello"))
+		// == check because we want an exact reference match,
+		// not a deep equals.
+		assert.True(t, err == giveErr, "error must match")
+	})
+}
+
+func TestNewApplier_errors(t *testing.T) {
+	t.Parallel()
+
+	stringType := reflect.TypeOf("")
+	tests := []struct {
+		desc string
+		give interface{}
+
+		// Part of the error message expected in return.
+		wantErr string
+	}{
+		{
+			desc:    "no params",
+			give:    func() int { return 0 },
+			wantErr: "applier must accept exactly one or two parameters, got 0",
+		},
+		{
+			desc:    "single param bad input",
+			give:    func(int) int { return 0 },
+			wantErr: "applier's first input parameter must be assignable from string, got int",
+		},
+		{
+			desc:    "two params bad context",
+			give:    func(int, string) int { return 0 },
+			wantErr: "applier's first input parameter must be assignable from context.Context, got int",
+		},
+		{
+			desc:    "two params bad input",
+			give:    func(context.Context, int) int { return 0 },
+			wantErr: "applier's second input parameter must be assignable from string, got int",
+		},
+		{
+			desc:    "three params",
+			give:    func(context.Context, string, int) int { return 0 },
+			wantErr: "applier must accept exactly one or two parameters, got 3",
+		},
+		{
+			desc:    "no returns",
+			give:    func(string) {},
+			wantErr: "applier must return exactly one or two values, got 0",
+		},
+		{
+			desc:    "two returns bad error",
+			give:    func(string) (int, int) { return 0, 0 },
+			wantErr: "applier's second return type must be assignable to error, got int",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newApplier(tt.give, stringType)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
ApplyT duplicates the applier validation logic used by ApplyTWithContext
with the exception that it expects one parameter instead of two.
It then wraps the applier in a wrapper function which ignores the context,
and passes it on to ApplyTWithContext,
which validates the function *again*.

This change de-dupes the validation logic
by introducing an internal "applier" object.
This object represents validated and normalized versions
of user-supplied appliers.

Given an applier object, ApplyTWithContext can use applier.Call
and always pass in a context, and always expect an error return.

    o, err := ap.Call(ctx, i)

This change is made in service to #11783 and #11784
