### PR TITLE
Use 'errors' not 'pkg/errors' in go codegen

### DIFF
--- a/changelog/pending/20230202--sdkgen-go--go-sdks-now-use-errors-new-instead-of-github-com-pkg-errors-new.yaml
+++ b/changelog/pending/20230202--sdkgen-go--go-sdks-now-use-errors-new-instead-of-github-com-pkg-errors-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/go
+  description: Go SDKs now use `errors.New` instead of `github.com/pkg/errors.New`.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -2802,7 +2802,7 @@ func (pkg *pkgContext) getImports(member interface{}, importsAndAliases map[stri
 			pkg.getTypeImports(p.Type, false, importsAndAliases, seen)
 
 			if p.IsRequired() {
-				importsAndAliases["github.com/pkg/errors"] = ""
+				importsAndAliases["errors"] = ""
 			}
 		}
 		for _, method := range member.Methods {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 
 	"dashed-import-schema/plant-provider"
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/nursery.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 
 	"different-enum/plant"
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	awsec2 "github.com/pulumi/pulumi-aws/sdk/v4/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/s3"
 	accesscontextmanager "github.com/pulumi/pulumi-google-native/sdk/go/google/accesscontextmanager/v1"

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/ec2"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/conditionalAccessPolicy.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/conditionalAccessPolicy.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/secrets/go/mypkg/resource.go
+++ b/pkg/codegen/testing/test/testdata/secrets/go/mypkg/resource.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"simple-enum-schema/plant"
 )

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Continue clean up of our use of pkg/errors. This changes our Go code generator to stop using it, there's still a few places in the sdk using it so go.mods will still reference it.

Looks like the only thing the code generator used "pkg/errors" for was `New` which is also on "errors".

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - Covered by existing tests
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
