### PR TITLE
Fix broken links related to resources named "index"

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1771,7 +1771,16 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 			return err
 		}
 
-		addFile(strings.ToLower(title), buffer.String())
+		resourceFileName := strings.ToLower(title)
+		// Handle file generation for resources named `index`. We prepend a double underscore
+		// here, since this ends up resulting in route of .../<module>/index which has trouble
+		// resolving and returns a 404 in the browser, likely due to `index` being some sort
+		// of reserved keyword.
+		if resourceFileName == "index" {
+			resourceFileName = "__index"
+		}
+
+		addFile(resourceFileName, buffer.String())
 	}
 
 	// Functions

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1777,7 +1777,7 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 		// resolving and returns a 404 in the browser, likely due to `index` being some sort
 		// of reserved keyword.
 		if resourceFileName == "index" {
-			resourceFileName = "__index"
+			resourceFileName = "--index"
 		}
 
 		addFile(resourceFileName, buffer.String())

--- a/pkg/codegen/docs/utils.go
+++ b/pkg/codegen/docs/utils.go
@@ -88,7 +88,7 @@ func getResourceLink(name string) string {
 	// here, since a link of .../<module>/index has trouble resolving and returns a 404 in
 	// the browser, likely due to `index` being some sort of reserved keyword.
 	if link == "index" {
-		return "__" + link
+		return "--" + link
 	}
 	return link
 }

--- a/pkg/codegen/docs/utils.go
+++ b/pkg/codegen/docs/utils.go
@@ -83,7 +83,14 @@ func getModuleLink(name string) string {
 }
 
 func getResourceLink(name string) string {
-	return strings.ToLower(name)
+	link := strings.ToLower(name)
+	// Handle URL generation for resources named `index`. We prepend a double underscore
+	// here, since a link of .../<module>/index has trouble resolving and returns a 404 in
+	// the browser, likely due to `index` being some sort of reserved keyword.
+	if link == "index" {
+		return "__" + link
+	}
+	return link
 }
 
 func getFunctionLink(name string) string {


### PR DESCRIPTION
fixes: https://github.com/pulumi/registry/issues/951

This PR fixes an issue where a resource named "index" has trouble resolving the url likely because "index" is some sort of reserved keyword. This change prepends a double underscore to the resource name in the URL that gets generated and also updates the links that reference this on both the module page and the package tree in the left nav. Visually everything looks the same, it is just the directory name and underlying links that get updated. It will still display as "Index" when rendered on the page.

As an example this route `/registry/packages/gcp/api-docs/firestore/index/` ends up resulting in a 404. With this change we add a double underscore which results in the following route `registry/packages/gcp/api-docs/firestore/__index/` and is now able to render the page.


![Peek 2023-01-20 12-00](https://user-images.githubusercontent.com/16751381/213794883-5e55d303-eaba-40ce-85c2-26443daee393.gif)
