### PR TITLE
update package details anchors

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -130,6 +130,7 @@ func titleLookup(shortName string) (string, bool) {
 		"opsgenie":                             "Opsgenie",
 		"packet":                               "Packet",
 		"pagerduty":                            "PagerDuty",
+		"pulumi-std":                           "Pulumi Standard Library",
 		"postgresql":                           "PostgreSQL",
 		"prometheus-helm":                      "Prometheus (Helm)",
 		"rabbitmq":                             "RabbitMQ",

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1637,9 +1637,11 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 	def, err := mod.pkg.Definition()
 	contract.AssertNoError(err)
 	packageDetails := packageDetails{
-		Repository: def.Repository,
-		License:    def.License,
-		Notes:      def.Attribution,
+		DisplayName:    getPackageDisplayName(def.Name),
+		Repository:     def.Repository,
+		RepositoryName: getRepositoryName(def.Repository),
+		License:        def.License,
+		Notes:          def.Attribution,
 	}
 
 	renderedCtorParams, typedCtorParams := mod.genConstructors(r, allOptionalInputs)

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -299,10 +299,12 @@ type formalParam struct {
 }
 
 type packageDetails struct {
-	Repository string
-	License    string
-	Notes      string
-	Version    string
+	DisplayName    string
+	Repository     string
+	RepositoryName string
+	License        string
+	Notes          string
+	Version        string
 }
 
 type resourceDocArgs struct {
@@ -1633,7 +1635,6 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 
 	def, err := mod.pkg.Definition()
 	contract.AssertNoError(err)
-
 	packageDetails := packageDetails{
 		Repository: def.Repository,
 		License:    def.License,
@@ -1913,10 +1914,12 @@ func (mod *modContext) genIndex() indexData {
 	}
 
 	packageDetails := packageDetails{
-		Repository: def.Repository,
-		License:    def.License,
-		Notes:      def.Attribution,
-		Version:    version,
+		DisplayName:    getPackageDisplayName(def.Name),
+		Repository:     def.Repository,
+		RepositoryName: getRepositoryName(def.Repository),
+		License:        def.License,
+		Notes:          def.Attribution,
+		Version:        version,
 	}
 
 	var titleTag string
@@ -1959,6 +1962,11 @@ func getPackageDisplayName(title string) string {
 		return val
 	}
 	return title
+}
+
+// getRepositoryName returns the repository name based on the repository's URL.
+func getRepositoryName(repoURL string) string {
+	return strings.TrimPrefix(repoURL, "https://github.com/")
 }
 
 func (dctx *docGenContext) getMod(

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -464,9 +464,11 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 	contract.AssertNoError(err)
 
 	packageDetails := packageDetails{
-		Repository: def.Repository,
-		License:    def.License,
-		Notes:      def.Attribution,
+		DisplayName:    getPackageDisplayName(def.Name),
+		Repository:     def.Repository,
+		RepositoryName: getRepositoryName(def.Repository),
+		License:        def.License,
+		Notes:          def.Attribution,
 	}
 
 	docInfo := dctx.decomposeDocstring(f.Comment)

--- a/pkg/codegen/docs/templates/package_details.tmpl
+++ b/pkg/codegen/docs/templates/package_details.tmpl
@@ -2,7 +2,7 @@
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="{{ htmlSafe .Repository }}">{{ htmlSafe .Repository }}</a></dd>
+	<dd><a href="{{ htmlSafe .Repository }}">{{ htmlSafe .DisplayName }} {{ htmlSafe .RepositoryName }}</a></dd>
 	<dt>License</dt>
 	<dd>{{ htmlSafe .License }}</dd>
     {{- if ne .Notes "" }}

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/_index.md
@@ -24,7 +24,7 @@ A native Pulumi package for creating and managing Azure resources.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-azure-native">https://github.com/pulumi/pulumi-azure-native</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-azure-native">Azure Native pulumi/pulumi-azure-native</a></dd>
 	<dt>License</dt>
 	<dd>Apache-2.0</dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/_index.md
@@ -19,7 +19,7 @@ Explore the resources and functions of the azure-native.documentdb module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-azure-native">https://github.com/pulumi/pulumi-azure-native</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-azure-native">Azure Native pulumi/pulumi-azure-native</a></dd>
 	<dt>License</dt>
 	<dd>Apache-2.0</dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -1086,7 +1086,7 @@ $ pulumi import azure-native:documentdb:SqlResourceSqlContainer containerName /s
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-azure-native">https://github.com/pulumi/pulumi-azure-native</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-azure-native"> </a></dd>
 	<dt>License</dt>
 	<dd>Apache-2.0</dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/documentdb/sqlresourcesqlcontainer/_index.md
@@ -1086,7 +1086,7 @@ $ pulumi import azure-native:documentdb:SqlResourceSqlContainer containerName /s
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-azure-native"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-azure-native">Azure Native pulumi/pulumi-azure-native</a></dd>
 	<dt>License</dt>
 	<dd>Apache-2.0</dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-azure-native"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-azure-native">Azure Native pulumi/pulumi-azure-native</a></dd>
 	<dt>License</dt>
 	<dd>Apache-2.0</dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-azure-native">https://github.com/pulumi/pulumi-azure-native</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-azure-native"> </a></dd>
 	<dt>License</dt>
 	<dd>Apache-2.0</dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/cyclic-types/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/docs/_index.md
@@ -19,7 +19,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/_index.md
@@ -20,7 +20,7 @@ Explore the resources and functions of the foo-bar.submodule1 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/fooencryptedbarclass/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -498,7 +498,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -498,7 +498,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/_index.md
@@ -19,7 +19,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/_index.md
@@ -20,7 +20,7 @@ Explore the resources and functions of the plant.tree/v1 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -603,7 +603,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -603,7 +603,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -1508,7 +1508,7 @@ The following state arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -1508,7 +1508,7 @@ The following state arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/_index.md
@@ -19,7 +19,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/_index.md
@@ -20,7 +20,7 @@ Explore the resources and functions of the plant.tree/v1 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
@@ -603,7 +603,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
@@ -603,7 +603,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -1508,7 +1508,7 @@ The following state arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -1508,7 +1508,7 @@ The following state arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/_index.md
@@ -19,7 +19,7 @@ Explore the resources and functions of the example.myModule module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
@@ -511,7 +511,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
@@ -511,7 +511,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/_index.md
@@ -27,7 +27,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
@@ -883,7 +883,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
@@ -883,7 +883,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
@@ -797,7 +797,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
@@ -797,7 +797,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/workload/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/docs/funcwithsecrets/_index.md
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/docs/funcwithsecrets/_index.md
@@ -478,7 +478,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/docs/funcwithsecrets/_index.md
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/docs/funcwithsecrets/_index.md
@@ -478,7 +478,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">registrygeoreplication </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">registrygeoreplication </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
@@ -522,7 +522,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/docs/registrygeoreplication/_index.md
@@ -522,7 +522,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">registrygeoreplication </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/_index.md
@@ -27,7 +27,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/maincomponent/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/maincomponent/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/maincomponent/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/maincomponent/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/_index.md
@@ -20,7 +20,7 @@ Explore the resources and functions of the example.mod module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component/_index.md
@@ -457,7 +457,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component/_index.md
@@ -457,7 +457,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component2/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component2/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component2/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component2/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resource/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/resourceinput/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/_index.md
@@ -19,7 +19,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/_index.md
@@ -19,7 +19,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/_index.md
@@ -19,7 +19,7 @@ Explore the resources and functions of the foo-bar.deeply/nested/module module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foo-bar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/nested/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/nested/_index.md
@@ -19,7 +19,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/_index.md
@@ -19,7 +19,7 @@ Explore the resources and functions of the foo.nested/module module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foo </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foo </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foo </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/_index.md
@@ -31,7 +31,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
@@ -591,7 +591,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
@@ -591,7 +591,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
@@ -1106,7 +1106,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
@@ -1106,7 +1106,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/_index.md
@@ -25,7 +25,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">myedgeorder </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
@@ -4651,7 +4651,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">myedgeorder </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
@@ -4651,7 +4651,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
@@ -5719,7 +5719,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">myedgeorder </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
@@ -5719,7 +5719,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">myedgeorder </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/_index.md
@@ -25,7 +25,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
@@ -996,7 +996,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
@@ -996,7 +996,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
@@ -673,7 +673,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
@@ -673,7 +673,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/_index.md
@@ -33,7 +33,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
@@ -348,7 +348,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
@@ -348,7 +348,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithconstinput/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithconstinput/_index.md
@@ -141,7 +141,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithconstinput/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithconstinput/_index.md
@@ -141,7 +141,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
@@ -336,7 +336,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
@@ -336,7 +336,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
@@ -336,7 +336,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
@@ -336,7 +336,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithemptyoutputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithemptyoutputs/_index.md
@@ -195,7 +195,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithemptyoutputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithemptyoutputs/_index.md
@@ -195,7 +195,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
@@ -336,7 +336,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
@@ -336,7 +336,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
@@ -511,7 +511,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
@@ -511,7 +511,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
@@ -351,7 +351,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getclientconfig/_index.md
@@ -351,7 +351,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
@@ -3237,7 +3237,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
@@ -3237,7 +3237,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
@@ -673,7 +673,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
@@ -673,7 +673,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">foobar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
@@ -1105,7 +1105,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foobar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
@@ -1105,7 +1105,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">foobar </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
@@ -1377,7 +1377,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
@@ -1377,7 +1377,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -556,7 +556,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -556,7 +556,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/mod1/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/mod1/_index.md
@@ -14,7 +14,7 @@ Explore the resources and functions of the example.mod1 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/mod2/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/mod2/_index.md
@@ -14,7 +14,7 @@ Explore the resources and functions of the example.mod2 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
@@ -863,7 +863,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
@@ -863,7 +863,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
@@ -620,7 +620,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
@@ -620,7 +620,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
@@ -1377,7 +1377,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
@@ -1377,7 +1377,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -556,7 +556,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -556,7 +556,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/mod1/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/mod1/_index.md
@@ -14,7 +14,7 @@ Explore the resources and functions of the example.mod1 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/mod2/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/mod2/_index.md
@@ -14,7 +14,7 @@ Explore the resources and functions of the example.mod2 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -863,7 +863,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -863,7 +863,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
@@ -620,7 +620,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
@@ -620,7 +620,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">xyz </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">xyz </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
@@ -607,7 +607,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">xyz </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
@@ -607,7 +607,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/_index.md
@@ -29,7 +29,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">configstation </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/config/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/config/_index.md
@@ -14,7 +14,7 @@ Explore the resources and functions of the configstation.config module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">configstation </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/funcwithalloptionalinputs/_index.md
@@ -348,7 +348,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/funcwithalloptionalinputs/_index.md
@@ -348,7 +348,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">configstation </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
@@ -657,7 +657,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">configstation </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
@@ -657,7 +657,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">MongoDB Atlas </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
@@ -222,7 +222,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/getcustomdbroles/_index.md
@@ -222,7 +222,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">MongoDB Atlas </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">MongoDB Atlas </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-8403/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">my8110 </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
@@ -197,7 +197,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">my8110 </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/examplefunc/_index.md
@@ -197,7 +197,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">my8110 </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
@@ -785,7 +785,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/cat/_index.md
@@ -785,7 +785,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/dog/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/god/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
@@ -545,7 +545,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/norecursive/_index.md
@@ -545,7 +545,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
@@ -1005,7 +1005,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/docs/toystore/_index.md
@@ -1005,7 +1005,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/_index.md
@@ -21,7 +21,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
@@ -547,7 +547,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
@@ -547,7 +547,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/_index.md
@@ -21,7 +21,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
@@ -547,7 +547,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
@@ -547,7 +547,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/docs/rec/_index.md
@@ -407,7 +407,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/secrets/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/secrets/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/secrets/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/secrets/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/secrets/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/secrets/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/secrets/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/secrets/docs/resource/_index.md
@@ -743,7 +743,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">mypkg </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/secrets/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/secrets/docs/resource/_index.md
@@ -743,7 +743,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/_index.md
@@ -24,7 +24,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/_index.md
@@ -19,7 +19,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/_index.md
@@ -20,7 +20,7 @@ Explore the resources and functions of the plant.tree/v1 module.
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -603,7 +603,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -603,7 +603,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -1508,7 +1508,7 @@ The following state arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">plant </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -1508,7 +1508,7 @@ The following state arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -576,7 +576,7 @@ The following arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -576,7 +576,7 @@ The following arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
@@ -1470,7 +1470,7 @@ The following arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
@@ -1470,7 +1470,7 @@ The following arguments are supported:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/_index.md
@@ -20,7 +20,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -1076,7 +1076,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -1076,7 +1076,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/_index.md
@@ -25,7 +25,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
@@ -1125,7 +1125,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
@@ -1125,7 +1125,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
@@ -521,7 +521,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/dofoo/_index.md
@@ -521,7 +521,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/_index.md
@@ -26,7 +26,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/_index.md
@@ -31,7 +31,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
@@ -354,7 +354,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
@@ -284,7 +284,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
@@ -591,7 +591,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
@@ -591,7 +591,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
@@ -456,7 +456,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
@@ -456,7 +456,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
@@ -1106,7 +1106,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
@@ -1106,7 +1106,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/_index.md
@@ -27,7 +27,7 @@ no_edit_this_page: true
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
@@ -282,7 +282,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
@@ -282,7 +282,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
@@ -403,7 +403,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
@@ -403,7 +403,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
@@ -408,7 +408,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
@@ -1557,7 +1557,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""> </a></dd>
+	<dd><a href="">example </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
@@ -1557,7 +1557,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href=""></a></dd>
+	<dd><a href=""> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/_index.md
@@ -33,7 +33,7 @@ Standard library functions
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 	<dt>Version</dt>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/abs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/abs/_index.md
@@ -335,7 +335,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/abs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/abs/_index.md
@@ -335,7 +335,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargs/_index.md
@@ -335,7 +335,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargs/_index.md
@@ -335,7 +335,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutput/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutput/_index.md
@@ -251,7 +251,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutput/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutput/_index.md
@@ -251,7 +251,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutputswapped/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutputswapped/_index.md
@@ -251,7 +251,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutputswapped/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutputswapped/_index.md
@@ -251,7 +251,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absreducedoutput/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absreducedoutput/_index.md
@@ -251,7 +251,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absreducedoutput/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absreducedoutput/_index.md
@@ -251,7 +251,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarchive/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarchive/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarchive/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarchive/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarraycustomresult/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarraycustomresult/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarraycustomresult/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarraycustomresult/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getasset/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getasset/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getasset/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getasset/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getcustomresult/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getcustomresult/_index.md
@@ -376,7 +376,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getcustomresult/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getcustomresult/_index.md
@@ -376,7 +376,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getdictionary/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getdictionary/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getdictionary/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getdictionary/_index.md
@@ -198,7 +198,7 @@ The following output properties are available:
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std"> </a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/provider/_index.md
@@ -359,7 +359,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
-	<dd><a href="https://github.com/pulumi/pulumi-std">https://github.com/pulumi/pulumi-std</a></dd>
+	<dd><a href="https://github.com/pulumi/pulumi-std">std pulumi/pulumi-std</a></dd>
 	<dt>License</dt>
 	<dd></dd>
 </dl>


### PR DESCRIPTION
fixes: https://github.com/pulumi/registry/issues/1819

OK taking this for round 2. The first [PR](https://github.com/pulumi/pulumi/pull/11861) to make this change I ended up reverting because there were some pages (the function pages and module pages) still being generated with empty href tags. 

I have addressed this and updated the change to define the DisplayName and RepositoryName props on the `packageDetails` struct for the individual module pages and function pages. This updates the repository anchor in the Package Details section of the api docs pages. I updated it to display `<package name> repository` for the anchor text in place of the url that was previously shown there. 

![image](https://user-images.githubusercontent.com/16751381/213036900-2938a9ad-1992-4170-9b83-0fbbcef409a0.png)

So now this will show the following on the following pages:
1. the root index package pages
2. the module pages
3. the resource pages
4. the function pages