### PR TITLE
pkg/hcl2/model: Make String methods thread-safe

### DIFF
--- a/pkg/codegen/hcl2/model/type_enum.go
+++ b/pkg/codegen/hcl2/model/type_enum.go
@@ -17,6 +17,7 @@ package model
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -52,7 +53,7 @@ type EnumType struct {
 	// Annotations records any annotations associated with the object type.
 	Annotations []interface{}
 
-	s string
+	s atomic.Value // Value<string>
 }
 
 func NewEnumType(token string, typ Type, elements []cty.Value, annotations ...interface{}) *EnumType {
@@ -166,16 +167,19 @@ func (t *EnumType) String() string {
 }
 
 func (t *EnumType) string(seen map[Type]struct{}) string {
-	if t.s == "" {
-		underlying := t.Type.string(seen)
-		elements := make([]string, len(t.Elements))
-		for i, e := range t.Elements {
-			elements[i] = e.GoString()
-		}
-
-		t.s = fmt.Sprintf("enum(%s(%s): %s)", t.Token, underlying, strings.Join(elements, ","))
+	if s := t.s.Load(); s != nil {
+		return s.(string)
 	}
-	return t.s
+
+	underlying := t.Type.string(seen)
+	elements := make([]string, len(t.Elements))
+	for i, e := range t.Elements {
+		elements[i] = e.GoString()
+	}
+
+	s := fmt.Sprintf("enum(%s(%s): %s)", t.Token, underlying, strings.Join(elements, ","))
+	t.s.Store(s)
+	return s
 }
 
 func (t *EnumType) unify(other Type) (Type, ConversionKind) {

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -32,7 +33,7 @@ type UnionType struct {
 	// Annotations records any annotations associated with the object type.
 	Annotations []interface{}
 
-	s string
+	s atomic.Value // Value<string>
 }
 
 // NewUnionTypeAnnotated creates a new union type with the given element types and annotations.
@@ -274,20 +275,23 @@ func (t *UnionType) String() string {
 }
 
 func (t *UnionType) string(seen map[Type]struct{}) string {
-	if t.s == "" {
-		elements := make([]string, len(t.ElementTypes))
-		for i, e := range t.ElementTypes {
-			elements[i] = e.string(seen)
-		}
-
-		annotations := ""
-		if len(t.Annotations) != 0 {
-			annotations = fmt.Sprintf(", annotated(%p)", t)
-		}
-
-		t.s = fmt.Sprintf("union(%s%v)", strings.Join(elements, ", "), annotations)
+	if s := t.s.Load(); s != nil {
+		return s.(string)
 	}
-	return t.s
+
+	elements := make([]string, len(t.ElementTypes))
+	for i, e := range t.ElementTypes {
+		elements[i] = e.string(seen)
+	}
+
+	annotations := ""
+	if len(t.Annotations) != 0 {
+		annotations = fmt.Sprintf(", annotated(%p)", t)
+	}
+
+	s := fmt.Sprintf("union(%s%v)", strings.Join(elements, ", "), annotations)
+	t.s.Store(s)
+	return s
 }
 
 func (t *UnionType) unify(other Type) (Type, ConversionKind) {


### PR DESCRIPTION
ObjectType.String and a few other types
do a fair bit of computation to build a string representation.
They memoize the result in an internal `s` field.
This causes a data race if two goroutines call `String()`
on the same object at the same time.

Tests in pkg/codegen/pcl ran into the following
from ObjectType.String.

```
WARNING: DATA RACE
Write at 0x00c00055c030 by goroutine 36:
  github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model.(*ObjectType).string()
      [..]/pulumi/pkg/codegen/hcl2/model/type_object.go:300 +0x418
  [.. snip ..]
  github.com/pulumi/pulumi/pkg/v3/codegen/pcl.TestApplyRewriter.func1()
      [..]/pulumi/pkg/codegen/pcl/rewrite_apply_test.go:176 +0x68
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.19.5/libexec/src/testing/testing.go:1446 +0x188
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.19.5/libexec/src/testing/testing.go:1493 +0x40

Previous read at 0x00c00055c030 by goroutine 37:
  github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model.(*ObjectType).string()
      [..]/pulumi/pkg/codegen/hcl2/model/type_object.go:276 +0x40
  github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model.(*OutputType).string()
      [..]/pulumi/pkg/codegen/hcl2/model/type_output.go:110 +0x4c
  [..]
```

To fix this, turn the memoized field into an `atomic.Value`
in all types that memoize it.

When two goroutines race to calculate this value,
one of them will do extra work that will be thrown away,
but it won't cause a data race.

Refs #10092
