### PR TITLE
fix panic when Pulumi.yaml has a provider with an empty/unspecified path key

### DIFF
--- a/changelog/pending/20230117--cli-display--fixes-11864-pulumi-panics-when-pulumi-yaml-provider-plugin-does-not-have-a-path-provided.yaml
+++ b/changelog/pending/20230117--cli-display--fixes-11864-pulumi-panics-when-pulumi-yaml-provider-plugin-does-not-have-a-path-provided.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: "Fixes #11864. Pulumi panics before main when Pulumi.yaml provider plugin does not have a path provided."

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -238,6 +238,11 @@
         "pluginOptions":{
             "title":"PluginOptions",
             "type":"object",
+            "additionalProperties":false,
+            "required":[
+                "name",
+                "path"
+            ],
             "properties":{
                 "name":{
                     "type":"string",


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11864 

This PR introduces a change such that Pulumi no longer panics before main when the Pulumi.yaml contains a provider plugin that has an empty/unspecified `path` key.

This PR removes the `contract.AssertNoError()` call and modifies the function to return the error. Instead of panicking, the error is now contained in the `DefaultPulumiPackageError` variable.

In terms of usage, it appears that [pulumi-lsp](https://github.com/pulumi/pulumi-lsp/blob/d5e1d1ef3750479a17e351675b0dfee654de61c0/sdk/yaml/completion.go#L353) uses this variable.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
