### PR TITLE
[do not land] gen_program_test: Don't run in parallel

### DIFF
--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -381,7 +381,7 @@ func TestProgramCodegen(
 	for _, tt := range testcase.TestCases {
 		tt := tt // avoid capturing loop variable
 		t.Run(tt.Directory, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			var err error
 			if tt.Skip.Has(testcase.Language) {
 				t.Skip()


### PR DESCRIPTION
As an investigative step for #11925,
temporarily remove parallism from gen_program_test test matrix.

This PR is on top of #11913 because that fails consistently.


