### PR TITLE
ci/build-targets: Use ubuntu runners for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
               { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-latest" },
-              { "os": "darwin",  "arch": "amd64", "build-platform": "macos-11" },
-              { "os": "darwin",  "arch": "arm64", "build-platform": "macos-11" }
+              { "os": "darwin",  "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
             ]'
           fi
 


### PR DESCRIPTION
With Go 1.20, we no longer need to use macOS runners for these builds
because it includes a CGo-free DNS resolver.

Depends on #12039
Refs #9224