### PR TITLE
Temporarily revert support for projects in the Self-Managed backend

### DIFF
--- a/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
+++ b/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: backend/filestate
-  description: The filestate backend now supports project scoped stacks. Unlike the service backend the CLI will not automatically name stacks with the current project; users will have to do this explicitly, as we have to continue supporting non-project scoped stacks as well. To make a project scoped stack use the full name in `init`, e.g. `pulumi stack init project/stack`.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -76,7 +76,7 @@ type StackReference interface {
 	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.Name
 
-	// Fully qualified name of the stack, including any organization, project, or other information.
+	// Fully qualified name of the stack.
 	FullyQualifiedName() tokens.QName
 }
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -88,27 +89,19 @@ type localBackend struct {
 }
 
 type localBackendReference struct {
-	name    tokens.Name
-	project tokens.Name
+	name tokens.Name
 }
 
 func (r localBackendReference) String() string {
-	return r.FullyQualifiedName().String()
+	return string(r.name)
 }
 
 func (r localBackendReference) Name() tokens.Name {
 	return r.name
 }
 
-func (r localBackendReference) Project() tokens.Name {
-	return r.project
-}
-
 func (r localBackendReference) FullyQualifiedName() tokens.QName {
-	if r.project == "" {
-		return r.name.Q()
-	}
-	return tokens.QName(fmt.Sprintf("%s/%s", r.project, r.name))
+	return r.Name().Q()
 }
 
 func IsFileStateBackendURL(urlstr string) bool {
@@ -287,56 +280,31 @@ func (b *localBackend) SupportsOrganizations() bool {
 	return false
 }
 
-func (b *localBackend) ParseStackReference(stackRef string) (backend.StackReference, error) {
-	var name, project string
-	split := strings.Split(stackRef, "/")
-	switch len(split) {
-	case 1:
-		name = split[0]
-	case 2:
-		project = split[0]
-		name = split[1]
-	default:
-		return nil, fmt.Errorf("could not parse stack reference '%s'", stackRef)
+func (b *localBackend) ParseStackReference(stackRefName string) (backend.StackReference, error) {
+	if err := b.ValidateStackName(stackRefName); err != nil {
+		return nil, err
 	}
-
-	if len(project) > 100 {
-		return nil, errors.New("project names must be less than 100 characters")
-	}
-
-	if project != "" && !tokens.IsName(project) {
-		return nil, fmt.Errorf(
-			"project names may only contain alphanumerics, hyphens, underscores, and periods: %s",
-			project)
-	}
-
-	if !tokens.IsName(name) || len(name) > 100 {
-		return nil, fmt.Errorf(
-			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods: %s",
-			name)
-	}
-
-	return localBackendReference{name: tokens.Name(name), project: tokens.Name(project)}, nil
+	return localBackendReference{name: tokens.Name(stackRefName)}, nil
 }
 
-// ValidateStackName verifies the stack name is valid for the local backend.
-func (b *localBackend) ValidateStackName(stackRef string) error {
-	_, err := b.ParseStackReference(stackRef)
-	return err
+// ValidateStackName verifies the stack name is valid for the local backend. We use the same rules as the
+// httpstate backend.
+func (b *localBackend) ValidateStackName(stackName string) error {
+	if strings.Contains(stackName, "/") {
+		return errors.New("stack names may not contain slashes")
+	}
+
+	validNameRegex := regexp.MustCompile("^[A-Za-z0-9_.-]{1,100}$")
+	if !validNameRegex.MatchString(stackName) {
+		return errors.New(
+			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods")
+	}
+
+	return nil
 }
 
 func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string) (bool, error) {
-	projects, err := b.getLocalProjects()
-	if err != nil {
-		return false, err
-	}
-
-	for _, project := range projects {
-		if string(project) == projectName {
-			return true, nil
-		}
-	}
-
+	// Local backends don't really have multiple projects, so just return false here.
 	return false, nil
 }
 
@@ -351,7 +319,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 
 	contract.Requiref(opts == nil, "opts", "local stacks do not support any options")
 
-	stackName := stackRef.FullyQualifiedName()
+	stackName := stackRef.Name()
 	if stackName == "" {
 		return nil, errors.New("invalid empty stack name")
 	}
@@ -364,7 +332,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 	if err != nil {
 		return nil, fmt.Errorf("getting stack tags: %w", err)
 	}
-	if err = validation.ValidateStackProperties(stackName.Name().String(), tags); err != nil {
+	if err = validation.ValidateStackProperties(string(stackName), tags); err != nil {
 		return nil, fmt.Errorf("validating stack properties: %w", err)
 	}
 
@@ -380,7 +348,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 }
 
 func (b *localBackend) GetStack(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
-	stackName := stackRef.FullyQualifiedName()
+	stackName := stackRef.Name()
 	snapshot, path, err := b.getStack(ctx, stackName)
 
 	switch {
@@ -409,7 +377,6 @@ func (b *localBackend) ListStacks(
 		if err != nil {
 			return nil, nil, err
 		}
-
 		stackRef, err := b.ParseStackReference(string(stackName))
 		if err != nil {
 			return nil, nil, err
@@ -428,7 +395,7 @@ func (b *localBackend) RemoveStack(ctx context.Context, stack backend.Stack, for
 	}
 	defer b.Unlock(ctx, stack.Ref())
 
-	stackName := stack.Ref().FullyQualifiedName()
+	stackName := stack.Ref().Name()
 	snapshot, _, err := b.getStack(ctx, stackName)
 	if err != nil {
 		return false, err
@@ -452,7 +419,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 	defer b.Unlock(ctx, stack.Ref())
 
 	// Get the current state from the stack to be renamed.
-	stackName := stack.Ref().FullyQualifiedName()
+	stackName := stack.Ref().Name()
 	snap, _, err := b.getStack(ctx, stackName)
 	if err != nil {
 		return nil, err
@@ -464,7 +431,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 		return nil, err
 	}
 
-	newStackName := newRef.FullyQualifiedName()
+	newStackName := newRef.Name()
 
 	// Ensure the destination stack does not already exist.
 	hasExisting, err := b.bucket.Exists(ctx, b.stackPath(newStackName))
@@ -477,7 +444,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 
 	// If we have a snapshot, we need to rename the URNs inside it to use the new stack name.
 	if snap != nil {
-		if err = edit.RenameStack(snap, newStackName.Name(), ""); err != nil {
+		if err = edit.RenameStack(snap, newStackName, ""); err != nil {
 			return nil, err
 		}
 	}
@@ -596,7 +563,7 @@ func (b *localBackend) apply(
 	events chan<- engine.Event) (*deploy.Plan, sdkDisplay.ResourceChanges, result.Result) {
 
 	stackRef := stack.Ref()
-	stackName := stackRef.FullyQualifiedName()
+	stackName := stackRef.Name()
 	actionLabel := backend.ActionLabel(kind, opts.DryRun)
 
 	if !(op.Opts.Display.JSONDisplay || op.Opts.Display.Type == display.DisplayWatch) {
@@ -615,7 +582,7 @@ func (b *localBackend) apply(
 	displayEvents := make(chan engine.Event)
 	displayDone := make(chan bool)
 	go display.ShowEvents(
-		strings.ToLower(actionLabel), kind, stackName.Name(), op.Proj.Name,
+		strings.ToLower(actionLabel), kind, stackName, op.Proj.Name,
 		displayEvents, displayDone, op.Opts.Display, opts.DryRun)
 
 	// Create a separate event channel for engine events that we'll pipe to both listening streams.
@@ -766,7 +733,7 @@ func (b *localBackend) GetHistory(
 	stackRef backend.StackReference,
 	pageSize int,
 	page int) ([]backend.UpdateInfo, error) {
-	stackName := stackRef.FullyQualifiedName()
+	stackName := stackRef.Name()
 	updates, err := b.getHistory(stackName, pageSize, page)
 	if err != nil {
 		return nil, err
@@ -778,7 +745,7 @@ func (b *localBackend) GetLogs(ctx context.Context,
 	secretsProvider secrets.Provider, stack backend.Stack, cfg backend.StackConfiguration,
 	query operations.LogQuery) ([]operations.LogEntry, error) {
 
-	stackName := stack.Ref().FullyQualifiedName()
+	stackName := stack.Ref().Name()
 	target, err := b.getTarget(ctx, stackName, cfg.Config, cfg.Decrypter)
 	if err != nil {
 		return nil, err
@@ -813,7 +780,7 @@ func GetLogsForTarget(target *deploy.Target, query operations.LogQuery) ([]opera
 func (b *localBackend) ExportDeployment(ctx context.Context,
 	stk backend.Stack) (*apitype.UntypedDeployment, error) {
 
-	stackName := stk.Ref().FullyQualifiedName()
+	stackName := stk.Ref().Name()
 	chk, err := b.getCheckpoint(stackName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load checkpoint: %w", err)
@@ -839,7 +806,7 @@ func (b *localBackend) ImportDeployment(ctx context.Context, stk backend.Stack,
 	}
 	defer b.Unlock(ctx, stk.Ref())
 
-	stackName := stk.Ref().FullyQualifiedName()
+	stackName := stk.Ref().Name()
 	chk, err := stack.MarshalUntypedDeploymentToVersionedCheckpoint(stackName, deployment)
 	if err != nil {
 		return err
@@ -865,7 +832,7 @@ func (b *localBackend) CurrentUser() (string, []string, error) {
 	return user.Username, nil, nil
 }
 
-func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
+func (b *localBackend) getLocalStacks() ([]tokens.Name, error) {
 	// Read the stack directory.
 	path := b.stackPath("")
 
@@ -873,58 +840,21 @@ func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error listing stacks: %w", err)
 	}
-	var stacks = make([]tokens.QName, 0, len(files))
+	var stacks = make([]tokens.Name, 0, len(files))
 
 	for _, file := range files {
-
+		// Ignore directories.
 		if file.IsDir {
-			projName := objectName(file)
-			// If this isn't a valid Name it won't be a project directory, so skip it
-			if !tokens.IsName(projName) {
-				continue
-			}
-
-			// TODO: Could we improve the efficiency here by firstly making listBucket return an enumerator not
-			// eagerly collecting all keys into a slice, and secondly by getting listBucket to return all
-			// descendent items not just the immediate children. We could then do the necessary splitting by
-			// file paths here to work out project names.
-			projectFiles, err := listBucket(b.bucket, filepath.Join(path, projName))
-			if err != nil {
-				return nil, fmt.Errorf("error listing stacks: %w", err)
-			}
-
-			for _, projectFile := range projectFiles {
-				// Can ignore directories at this level
-				if projectFile.IsDir {
-					continue
-				}
-
-				objName := objectName(projectFile)
-				// Skip files without valid extensions (e.g., *.bak files).
-				ext := filepath.Ext(objName)
-				// But accept gzip compression
-				if ext == encoding.GZIPExt {
-					objName = strings.TrimSuffix(objName, encoding.GZIPExt)
-					ext = filepath.Ext(objName)
-				}
-
-				if _, has := encoding.Marshalers[ext]; !has {
-					continue
-				}
-
-				// Read in this stack's information.
-				name := objName[:len(objName)-len(ext)]
-				stacks = append(stacks, tokens.QName(projName+tokens.QNameDelimiter+name))
-			}
+			continue
 		}
 
-		objName := objectName(file)
 		// Skip files without valid extensions (e.g., *.bak files).
-		ext := filepath.Ext(objName)
+		stackfn := objectName(file)
+		ext := filepath.Ext(stackfn)
 		// But accept gzip compression
 		if ext == encoding.GZIPExt {
-			objName = strings.TrimSuffix(objName, encoding.GZIPExt)
-			ext = filepath.Ext(objName)
+			stackfn = strings.TrimSuffix(stackfn, encoding.GZIPExt)
+			ext = filepath.Ext(stackfn)
 		}
 
 		if _, has := encoding.Marshalers[ext]; !has {
@@ -932,47 +862,12 @@ func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
 		}
 
 		// Read in this stack's information.
-		name := objName[:len(objName)-len(ext)]
-		stacks = append(stacks, tokens.QName(name))
+		name := tokens.Name(stackfn[:len(stackfn)-len(ext)])
+
+		stacks = append(stacks, name)
 	}
 
 	return stacks, nil
-}
-
-func (b *localBackend) getLocalProjects() ([]tokens.Name, error) {
-	// Read the stack directory.
-	path := b.stackPath("")
-
-	files, err := listBucket(b.bucket, path)
-	if err != nil {
-		return nil, fmt.Errorf("error listing projects: %w", err)
-	}
-	var projects = make([]tokens.Name, 0, len(files))
-
-	for _, file := range files {
-		// Ignore files.
-		if !file.IsDir {
-			continue
-		}
-
-		// Skip directories without valid names
-		objName := objectName(file)
-		if !tokens.IsName(objName) {
-			continue
-		}
-
-		projects = append(projects, tokens.Name(objName))
-	}
-
-	return projects, nil
-}
-
-// GetStackTags fetches the stack's existing tags.
-func (b *localBackend) GetStackTags(ctx context.Context,
-	stack backend.Stack) (map[apitype.StackTagName]string, error) {
-
-	// The local backend does not currently persist tags.
-	return nil, errors.New("stack tags not supported in --local mode")
 }
 
 // UpdateStackTags updates the stacks's tags, replacing all existing tags.
@@ -985,7 +880,7 @@ func (b *localBackend) UpdateStackTags(ctx context.Context,
 
 func (b *localBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend.StackReference) error {
 	// Try to delete ALL the lock files
-	allFiles, err := listBucket(b.bucket, stackLockDir(stackRef.FullyQualifiedName()))
+	allFiles, err := listBucket(b.bucket, stackLockDir(stackRef.Name()))
 	if err != nil {
 		// Don't error if it just wasn't found
 		if gcerrors.Code(err) == gcerrors.NotFound {

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -249,14 +249,14 @@ func TestCancel(t *testing.T) {
 	err = lb.Lock(ctx, aStackRef)
 	assert.NoError(t, err)
 	// check the lock file exists
-	lockExists, err := lb.bucket.Exists(ctx, lb.lockPath(aStackRef.(localBackendReference).FullyQualifiedName()))
+	lockExists, err := lb.bucket.Exists(ctx, lb.lockPath(aStackRef.Name()))
 	assert.NoError(t, err)
 	assert.True(t, lockExists)
 	// Call CancelCurrentUpdate
 	err = lb.CancelCurrentUpdate(ctx, aStackRef)
 	assert.NoError(t, err)
 	// Now check the lock file no longer exists
-	lockExists, err = lb.bucket.Exists(ctx, lb.lockPath(aStackRef.(localBackendReference).FullyQualifiedName()))
+	lockExists, err = lb.bucket.Exists(ctx, lb.lockPath(aStackRef.Name()))
 	assert.NoError(t, err)
 	assert.False(t, lockExists)
 
@@ -301,10 +301,10 @@ func TestRemoveMakesBackups(t *testing.T) {
 	assert.NotNil(t, aStack)
 
 	// Check the stack file now exists, but the backup file doesn't
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef.FullyQualifiedName()))
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef.Name()))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef.FullyQualifiedName())+".bak")
+	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef.Name())+".bak")
 	assert.NoError(t, err)
 	assert.False(t, backupFileExists)
 
@@ -314,10 +314,10 @@ func TestRemoveMakesBackups(t *testing.T) {
 	assert.False(t, removed)
 
 	// Check the stack file is now gone, but the backup file exists
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef.FullyQualifiedName()))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef.Name()))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
-	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef.FullyQualifiedName())+".bak")
+	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef.Name())+".bak")
 	assert.NoError(t, err)
 	assert.True(t, backupFileExists)
 }
@@ -344,7 +344,7 @@ func TestRenameWorks(t *testing.T) {
 	assert.NotNil(t, aStack)
 
 	// Check the stack file now exists
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef.FullyQualifiedName()))
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef.Name()))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
 
@@ -361,10 +361,10 @@ func TestRenameWorks(t *testing.T) {
 	assert.Equal(t, "b", bStackRef.String())
 
 	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef.FullyQualifiedName()))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef.Name()))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef.FullyQualifiedName()))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef.Name()))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
 
