### PR TITLE
Add resource count to update info struct

### DIFF
--- a/sdk/go/common/apitype/history.go
+++ b/sdk/go/common/apitype/history.go
@@ -113,6 +113,7 @@ type UpdateInfo struct {
 	Version         int             `json:"version"`
 	Deployment      json.RawMessage `json:"deployment,omitempty"`
 	ResourceChanges map[OpType]int  `json:"resourceChanges,omitempty"`
+	ResourceCount   int             `json:"resourceCount,omitempty"`
 }
 
 // GetHistoryResponse is the response from the Pulumi Service when requesting


### PR DESCRIPTION
Part of: https://github.com/pulumi/service-requests/issues/155

This adds the resource count to the update info struct. We want to surface this through the stack updates endpoint in the service. We import this type in the pulumi-service from here so I need to get the struct updated. See: https://github.com/pulumi/pulumi-service/pull/11990.