### PR TITLE
ci: Test against Go 1.18 as well

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -94,7 +94,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 MINIMUM_SUPPORTED_VERSION_SET = {
     "name": "minimum",
     "dotnet": "6",
-    "go": "1.19.x",
+    "go": "1.18.x",
     "nodejs": "14.x",
     "python": "3.9.x",
 }


### PR DESCRIPTION
In 148f040fa, we switched to testing against Go 1.19 and and 1.20.
This isn't quite right because our documentation states that we still
support Go 1.18.

Add back testing against 1.18 until we decide to drop support for it.
