### PR TITLE
ci: Don't ignore smoke test failures on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,6 @@ jobs:
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
       version-set: ${{ toJson(matrix.version-set) }}
-      continue-on-error: ${{ contains(matrix.platform, 'windows') }}
     secrets: inherit
 
   test-collect-reports:

--- a/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/b5bbc3d0d660602a096a3956016c5a0f57eddd321f15e9c6276d05290424365a
+++ b/pkg/cmd/pulumi/testdata/fuzz/FuzzPowershellStackOutputWriter/b5bbc3d0d660602a096a3956016c5a0f57eddd321f15e9c6276d05290424365a
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("ώώ")


### PR DESCRIPTION
We were ignoring smoke test failures on Windows.
This is not desirable.
