### PR TITLE
ApplyT: Coerce new type wrappers

### DIFF
--- a/changelog/pending/20230118--sdk-go--coerces-outputs-to-applyt-functions-if-the-types-are-convertible.yaml
+++ b/changelog/pending/20230118--sdk-go--coerces-outputs-to-applyt-functions-if-the-types-are-convertible.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Coerces output values in ApplyT calls if the types are equivalent.


### PR DESCRIPTION
Adds support to ApplyT to automatically coerce new type wrappers
when calling the provided functions.

With this change, the following is valid:

    var idout pu.IDOutput = ...
    idout.ApplyT(func(id string) string {
        // ...
    })

Note that this does not use `To{Type}Output` methods at this time.
We will likely want to add that in the future given #11750.
We can do that in a backwards compatible way.

This coerces only those values that are defined
with language-level type wrappers in the following form:

    type ID string

This *does not* coerce types with different undedrlying representations.
Specifically, the following conversons are not supported
even though they're supported by Go using the `T(v)` syntax.

    string => int
    string => []byte
    []byte => string

The choice to convert between these types
should be made explicitly by the user
so that they get the semantics they want.

Resolves #11784
