### PR TITLE
sdk/py/stack: Original traceback in wait_for_rpcs

### DIFF
--- a/sdk/python/lib/test/runtime/test_stack.py
+++ b/sdk/python/lib/test/runtime/test_stack.py
@@ -1,0 +1,46 @@
+# Copyright 2023, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import traceback
+import pytest
+
+from pulumi.runtime import stack
+from pulumi.runtime.rpc_manager import RPC_MANAGER
+
+
+async def _explode(n = 10):
+    if n == 0:
+        raise Exception("sadness")
+    await _explode(n-1)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_rpcs():
+    """
+    Verifies that the exception produced by wait_for_rpcs
+    reproduces the original stack trace
+    rather than wait_for_rpcs's own stack trace.
+    """
+
+    await RPC_MANAGER.do_rpc("sadness", _explode)()
+    try:
+        await stack.wait_for_rpcs()
+    except Exception:
+        tb = "".join(traceback.format_tb(sys.exc_info()[2]))
+    else:
+        pytest.fail("Expected Exception")
+        tb = ""
+
+    assert "await _explode(n-1)" in tb


### PR DESCRIPTION
When the `await RPC_MANAGER.rpcs.pop()` explodes,
the traceback is for `RPC_MANAGER.rpcs.pop()`, e.g.

```
error: Program failed with an unhandled exception:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/pulumi/3.43.1/x64/pulumi-language-python-exec", line 179, in <module>
    loop.run_until_complete(coro)
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "[..]/venv/lib/python3.10/site-packages/pulumi/runtime/stack.py", line 126, in run_in_stack
    await run_pulumi_func(lambda: Stack(func))
  File "[..]/venv/lib/python3.10/site-packages/pulumi/runtime/stack.py", line 51, in run_pulumi_func
    await wait_for_rpcs()
  File "[..]/venv/lib/python3.10/site-packages/pulumi/runtime/stack.py", line 73, in wait_for_rpcs
    await RPC_MANAGER.rpcs.pop()
RecursionError: maximum recursion depth exceeded
```

This isn't super helpful in debugging these errors.

RPC_MANAGER already tracks uncaught excpetions from such RPCs
but wait_for_rpcs doesn't account for these until aftewards.

This changes wait_for_rpcs to reproduce the original tracebacks
when it encounters errors in waiting for RPCs.

The included test verifies that the more helpful traceback is produced.

Refs #11887
