### PR TITLE
[go/sdk] Delegate alias computation to the engine

### DIFF
--- a/changelog/pending/20230120--sdk-go--delegate-alias-computation-to-the-engine.yaml
+++ b/changelog/pending/20230120--sdk-go--delegate-alias-computation-to-the-engine.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Delegate alias computation to the engine

--- a/sdk/go/pulumi/alias.go
+++ b/sdk/go/pulumi/alias.go
@@ -134,17 +134,3 @@ func CreateURN(name, t, parent, project, stack StringInput) URNOutput {
 		return createURN(a[0].(string), a[1].(string), a[2].(string), a[3].(string), a[4].(string))
 	}).(URNOutput)
 }
-
-// inheritedChildAlias computes the alias that should be applied to a child based on an alias applied to it's parent.
-// This may involve changing the name of the resource in cases where the resource has a named derived from the name of
-// the parent, and the parent name changed.
-func inheritedChildAlias(childName, parentName, childType, project, stack string, parentURN URNOutput) URNOutput {
-	aliasName := StringInput(String(childName))
-	if strings.HasPrefix(childName, parentName) {
-		aliasName = parentURN.ApplyT(func(urn URN) string {
-			parentPrefix := urn[strings.LastIndex(string(urn), "::")+2:]
-			return string(parentPrefix) + childName[len(parentName):]
-		}).(StringOutput)
-	}
-	return CreateURN(aliasName, String(childType), parentURN.ToStringOutput(), String(project), String(stack))
-}

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -420,7 +420,7 @@ func TestResourceState(t *testing.T) {
 	assert.Nil(t, err)
 
 	var theResource testResource
-	state := ctx.makeResourceState("", "", &theResource, nil, nil, "", "", nil, nil)
+	state := ctx.makeResourceState("", "", &theResource, nil, nil, "", "", nil)
 
 	resolved, _, _, _ := marshalInputs(&testResourceInputs{
 		Any:     String("foo"),
@@ -875,7 +875,7 @@ func TestDependsOnComponent(t *testing.T) {
 
 	registerResource := func(name string, res Resource, custom bool, options ...ResourceOption) (Resource, []string) {
 		opts := merge(options...)
-		state := ctx.makeResourceState("", "", res, nil, nil, "", "", nil, nil)
+		state := ctx.makeResourceState("", "", res, nil, nil, "", "", nil)
 		state.resolve(ctx, nil, nil, name, "", &structpb.Struct{}, nil)
 
 		inputs, err := ctx.prepareResourceInputs(res, Map{}, "", opts, state, false, custom)


### PR DESCRIPTION

# Description

This PR removes the use of `collapseAliases` from the go SDK which used to calculate aliases of resources from `ResourceOptions` and their inherited child aliases (a.k.a. alias explosion) and starts using the new alias specification `pulumirpc.Alias` that is handled by the engine in a language-agnostic manner. 

This PR removes `aliases: []URNOutput` from `resourceState` because we no longer have to keep track of them in `makeResourceState` but instead calculate them in `prepareResourceInputs`. 

Fixes #11066
Potentially addresses #11697 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
