### PR TITLE
cmd/stack output: Add --shell option

### DIFF
--- a/changelog/pending/20230123--cli--adds-a-shell-flag-to-pulumi-stack-output-to-print-outputs-as-a-shell-script.yaml
+++ b/changelog/pending/20230123--cli--adds-a-shell-flag-to-pulumi-stack-output-to-print-outputs-as-a-shell-script.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Adds a --shell flag to 'pulumi stack output' to print outputs as a shell script.

--- a/pkg/cmd/pulumi/stack_output_fuzz_test.go
+++ b/pkg/cmd/pulumi/stack_output_fuzz_test.go
@@ -1,0 +1,51 @@
+//go:build go1.18
+// +build go1.18
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzShellStackOutputWriter(f *testing.F) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		f.Skipf("Skipping: no 'bash' found: %v", err)
+	}
+
+	dir := f.TempDir()
+
+	f.Add("foo")
+	f.Add(`"bar"`)
+	f.Add(`'baz'`)
+	f.Add(`foo \"bar'\\baz`)
+	f.Fuzz(func(t *testing.T, give string) {
+		// Only consider valid unicode strings
+		// that do ot contain the null character.
+		if strings.IndexByte(give, 0) >= 0 || !utf8.Valid([]byte(give)) {
+			t.Skip()
+		}
+
+		f, err := os.CreateTemp(dir, "script.sh")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		err = (&shellStackOutputWriter{W: f}).WriteOne("output", give)
+		require.NoError(t, err)
+		fmt.Fprintln(f, `echo "$output"`)
+		require.NoError(t, f.Close())
+
+		got, err := exec.Command(bash, f.Name()).Output()
+		require.NoError(t, err)
+
+		assert.Equal(t, give+"\n", string(got))
+	})
+}

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -269,6 +270,190 @@ func TestStackOutputCmd_json(t *testing.T) {
 				"output is not valid JSON:\n%s", stdout)
 
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Tests the output of 'pulumi stack output --shell'
+// under different conditions.
+//
+//nolint:paralleltest // hijacks os.Stdout
+func TestStackOutputCmd_shell(t *testing.T) {
+	// This test temporarily hijacks os.Stdout
+	// so that we can read the output printed to it.
+	// This will not be necessary once the relevant functions
+	// are modified to accept io.Writers.
+
+	outputsWithSecret := resource.PropertyMap{
+		"bucketName": resource.NewStringProperty("mybucket-1234"),
+		"password": resource.NewSecretProperty(&resource.Secret{
+			Element: resource.NewStringProperty("hunter2"),
+		}),
+	}
+
+	tests := []struct {
+		desc string
+
+		// Map of stack outputs.
+		outputs resource.PropertyMap
+
+		// Whether the --show-secrets flag is set.
+		showSecrets bool
+
+		// Any additional command line arguments.
+		args []string
+
+		// Lines expected in the output.
+		want []string
+	}{
+		{
+			desc:    "default",
+			outputs: outputsWithSecret,
+			want: []string{
+				"bucketName=mybucket-1234",
+				`password=\[secret]`,
+			},
+		},
+		{
+			desc:        "show-secrets",
+			outputs:     outputsWithSecret,
+			showSecrets: true,
+			want: []string{
+				"bucketName=mybucket-1234",
+				"password=hunter2",
+			},
+		},
+		{
+			desc:    "single property",
+			outputs: outputsWithSecret,
+			args:    []string{"bucketName"},
+			want:    []string{"bucketName=mybucket-1234"},
+		},
+		{
+			// Should not show the secret even if requested
+			// if --show-secrets is not set.
+			desc:    "single hidden property",
+			outputs: outputsWithSecret,
+			args:    []string{"password"},
+			want:    []string{`password=\[secret]`},
+		},
+		{
+			desc:        "single property with show-secrets",
+			outputs:     outputsWithSecret,
+			showSecrets: true,
+			args:        []string{"password"},
+			want:        []string{"password=hunter2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			getStdout := hijackStdout(t)
+
+			snap := deploy.Snapshot{
+				Resources: []*resource.State{
+					{
+						Type:    resource.RootStackType,
+						Outputs: tt.outputs,
+					},
+				},
+			}
+			requireStack := func(context.Context,
+				string, stackLoadOption, display.Options) (backend.Stack, error) {
+				return &backend.MockStack{
+					SnapshotF: func(ctx context.Context) (*deploy.Snapshot, error) {
+						return &snap, nil
+					},
+				}, nil
+			}
+
+			cmd := stackOutputCmd{
+				requireStack: requireStack,
+				showSecrets:  tt.showSecrets,
+				shellOut:     true,
+			}
+			require.NoError(t, cmd.Run(context.Background(), tt.args))
+
+			// Drop trailing "\n" from stdout
+			// rather than add a "" at the end of every tt.want.
+			stdout := strings.TrimSuffix(string(getStdout()), "\n")
+			got := strings.Split(stdout, "\n")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStackOutputCmd_jsonAndShellConflict(t *testing.T) {
+	t.Parallel()
+
+	cmd := stackOutputCmd{
+		requireStack: func(context.Context, string, stackLoadOption, display.Options) (backend.Stack, error) {
+			t.Fatal("This function should not be called")
+			return nil, errors.New("should not be called")
+		},
+		shellOut: true,
+		jsonOut:  true,
+	}
+
+	err := cmd.Run(context.Background(), nil)
+	assert.ErrorContains(t, err, "only one of --json and --shell may be set")
+}
+
+func TestShellStackOutputWriter_quoting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give interface{}
+		want string // lines expected in the output
+	}{
+		{
+			desc: "string",
+			give: "foo",
+			want: "foo",
+		},
+		{
+			desc: "number",
+			give: 42,
+			want: "42",
+		},
+		{
+			desc: "string/spaces",
+			give: "foo bar",
+			want: "'foo bar'",
+		},
+		{
+			desc: "string/double quotes",
+			give: `foo "bar" baz`,
+			want: `'foo "bar" baz'`,
+		},
+		{
+			desc: "string/single quotes",
+			give: "foo 'bar' baz",
+			want: `'foo '\''bar'\'' baz'`,
+		},
+		{
+			desc: "string/single and double quotes",
+			give: `foo "bar" 'baz' qux`,
+			want: `'foo "bar" '\''baz'\'' qux'`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var got bytes.Buffer
+			writer := shellStackOutputWriter{W: &got}
+
+			err := writer.WriteMany(map[string]interface{}{
+				"myoutput": tt.give,
+			})
+			require.NoError(t, err)
+
+			want := "myoutput=" + tt.want + "\n"
+			assert.Equal(t, want, got.String())
 		})
 	}
 }

--- a/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/5838cdfae7b16cde2707c04599b62223e7bade8dafdd8a1c53b8f881e8f79d99
+++ b/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/5838cdfae7b16cde2707c04599b62223e7bade8dafdd8a1c53b8f881e8f79d99
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("")

--- a/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/b5bbc3d0d660602a096a3956016c5a0f57eddd321f15e9c6276d05290424365a
+++ b/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/b5bbc3d0d660602a096a3956016c5a0f57eddd321f15e9c6276d05290424365a
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("ώώ")

--- a/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/d0b1335002dd171e1b89df7e6ea2ccbf017be0459542a11ec676c3bf280dc292
+++ b/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/d0b1335002dd171e1b89df7e6ea2ccbf017be0459542a11ec676c3bf280dc292
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\"Tar\x19")

