### PR TITLE
[codegen/docs] Only emit first 200 nested types

### DIFF
--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -296,14 +296,20 @@ The following state arguments are supported:
 
 ## Supporting Types
 
-{{ range .NestedTypes }}
+{{ if ge (len .NestedTypes) 200 }}
+> **Note:** There are over 200 nested types for this resource.
+Only the first 200 types are included in this documentation.
+{{ end }}
 
-<h4 id="{{ .AnchorID }}">{{ htmlSafe .Name }}</h4>
+{{ range $index, $elem := .NestedTypes }}
+{{ if lt $index 200 }}
 
-{{- if .Properties }}{{template "properties" .Properties -}}{{ end -}}
-{{- if .EnumValues }}{{- template "enums" .EnumValues -}}{{ end -}}
+<h4 id="{{ $elem.AnchorID }}">{{ htmlSafe $elem.Name }}</h4>
+
+{{- if $elem.Properties }}{{template "properties" $elem.Properties -}}{{ end -}}
+{{- if $elem.EnumValues }}{{- template "enums" $elem.EnumValues -}}{{ end -}}
 {{- end -}}
-
+{{- end -}}
 {{- end -}}
 
 {{ if .ImportDocs  }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -296,14 +296,13 @@ The following state arguments are supported:
 
 ## Supporting Types
 
-{{ if ge (len .NestedTypes) 200 }}
+{{- if ge (len .NestedTypes) 200 }}
 > **Note:** There are over 200 nested types for this resource.
 Only the first 200 types are included in this documentation.
 {{ end }}
 
 {{ range $index, $elem := .NestedTypes }}
 {{ if lt $index 200 }}
-
 <h4 id="{{ $elem.AnchorID }}">{{ htmlSafe $elem.Name }}</h4>
 
 {{- if $elem.Properties }}{{template "properties" $elem.Properties -}}{{ end -}}


### PR DESCRIPTION
There are a few resources with a *very* large number of nested types.  We have seen this lead to generating docs pages that cannot be loaded in a browser.

Instead, only emit the first 200 nested types, and emit a note to users if we have done this.

In the AWS provider, this only triggers for `wafv2.WebAcl` and `wafv2.RuleGroup`.

This reduces the size of http://localhost:1313/registry/packages/aws/api-docs/wafv2/webacl/ from 64MB to 2.5MB (still huge - but manageable).

<img width="1295" alt="Screenshot 2023-02-03 at 3 28 40 PM" src="https://user-images.githubusercontent.com/223467/216729590-955fac65-e7e6-46cf-9960-f84c4238f911.png">

Fixes https://github.com/pulumi/registry/issues/1481 (once this is incorporate into `registrygen`).