### PR TITLE
ci: Wait to run tests till after linting

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -36,7 +36,7 @@ jobs:
             exit 1
           fi
       - name: Lint
-        run: make lint
+        run: make lint -j5
 
   protobuf-lint:
     name: Lint Protobufs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
     # To this:
     #   CI / Unit Test / sdk/dotnet dotnet_test on macos-11/current
     name: Unit Test${{ matrix.platform && '' }}
-    needs: [matrix]
+    needs: [matrix, lint]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ contains(needs.matrix.outputs.unit-test-matrix, 'macos') }}
@@ -267,7 +267,7 @@ jobs:
     # By putting a variable in the name, we remove GitHub's auto-generated matrix parameters from
     # appearing in the rendered title of the job name. See: unit test.
     name: Integration Test${{ matrix.platform && '' }}
-    needs: [matrix, build-binaries, build-sdks]
+    needs: [matrix, build-binaries, build-sdks, lint]
     if: ${{ needs.matrix.outputs.integration-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ contains(needs.matrix.outputs.integration-test-matrix, 'macos') }}
@@ -292,7 +292,7 @@ jobs:
     # By putting a variable in the name, we remove GitHub's auto-generated matrix parameters from
     # appearing in the rendered title of the job name. See: unit test.
     name: Smoke Test${{ matrix.platform && '' }}
-    needs: [matrix, build-binaries, build-sdks]
+    needs: [matrix, build-binaries, build-sdks, lint]
     if: ${{ needs.matrix.outputs.smoke-test-matrix != '{}' }}
     # alow jobs to fail if the platform contains windows
     strategy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   timeout: 10m
+  allow-parallel-runners: true
   # Enable checking the by default skipped "examples" dirs
   skip-dirs:
     - vendor$


### PR DESCRIPTION
Take two of #11930

A large number of our CI failures are from linting.
We spent time running tests on changes that won't land anyway
because they fail lint.

This change prevents tests from running until all lint checks have passed.

In an attempt to alleviate the delay to CI time,
we change golangci-lint to run lints in parallel
since otherwise it takes 3+ minutes for the 3 Go modules.
