### PR TITLE
ci: Resume testing on Node current with 19.4 release

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -103,7 +103,7 @@ CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "7",
     "go": "1.19.x",
-    "nodejs": "19.1",
+    "nodejs": "19.x",
     "python": "3.10.x",
 }
 


### PR DESCRIPTION
Fixes #11488. 

Upstream PR to Node was merged and included in 19.4: https://github.com/nodejs/node/releases/tag/v19.4.0