### PR TITLE
Update @types/node version in tests

### DIFF
--- a/pkg/codegen/testing/test/testdata/enum-reference/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/enum-reference/nodejs/package.json
@@ -10,7 +10,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts3.7",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/pkg/codegen/testing/test/testdata/enum-reference/schema.json
+++ b/pkg/codegen/testing/test/testdata/enum-reference/schema.json
@@ -31,7 +31,7 @@
             },
             "devDependencies": {
                 "typescript": "^3.7.0",
-                "@types/node": "latest"
+                "@types/node": "ts3.7"
             },
             "respectSchemaVersion": true,
             "pluginVersion": "3.2.1"

--- a/pkg/codegen/testing/test/testdata/external-enum/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/external-enum/nodejs/package.json
@@ -10,7 +10,7 @@
         "@pulumi/pulumi": "^3.12"
     },
     "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts3.7",
         "typescript": "^3.7.0"
     },
     "pulumi": {

--- a/pkg/codegen/testing/test/testdata/external-enum/schema.json
+++ b/pkg/codegen/testing/test/testdata/external-enum/schema.json
@@ -47,7 +47,7 @@
       },
       "devDependencies": {
         "typescript": "^3.7.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.7"
       },
       "respectSchemaVersion": true,
       "pluginVersion": "3.2.1"

--- a/pkg/codegen/testing/test/testdata/functions-secrets/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/pkg/codegen/testing/test/testdata/functions-secrets/schema.json
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/schema.json
@@ -48,7 +48,7 @@
     "language": {
         "nodejs": {
             "devDependencies": {
-                "@types/node": "latest"
+                "@types/node": "ts4.3"
             }
         },
         "go": {},

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "ts-node": "latest",
         "typescript": "^4.3.5"
     },

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/schema.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/schema.json
@@ -4,7 +4,7 @@
   "language": {
     "nodejs": {
       "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "ts-node": "latest"
       }
     },

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/package.json
@@ -10,7 +10,7 @@
     },
     "devDependencies": {
         "@types/mocha": "latest",
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "mocha": "latest",
         "ts-node": "latest",
         "typescript": "^4.3.5"

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/schema.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/schema.json
@@ -194,7 +194,7 @@
       "compatibility": "tfbridge20",
       "devDependencies": {
         "@types/mocha": "latest",
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "mocha": "latest",
         "ts-node": "latest"
       },

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/package.json
@@ -10,7 +10,7 @@
     },
     "devDependencies": {
         "@types/mocha": "latest",
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "mocha": "latest",
         "ts-node": "latest",
         "typescript": "^4.3.5"

--- a/pkg/codegen/testing/test/testdata/output-funcs/schema.json
+++ b/pkg/codegen/testing/test/testdata/output-funcs/schema.json
@@ -642,7 +642,7 @@
       "optimizeNodeModuleLoading": ["lazy-load-functions", "lazy-load-resources", "use-type-only-enums-references"],
       "devDependencies": {
         "@types/mocha": "latest",
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "mocha": "latest",
         "ts-node": "latest"
       },

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "ts-node": "latest",
         "typescript": "^4.3.5"
     },

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/schema.json
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/schema.json
@@ -47,7 +47,7 @@
   "language": {
     "nodejs": {
       "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "ts-node": "latest"
       },
       "extraTypeScriptFiles": [

--- a/pkg/codegen/testing/test/testdata/secrets/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/secrets/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/pkg/codegen/testing/test/testdata/secrets/schema.json
+++ b/pkg/codegen/testing/test/testdata/secrets/schema.json
@@ -97,7 +97,7 @@
     "language": {
         "nodejs": {
             "devDependencies": {
-                "@types/node": "latest"
+                "@types/node": "ts4.3"
             }
         },
         "go": {},

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/package.json
@@ -9,7 +9,7 @@
         "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/node": "latest",
+        "@types/node": "ts4.3",
         "typescript": "^4.3.5"
     },
     "pulumi": {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/schema.json
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/schema.json
@@ -46,7 +46,7 @@
     },
     "nodejs": {
       "devDependencies": {
-        "@types/node": "latest"
+        "@types/node": "ts4.3"
       },
       "liftSingleValueMethodReturns": true
     },

--- a/tests/integration/component_provider_schema/testcomponent/package.json
+++ b/tests/integration/component_provider_schema/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component/testcomponent/package.json
+++ b/tests/integration/construct_component/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_error_apply/testcomponent/package.json
+++ b/tests/integration/construct_component_error_apply/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_methods/testcomponent/package.json
+++ b/tests/integration/construct_component_methods/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_methods_errors/nodejs/package.json
+++ b/tests/integration/construct_component_methods_errors/nodejs/package.json
@@ -3,7 +3,7 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_methods_errors/testcomponent/package.json
+++ b/tests/integration/construct_component_methods_errors/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_methods_resources/testcomponent/package.json
+++ b/tests/integration/construct_component_methods_resources/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_methods_unknown/nodejs/package.json
+++ b/tests/integration/construct_component_methods_unknown/nodejs/package.json
@@ -3,7 +3,7 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_methods_unknown/testcomponent/package.json
+++ b/tests/integration/construct_component_methods_unknown/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_output_values/testcomponent/package.json
+++ b/tests/integration/construct_component_output_values/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_plain/testcomponent/package.json
+++ b/tests/integration/construct_component_plain/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_provider/testcomponent/package.json
+++ b/tests/integration/construct_component_provider/testcomponent/package.json
@@ -2,8 +2,8 @@
     "name": "pulumi-resource-testcomponent",
     "main": "index.js",
     "devDependencies": {
-        "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "typescript": "~3.8.0",
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_slow/testcomponent/package.json
+++ b/tests/integration/construct_component_slow/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/construct_component_unknown/testcomponent/package.json
+++ b/tests/integration/construct_component_unknown/testcomponent/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"

--- a/tests/integration/deleted_with/nodejs/package.json
+++ b/tests/integration/deleted_with/nodejs/package.json
@@ -3,7 +3,7 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "ts3.9"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"


### PR DESCRIPTION
Fix tests to point to a version of `@types/node` they work with. [18.11.9](https://www.npmjs.com/package/@types/node/v/18.11.9) was just released today for TS 4 with syntax that TS 3 is failing against (see https://github.com/pulumi/pulumi/actions/runs/4112259113/jobs/7097593867 for example)