### PR TITLE
test/integration: Avoid data race from FileMutex

### DIFF
--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +40,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -257,33 +259,82 @@ func runComponentSetup(t *testing.T, testDir string) {
 	synchronouslyDo(t, lockfile, timeout, fn)
 }
 
-func synchronouslyDo(t *testing.T, lockfile string, timeout time.Duration, fn func()) {
-	mutex := fsutil.NewFileMutex(lockfile)
-	defer func() {
-		assert.NoError(t, mutex.Unlock())
-	}()
+func synchronouslyDo(t testing.TB, lockfile string, timeout time.Duration, fn func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
-	lockWait := make(chan struct{}, 1)
+	lockWait := make(chan struct{})
 	go func() {
-		for {
+		mutex := fsutil.NewFileMutex(lockfile)
+
+		// ctx.Err will be non-nil when the context finishes
+		// either because it timed out or because it got canceled.
+		for ctx.Err() == nil {
 			if err := mutex.Lock(); err != nil {
 				time.Sleep(1 * time.Second)
 				continue
 			} else {
+				defer func() {
+					assert.NoError(t, mutex.Unlock())
+				}()
 				break
 			}
 		}
 
-		fn()
-		lockWait <- struct{}{}
+		// Context may hav expired
+		// by the time we acquired the lock.
+		if ctx.Err() == nil {
+			fn()
+			close(lockWait)
+		}
 	}()
 
 	select {
-	case <-time.After(timeout):
+	case <-ctx.Done():
 		t.Fatalf("timed out waiting for lock on %s", lockfile)
 	case <-lockWait:
 		// waited for fn, success.
 	}
+}
+
+// Verifies that if a file lock is already acquired,
+// synchronouslyDo is able to time out properly.
+func TestSynchronouslyDo_timeout(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "foo")
+	mu := fsutil.NewFileMutex(path)
+	require.NoError(t, mu.Lock())
+	defer func() {
+		assert.NoError(t, mu.Unlock())
+	}()
+
+	fakeT := nonfatalT{T: t}
+	synchronouslyDo(&fakeT, path, 10*time.Millisecond, func() {
+		t.Errorf("timed-out operation should not be called")
+	})
+
+	assert.True(t, fakeT.fatal, "must have a fatal failure")
+	if assert.Len(t, fakeT.messages, 1) {
+		assert.Contains(t, fakeT.messages[0], "timed out waiting")
+	}
+}
+
+// nonfatalT wraps a testing.T to capture fatal errors.
+type nonfatalT struct {
+	*testing.T
+
+	mu       sync.Mutex
+	fatal    bool
+	messages []string
+}
+
+func (t *nonfatalT) Fatalf(msg string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.fatal = true
+	t.messages = append(t.messages, fmt.Sprintf(msg, args...))
 }
 
 // Test methods that create resources.


### PR DESCRIPTION
integration_util_test contains a helper function synchronouslyDo
which attempts to run an operation with a file lock with a timeout,
in a blocking manner.
This implementation has a couple issues.

First, there's a data race between Lock() and Unlock() of the mutex:
the function defers an unlock regardless of whether a lock was acquired,
and if the timing is right, it causes a data race in FileMutex
on reading and writing the fsunlock field.

```
WARNING: DATA RACE
Read at 0x00c000388040 by goroutine 16:
  github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil.(*FileMutex).Unlock()
      /Users/runner/work/pulumi/pulumi/sdk/go/common/util/fsutil/lock.go:64 +0x3e
  github.com/pulumi/pulumi/tests/integration.synchronouslyDo.func1()
      /Users/runner/work/pulumi/pulumi/tests/integration/integration_util_test.go:263 +0x39
  [..]

Previous write at 0x00c000388040 by goroutine 17:
  github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil.(*FileMutex).Lock()
      /Users/runner/work/pulumi/pulumi/sdk/go/common/util/fsutil/lock.go:55 +0x72
  github.com/pulumi/pulumi/tests/integration.synchronouslyDo.func2()
      /Users/runner/work/pulumi/pulumi/tests/integration/integration_util_test.go:269 +0x4e
```

This data race is not expected because the contract for FileMutex is
that the Unlock method should only be called after Lock,
typicaly from the same goroutine --- synchronouslyDo does not do this.

Secondly, synchronouslyDo has a minor bug:
it will run the function *eventually* when the lock has been acquired
even if the timeout has expirted and the test has failed by then.

Resolve these issues by making the following changes:

- use a context to track the timeout
- defer an unlock only if a lock was successfully acquired
- run the operation only if we still have time to run it

Includes a failing test case.
