### PR TITLE
ci: Use macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ on:
         type: string
       acceptance-test-platforms:
         required: false
-        default: windows-latest macos-11
+        default: windows-latest macos-latest
         description: Platforms on which to run integration tests, as a space delimited list
         type: string
       enable-coverage:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -69,7 +69,7 @@ jobs:
       acceptance-test-platforms: >- # No newlines or trailing newline.
         ${{
           contains(github.event.pull_request.labels.*.name, 'ci/test')
-          && 'macos-11 windows-latest'
+          && 'macos-latest windows-latest'
           || ''
         }}
       enable-coverage: true

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -88,7 +88,7 @@ MAKEFILE_UNIT_TESTS: List[MakefileTest] = [
     {"name": "sdk/nodejs sxs_tests", "run": "cd sdk/nodejs && ../../scripts/retry make sxs_tests", "eta": 3},
 ]
 
-ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-11"]
+ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
 
 MINIMUM_SUPPORTED_VERSION_SET = {


### PR DESCRIPTION
In #11155, we pinned CI to macos-11
because we want to continue to support macOS 11.

This, however hsa created a new issue:
grpcio does not publish wheels for macos-11 anymore
and building it from source takes long enough to kill our CI
(see #12054 #12050).

To fix the issue while continuing to support older macOS,
run CI on macos-latest, but leave build jobs and friends on macos-11.

Resolves #12054, #12050
