### PR TITLE
Temporarily disable Python component tests to unblock merging

### DIFF
--- a/tests/integration/component_setup.sh
+++ b/tests/integration/component_setup.sh
@@ -40,15 +40,17 @@ setup_nodejs() (
 )
 
 setup_python() (
-  set -euo pipefail
-  if [ -d "testcomponent-python" ]; then
-    cd testcomponent-python
-    # Clear out any existing venv to prevent 'permission denied' issues
-    python3 -m venv venv --clear
-    # shellcheck disable=SC1090
-    . venv/*/activate
-    python3 -m pip install -e ../../../../sdk/python/env/src
-  fi
+  # TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+  # set -euo pipefail
+  # if [ -d "testcomponent-python" ]; then
+  #   cd testcomponent-python
+  #   # Clear out any existing venv to prevent 'permission denied' issues
+  #   python3 -m venv venv --clear
+  #   # shellcheck disable=SC1090
+  #   . venv/*/activate
+  #   python3 -m pip install -e ../../../../sdk/python/env/src
+  # fi
+  true
 )
 
 setup_nodejs

--- a/tests/integration/integration_go_acceptance_test.go
+++ b/tests/integration/integration_go_acceptance_test.go
@@ -89,10 +89,11 @@ func TestConstructGo(t *testing.T) {
 			// test module should be removed.
 			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
 		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir:          "testcomponent-python",
+		// 	expectedResourceCount: 9,
+		// },
 		{
 			componentDir:          "testcomponent-go",
 			expectedResourceCount: 8, // One less because no dynamic provider.

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -530,10 +530,11 @@ func TestConstructPlainGo(t *testing.T) {
 			// test module should be removed.
 			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
 		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir:          "testcomponent-python",
+		// 	expectedResourceCount: 9,
+		// },
 		{
 			componentDir:          "testcomponent-go",
 			expectedResourceCount: 8, // One less because no dynamic provider.
@@ -587,9 +588,10 @@ func TestConstructMethodsGo(t *testing.T) {
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},
@@ -640,9 +642,10 @@ func TestConstructProviderGo(t *testing.T) {
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},

--- a/tests/integration/integration_nodejs_acceptance_test.go
+++ b/tests/integration/integration_nodejs_acceptance_test.go
@@ -75,10 +75,11 @@ func TestConstructNode(t *testing.T) {
 			componentDir:          "testcomponent",
 			expectedResourceCount: 9,
 		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir:          "testcomponent-python",
+		// 	expectedResourceCount: 9,
+		// },
 		{
 			componentDir:          "testcomponent-go",
 			expectedResourceCount: 8, // One less because no dynamic provider.

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -870,10 +870,11 @@ func TestConstructPlainNode(t *testing.T) {
 			componentDir:          "testcomponent",
 			expectedResourceCount: 9,
 		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir:          "testcomponent-python",
+		// 	expectedResourceCount: 9,
+		// },
 		{
 			componentDir:          "testcomponent-go",
 			expectedResourceCount: 8, // One less because no dynamic provider.
@@ -924,9 +925,10 @@ func TestConstructMethodsNode(t *testing.T) {
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},
@@ -974,9 +976,10 @@ func TestConstructProviderNode(t *testing.T) {
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -93,6 +93,7 @@ func TestDynamicPython(t *testing.T) {
 
 // Test remote component construction in Python.
 func TestConstructPython(t *testing.T) {
+	t.Skip("Temporarily skipping to unblock merging") // TODO[pulumi/pulumi#12062]: Re-enable
 	t.Parallel()
 
 	testDir := "construct_component"

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -584,6 +584,7 @@ func TestConstructSlowPython(t *testing.T) {
 
 // Test remote component construction with prompt inputs.
 func TestConstructPlainPython(t *testing.T) {
+	t.Skip("Temporarily skipping to unblock merging") // TODO[pulumi/pulumi#12062]: Re-enable
 	t.Parallel()
 
 	testDir := "construct_component_plain"
@@ -652,6 +653,7 @@ func TestConstructUnknownPython(t *testing.T) {
 
 // Test methods on remote components.
 func TestConstructMethodsPython(t *testing.T) {
+	t.Skip("Temporarily skipping to unblock merging") // TODO[pulumi/pulumi#12062]: Re-enable
 	t.Parallel()
 
 	testDir := "construct_component_methods"
@@ -704,6 +706,7 @@ func TestConstructMethodsErrorsPython(t *testing.T) {
 }
 
 func TestConstructProviderPython(t *testing.T) {
+	t.Skip("Temporarily skipping to unblock merging") // TODO[pulumi/pulumi#12062]: Re-enable
 	t.Parallel()
 
 	const testDir = "construct_component_provider"
@@ -963,6 +966,7 @@ func TestPythonTranslation(t *testing.T) {
 }
 
 func TestComponentProviderSchemaPython(t *testing.T) {
+	t.Skip("Temporarily skipping to unblock merging") // TODO[pulumi/pulumi#12062]: Re-enable
 	path := filepath.Join("component_provider_schema", "testcomponent-python", "pulumi-resource-testcomponent")
 	if runtime.GOOS == WindowsOS {
 		path += ".cmd"

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -165,9 +165,10 @@ func testConstructUnknown(t *testing.T, lang string, dependencies ...string) {
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},
@@ -206,9 +207,10 @@ func testConstructMethodsUnknown(t *testing.T, lang string, dependencies ...stri
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},
@@ -299,9 +301,10 @@ func testConstructMethodsResources(t *testing.T, lang string, dependencies ...st
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},
@@ -352,9 +355,10 @@ func testConstructMethodsErrors(t *testing.T, lang string, dependencies ...strin
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},
@@ -396,9 +400,10 @@ func testConstructOutputValues(t *testing.T, lang string, dependencies ...string
 		{
 			componentDir: "testcomponent",
 		},
-		{
-			componentDir: "testcomponent-python",
-		},
+		// TODO[pulumi/pulumi#12062]: Temporarily skipping to unblock merging.
+		// {
+		// 	componentDir: "testcomponent-python",
+		// },
 		{
 			componentDir: "testcomponent-go",
 		},


### PR DESCRIPTION
CI is blocked building wheels for grpcio, which is causing macos runs of the integration tests to time out. We're temporarily disabling the Python tests that are hitting this until we have a better solution.