--- a/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/ddca139cc2f39efdaed4ae893f402e930890e37ef70be194dfe16dbfec241877
+++ b/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/ddca139cc2f39efdaed4ae893f402e930890e37ef70be194dfe16dbfec241877
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("00\x0f000Ec")

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/json-iterator/go v1.1.12
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/muesli/cancelreader v0.2.2
 	github.com/natefinch/atomic v1.0.1
 	github.com/pulumi/pulumi-java/pkg v0.7.1
@@ -181,7 +182,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect


### PR DESCRIPTION
Adds a `--shell` option to `pulumi stack output`
that writes the outputs for a stack as a shell script.

    % pulumi stack output --shell
    bucketName=mybucket-1234
    websiteURL="http://mybucket-1234.example.com"

On Windows, it will produce a Powershell script:

    % pulumi stack output --shell
    $bucketName = 'mybucket-1234'
    $websiteURL = 'http://mybucket-1234.example.com'

The idea is that given:

    % pulumi stack output
    [..]
        bucketName   mybucket-1234
        websiteURL   http://mybucket-1234.example.com

A user will be able to do the following
in a shell script:

    eval "$(pulumi stack output --shell)"
    echo "Created bucket $bucketName"
    # => Created bucket mybucket-1234

    echo "Visit at $websiteURL"
    # => Visit at http://mybucket-1234.example.com

If a user specifies a single property name,
only that will be written in the shell script.

    eval "$(pulumi stack output --shell bucketName)"
    echo "$bucketName"

Although that's no better than:

    bucketName="$(pulumi stack output bucketName)"

Future improvements we could make here:

- Support multiple output names in `pulumi stack output`
  so that users can use `--shell` for a subset of the variables
  in one go (e.g. `pulumi stack outputs --shell bucketName websiteURL`).
  I've created #11955 to discuss that.
- Add a flag that adds a prefix to each variable in the shell script.
  This would be useful if multiple stacks are in play in the same
  script.

Testing:
Besides unit tests that verify the exact output,
this change includes a fuzz test
that feeds the result of shell quoting a string into `bash`/`pwsh`
and verifies that we get the original string back.
The test runs only if the corresponding shell is available
and we're on Go 1.18 or newer.

Note that the fuzz test will only run against the given sample inputs
and prior failures (if any) in CI.
To actually fuzz, you have to run:

```
go test -run '^$' -fuzz .
```

I ran this on my laptop for a couple minutes with no failures in bash
and segfaults in Powershell after several minutes of running,
however those segfaults were not reproducible.

Resolves #2632