### PR TITLE
sdk/py/StackReference: Add get_output_details

### DIFF
--- a/changelog/pending/20230203--sdk-python--sdk-py-stackreference-getoutputdetails-py-yaml.yaml
+++ b/changelog/pending/20230203--sdk-python--sdk-py-stackreference-getoutputdetails-py-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Adds StackReference.get_output_details to retrieve outputs from StackReferences as plain objects.

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -84,6 +84,7 @@ from .log import (
 
 from .stack_reference import (
     StackReference,
+    StackReferenceOutputDetails,
 )
 
 # pylint: disable=redefined-builtin
@@ -149,6 +150,7 @@ __all__ = [
     "error",
     # stack_reference
     "StackReference",
+    "StackReferenceOutputDetails",
     # _types
     "MISSING",
     "input_type",

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -19,6 +19,39 @@ from .output import Output, Input
 from .resource import CustomResource, ResourceOptions
 
 
+class StackReferenceOutputDetails:
+    """
+    Records the output of a StackReference.
+    At most one of the value and secret_value fields will be set.
+    """
+
+    value = Optional[Any]
+    """
+    Output value returned by the StackReference.
+    None if the value is a secret or if it does not exist.
+    """
+
+    secret_value = Optional[Any]
+    """
+    Secret value returned by the StackReference.
+    None if the value is not a secret or if it does not exist.
+    """
+
+    def __init__(
+        self,
+        value: Optional[Any] = None,
+        secret_value: Optional[Any] = None,
+    ) -> None:
+        """
+        :param Optional[Any] value:
+            Non-secret output value, if any.
+        :param Optional[Any] secret_value:
+            Secret output value, if any.
+        """
+        self.value = value
+        self.secret_value = secret_value
+
+
 class StackReference(CustomResource):
     """
     Manages a reference to a Pulumi stack. The referenced stack's outputs are available via its "outputs" property or
@@ -90,6 +123,26 @@ class StackReference(CustomResource):
         is_secret = ensure_future(self.__is_secret_name(name))
 
         return Output(value.resources(), value.future(), value.is_known(), is_secret)
+
+    async def get_output_details(self, name: str) -> StackReferenceOutputDetails:
+        """
+        Fetches the value of the named stack output
+        and builds a StackReferenceOutputDetails object from it.
+
+        The returned object has its `value` or `secret_value` fields set
+        depending on whether the output is a secret.
+        Neither field is set if the output was not found.
+        """
+
+        is_secret = await ensure_future(self.__is_secret_name(name))
+        output_val = self.outputs.apply(lambda os: os[name])
+        if not await output_val.is_known():
+            return StackReferenceOutputDetails()
+
+        value = await output_val.future()
+        if is_secret:
+            return StackReferenceOutputDetails(secret_value=value)
+        return StackReferenceOutputDetails(value=value)
 
     def translate_output_property(self, prop: str) -> str:
         """

--- a/sdk/python/lib/test/test_stack_reference.py
+++ b/sdk/python/lib/test/test_stack_reference.py
@@ -1,0 +1,60 @@
+# Copyright 2016-2023, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import pytest
+import unittest
+
+import pulumi
+from pulumi.runtime import mocks
+from pulumi import StackReference, StackReferenceOutputDetails
+
+
+@pytest.mark.asyncio
+async def test_stack_reference_output_details(simple_mock):
+    ref = StackReference("ref")
+
+    non_secret = await ref.get_output_details("bucket")
+    assert StackReferenceOutputDetails(value = "mybucket-1234"), non_secret
+
+    secret = await ref.get_output_details("password")
+    assert StackReferenceOutputDetails(secret_value = "mypassword"), non_secret
+
+    unknown = await ref.get_output_details("does-not-exist")
+    assert StackReferenceOutputDetails(), non_secret
+
+
+@pytest.fixture
+def simple_mock():
+    mock = StackReferenceOutputMock()
+    mocks.set_mocks(mock)
+    yield mock
+
+
+class StackReferenceOutputMock(pulumi.runtime.Mocks):
+
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        assert "pulumi:pulumi:StackReference" == args.typ
+        return [
+                args.name + '_id',
+                {
+                    "outputs": {
+                        "bucket": "mybucket-1234",
+                        "password": pulumi.Output.secret("mypassword"),
+                    },
+                },
+        ]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):
+        return {}


### PR DESCRIPTION
This is the Python equivalent to the StackReference.GetOutputDetails
method and accompanying type added to the Go SDK in #12034.

This will allow users of the Python SDK to fetch outputs from stack
references directly--without going through an Output type.

Refs #10839, #5035
