### PR TITLE
ci: Test with Go 1.19, 1.20

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.50
+  GOLANGCI_LINT_VERSION: v1.51
 
 jobs:
   golangci:

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x # TODO(friel) use version_set
+          go-version: 1.20.x # TODO(friel) use version_set
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -94,7 +94,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
     "dotnet": "6",
-    "go": "1.18.x",
+    "go": "1.19.x",
     "nodejs": "14.x",
     "python": "3.9.x",
 }
@@ -102,7 +102,7 @@ MINIMUM_SUPPORTED_VERSION_SET = {
 CURRENT_VERSION_SET = {
     "name": "current",
     "dotnet": "7",
-    "go": "1.19.x",
+    "go": "1.20.x",
     "nodejs": "19.x",
     "python": "3.10.x",
 }


### PR DESCRIPTION
Go 1.20 was just released.
Switch to testing with Go 1.19 and 1.20.

Resolves #12040