### PR TITLE
Handle Outputs in dict keys passed to from_input

### DIFF
--- a/changelog/pending/20230124--sdk-python--fix-handling-of-output-keys-in-dicts-passed-to-output-from_input.yaml
+++ b/changelog/pending/20230124--sdk-python--fix-handling-of-output-keys-in-dicts-passed-to-output-from_input.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix handling of Output keys in dicts passed to Output.from_input.

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -307,7 +307,17 @@ class Output(Generic[T_co]):
 
         # Is a (non-empty) dict or list? Recurse into the values within them.
         if val and isinstance(val, dict):
-            o_dict: Output[dict] = Output.all(**val)
+            # The keys themselves might be outputs, so we can't just pass `**val` to all.
+
+            # keys() and values() will be in the same order: https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects
+            keys = list(val.keys())
+            values = list(val.values())
+
+            def liftValues(keys: List[Any]):
+                d = {keys[i]: values[i] for i in range(len(keys))}
+                return Output.all(**d)
+
+            o_dict: Output[dict] = Output.all(*keys).apply(liftValues)
             return cast(Output[T_co], o_dict)
 
         if val and isinstance(val, list):

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -70,6 +70,12 @@ class OutputFromInputTests(unittest.TestCase):
         self.assertEqual(x_val, {"hello": "world"})
 
     @pulumi_test
+    async def test_unwrap_dict_output_key(self):
+        x = Output.from_input({Output.from_input("hello"): Output.from_input("world")})
+        x_val = await x.future()
+        self.assertEqual(x_val, {"hello": "world"})
+
+    @pulumi_test
     async def test_unwrap_dict_secret(self):
         x = Output.from_input({"hello": Output.secret("world")})
         x_val = await x.future()
@@ -379,6 +385,14 @@ class OutputJsonDumpsTests(unittest.TestCase):
         self.assertEqual(await x.is_secret(), False)
         self.assertEqual(await x.is_known(), True)
         self.assertIn(resource, await x.resources())
+
+    @pulumi_test
+    async def test_output_keys(self):
+        i = {Output.from_input("hello"): Output.from_input(1)}
+        x = Output.json_dumps(i)
+        self.assertEqual(await x.future(), "{\"hello\": 1}")
+        self.assertEqual(await x.is_secret(), False)
+        self.assertEqual(await x.is_known(), True)
 
 class OutputJsonLoadsTests(unittest.TestCase):
     @pulumi_test


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Turned out if you passed a dict with an Output type key to `Output.from_input` you'd get a type error:
```
TypeError: keywords must be strings
```
This adds a test and fixes the dict handling in from_input to also support keys that are Outputs.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