@@ -376,10 +376,10 @@ func TestRenameWorks(t *testing.T) {
 	assert.Equal(t, "c", cStackRef.String())
 
 	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(cStackRef.FullyQualifiedName()))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(cStackRef.Name()))
 	assert.NoError(t, err)
 	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef.FullyQualifiedName()))
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef.Name()))
 	assert.NoError(t, err)
 	assert.False(t, stackFileExists)
 
@@ -470,98 +470,4 @@ func TestHtmlEscaping(t *testing.T) {
 	assert.NoError(t, err)
 	state := string(bytes)
 	assert.Contains(t, state, "<html@tags>")
-}
-
-func TestLegacyFolderStructure(t *testing.T) {
-	t.Parallel()
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
-	assert.NoError(t, err)
-	ctx := context.Background()
-
-	// Make a dummy stack file in the legacy location
-	err = os.MkdirAll(path.Join(tmpDir, ".pulumi", "stacks"), os.ModePerm)
-	assert.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "a.json"), []byte("{}"), os.ModePerm)
-	assert.NoError(t, err)
-
-	// Check that list stack shows that stack
-	stacks, token, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
-	assert.NoError(t, err)
-	assert.Nil(t, token)
-	assert.Len(t, stacks, 1)
-	assert.Equal(t, "a", stacks[0].Name().String())
-
-	// Create a new non-project stack
-	bRef, err := b.ParseStackReference("b")
-	assert.NoError(t, err)
-	assert.Equal(t, "b", bRef.String())
-	bStack, err := b.CreateStack(ctx, bRef, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "b", bStack.Ref().String())
-	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "b.json"))
-}
-
-func TestProjectFolderStructure(t *testing.T) {
-	t.Parallel()
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
-	assert.NoError(t, err)
-	ctx := context.Background()
-
-	// Make a dummy stack file in the legacy location
-	err = os.MkdirAll(path.Join(tmpDir, ".pulumi", "stacks", "testproj"), os.ModePerm)
-	assert.NoError(t, err)
-	err = os.WriteFile(path.Join(tmpDir, ".pulumi", "stacks", "testproj", "a.json"), []byte("{}"), os.ModePerm)
-	assert.NoError(t, err)
-
-	// Check that testproj is reported as existing
-	exists, err := b.DoesProjectExist(ctx, "testproj")
-	assert.NoError(t, err)
-	assert.True(t, exists)
-
-	// Check that list stack shows that stack
-	stacks, token, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
-	assert.NoError(t, err)
-	assert.Nil(t, token)
-	assert.Len(t, stacks, 1)
-	assert.Equal(t, "testproj/a", stacks[0].Name().String())
-
-	// Create a new project stack
-	bRef, err := b.ParseStackReference("testproj/b")
-	assert.NoError(t, err)
-	assert.Equal(t, "testproj/b", bRef.String())
-	bStack, err := b.CreateStack(ctx, bRef, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "testproj/b", bStack.Ref().String())
-	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "testproj", "b.json"))
-}
-
-func TestCanRenameStack(t *testing.T) {
-	t.Parallel()
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
-	assert.NoError(t, err)
-	ctx := context.Background()
-
-	// Create a new non-project stack
-	bRef, err := b.ParseStackReference("b")
-	assert.NoError(t, err)
-	assert.Equal(t, "b", bRef.String())
-	bStack, err := b.CreateStack(ctx, bRef, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "b", bStack.Ref().String())
-	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "b.json"))
-
-	// Rename it
-	newBStack, err := b.RenameStack(ctx, bStack, "testproj/b")
-	assert.NoError(t, err)
-	assert.Equal(t, "testproj/b", newBStack.String())
-	assert.FileExists(t, path.Join(tmpDir, ".pulumi", "stacks", "testproj", "b.json"))
 }

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -87,12 +87,7 @@ func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
 
 // objectName returns the filename of a ListObject (an object from a bucket).
 func objectName(obj *blob.ListObject) string {
-	// If obj.Key ends in "/" we want to trim that to get the name just before
-	key := obj.Key
-	if key[len(key)-1] == '/' {
-		key = key[0 : len(key)-1]
-	}
-	_, filename := path.Split(key)
+	_, filename := path.Split(obj.Key)
 	return filename
 }
 

