### PR TITLE
[do not land] ci/setup-go: Disable cache on Windows

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -140,7 +140,10 @@ jobs:
         id: setup-go
         with:
           go-version: ${{ fromJson(inputs.version-set).go }}
-          cache: true
+          # Our cache tends to get pretty large.
+          # The Windows workers take longer to extract it
+          # than it would take to just re-download the dependencies.
+          cache: ${{ !contains(inputs.platform, 'windows') }}
           cache-dependency-path: '*/go.sum'
       - name: Prime Go cache
         if: ${{ steps.setup-go.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
It takes very long to extract the 700MB+ setup-go cache
on our Windows workers.

This disables caching in setup-go for Windows machines,
trusting that downloading dependencies over the network will be faster.

Resolves #12084

---

This PR has been created speculatively to determine whether disabling the cache has the desired effect.
**DO NOT MERGE YET**
