### PR TITLE
feat: enable simpler Go programtest replacements

### DIFF
--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -148,9 +148,9 @@ func TestGoModEdits(t *testing.T) {
 			expectedValue: "github.com/pulumi/pulumi/sdk/v3=" + filepath.Join(cwd, "../../../sdk"),
 		},
 		{
-			name:          "invalid-module-name",
-			dep:           "github.com/pulumi/pulumi/sdk/v2", // v2 not v3
-			expectedError: "found module github.com/pulumi/pulumi/sdk/v3, expected github.com/pulumi/pulumi/sdk/v2",
+			name:          "valid-module-name-version-skew",
+			dep:           "github.com/pulumi/pulumi/sdk",
+			expectedValue: "github.com/pulumi/pulumi/sdk=" + filepath.Join(cwd, "../../../sdk"),
 		},
 		{
 			name:          "valid-rel-path",
@@ -158,9 +158,14 @@ func TestGoModEdits(t *testing.T) {
 			expectedValue: "github.com/pulumi/pulumi/sdk/v3=" + filepath.Join(cwd, "../../../sdk"),
 		},
 		{
+			name:          "valid-rel-path-version-skew",
+			dep:           "github.com/pulumi/pulumi/sdk=../../../sdk",
+			expectedValue: "github.com/pulumi/pulumi/sdk=" + filepath.Join(cwd, "../../../sdk"),
+		},
+		{
 			name:          "invalid-rel-path",
-			dep:           "github.com/pulumi/pulumi/sdk/v2=../../../sdk",
-			expectedError: "found module github.com/pulumi/pulumi/sdk/v3, expected github.com/pulumi/pulumi/sdk/v2",
+			dep:           "github.com/pulumi/pulumi/pkg=../../../sdk",
+			expectedError: "found module path with prefix github.com/pulumi/pulumi/sdk, expected github.com/pulumi/pulumi/pkg",
 		},
 	}
 


### PR DESCRIPTION
This change to ProgramTest allows Go module replacements to omit the major version number, simplifying the process to release a provider with a new major version.

When the major version is incremented in a PR, the examples fail to compile if they reference the incorrect SDK version.

This enables the examples to be written to target a versionless `/sdk`, and have a Dependencies line such as:

```go
	integration.ProgramTestOptions{
		Dependencies: []string{
			"github.com/pulumi/pulumi-keycloak/sdk=../sdk",
		},
	}
```

This versionless import mapping means that examples run regardless of the major version of the provider, and updates to major versions in PRs will require only one PR.

A provider PR proving out the implementation was created against this commit here:
- https://github.com/pulumi/pulumi-keycloak/pull/165
