### PR TITLE
Push DefaultSecretsProvider up to pkg/cmd

### DIFF
--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
@@ -51,7 +52,7 @@ func TestGetStackResourceOutputs(t *testing.T) {
 		},
 		GetStackF: func(ctx context.Context, stackRef StackReference) (Stack, error) {
 			return &MockStack{
-				SnapshotF: func(ctx context.Context) (*deploy.Snapshot, error) {
+				SnapshotF: func(ctx context.Context, sp secrets.Provider) (*deploy.Snapshot, error) {
 					return &deploy.Snapshot{Resources: []*resource.State{
 						resc1, resc2, deleted,
 					}}, nil

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -53,11 +53,15 @@ func newStack(ref backend.StackReference, path string, snapshot *deploy.Snapshot
 	}
 }
 
-func (s *localStack) Ref() backend.StackReference                            { return s.ref }
-func (s *localStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) { return s.snapshot, nil }
-func (s *localStack) Backend() backend.Backend                               { return s.b }
-func (s *localStack) Path() string                                           { return s.path }
-func (s *localStack) Tags() map[apitype.StackTagName]string                  { return nil }
+func (s *localStack) Ref() backend.StackReference { return s.ref }
+func (s *localStack) Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+	// TODO: We should delay snapshot reading till here like we do for httpstate, which _also_ means we can
+	// use the secretsProvider passed in rather than assuming DefaultSecretsProvider.
+	return s.snapshot, nil
+}
+func (s *localStack) Backend() backend.Backend              { return s.b }
+func (s *localStack) Path() string                          { return s.path }
+func (s *localStack) Tags() map[apitype.StackTagName]string { return nil }
 
 func (s *localStack) Remove(ctx context.Context, force bool) (bool, error) {
 	return backend.RemoveStack(ctx, s, force)
@@ -95,9 +99,9 @@ func (s *localStack) Watch(ctx context.Context, op backend.UpdateOperation, path
 	return backend.WatchStack(ctx, s, op, paths)
 }
 
-func (s *localStack) GetLogs(ctx context.Context, cfg backend.StackConfiguration,
+func (s *localStack) GetLogs(ctx context.Context, secretsProvider secrets.Provider, cfg backend.StackConfiguration,
 	query operations.LogQuery) ([]operations.LogEntry, error) {
-	return backend.GetStackLogs(ctx, s, cfg, query)
+	return backend.GetStackLogs(ctx, secretsProvider, s, cfg, query)
 }
 
 func (s *localStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error) {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -123,12 +123,12 @@ func (s *cloudStack) StackIdentifier() client.StackIdentifier {
 	return si
 }
 
-func (s *cloudStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) {
+func (s *cloudStack) Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
 	if s.snapshot != nil {
 		return *s.snapshot, nil
 	}
 
-	snap, err := s.b.getSnapshot(ctx, s.ref)
+	snap, err := s.b.getSnapshot(ctx, secretsProvider, s.ref)
 	if err != nil {
 		return nil, err
 	}
@@ -176,9 +176,9 @@ func (s *cloudStack) Watch(ctx context.Context, op backend.UpdateOperation, path
 	return backend.WatchStack(ctx, s, op, paths)
 }
 
-func (s *cloudStack) GetLogs(ctx context.Context, cfg backend.StackConfiguration,
+func (s *cloudStack) GetLogs(ctx context.Context, secretsProvider secrets.Provider, cfg backend.StackConfiguration,
 	query operations.LogQuery) ([]operations.LogEntry, error) {
-	return backend.GetStackLogs(ctx, s, cfg, query)
+	return backend.GetStackLogs(ctx, secretsProvider, s, cfg, query)
 }
 
 func (s *cloudStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error) {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -69,7 +69,7 @@ type MockBackend struct {
 		UpdateOperation) (sdkDisplay.ResourceChanges, result.Result)
 	WatchF func(context.Context, Stack,
 		UpdateOperation, []string) result.Result
-	GetLogsF func(context.Context, Stack, StackConfiguration,
+	GetLogsF func(context.Context, secrets.Provider, Stack, StackConfiguration,
 		operations.LogQuery) ([]operations.LogEntry, error)
 
 	CancelCurrentUpdateF func(ctx context.Context, stackRef StackReference) error
@@ -261,11 +261,12 @@ func (be *MockBackend) GetHistory(ctx context.Context,
 	panic("not implemented")
 }
 
-func (be *MockBackend) GetLogs(ctx context.Context, stack Stack, cfg StackConfiguration,
-	query operations.LogQuery) ([]operations.LogEntry, error) {
+func (be *MockBackend) GetLogs(
+	ctx context.Context, secretsProvider secrets.Provider, stack Stack,
+	cfg StackConfiguration, query operations.LogQuery) ([]operations.LogEntry, error) {
 
 	if be.GetLogsF != nil {
-		return be.GetLogsF(ctx, stack, cfg, query)
+		return be.GetLogsF(ctx, secretsProvider, stack, cfg, query)
 	}
 	panic("not implemented")
 }
@@ -341,7 +342,7 @@ func (be *MockBackend) CancelCurrentUpdate(ctx context.Context, stackRef StackRe
 type MockStack struct {
 	RefF      func() StackReference
 	ConfigF   func() config.Map
-	SnapshotF func(ctx context.Context) (*deploy.Snapshot, error)
+	SnapshotF func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
 	TagsF     func() map[apitype.StackTagName]string
 	BackendF  func() Backend
 	PreviewF  func(ctx context.Context, op UpdateOperation) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result)
@@ -354,7 +355,7 @@ type MockStack struct {
 	QueryF   func(ctx context.Context, op UpdateOperation) result.Result
 	RemoveF  func(ctx context.Context, force bool) (bool, error)
 	RenameF  func(ctx context.Context, newName tokens.QName) (StackReference, error)
-	GetLogsF func(ctx context.Context, cfg StackConfiguration,
+	GetLogsF func(ctx context.Context, secretsProvider secrets.Provider, cfg StackConfiguration,
 		query operations.LogQuery) ([]operations.LogEntry, error)
 	ExportDeploymentF     func(ctx context.Context) (*apitype.UntypedDeployment, error)
 	ImportDeploymentF     func(ctx context.Context, deployment *apitype.UntypedDeployment) error
@@ -377,9 +378,9 @@ func (ms *MockStack) Config() config.Map {
 	panic("not implemented")
 }
 
-func (ms *MockStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) {
+func (ms *MockStack) Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
 	if ms.SnapshotF != nil {
-		return ms.SnapshotF(ctx)
+		return ms.SnapshotF(ctx, secretsProvider)
 	}
 	panic("not implemented")
 }
@@ -465,10 +466,10 @@ func (ms *MockStack) Rename(ctx context.Context, newName tokens.QName) (StackRef
 	panic("not implemented")
 }
 
-func (ms *MockStack) GetLogs(ctx context.Context, cfg StackConfiguration,
+func (ms *MockStack) GetLogs(ctx context.Context, secretsProvider secrets.Provider, cfg StackConfiguration,
 	query operations.LogQuery) ([]operations.LogEntry, error) {
 	if ms.GetLogsF != nil {
-		return ms.GetLogsF(ctx, cfg, query)
+		return ms.GetLogsF(ctx, secretsProvider, cfg, query)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/query.go
+++ b/pkg/backend/query.go
@@ -46,7 +46,7 @@ func RunQuery(ctx context.Context, b Backend, op QueryOperation,
 	engineCtx := &engine.Context{
 		Cancel:        cancellationScope.Context(),
 		Events:        engineEvents,
-		BackendClient: NewBackendClient(b),
+		BackendClient: NewBackendClient(b, op.SecretsProvider),
 	}
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
 		engineCtx.ParentSpan = parentSpan.Context()

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -34,11 +34,14 @@ import (
 
 // Stack is used to manage stacks of resources against a pluggable backend.
 type Stack interface {
-	Ref() StackReference                                    // this stack's identity.
-	Snapshot(ctx context.Context) (*deploy.Snapshot, error) // the latest deployment snapshot.
-	Backend() Backend                                       // the backend this stack belongs to.
-	Tags() map[apitype.StackTagName]string                  // the stack's existing tags.
-
+	// this stack's identity.
+	Ref() StackReference
+	// the latest deployment snapshot.
+	Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
+	// the backend this stack belongs to.
+	Backend() Backend
+	// the stack's existing tags.
+	Tags() map[apitype.StackTagName]string
 	// Preview changes to this stack.
 	Preview(ctx context.Context, op UpdateOperation) (*deploy.Plan, display.ResourceChanges, result.Result)
 	// Update this stack.
@@ -57,7 +60,8 @@ type Stack interface {
 	// rename this stack.
 	Rename(ctx context.Context, newName tokens.QName) (StackReference, error)
 	// list log entries for this stack.
-	GetLogs(ctx context.Context, cfg StackConfiguration, query operations.LogQuery) ([]operations.LogEntry, error)
+	GetLogs(ctx context.Context, secretsProvider secrets.Provider,
+		cfg StackConfiguration, query operations.LogQuery) ([]operations.LogEntry, error)
 	// export this stack's deployment.
 	ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error)
 	// import the given deployment into this stack.
@@ -120,9 +124,9 @@ func GetLatestConfiguration(ctx context.Context, s Stack) (config.Map, error) {
 }
 
 // GetStackLogs fetches a list of log entries for the current stack in the current backend.
-func GetStackLogs(ctx context.Context, s Stack, cfg StackConfiguration,
+func GetStackLogs(ctx context.Context, secretsProvider secrets.Provider, s Stack, cfg StackConfiguration,
 	query operations.LogQuery) ([]operations.LogEntry, error) {
-	return s.Backend().GetLogs(ctx, s, cfg, query)
+	return s.Backend().GetLogs(ctx, secretsProvider, s, cfg, query)
 }
 
 // ExportStackDeployment exports the given stack's deployment as an opaque JSON message.

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -38,7 +39,7 @@ import (
 
 // Watch watches the project's working directory for changes and automatically updates the active
 // stack.
-func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
+func Watch(ctx context.Context, secretsProvider secrets.Provider, b Backend, stack Stack, op UpdateOperation,
 	apply Applier, paths []string) result.Result {
 
 	opts := ApplierOptions{
@@ -51,7 +52,7 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
 	go func() {
 		shown := map[operations.LogEntry]bool{}
 		for {
-			logs, err := b.GetLogs(ctx, stack, op.StackConfiguration, operations.LogQuery{
+			logs, err := b.GetLogs(ctx, secretsProvider, stack, op.StackConfiguration, operations.LogQuery{
 				StartTime: &startTime,
 			})
 			if err != nil {

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -305,7 +305,7 @@ func newImportCmd() *cobra.Command {
 
 	var debug bool
 	var message string
-	var stack string
+	var stackName string
 	var execKind string
 	var execAgent string
 
@@ -509,7 +509,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack.
-			s, err := requireStack(ctx, stack, stackLoadOnly, opts.Display)
+			s, err := requireStack(ctx, stackName, stackLoadOnly, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -554,6 +554,7 @@ func newImportCmd() *cobra.Command {
 				Opts:               opts,
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
+				SecretsProvider:    stack.DefaultSecretsProvider,
 				Scopes:             cancellationScopes,
 			}, imports)
 
@@ -626,7 +627,7 @@ func newImportCmd() *cobra.Command {
 		&message, "message", "m", "",
 		"Optional message to associate with the update operation")
 	cmd.PersistentFlags().StringVarP(
-		&stack, "stack", "s", "",
+		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
 		&stackConfigFile, "config-file", "",

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -37,7 +38,7 @@ import (
 const timeFormat = "2006-01-02T15:04:05.000Z07:00"
 
 func newLogsCmd() *cobra.Command {
-	var stack string
+	var stackName string
 	var follow bool
 	var since string
 	var resource string
@@ -64,7 +65,7 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			s, err := requireStack(ctx, stack, stackLoadOnly, opts)
+			s, err := requireStack(ctx, stackName, stackLoadOnly, opts)
 			if err != nil {
 				return err
 			}
@@ -116,7 +117,7 @@ func newLogsCmd() *cobra.Command {
 			// rendered now even though they are technically out of order.
 			shown := map[operations.LogEntry]bool{}
 			for {
-				logs, err := s.GetLogs(ctx, cfg, operations.LogQuery{
+				logs, err := s.GetLogs(ctx, stack.DefaultSecretsProvider, cfg, operations.LogQuery{
 					StartTime:      startTime,
 					ResourceFilter: resourceFilter,
 				})
@@ -181,7 +182,7 @@ func newLogsCmd() *cobra.Command {
 	}
 
 	logsCmd.PersistentFlags().StringVarP(
-		&stack, "stack", "s", "",
+		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	logsCmd.PersistentFlags().StringVar(
 		&stackConfigFile, "config-file", "",

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -39,7 +40,7 @@ func newPreviewCmd() *cobra.Command {
 	var message string
 	var execKind string
 	var execAgent string
-	var stack string
+	var stackName string
 	var configArray []string
 	var configPath bool
 	var client string
@@ -132,7 +133,7 @@ func newPreviewCmd() *cobra.Command {
 					return result.FromError(err)
 				}
 
-				return runDeployment(ctx, displayOpts, apitype.Preview, stack, args[0], remoteArgs)
+				return runDeployment(ctx, displayOpts, apitype.Preview, stackName, args[0], remoteArgs)
 			}
 
 			filestateBackend, err := isFilestateBackend(displayOpts)
@@ -150,7 +151,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(ctx, stack, stackOfferNew, displayOpts)
+			s, err := requireStack(ctx, stackName, stackOfferNew, displayOpts)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -239,6 +240,7 @@ func newPreviewCmd() *cobra.Command {
 				Opts:               opts,
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
+				SecretsProvider:    stack.DefaultSecretsProvider,
 				Scopes:             cancellationScopes,
 			})
 
@@ -280,7 +282,7 @@ func newPreviewCmd() *cobra.Command {
 		&expectNop, "expect-no-changes", false,
 		"Return an error if any changes are proposed by this preview")
 	cmd.PersistentFlags().StringVarP(
-		&stack, "stack", "s", "",
+		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
 		&stackConfigFile, "config-file", "",

--- a/pkg/cmd/pulumi/query.go
+++ b/pkg/cmd/pulumi/query.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
@@ -30,7 +31,7 @@ import (
 //
 //nolint:vetshadow
 func newQueryCmd() *cobra.Command {
-	var stack string
+	var stackName string
 
 	var cmd = &cobra.Command{
 		Use:   "query",
@@ -72,10 +73,11 @@ func newQueryCmd() *cobra.Command {
 			}
 
 			res := b.Query(ctx, backend.QueryOperation{
-				Proj:   proj,
-				Root:   root,
-				Opts:   opts,
-				Scopes: cancellationScopes,
+				Proj:            proj,
+				Root:            root,
+				Opts:            opts,
+				Scopes:          cancellationScopes,
+				SecretsProvider: stack.DefaultSecretsProvider,
 			})
 			switch {
 			case res != nil && res.Error() == context.Canceled:
@@ -89,7 +91,7 @@ func newQueryCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(
-		&stack, "stack", "s", "",
+		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 
 	return cmd

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
@@ -63,7 +64,7 @@ func newStackCmd() *cobra.Command {
 				return nil
 			}
 
-			snap, err := s.Snapshot(ctx)
+			snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/graph"
 	"github.com/pulumi/pulumi/pkg/v3/graph/dotconv"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
@@ -65,7 +66,7 @@ func newStackGraphCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			snap, err := s.Snapshot(ctx)
+			snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -107,7 +107,7 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	snap, err := s.Snapshot(ctx)
+	snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,7 +139,7 @@ func TestStackOutputCmd_plainText(t *testing.T) {
 			requireStack := func(context.Context,
 				string, stackLoadOption, display.Options) (backend.Stack, error) {
 				return &backend.MockStack{
-					SnapshotF: func(ctx context.Context) (*deploy.Snapshot, error) {
+					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
 						return &snap, nil
 					},
 				}, nil
@@ -251,7 +252,7 @@ func TestStackOutputCmd_json(t *testing.T) {
 			requireStack := func(context.Context,
 				string, stackLoadOption, display.Options) (backend.Stack, error) {
 				return &backend.MockStack{
-					SnapshotF: func(ctx context.Context) (*deploy.Snapshot, error) {
+					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
 						return &snap, nil
 					},
 				}, nil
@@ -374,7 +375,7 @@ func TestStackOutputCmd_shell(t *testing.T) {
 			requireStack := func(context.Context,
 				string, stackLoadOption, display.Options) (backend.Stack, error) {
 				return &backend.MockStack{
-					SnapshotF: func(ctx context.Context) (*deploy.Snapshot, error) {
+					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
 						return &snap, nil
 					},
 				}, nil

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -140,7 +140,7 @@ func runTotalStateEdit(
 
 func totalStateEdit(ctx context.Context, s backend.Stack, showPrompt bool, opts display.Options,
 	operation func(opts display.Options, snap *deploy.Snapshot) error) result.Result {
-	snap, err := s.Snapshot(ctx)
+	snap, err := s.Snapshot(ctx, stack.DefaultSecretsProvider)
 	if err != nil {
 		return result.FromError(err)
 	} else if snap == nil {

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -36,7 +37,7 @@ func newWatchCmd() *cobra.Command {
 	var debug bool
 	var message string
 	var execKind string
-	var stack string
+	var stackName string
 	var configArray []string
 	var pathArray []string
 	var configPath bool
@@ -88,7 +89,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(ctx, stack, stackOfferNew, opts.Display)
+			s, err := requireStack(ctx, stackName, stackOfferNew, opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -148,6 +149,7 @@ func newWatchCmd() *cobra.Command {
 				Opts:               opts,
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
+				SecretsProvider:    stack.DefaultSecretsProvider,
 				Scopes:             cancellationScopes,
 			}, pathArray)
 
@@ -170,7 +172,7 @@ func newWatchCmd() *cobra.Command {
 		&debug, "debug", "d", false,
 		"Print detailed debugging output during resource operations")
 	cmd.PersistentFlags().StringVarP(
-		&stack, "stack", "s", "",
+		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
 		&stackConfigFile, "config-file", "",

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -155,7 +155,8 @@ type deploymentSourceFunc func(
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error)
 
 // newDeployment creates a new deployment with the given context and options.
-func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions, dryRun bool) (*deployment, error) {
+func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions,
+	dryRun bool) (*deployment, error) {
 	contract.Assert(info != nil)
 	contract.Assert(info.Update != nil)
 	contract.Assert(opts.SourceFunc != nil)
@@ -187,7 +188,8 @@ func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions
 	var depl *deploy.Deployment
 	if !opts.isImport {
 		depl, err = deploy.NewDeployment(
-			plugctx, target, target.Snapshot, opts.Plan, source, localPolicyPackPaths, dryRun, ctx.BackendClient)
+			plugctx, target, target.Snapshot, opts.Plan, source,
+			localPolicyPackPaths, dryRun, ctx.BackendClient)
 	} else {
 		_, defaultProviderInfo, pluginErr := installPlugins(proj, pwd, main, target, plugctx,
 			false /*returnInstallErrors*/)

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

All uses of stack.DefaultSecretsProvider are now in pkg/cmd, every other use has been changed to take a secrets.Provider as a parameter in someway.

I renamed a load of variables from "stack" to "stackName" as part of this because it clashed with the "stack" module that DefaultSecretsProvider is currently defined in, but I think this is probably a good change anyway given these were `string`s not `Stack`s.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A Just moving parameters up call chain, should be covered by existing tests.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - N/A Not user facing.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
