### PR TITLE
Require linting before running unit, integ, and smoke tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
       build-targets: "${{ fromJson(steps.matrix.outputs.build-targets) }}"
 
   lint:
-    name: lint
+    name: Lint
     needs: [matrix]
     if: ${{ inputs.lint }}
     uses: ./.github/workflows/ci-lint.yml
@@ -243,7 +243,7 @@ jobs:
     # To this:
     #   CI / Unit Test / sdk/dotnet dotnet_test on macos-11/current
     name: Unit Test${{ matrix.platform && '' }}
-    needs: [matrix]
+    needs: [matrix, lint]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ contains(needs.matrix.outputs.unit-test-matrix, 'macos') }}
@@ -268,7 +268,7 @@ jobs:
     # By putting a variable in the name, we remove GitHub's auto-generated matrix parameters from
     # appearing in the rendered title of the job name. See: unit test.
     name: Integration Test${{ matrix.platform && '' }}
-    needs: [matrix, build-binaries, build-sdks]
+    needs: [matrix, build-binaries, build-sdks, lint]
     if: ${{ needs.matrix.outputs.integration-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ contains(needs.matrix.outputs.integration-test-matrix, 'macos') }}

--- a/bors.toml
+++ b/bors.toml
@@ -8,8 +8,8 @@ status = [
 ]
 pr_status = [
 	'linear-history',
-	'CI / lint / Lint GHA',
-	'CI / lint / Lint Go',
-	'CI / lint / Lint Protobufs',
-	'CI / lint / Lint SDKs',
+	'CI / Lint / Lint GHA',
+	'CI / Lint / Lint Go',
+	'CI / Lint / Lint Protobufs',
+	'CI / Lint / Lint SDKs',
 ]


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

**Update:** With https://github.com/pulumi/pulumi/pull/12031 linting runs in about a minute.

Linting should be an extremely low-watermark requirement for evaluating build health. Blocking on it allows use to reduce the number of concurrent runners who are canceled early.

**Trade-offs:**
* This should delay CI time by the amount of time it takes to lint: _e.g._ CI will be ~5 minutes slower on the happy path.
* When a job is queued that fails a lint check, fewer runners will be soaked up just to fail lint checks. This will decrease the overall queue time across all builds.
* Ultimately, we're trading slower happy-path builds for smarter build scheduling. 
* We can mitigate the linting bottleneck by speeding up the linting process (https://github.com/pulumi/pulumi/pull/12023).

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR supports but isn't sufficient for https://github.com/pulumi/pulumi/issues/12019

## Checklist

**This PR is intended to impact CI only, and thus does not justify a CHANGELOG entry or a test.**

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
