### PR TITLE
ci/lint: Use golangci-lint-action

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,17 +17,60 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GOLANGCI_LINT_VERSION: v1.50
 
 jobs:
   golangci:
-    container: golangci/golangci-lint:latest
     name: Lint Go
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-      - name: Tidy
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ fromJson(inputs.version-set).go }}
+
+      # Only the first of the following lint actions
+      # should enable the cache.
+      # The rest should 'skip-cache: true'.
+      # They'll all still be cached,
+      # but only the first one will be responsible
+      # for downloading and uploading the cache.
+      - name: Lint pkg
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: pkg
+          args: --config ../.golangci.yml ./...
+      - name: Lint sdk
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: sdk
+          args: --config ../.golangci.yml ./...
+          skip-cache: true  # first lint action will handle
+      - name: Lint tests
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: tests
+          args: --config ../.golangci.yml ./...
+          skip-cache: true  # first lint action will handle
+
+  tidy:
+    name: go mod tidy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ fromJson(inputs.version-set).go }}
+      - name: Run go mod tidy
         run: make tidy
       - name: Fail if go mod not tidy
         run: |
@@ -35,10 +78,6 @@ jobs:
             echo "::error go.mod not tidy"
             exit 1
           fi
-      - name: Lint
-        run: |
-          go work init ./pkg ./sdk ./tests
-          make lint
 
   protobuf-lint:
     name: Lint Protobufs
@@ -58,7 +97,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
       - name: Set up Python ${{ fromJson(inputs.version-set).python }}

--- a/Makefile
+++ b/Makefile
@@ -97,15 +97,7 @@ brew::
 	./scripts/brew.sh "${PROJECT}"
 
 .PHONY: lint_%
-lint:: golangci-lint.ensure
-
-# If we're in a Go workspace, assume that pkg, sdk, and tests are all covered.
-ifeq ($(shell go env GOWORK),)
-lint:: lint_pkg lint_sdk lint_tests
-else
-lint::
-	golangci-lint run ./pkg/... ./sdk/... ./tests/... --timeout 7m
-endif
+lint:: golangci-lint.ensure lint_pkg lint_sdk lint_tests
 
 lint_pkg: lint_deps
 	cd pkg && golangci-lint run -c ../.golangci.yml --timeout 5m


### PR DESCRIPTION
Instead of rolling our own caching logic,
use the official golangci-lint-action
and run `go mod tidy` concurrently.

This has a few advantages over the current setup:

- Non-container builds are faster to run
  (we take ~20 seconds to set up the container)
- golangci-lint-action's caching logic is better:
  it periodically invalidates itself automatically
- `go mod tidy` takes over am inute to run;
  this can be done in parallel

Caveats:

- golangci-lint-action does not support multiple modules in one call,
  so we have to run the action separately for each submodule.
- We have to duplicate some of what `make lint` specifies.
  If we ever add more checks to `make lint`,
  we'll need to also update this job.

Refs #12019
Supersedes #12029
