### PR TITLE
Add support for a Teams array in the CreateStackRequest

### DIFF
--- a/changelog/pending/20230118--sdk--add-support-for-a-teams-array-in-the-createstackrequest-which-allows-specifying-teams-when-a-stack-is-created.yaml
+++ b/changelog/pending/20230118--sdk--add-support-for-a-teams-array-in-the-createstackrequest-which-allows-specifying-teams-when-a-stack-is-created.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: sdk
-  description: Add support for a Teams array in the CreateStackRequest which allows specifying Teams when a Stack is created.

--- a/changelog/pending/20230118--sdk--add-support-for-a-teams-array-in-the-createstackrequest-which-allows-specifying-teams-when-a-stack-is-created.yaml
+++ b/changelog/pending/20230118--sdk--add-support-for-a-teams-array-in-the-createstackrequest-which-allows-specifying-teams-when-a-stack-is-created.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk
+  description: Add support for a Teams array in the CreateStackRequest which allows specifying Teams when a Stack is created.

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -48,6 +48,9 @@ type CreateStackRequest struct {
 
 	// An optional set of tags to apply to the stack.
 	Tags map[StackTagName]string `json:"tags,omitempty"`
+
+	// An optional set of teams to assign to the stack.
+	Teams []string `json:"teams,omitempty"`
 }
 
 // CreateStackResponse is the response from a create Stack request.


### PR DESCRIPTION
# Description

Add support for a Teams array in the CreateStackRequest which allows specifying Teams when a Stack is created.

Updates #10784

Signed-off-by: Steve Sloka <steve@pulumi.com>

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
