### PR TITLE
Revert "ci/build-targets: Use ubuntu runners"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
               { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
               { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-latest" },
-              { "os": "darwin",  "arch": "amd64", "build-platform": "ubuntu-latest" },
-              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
+              { "os": "darwin",  "arch": "amd64", "build-platform": "macos-11" },
+              { "os": "darwin",  "arch": "arm64", "build-platform": "macos-11" }
             ]'
           fi
 


### PR DESCRIPTION
PR #12051 was landed by bors without a request to land
or a review.

Reverting so that we can review it before landing.

This reverts commit 389860058dd6be35e1adf27b74b062ac180d819d.
