### PR TITLE
sdk/go: Don't store DependsOn in a lossy form

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1427,8 +1427,8 @@ func (ctx *Context) getOpts(
 	var depURNs []URN
 	if opts.DependsOn != nil {
 		depSet := urnSet{}
-		for _, r := range opts.DependsOn {
-			dependsOn, err := r(ctx.ctx)
+		for _, ds := range opts.DependsOn {
+			dependsOn, err := ds.dependencies(ctx.ctx)
 			if err != nil {
 				return resourceOpts{}, err
 			}

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1428,11 +1428,9 @@ func (ctx *Context) getOpts(
 	if opts.DependsOn != nil {
 		depSet := urnSet{}
 		for _, ds := range opts.DependsOn {
-			dependsOn, err := ds.dependencies(ctx.ctx)
-			if err != nil {
+			if err := ds.addURNs(ctx.ctx, depSet); err != nil {
 				return resourceOpts{}, err
 			}
-			depSet.union(dependsOn)
 		}
 		depURNs = depSet.values()
 	}

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -108,11 +108,7 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 	}
 	opts := resourceOption(func(ro *resourceOptions) {
 		ro.Aliases = aliases
-		ro.DependsOn = []func(ctx context.Context) (urnSet, error){
-			func(ctx context.Context) (urnSet, error) {
-				return dependencyURNs, nil
-			},
-		}
+		ro.DependsOn = []dependencySet{urnDependencySet(dependencyURNs)}
 		ro.Protect = req.GetProtect()
 		ro.Providers = providers
 		ro.Parent = parent

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -419,8 +419,9 @@ func CompositeInvoke(opts ...InvokeOption) InvokeOption {
 // dependencySet unifies types that can provide dependencies for a
 // resource.
 type dependencySet interface {
-	// Returns the URNs for this dependencySet.
-	dependencies(context.Context) (urnSet, error)
+	// Adds URNs for addURNs from this set
+	// into the given urnSet.
+	addURNs(context.Context, urnSet) error
 }
 
 // urnDependencySet is a dependencySet built from a constant set of URNs.
@@ -428,8 +429,9 @@ type urnDependencySet urnSet
 
 var _ dependencySet = (urnDependencySet)(nil)
 
-func (us urnDependencySet) dependencies(ctx context.Context) (urnSet, error) {
-	return urnSet(us), nil
+func (us urnDependencySet) addURNs(ctx context.Context, urns urnSet) error {
+	urns.union(urnSet(us))
+	return nil
 }
 
 // DependsOn is an optional array of explicit dependencies on other resources.
@@ -445,8 +447,13 @@ type resourceDependencySet []Resource
 
 var _ dependencySet = (resourceDependencySet)(nil)
 
-func (rs resourceDependencySet) dependencies(ctx context.Context) (urnSet, error) {
-	return expandDependencies(ctx, []Resource(rs))
+func (rs resourceDependencySet) addURNs(ctx context.Context, urns urnSet) error {
+	for _, r := range rs {
+		if err := addDependency(ctx, urns, r); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Declares explicit dependencies on other resources. Similar to
@@ -469,24 +476,29 @@ type resourceArrayInputDependencySet struct{ input ResourceArrayInput }
 
 var _ dependencySet = (*resourceArrayInputDependencySet)(nil)
 
-func (ra *resourceArrayInputDependencySet) dependencies(ctx context.Context) (urnSet, error) {
+func (ra *resourceArrayInputDependencySet) addURNs(ctx context.Context, urns urnSet) error {
 	out := ra.input.ToResourceArrayOutput()
 
 	value, known, _ /* secret */, _ /* deps */, err := out.await(ctx)
 	if err != nil || !known {
-		return nil, err
+		return err
 	}
 
 	resources, ok := value.([]Resource)
 	if !ok {
-		return nil, fmt.Errorf("ResourceArrayInput resolved to a value of unexpected type %v, expected []Resource",
+		return fmt.Errorf("ResourceArrayInput resolved to a value of unexpected type %v, expected []Resource",
 			reflect.TypeOf(value))
 	}
 
 	// For some reason, deps returned above are incorrect; instead:
 	toplevelDeps := out.dependencies()
 
-	return expandDependencies(ctx, append(resources, toplevelDeps...))
+	for _, r := range append(resources, toplevelDeps...) {
+		if err := addDependency(ctx, urns, r); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Ignore changes to any of the specified properties.

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -275,7 +275,7 @@ type resourceOptions struct {
 	// DeleteBeforeReplace, when set to true, ensures that this resource is deleted prior to replacement.
 	DeleteBeforeReplace bool
 	// DependsOn is an optional array of explicit dependencies on other resources.
-	DependsOn []func(ctx context.Context) (urnSet, error)
+	DependsOn []dependencySet
 	// IgnoreChanges ignores changes to any of the specified properties.
 	IgnoreChanges []string
 	// Import, when provided with a resource ID, indicates that this resource's provider should import its state from
@@ -416,13 +416,37 @@ func CompositeInvoke(opts ...InvokeOption) InvokeOption {
 	})
 }
 
+// dependencySet unifies types that can provide dependencies for a
+// resource.
+type dependencySet interface {
+	// Returns the URNs for this dependencySet.
+	dependencies(context.Context) (urnSet, error)
+}
+
+// urnDependencySet is a dependencySet built from a constant set of URNs.
+type urnDependencySet urnSet
+
+var _ dependencySet = (urnDependencySet)(nil)
+
+func (us urnDependencySet) dependencies(ctx context.Context) (urnSet, error) {
+	return urnSet(us), nil
+}
+
 // DependsOn is an optional array of explicit dependencies on other resources.
 func DependsOn(o []Resource) ResourceOption {
 	return resourceOption(func(ro *resourceOptions) {
-		ro.DependsOn = append(ro.DependsOn, func(ctx context.Context) (urnSet, error) {
-			return expandDependencies(ctx, o)
-		})
+		ro.DependsOn = append(ro.DependsOn, resourceDependencySet(o))
 	})
+}
+
+// resourceDependencySet is a dependencySet comprised of references to
+// resources.
+type resourceDependencySet []Resource
+
+var _ dependencySet = (resourceDependencySet)(nil)
+
+func (rs resourceDependencySet) dependencies(ctx context.Context) (urnSet, error) {
+	return expandDependencies(ctx, []Resource(rs))
 }
 
 // Declares explicit dependencies on other resources. Similar to
@@ -435,26 +459,34 @@ func DependsOn(o []Resource) ResourceOption {
 //	DependsOnInputs(allDeps)
 func DependsOnInputs(o ResourceArrayInput) ResourceOption {
 	return resourceOption(func(ro *resourceOptions) {
-		ro.DependsOn = append(ro.DependsOn, func(ctx context.Context) (urnSet, error) {
-			out := o.ToResourceArrayOutput()
-
-			value, known, _ /* secret */, _ /* deps */, err := out.await(ctx)
-			if err != nil || !known {
-				return nil, err
-			}
-
-			resources, ok := value.([]Resource)
-			if !ok {
-				return nil, fmt.Errorf("ResourceArrayInput resolved to a value of unexpected type %v, expected []Resource",
-					reflect.TypeOf(value))
-			}
-
-			// For some reason, deps returned above are incorrect; instead:
-			toplevelDeps := out.dependencies()
-
-			return expandDependencies(ctx, append(resources, toplevelDeps...))
-		})
+		ro.DependsOn = append(ro.DependsOn, &resourceArrayInputDependencySet{o})
 	})
+}
+
+// resourceArrayInputDependencySet is a dependencySet built from
+// collections of resources that are not yet known.
+type resourceArrayInputDependencySet struct{ input ResourceArrayInput }
+
+var _ dependencySet = (*resourceArrayInputDependencySet)(nil)
+
+func (ra *resourceArrayInputDependencySet) dependencies(ctx context.Context) (urnSet, error) {
+	out := ra.input.ToResourceArrayOutput()
+
+	value, known, _ /* secret */, _ /* deps */, err := out.await(ctx)
+	if err != nil || !known {
+		return nil, err
+	}
+
+	resources, ok := value.([]Resource)
+	if !ok {
+		return nil, fmt.Errorf("ResourceArrayInput resolved to a value of unexpected type %v, expected []Resource",
+			reflect.TypeOf(value))
+	}
+
+	// For some reason, deps returned above are incorrect; instead:
+	toplevelDeps := out.dependencies()
+
+	return expandDependencies(ctx, append(resources, toplevelDeps...))
 }
 
 // Ignore changes to any of the specified properties.

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -149,8 +149,8 @@ func TestResourceOptionMergingDependsOn(t *testing.T) {
 
 	resolveDependsOn := func(opts *resourceOptions) []URN {
 		allDeps := urnSet{}
-		for _, f := range opts.DependsOn {
-			deps, err := f(context.TODO())
+		for _, ds := range opts.DependsOn {
+			deps, err := ds.dependencies(context.TODO())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -150,11 +150,9 @@ func TestResourceOptionMergingDependsOn(t *testing.T) {
 	resolveDependsOn := func(opts *resourceOptions) []URN {
 		allDeps := urnSet{}
 		for _, ds := range opts.DependsOn {
-			deps, err := ds.dependencies(context.TODO())
-			if err != nil {
+			if err := ds.addURNs(context.TODO(), allDeps); err != nil {
 				t.Fatal(err)
 			}
-			allDeps.union(deps)
 		}
 		return allDeps.sortedValues()
 	}


### PR DESCRIPTION


The `DependsOn` and `DependsOnInputs` resource options
store their captured information on the `resourceOptions` struct
in a lossy format: they store function references.

This makes it impossible to go back to the original lists of resources
or resource array inputs for use cases like #11698.

As a step towards making this possible,
replace the stored closures with interfaces.

The implementations in the first commit
are a drop-in replacement for the prior behavior
with no logic changes whatsoever.

The second commit makes a minor optimization:
it adds URNs to the same set instead
of constantly allocating new sets and combining them afterwards.

Refs #11698
