### PR TITLE
pcl/codegen: Fix typeNameID data race

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -764,16 +764,8 @@ func (g *generator) GenUnaryOpExpression(w io.Writer, expr *model.UnaryOpExpress
 	g.Fgenf(w, "%[2]v%.[1]*[3]v", precedence, opstr, expr.Operand)
 }
 
-var typeNameID = 0
-
 // argumentTypeName computes the go type for the given expression and model type.
 func (g *generator) argumentTypeName(expr model.Expression, destType model.Type, isInput bool) (result string) {
-	//	defer func(id int, t model.Type) {
-	//		schemaType, _ := pcl.GetSchemaForType(destType)
-	//		log.Printf("%v: argumentTypeName(%v, %v, %v) = %v", id, t, isInput, schemaType, result)
-	//	}(typeNameID, destType)
-	typeNameID++
-
 	if cns, ok := destType.(*model.ConstType); ok {
 		destType = cns.Type
 	}


### PR DESCRIPTION
generator.argumentTypeName increments a typeNameID global variable.
This causes a data race when tests run in parallel:

```
WARNING: DATA RACE
Read at 0x000005d9dd28 by goroutine 20:
  github.com/pulumi/pulumi/pkg/v3/codegen/go.(*generator).argumentTypeName()
      /home/runner/work/pulumi/pulumi/pkg/codegen/go/gen_program_expressions.go:775 +0x84
  github.com/pulumi/pulumi/pkg/v3/codegen/go.(*generator).genObjectConsExpression()
  ...

Previous write at 0x000005d9dd28 by goroutine 19:
  github.com/pulumi/pulumi/pkg/v3/codegen/go.(*generator).argumentTypeName()
      /home/runner/work/pulumi/pulumi/pkg/codegen/go/gen_program_expressions.go:775 +0xa4
  github.com/pulumi/pulumi/pkg/v3/codegen/go.(*generator).genTemplateExpression()
      /home/runner/work/pulumi/pulumi/pkg/codegen/go/gen_program_expressions.go:672 +0xbe
```

This variable is not used anywhere else in the system.
Fix the data race by deleting the variable.

Refs #10092
