### PR TITLE
make passing lint required to bors merge a PR

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,5 +7,9 @@ status = [
 	'bors-ok',
 ]
 pr_status = [
-	'linear-history'
+	'linear-history',
+	'CI / lint / Lint GHA',
+	'CI / lint / Lint Go',
+	'CI / lint / Lint Protobufs',
+	'CI / lint / Lint SDKs',
 ]


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #11923 

Lints failing has caused bors to fail very often. This PR makes passing lint required for bors merge.