### PR TITLE
cmd/stack output: Print to an io.Writer

### DIFF
--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -858,12 +859,17 @@ func makeJSONString(v interface{}) (string, error) {
 
 // printJSON simply prints out some object, formatted as JSON, using standard indentation.
 func printJSON(v interface{}) error {
+	return fprintJSON(os.Stdout, v)
+}
+
+// fprintJSON simply prints out some object, formatted as JSON, using standard indentation.
+func fprintJSON(w io.Writer, v interface{}) error {
 	jsonStr, err := makeJSONString(v)
 	if err != nil {
 		return err
 	}
-	fmt.Print(jsonStr)
-	return nil
+	_, err = fmt.Fprint(w, jsonStr)
+	return err
 }
 
 // updateFlagsToOptions ensures that the given update flags represent a valid combination.  If so, an UpdateOptions

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -16,6 +16,7 @@ package cmdutil
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"runtime"
@@ -123,11 +124,19 @@ type TableRow struct {
 	AdditionalInfo string   // an optional line of information to print after the row
 }
 
-// PrintTable prints a grid of rows and columns.  Width of columns is automatically determined by
+// FprintTable prints a grid of rows and columns.  Width of columns is automatically determined by
 // the max length of the items in each column.  A default gap of two spaces is printed between each
 // column.
+func FprintTable(w io.Writer, table Table) error {
+	_, err := fmt.Fprint(w, table)
+	return err
+}
+
+// PrintTable prints the table to stdout.
+// See [FprintTable] for details.
 func PrintTable(table Table) {
-	fmt.Print(table)
+	_ = FprintTable(os.Stdout, table)
+	// Ignore error for stdout.
 }
 
 // PrintTableWithGap prints a grid of rows and columns.  Width of columns is automatically determined


### PR DESCRIPTION
The implementation of `pulumi stack output` prints everything
to a global `io.Writer`.
This makes testing its output a bit hacky and unparalellizable
because we have to hijack `os.Stdout` to capture the output.

This changes it the command implementation
and all the functions it relies on
to accept an `io.Writer` as an argument.

This allows us to delete the os.Stdout hijacking hack
that was introduced in #11952,
and have those tests run in parallel, writing to an in-memory buffer.
