### PR TITLE
ci/golangci-lint: Retain golangci-lint cache

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -27,6 +27,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+      - name: Cache golangci-lint
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/golangci-lint
+            ~/.cache/go-build
+            ~/go/pkg
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/go.mod') }}
       - name: Tidy
         run: make tidy
       - name: Fail if go mod not tidy


### PR DESCRIPTION
I found that my local golangci-lint ran *a lot faster* than CI.
Turns out that golangci-lint caches information:
https://golangci-lint.run/usage/configuration/#cache
We didn't have this cache between runs.

This change adds a cache to retain golangci-lint and other Go build data
using a unique cache key specific to this lint job.

Follow up to #12023
Refs #12019

---

This PR depends on #12023
