### PR TITLE
sdk/go/plugin: Fix data race between Configure and Delete

### DIFF
--- a/changelog/pending/20230125--sdk-go--fixes-data-race-in-provider-plugin-resulting-in-weakly-typed-secrets.yaml
+++ b/changelog/pending/20230125--sdk-go--fixes-data-race-in-provider-plugin-resulting-in-weakly-typed-secrets.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fixes data race in provider plugin resulting in weakly typed secrets.

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1146,18 +1146,18 @@ func (p *provider) Delete(urn resource.URN, id resource.ID, props resource.Prope
 	label := fmt.Sprintf("%s.Delete(%s,%s)", p.label(), urn, id)
 	logging.V(7).Infof("%s executing (#props=%d)", label, len(props))
 
+	// Get the RPC client and ensure it's configured.
+	client, err := p.getClient()
+	if err != nil {
+		return resource.StatusOK, err
+	}
+
 	mprops, err := MarshalProperties(props, MarshalOptions{
 		Label:              label,
 		ElideAssetContents: true,
 		KeepSecrets:        p.acceptSecrets,
 		KeepResources:      p.acceptResources,
 	})
-	if err != nil {
-		return resource.StatusOK, err
-	}
-
-	// Get the RPC client and ensure it's configured.
-	client, err := p.getClient()
 	if err != nil {
 		return resource.StatusOK, err
 	}


### PR DESCRIPTION
The data race results from Delete accessing configuration
before Configure has been called.

The immediate fix for this is to fix the call ordering.

Resolves #11971

---

A better fix is to make it impossible
to access configuration before Configure is called.
That will address any other similar cases (if any).
Doing that requires a little more information,
so I'd appreciate some guidance in that direction
before I can fix this.

Specficially:

- Is Configure *required* to be called?
- Are those fields all invalid until Configure is called?
- If Configure fails, what happens to all these calls
  that depend on that informaton?
