### PR TITLE
cmd/stack: Reduce noise from offerNew, setCurrent bool

### DIFF
--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -56,7 +56,7 @@ func newCancelCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -62,7 +62,7 @@ func newConfigCmd() *cobra.Command {
 				return err
 			}
 
-			stack, err := requireStack(ctx, stack, true, opts, true /*setCurrent*/)
+			stack, err := requireStack(ctx, stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 			}
 
 			// Get current stack and ensure that it is a different stack to the destination stack
-			currentStack, err := requireStack(ctx, *stack, false, opts, true /*setCurrent*/)
+			currentStack, err := requireStack(ctx, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -131,7 +131,7 @@ func newConfigCopyCmd(stack *string) *cobra.Command {
 			}
 
 			// Get the destination stack
-			destinationStack, err := requireStack(ctx, destinationStackName, false, opts, false /*setCurrent*/)
+			destinationStack, err := requireStack(ctx, destinationStackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -271,7 +271,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, *stack, true, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -318,7 +318,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			stack, err := requireStack(ctx, *stack, true, opts, true /*setCurrent*/)
+			stack, err := requireStack(ctx, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -372,7 +372,7 @@ func newConfigRmAllCmd(stack *string) *cobra.Command {
 				return err
 			}
 
-			stack, err := requireStack(ctx, *stack, true, opts, false /*setCurrent*/)
+			stack, err := requireStack(ctx, *stack, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}
@@ -422,7 +422,7 @@ func newConfigRefreshCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(ctx, *stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -513,7 +513,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(ctx, *stack, true, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -629,7 +629,7 @@ func newConfigSetAllCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			stack, err := requireStack(ctx, *stack, true, opts, false /*setCurrent*/)
+			stack, err := requireStack(ctx, *stack, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -161,7 +161,7 @@ func newDestroyCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(ctx, stack, false, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackLoadOnly, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -509,7 +509,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack.
-			s, err := requireStack(ctx, stack, false, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackLoadOnly, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -64,7 +64,7 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -150,7 +150,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(ctx, stack, true, displayOpts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackOfferNew, displayOpts)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -158,7 +158,7 @@ func newRefreshCmd() *cobra.Command {
 				opts.Display.SuppressPermalink = true
 			}
 
-			s, err := requireStack(ctx, stack, true, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackOfferNew, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -53,7 +53,7 @@ func newStackCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stackName, true, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, stackOfferNew, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -71,7 +71,7 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			}
 
 			// Get the current stack and its project
-			currentStack, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
+			currentStack, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -51,7 +51,7 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -61,7 +61,7 @@ func newStackGraphCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -41,7 +41,7 @@ This command displays data about previous updates for a stack.`,
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, stack, false /*offerNew */, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -52,7 +52,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and import a deployment.
-			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -131,7 +131,7 @@ func newStackInitCmd() *cobra.Command {
 				}
 
 				// load the old stack and its project
-				copyStack, err := requireStack(ctx, stackToCopy, false, opts, false /*setCurrent*/)
+				copyStack, err := requireStack(ctx, stackToCopy, stackLoadOnly, opts)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -46,7 +46,7 @@ func newStackOutputCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and its output properties.
-			s, err := requireStack(ctx, stackName, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -51,7 +51,7 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Look up the stack to be moved, and find the path to the project file's location.
-			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -60,7 +60,7 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -87,7 +87,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			// If no stack was given, prompt the user to select a name from the available ones.
-			stack, err := chooseStack(ctx, b, true, opts, true /*setCurrent*/)
+			stack, err := chooseStack(ctx, b, stackOfferNew|stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -64,7 +64,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, *stack, false, opts, false /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -97,7 +97,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(ctx, *stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -154,7 +154,7 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, *stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}
@@ -185,7 +185,7 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(ctx, *stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(ctx, *stack, stackSetCurrent, opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -131,7 +131,7 @@ func runTotalStateEdit(
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
-	s, err := requireStack(ctx, stackName, true, opts, false /*setCurrent*/)
+	s, err := requireStack(ctx, stackName, stackOfferNew, opts)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -84,7 +84,7 @@ func newUpCmd() *cobra.Command {
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(ctx context.Context, opts backend.UpdateOptions) result.Result {
-		s, err := requireStack(ctx, stack, true, opts.Display, false /*setCurrent*/)
+		s, err := requireStack(ctx, stack, stackOfferNew, opts.Display)
 		if err != nil {
 			return result.FromError(err)
 		}

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -321,6 +322,35 @@ func TestGetRefreshOption(t *testing.T) {
 			if shouldRefresh != tt.expectedRefreshState {
 				t.Errorf("getRefreshOption got = %t, expected %t", shouldRefresh, tt.expectedRefreshState)
 			}
+		})
+	}
+}
+
+func TestStackLoadOption(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		give       stackLoadOption
+		offerNew   bool
+		setCurrent bool
+	}{
+		{stackLoadOnly, false, false},
+		{stackOfferNew, true, false},
+		{stackSetCurrent, false, true},
+		{stackOfferNew | stackSetCurrent, true, true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprint(tt.give), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t,
+				tt.offerNew, tt.give.OfferNew(),
+				"OfferNew did not match")
+			assert.Equal(t,
+				tt.setCurrent, tt.give.SetCurrent(),
+				"SetCurrent did not match")
 		})
 	}
 }

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -88,7 +88,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(ctx, stack, true, opts.Display, false /*setCurrent*/)
+			s, err := requireStack(ctx, stack, stackOfferNew, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}


### PR DESCRIPTION
There are a few helper functions in util.go
that accept two booleans: offerNew and setCurrent.
These functions are called *quite* often
and callers always have to pass these two naked booleans:

    requireStack(ctx, stack, false, opts, true)

To reduce confusion, these booleans have to be annotated with a comment.

    requireStack(ctx, stack, false, opts, true /* setCurrent */)

Given how pervasive these two are,
this change turns them into a set of bit flags:

    stackLoadOnly
    stackOfferNew
    stackSetCurrent

Callers pass in a bitwise OR of these as needed:

           Before                   Now
    offerNew  setCurrent       stackLoadOption
    ------------------------------------------
      false     false           stackLoadOnly
      true      false           stackOfferNew
      false     true            stackSetCurrent
      true      true    stackOfferNew|stackSetCurrent

This reduces risk of passing the booleans out of order,
and improves readability at those call sites.
