### PR TITLE
Don't marshal/unmarshal deployments for import/export

### DIFF
--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -430,8 +431,12 @@ func TestHtmlEscaping(t *testing.T) {
 	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrsts */)
 	assert.NoError(t, err)
 
-	data, err := json.Marshal(sdep)
+	data, err := encoding.JSON.Marshal(sdep)
 	assert.NoError(t, err)
+
+	// Ensure data has the string contents "<html@tags>"", not "\u003chtml\u0026tags\u003e"
+	// ImportDeployment below should not modify the data
+	assert.Contains(t, string(data), "<html@tags>")
 
 	udep := &apitype.UntypedDeployment{
 		Version:    3,

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -79,6 +79,28 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(m encoding.Marshaler, bytes 
 	}
 }
 
+func MarshalUntypedDeploymentToVersionedCheckpoint(
+	stack tokens.Name, deployment *apitype.UntypedDeployment) (*apitype.VersionedCheckpoint, error) {
+
+	chk := struct {
+		Stack  tokens.QName
+		Latest json.RawMessage
+	}{
+		Stack:  stack.Q(),
+		Latest: deployment.Deployment,
+	}
+
+	bytes, err := encoding.JSON.Marshal(chk)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling checkpoint: %w", err)
+	}
+
+	return &apitype.VersionedCheckpoint{
+		Version:    deployment.Version,
+		Checkpoint: bytes,
+	}, nil
+}
+
 // SerializeCheckpoint turns a snapshot into a data structure suitable for serialization.
 func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
 	sm secrets.Manager, showSecrets bool) (*apitype.VersionedCheckpoint, error) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

ImportDeployment and ExportDeployment for the filestate backend would try to fully serialize/deserialize both the current deployment data for the stack, and for import also the new deployment data. This would require the creating of secret managers and possibly the prompting for passphrases.

It was all unnecessary, Import/Export is defined in terms of untyped deployments. We can just do a simple marshal to/from the checkpoint structure rather than doing a full deployment serialization/deserialization.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
