### PR TITLE
Enable type checking in some inner functions

### DIFF
--- a/sdk/python/lib/pulumi/runtime/rpc_manager.py
+++ b/sdk/python/lib/pulumi/runtime/rpc_manager.py
@@ -14,8 +14,11 @@
 import asyncio
 import sys
 import traceback
-from typing import Callable, Awaitable, Tuple, Any, Optional, List
+from typing import Any, Awaitable, Callable, List, Optional, Tuple, TypeVar
+
 from .. import log
+
+T = TypeVar("T")
 
 
 class RPCManager:
@@ -45,8 +48,8 @@ class RPCManager:
         self.clear()
 
     def do_rpc(
-        self, name: str, rpc_function: Callable[..., Awaitable[Tuple[Any, Exception]]]
-    ) -> Callable[..., Awaitable[Tuple[Any, Exception]]]:
+        self, name: str, rpc_function: Callable[..., Awaitable[T]]
+    ) -> Callable[..., Awaitable[Tuple[T, Exception]]]:
         """
         Wraps a given RPC function by producing an awaitable function suitable to be run in the asyncio
         event loop. The wrapped function catches all unhandled exceptions and reports them to the exception


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

A couple of the inner functions (`do_call`, `do_register`) weren't being type checked (mypy doesn't type check unannotated functions: https://mypy.readthedocs.io/en/stable/common_issues.html#no-errors-reported-for-obviously-wrong-code).

This adds annotations for those functions and then fixes up _all_ the type errors that fell out from that.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - Covered by existing tests
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - Just internal changes to correct types
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
