### PR TITLE
sdk/node/StackReference: Add getOutputDetails

### DIFF
--- a/changelog/pending/20230204--sdk-nodejs--stackreference-getoutputdetails-node.yaml
+++ b/changelog/pending/20230204--sdk-nodejs--stackreference-getoutputdetails-node.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Adds StackReference.getOutputDetails to retrieve outputs from StackReferences as plain objects.

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -142,12 +142,17 @@ export class MockMonitor {
 
     public async readResource(req: any, callback: (err: any, innterResponse: any) => void) {
         try {
+            let custom = false;
+            if (typeof req.getCustom === "function") {
+                custom = req.getCustom();
+            }
+
             const result = this.mocks.newResource({
                 type: req.getType(),
                 name: req.getName(),
                 inputs: deserializeProperties(req.getProperties()),
                 provider: req.getProvider(),
-                custom: req.getCustom(),
+                custom: custom,
                 id: req.getId(),
             });
 

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -94,6 +94,25 @@ export class StackReference extends CustomResource {
     }
 
     /**
+     * Fetches the value of the named stack output
+     * and builds a StackReferenceOutputDetails with it.
+     *
+     * The returned object has its `value` or `secretValue` fields set
+     * depending on wehther the output is a secret.
+     * Neither field is set if the output was not found.
+     *
+     * @param name The name of the stack output to fetch.
+     */
+    public async getOutputDetails(name: string): Promise<StackReferenceOutputDetails> {
+        const [out, isSecret] = await this.readOutputValue("getOutputValueDetails", name, false /*required*/);
+        if (isSecret) {
+            return {secretValue: out};
+        } else {
+            return {value: out};
+        }
+    }
+
+    /**
      * Fetches the value promptly of the named stack output. May return undefined if the value is
      * not known for some reason.
      *
@@ -139,6 +158,23 @@ export interface StackReferenceArgs {
      * The name of the stack to reference.
      */
     readonly name?: Input<string>;
+}
+
+/**
+ * Records the output of a StackReference.
+ * At most one of th evalue and secretValue fields will be set.
+ */
+export interface StackReferenceOutputDetails {
+    /**
+     * Output value returned by the StackReference.
+     * This is null if the value is a secret or it does not exist.
+     */
+    readonly value?: any;
+    /**
+     * Secret value returned by the StackReference.
+     * This is null if the value is not a secret or it does not exist.
+     */
+    readonly secretValue?: any;
 }
 
 async function isSecretOutputName(sr: StackReference, name: Input<string>): Promise<boolean> {

--- a/sdk/nodejs/tests/stackReference.spec.ts
+++ b/sdk/nodejs/tests/stackReference.spec.ts
@@ -1,0 +1,69 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as pulumi from "..";
+
+class TestMocks implements pulumi.runtime.Mocks {
+    outputs: any;
+
+    constructor(outputs: any) {
+        this.outputs = outputs;
+    }
+
+    call(args: pulumi.runtime.MockCallArgs): Record<string, any> {
+        throw new Error(`unknown function ${args.token}`);
+    }
+
+    newResource(args: pulumi.runtime.MockResourceArgs): { id: string | undefined; state: Record<string, any> } {
+        switch (args.type) {
+        case "pulumi:pulumi:StackReference":
+            return {
+                id: `${args.name}_id`,
+                state: {
+                    outputs: this.outputs,
+                },
+            };
+        default:
+            throw new Error(`unknown type ${args.type}`);
+        }
+    }
+}
+
+describe("StackReference.getOutputDetails", () => {
+    // The two tests don't share a mock because in the JS SDK,
+    // if a map item is a secret, the entire map gets promoted to secret.
+
+    it("supports plain text", async () => {
+        pulumi.runtime.setMocks(new TestMocks({
+            bucket: "mybucket-1234",
+        }));
+        const ref = new pulumi.StackReference("foo");
+
+        assert.deepStrictEqual(await ref.getOutputDetails("bucket"), {
+            value: "mybucket-1234",
+        });
+    });
+
+    it("supports secrets", async () => {
+        pulumi.runtime.setMocks(new TestMocks({
+            password: pulumi.secret("supersecretpassword"),
+        }));
+        const ref = new pulumi.StackReference("foo");
+
+        assert.deepStrictEqual(await ref.getOutputDetails("password"), {
+            secretValue: "supersecretpassword",
+        });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -90,6 +90,7 @@
         "tests/options.spec.ts",
         "tests/output.spec.ts",
         "tests/resource.spec.ts",
+        "tests/stackReference.spec.ts",
         "tests/provider.spec.ts",
         "tests/unwrap.spec.ts",
         "tests/util.ts",


### PR DESCRIPTION
NodeJS equivalent of the StackReference.GetOutputDetails
method and accompanying type added to the Go SDK in #12034.

This will allow users of the TypeScript and JavaScript SDKs
to fetch outputs from stack references directly--without going through
an Output type.

Couple notes about testing:

- `MockMonitor.readResource` kept exploding because the getCustom method
  was missing on the provided object.
  I didn't find any examples in the Node SDK
  of using mocks to test StackReferences,
  so I'm guessing this was an unexercised code path.
  I've fixed that.
- It seems that the JavaScript SDK promotes an entire map to secret
  if an item inside it is a secret.
  So I had to isolate the two test cases into separate outputs
  to get the plain text case to be written as a "value".
  If there's a more correct way of setting up that mock,
  I'm happy to merge the outputs back into a single map
  for a more representative test case.

Refs #10839, #5035
