### PR TITLE
Fix port string parsing on Windows

### DIFF
--- a/changelog/pending/20230119--engine--fix-launching-non-go-plugins-on-windows.yaml
+++ b/changelog/pending/20230119--engine--fix-launching-non-go-plugins-on-windows.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix launching non-Go plugins on Windows.

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -267,6 +267,9 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 		}
 		portString += string(b[:n])
 	}
+	// Trim any whitespace from the first line (this is to handle things like windows that will write
+	// "1234\r\n", or slightly odd providers that might add whitespace like "1234 ")
+	portString = strings.TrimSpace(portString)
 
 	// Parse the output line (minus the '\n') to ensure it's a numeric port.
 	var port int


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes launching plugins on Windows. Most runtimes will write out "1234\r\n" on Windows for the port number, we never noticed this before because Go _doesn't_ write "\r\n" for new lines even on Windows.

The plugin parse code would read up to the "\n", then try to parse all the characters before it (e.g. "1234\r") and fail on the line feed character.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
