### PR TITLE
Fix V logging to also filter out secrets

### DIFF
--- a/changelog/pending/20230206--cli--fix-verbose-logging-to-filter-secrets.yaml
+++ b/changelog/pending/20230206--cli--fix-verbose-logging-to-filter-secrets.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix verbose logging to filter secrets.

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -43,8 +43,36 @@ var LogFlow = false     // true to flow logging settings to child processes.
 var rwLock sync.RWMutex
 var filters []Filter
 
-func V(level glog.Level) glog.Verbose {
-	return glog.V(level)
+// VerboseLogger logs messages only if verbosity matches the level it was built with.
+//
+// It may be used as a boolean to check if it's enabled.
+//
+//	if log := logging.V(lvl); log {
+//		log.Infoln(expensiveComputation())
+//	}
+type VerboseLogger glog.Verbose
+
+// Info is equivalent to the global Info function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v VerboseLogger) Info(args ...interface{}) {
+	glog.Verbose(v).Info(FilterString(fmt.Sprint(args...)))
+}
+
+// Infoln is equivalent to the global Infoln function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v VerboseLogger) Infoln(args ...interface{}) {
+	glog.Verbose(v).Infoln(FilterString(fmt.Sprint(args...)))
+}
+
+// Infof is equivalent to the global Infof function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v VerboseLogger) Infof(format string, args ...interface{}) {
+	glog.Verbose(v).Infof("%s", FilterString(fmt.Sprintf(format, args...)))
+}
+
+// V builds a logger that logs messages only if verbosity is at least at the provided level.
+func V(level glog.Level) VerboseLogger {
+	return VerboseLogger(glog.V(level))
 }
 
 func Errorf(format string, args ...interface{}) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

We use a small logging wrapper around glog for most of our logging. The global Errorf/Warningf/Infof methods in that module format the string and args passed in then filter out any secrets before calling into glog with the final string.

The wrapper also exposed a `V` method to only log if verbosity was set, but that directly returned a glog.Verbose which mean the Infof calls to that didn't run our secret filtering code.

This changes the logging wrapper to return a `VerboseShim` (Not a great name, but `Verbose` was already taken in this module) which is simply a new type over `glog.Verbose` with the same methods but it calls `FilterString` on the inputs.

Technically a breaking change, but I think the uses of this will be source compatible.
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
