### PR TITLE
sdk/go/StackReference: Add GetOutputDetails

### DIFF
--- a/changelog/pending/20230203--sdk-go--stackreference-getoutputdetails-go.yaml
+++ b/changelog/pending/20230203--sdk-go--stackreference-getoutputdetails-go.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Adds StackReference.GetOutputDetails to retrieve outputs from StackReferences as plain objects.


### PR DESCRIPTION
Outputs received from StackReferences are currently
unnecessarily wrapped in `Output<T>`.
If the name is known (`string`, not `Input<string>`),
these values are largely fixed and "known" at runtime.

This change introduces a
StackReference.GetOutputDetails method to Go
and a StackReference.get_output_details method to Python.
This method returns a plain OutputDetails object.
This object has two fields: value and secretValue.
At most one of these fields is set,
depending on whether the stack reference output is a secret.

Refs #10839, #5035

---

**Related**

- [ ] Python https://github.com/pulumi/pulumi/pull/12071
- [ ] Node https://github.com/pulumi/pulumi/pull/12072
- [ ] Equivalent change to Java SDK
- [ ] Equivalent change to DotNet SDK
