### PR TITLE
sdk/Unsecret: Fix data race

### DIFF
--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -630,10 +630,8 @@ func Unsecret(input Output) Output {
 
 // UnsecretWithContext will unwrap a secret output as a new output with a resolved value and no secretness
 func UnsecretWithContext(ctx context.Context, input Output) Output {
-	var x bool
-	o := toOutputWithContext(ctx, input.getState().join, input, &x)
-	// set immediate secretness ahead of resolution/fulfillment
-	o.getState().secret = false
+	secret := false
+	o := toOutputWithContext(ctx, input.getState().join, input, &secret)
 	return o
 }
 


### PR DESCRIPTION
`pulumi.Unsecret` currently has an unconditional data race:

```
WARNING: DATA RACE
Write at 0x00c0000f80a9 by goroutine 132:
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*OutputState).fulfillValue()
      [..]/pulumi/sdk/go/pulumi/types.go:197 +0x3c4
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*OutputState).resolveValue()
      [..]/pulumi/sdk/go/pulumi/types.go:235 +0x2b0
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.toOutputTWithContext.func3()
      [..]/pulumi/sdk/go/pulumi/types.go:1060 +0x278

Previous write at 0x00c0000f80a9 by goroutine 130:
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.UnsecretWithContext()
      [..]/pulumi/sdk/go/pulumi/types.go:636 +0xd8
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.Unsecret()
      [..]/pulumi/sdk/go/pulumi/types.go:628 +0xa4
  github.com/pulumi/pulumi/sdk/v3/go/pulumi.TestUnsecret()
      [..]/pulumi/sdk/go/pulumi/types_test.go:502 +0x78
```

The data race is a bit flaky. To reproduce on master,
you'll want to run:

    go test -race -run TestUnsecret -count 100

The following:

    func UnsecretWithContext(ctx context.Context, input Output) Output {
        // ..
        o.getState().secret = false

Races with:

    func (o *OutputState) fulfillValue(value reflect.Value, known, secret bool, deps []Resource, err error) {
        // ...
        o.state, o.known, o.secret = outputResolved, known, secret

Where OutputState.fulfillValue is called by a goroutine
spawned by toOutputTWithContext,
which itself was called by UnsecretWithContext.

The line `o.getState().secret = false` in UnsecretWithContext
is unnecessary because of toOutputTWithContext's optional
`forceSecretVal` parameter:

    func toOutputTWithContext(..., forceSecretVal *bool) Output {

If this is non-nil, which it is in our call from ToSecret,
toOutputTWithContext already overrides the output state's secret field
with it:

    if forceSecretVal != nil {
        output.getState().secret = *forceSecretVal
    }

This value also takes precedence over the secret value of the Output
that we're currently unsecret-ing.

    known, secret, deps, err := awaitInputs(ctx, reflect.ValueOf(v), result)
    if forceSecretVal != nil {
        secret = *forceSecretVal
    }

This change addresses the data race by removing the unnecessary line.

Verification:

    % go test -race -run TestUnsecret -count 1000
    PASS
    ok      github.com/pulumi/pulumi/sdk/v3/go/pulumi       2.448s

Refs #10092
