### PR TITLE
sdk/go: Fix TestDependsOnInputs data race

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -133,6 +133,10 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 		return nil, err
 	}
 
+	if wrap := info.wrapResourceMonitorClient; wrap != nil {
+		monitor = wrap(monitor)
+	}
+
 	context := &Context{
 		ctx:                 ctx,
 		info:                info,

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/constant"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"google.golang.org/grpc"
 )
@@ -150,8 +151,12 @@ type RunInfo struct {
 	EngineAddr       string
 	Organization     string
 	Mocks            MockResourceMonitor
-	getPlugins       bool
-	engineConn       *grpc.ClientConn // Pre-existing engine connection. If set this is used over EngineAddr.
+
+	getPlugins bool
+	engineConn *grpc.ClientConn // Pre-existing engine connection. If set this is used over EngineAddr.
+
+	// If non-nil, wraps the resource monitor client used by Context.
+	wrapResourceMonitorClient func(pulumirpc.ResourceMonitorClient) pulumirpc.ResourceMonitorClient
 }
 
 // getEnvInfo reads various program information from the process environment.

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,6 +19,16 @@ import (
 func WithDryRun(dryRun bool) RunOption {
 	return func(r *RunInfo) {
 		r.DryRun = dryRun
+	}
+}
+
+// WrapResourceMonitorClient is an internal, test-only option
+// that wraps the ResourceMonitorClient used by Context.
+func WrapResourceMonitorClient(
+	wrap func(pulumirpc.ResourceMonitorClient) pulumirpc.ResourceMonitorClient,
+) RunOption {
+	return func(ri *RunInfo) {
+		ri.wrapResourceMonitorClient = wrap
 	}
 }
 


### PR DESCRIPTION
TestDependsOnInputs modified the `monitor` attached to the context
while the context was still using it.
This caused a data race:

```
WARNING: DATA RACE
Read at 0x00c00041d8d8 by goroutine 4280:
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*interceptingResourceMonitor).RegisterResource()
      [..]/pulumi/sdk/go/pulumi/resource_test.go:708 +0x44
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*Context).registerResource.func1()
      [..]/pulumi/sdk/go/pulumi/context.go:854 +0xd28

Previous write at 0x00c00041d8d8 by goroutine 2880:
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.newInterceptingResourceMonitor()
      [..]/pulumi/sdk/go/pulumi/resource_test.go:671 +0xac
```

Replacing the ResourceMonitorClient appears to be the only way
to get the information that the dependency tracker needs,
but replacing the client after Context creation is a data race.

To address this issue, introduce a new internal RunOption
that allows installing a ResourceMonitorClient middleware
at creation.

    WrapResourceMonitorClient(
        func(ResourceMonitorClient) ResourceMonitorClient,
    ) RunOpton

With this option present, we can decorate the client
with the dependency tracker when the context gets created
rather than afterwards.

This also simplifies the implementation
of the dependency tracker in the process.
That change is on a separate commit
so that it can be reviewed separately.

Refs #10092 
Depends on #11906