--- a/pkg/backend/filestate/snapshot.go
+++ b/pkg/backend/filestate/snapshot.go
@@ -23,7 +23,7 @@ import (
 // localSnapshotManager is a simple SnapshotManager implementation that persists snapshots
 // to disk on the local machine.
 type localSnapshotPersister struct {
-	name    tokens.QName
+	name    tokens.Name
 	backend *localBackend
 	sm      secrets.Manager
 }
@@ -38,6 +38,6 @@ func (sp *localSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 
 }
 
-func (b *localBackend) newSnapshotPersister(stackName tokens.QName, sm secrets.Manager) *localSnapshotPersister {
+func (b *localBackend) newSnapshotPersister(stackName tokens.Name, sm secrets.Manager) *localSnapshotPersister {
 	return &localSnapshotPersister{name: stackName, backend: b, sm: sm}
 }

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -38,13 +38,13 @@ type Stack interface {
 
 // localStack is a local stack descriptor.
 type localStack struct {
-	ref      localBackendReference // the stack's reference (qualified name).
-	path     string                // a path to the stack's checkpoint file on disk.
-	snapshot *deploy.Snapshot      // a snapshot representing the latest deployment state.
-	b        *localBackend         // a pointer to the backend this stack belongs to.
+	ref      backend.StackReference // the stack's reference (qualified name).
+	path     string                 // a path to the stack's checkpoint file on disk.
+	snapshot *deploy.Snapshot       // a snapshot representing the latest deployment state.
+	b        *localBackend          // a pointer to the backend this stack belongs to.
 }
 
-func newStack(ref localBackendReference, path string, snapshot *deploy.Snapshot, b *localBackend) Stack {
+func newStack(ref backend.StackReference, path string, snapshot *deploy.Snapshot, b *localBackend) Stack {
 	return &localStack{
 		ref:      ref,
 		path:     path,

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -96,7 +96,7 @@ func (b *localBackend) newQuery(
 
 func (b *localBackend) newUpdate(
 	ctx context.Context,
-	stackName tokens.QName,
+	stackName tokens.Name,
 	op backend.UpdateOperation) (*update, error) {
 	contract.Require(stackName != "", "stackName")
 
@@ -118,7 +118,7 @@ func (b *localBackend) newUpdate(
 
 func (b *localBackend) getTarget(
 	ctx context.Context,
-	stackName tokens.QName,
+	stackName tokens.Name,
 	cfg config.Map,
 	dec config.Decrypter) (*deploy.Target, error) {
 	snapshot, _, err := b.getStack(ctx, stackName)
@@ -126,7 +126,7 @@ func (b *localBackend) getTarget(
 		return nil, err
 	}
 	return &deploy.Target{
-		Name:         stackName.Name(),
+		Name:         stackName,
 		Organization: "", // filestate has no organizations
 		Config:       cfg,
 		Decrypter:    dec,
@@ -136,7 +136,7 @@ func (b *localBackend) getTarget(
 
 func (b *localBackend) getStack(
 	ctx context.Context,
-	name tokens.QName) (*deploy.Snapshot, string, error) {
+	name tokens.Name) (*deploy.Snapshot, string, error) {
 	if name == "" {
 		return nil, "", errors.New("invalid empty stack name")
 	}
@@ -165,7 +165,7 @@ func (b *localBackend) getStack(
 }
 
 // GetCheckpoint loads a checkpoint file for the given stack in this project, from the current project workspace.
-func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.CheckpointV3, error) {
+func (b *localBackend) getCheckpoint(stackName tokens.Name) (*apitype.CheckpointV3, error) {
 	chkpath := b.stackPath(stackName)
 	bytes, err := b.bucket.ReadAll(context.TODO(), chkpath)
 	if err != nil {
@@ -180,7 +180,7 @@ func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.Checkpoin
 }
 
 func (b *localBackend) saveCheckpoint(
-	name tokens.QName, checkpoint *apitype.VersionedCheckpoint) (backupFile string, file string, _ error) {
+	name tokens.Name, checkpoint *apitype.VersionedCheckpoint) (backupFile string, file string, _ error) {
 
 	// Make a serializable stack and then use the encoder to encode it.
 	file = b.stackPath(name)
@@ -267,7 +267,7 @@ func (b *localBackend) saveCheckpoint(
 	return backupFile, file, nil
 }
 
-func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm secrets.Manager) (string, error) {
+func (b *localBackend) saveStack(name tokens.Name, snap *deploy.Snapshot, sm secrets.Manager) (string, error) {
 	chk, err := stack.SerializeCheckpoint(name, snap, sm, false /* showSecrets */)
 	if err != nil {
 		return "", fmt.Errorf("serializaing checkpoint: %w", err)
@@ -294,7 +294,7 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 }
 
 // removeStack removes information about a stack from the current workspace.
-func (b *localBackend) removeStack(name tokens.QName) error {
+func (b *localBackend) removeStack(name tokens.Name) error {
 	contract.Require(name != "", "name")
 
 	// Just make a backup of the file and don't write out anything new.
@@ -327,7 +327,7 @@ func backupTarget(bucket Bucket, file string, keepOriginal bool) string {
 }
 
 // backupStack copies the current Checkpoint file to ~/.pulumi/backups.
-func (b *localBackend) backupStack(name tokens.QName) error {
+func (b *localBackend) backupStack(name tokens.Name) error {
 	contract.Require(name != "", "name")
 
 	// Exit early if backups are disabled.
@@ -360,7 +360,7 @@ func (b *localBackend) backupStack(name tokens.QName) error {
 	return b.bucket.WriteAll(context.TODO(), filepath.Join(backupDir, backupFile), byts, nil)
 }
 
-func (b *localBackend) stackPath(stack tokens.QName) string {
+func (b *localBackend) stackPath(stack tokens.Name) string {
 	path := filepath.Join(b.StateDir(), workspace.StackDir)
 	if stack == "" {
 		return path
@@ -369,7 +369,7 @@ func (b *localBackend) stackPath(stack tokens.QName) string {
 	// We can't use listBucket here for as we need to do a partial prefix match on filename, while the
 	// "dir" option to listBucket is always suffixed with "/". Also means we don't need to save any
 	// results in a slice.
-	plainPath := filepath.ToSlash(filepath.Join(path, fsutil.QnamePath(stack)) + ".json")
+	plainPath := filepath.ToSlash(filepath.Join(path, fsutil.NamePath(stack)) + ".json")
 	gzipedPath := plainPath + ".gz"
 
 	bucketIter := b.bucket.List(&blob.ListOptions{
@@ -405,19 +405,19 @@ func (b *localBackend) stackPath(stack tokens.QName) string {
 	return plainPath
 }
 
-func (b *localBackend) historyDirectory(stack tokens.QName) string {
+func (b *localBackend) historyDirectory(stack tokens.Name) string {
 	contract.Require(stack != "", "stack")
-	return filepath.Join(b.StateDir(), workspace.HistoryDir, fsutil.QnamePath(stack))
+	return filepath.Join(b.StateDir(), workspace.HistoryDir, fsutil.NamePath(stack))
 }
 
-func (b *localBackend) backupDirectory(stack tokens.QName) string {
+func (b *localBackend) backupDirectory(stack tokens.Name) string {
 	contract.Require(stack != "", "stack")
-	return filepath.Join(b.StateDir(), workspace.BackupDir, fsutil.QnamePath(stack))
+	return filepath.Join(b.StateDir(), workspace.BackupDir, fsutil.NamePath(stack))
 }
 
 // getHistory returns locally stored update history. The first element of the result will be
 // the most recent update record.
-func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]backend.UpdateInfo, error) {
+func (b *localBackend) getHistory(name tokens.Name, pageSize int, page int) ([]backend.UpdateInfo, error) {
 	contract.Require(name != "", "name")
 
 	dir := b.historyDirectory(name)
@@ -489,7 +489,7 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 	return updates, nil
 }
 
-func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName) error {
+func (b *localBackend) renameHistory(oldName tokens.Name, newName tokens.Name) error {
 	contract.Require(oldName != "", "oldName")
 	contract.Require(newName != "", "newName")
 
@@ -533,7 +533,7 @@ func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName)
 }
 
 // addToHistory saves the UpdateInfo and makes a copy of the current Checkpoint file.
-func (b *localBackend) addToHistory(name tokens.QName, update backend.UpdateInfo) error {
+func (b *localBackend) addToHistory(name tokens.Name, update backend.UpdateInfo) error {
 	contract.Require(name != "", "name")
 
 	dir := b.historyDirectory(name)

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -80,13 +80,13 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(m encoding.Marshaler, bytes 
 }
 
 func MarshalUntypedDeploymentToVersionedCheckpoint(
-	stack tokens.QName, deployment *apitype.UntypedDeployment) (*apitype.VersionedCheckpoint, error) {
+	stack tokens.Name, deployment *apitype.UntypedDeployment) (*apitype.VersionedCheckpoint, error) {
 
 	chk := struct {
 		Stack  tokens.QName
 		Latest json.RawMessage
 	}{
-		Stack:  stack,
+		Stack:  stack.Q(),
 		Latest: deployment.Deployment,
 	}
 
@@ -102,7 +102,7 @@ func MarshalUntypedDeploymentToVersionedCheckpoint(
 }
 
 // SerializeCheckpoint turns a snapshot into a data structure suitable for serialization.
-func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
+func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
 	sm secrets.Manager, showSecrets bool) (*apitype.VersionedCheckpoint, error) {
 	// If snap is nil, that's okay, we will just create an empty deployment; otherwise, serialize the whole snapshot.
 	var latest *apitype.DeploymentV3
@@ -115,7 +115,7 @@ func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
 	}
 
 	b, err := encoding.JSON.Marshal(apitype.CheckpointV3{
-		Stack:  stack,
+		Stack:  stack.Q(),
 		Latest: latest,
 	})
 	if err != nil {

--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -83,7 +83,6 @@ func IntoQName(s string) QName {
 	if result == "" {
 		result = "_"
 	}
-
 	return QName(result)
 }
 


### PR DESCRIPTION
Temporarily reverting this to keep master in a releasable state while we finalize the design.

As it was, the syntax `pulumi stack select foo/bar` could mean fundamentally different things based on what backend you're logged into. In the Service backend, the `foo` is the org. In the Self-Managed backend, the `foo` would be the project name. Moreover, in the Service backend, there is one "fully-qualified" name, and all the others are just shorthands. But this wouldn't be true in the Self-Managed backend where `bar` represents a fundamentally different stack than `foo/bar`. This makes it hard to explain what stack identities are. Self-Managed has been a pure subset of what Service supported in terms of stack identities. If we went with this design, it would be a partially overlapping, but inconsistent subset/superset.

We're discussing some design alternatives that would make stack identities in the Self-Managed backend more consistent with the Service backend, and will reintroduce the changes with the adjusted design soon.