### PR TITLE
ci: Wait to run tests till after linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
     # To this:
     #   CI / Unit Test / sdk/dotnet dotnet_test on macos-11/current
     name: Unit Test${{ matrix.platform && '' }}
-    needs: [matrix]
+    needs: [matrix, lint]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ contains(needs.matrix.outputs.unit-test-matrix, 'macos') }}
@@ -267,7 +267,7 @@ jobs:
     # By putting a variable in the name, we remove GitHub's auto-generated matrix parameters from
     # appearing in the rendered title of the job name. See: unit test.
     name: Integration Test${{ matrix.platform && '' }}
-    needs: [matrix, build-binaries, build-sdks]
+    needs: [matrix, build-binaries, build-sdks, lint]
     if: ${{ needs.matrix.outputs.integration-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ contains(needs.matrix.outputs.integration-test-matrix, 'macos') }}
@@ -292,7 +292,7 @@ jobs:
     # By putting a variable in the name, we remove GitHub's auto-generated matrix parameters from
     # appearing in the rendered title of the job name. See: unit test.
     name: Smoke Test${{ matrix.platform && '' }}
-    needs: [matrix, build-binaries, build-sdks]
+    needs: [matrix, build-binaries, build-sdks, lint]
     if: ${{ needs.matrix.outputs.smoke-test-matrix != '{}' }}
     # alow jobs to fail if the platform contains windows
     strategy:


### PR DESCRIPTION
@dixler found that in staging,
lint issues were the most frequent cause of failures.
So we have changes that aren't passing lint
(and therefore, will have to be updated anyway)
locking up a number of GitHub workers to run tests.

We can free up resources for other PRs and staging checks
by running tests only after verifying lint.

This comes with a couple disadvantages:

- Tests will take slightly longer to start running.
  It'll take 2-4 minutes to run all lint checks.
- It will be slightly more difficult to validate experimental changes
  that aren't intended be landed (or pass lint) in CI.

We should discuss whether these are acceptable trade-offs.
