### PR TITLE
Test and fix for nodejs automation api

### DIFF
--- a/changelog/pending/20230123--auto-nodejs--fix-nodejs-automation-api-always-setting-the-pulumi_config-environment-variable.yaml
+++ b/changelog/pending/20230123--auto-nodejs--fix-nodejs-automation-api-always-setting-the-pulumi_config-environment-variable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Fix NodeJS automation api always setting the PULUMI_CONFIG environment variable.

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import execa from "execa";
-import { getStore } from "../runtime/state";
 
 import { createCommandError } from "./errors";
 
@@ -54,11 +53,7 @@ export async function runPulumiCmd(
         args.push("--non-interactive");
     }
 
-    const store = getStore();
-
-    const config = store?.config ?? {};
-
-    const env = { ...config, ...additionalEnv };
+    const env = { ...additionalEnv };
 
     try {
         const proc = execa("pulumi", args, { env, cwd });

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -24,7 +24,6 @@ import { minimumVersion } from "./minimumVersion";
 import { ProjectSettings } from "./projectSettings";
 import { RemoteGitProgramArgs } from "./remoteWorkspace";
 import { OutputMap, Stack } from "./stack";
-import * as localState from "../runtime/state";
 import { StackSettings, stackSettingsSerDeKeys } from "./stackSettings";
 import { Deployment, PluginInfo, PulumiFn, StackSummary, WhoAmIResult, Workspace } from "./workspace";
 
@@ -246,8 +245,6 @@ export class LocalWorkspace implements Workspace {
     private constructor(opts?: LocalWorkspaceOptions) {
         let dir = "";
         let envs = {};
-        const store = new localState.LocalStore();
-        localState.asyncLocalStorage.enterWith(store);
 
         if (opts) {
             const { workDir, pulumiHome, program, envVars, secretsProvider,

--- a/sdk/nodejs/tests/automation/data/testproj_dotnet/.gitignore
+++ b/sdk/nodejs/tests/automation/data/testproj_dotnet/.gitignore
@@ -1,0 +1,5 @@
+/.pulumi/
+[Bb]in/
+[Oo]bj/
+
+

--- a/sdk/nodejs/tests/automation/data/testproj_dotnet/Program.cs
+++ b/sdk/nodejs/tests/automation/data/testproj_dotnet/Program.cs
@@ -1,0 +1,12 @@
+﻿// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+
+using System.Collections.Generic;
+using Pulumi;
+
+return await Deployment.RunAsync(() =>
+{
+    return new Dictionary<string, object>
+    {
+        {  "exp_static", "foo" },
+    };
+});

--- a/sdk/nodejs/tests/automation/data/testproj_dotnet/Pulumi.yaml
+++ b/sdk/nodejs/tests/automation/data/testproj_dotnet/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: testproj_dotnet
+runtime: dotnet
+description: A minimal dotnet Pulumi program

--- a/sdk/nodejs/tests/automation/data/testproj_dotnet/TestProj.csproj
+++ b/sdk/nodejs/tests/automation/data/testproj_dotnet/TestProj.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
nodejs automation api was setting the envvar PULUMI_CONFIG for every pulumi command it called, this tripped up the dotnet sdk which only expects PULUMI_CONFIG to be set to a valid JSON string (not the empty string).

Looks like this was just a slightly confused bit of code to try and deal with parallel programs, I've moved it out of the workspace part of automation api and fixed up the inline server to deal with parallel programs correctly instead.

Fixes #11945