### PR TITLE
test/codegen: Don't run in parallel

### DIFF
--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -381,7 +381,10 @@ func TestProgramCodegen(
 	for _, tt := range testcase.TestCases {
 		tt := tt // avoid capturing loop variable
 		t.Run(tt.Directory, func(t *testing.T) {
-			t.Parallel()
+			// These tests should not run in parallel.
+			// They take up a fair bit of memory
+			// and can OOM in CI with too many running.
+
 			var err error
 			if tt.Skip.Has(testcase.Language) {
 				t.Skip()


### PR DESCRIPTION
Landable version of #11928

We seem to be hitting OOMs in CI quite often
whlie running code generation integration tests.

This drops parallelism from these tests because
experimentation revealed that running these tests serially
mitigates this issue somewhat.

Resolves #11925
