### PR TITLE
Remove interactive flow in `pulumi state` commands

### DIFF
--- a/pkg/cmd/pulumi/state_test.go
+++ b/pkg/cmd/pulumi/state_test.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourcesPendingDelete(t *testing.T) {
+	assert.True(t, hasResourcesPendingDeletion([]*resource.State{
+		{
+			Delete: true,
+		},
+		{},
+	}))
+	assert.False(t, hasResourcesPendingDeletion([]*resource.State{}))
+	assert.False(t, hasResourcesPendingDeletion([]*resource.State{
+		{},
+		{},
+	}))
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

`pulumi state delete` would provide a selector for the user to specify which resource to delete. (All of the resources listed having the same URN).

 It would proceed to delete all of the resources in the state with the same URN meaning that every resource displayed in the selector is deleted from state.

New output:
```
% pulumi state delete urn:pulumi:dev::bad_state::random:index/randomPet:RandomPet::username
 warning: This command will edit your stack's state directly. Confirm? Yes
error: Unable to perform state edit.

You can edit your stack's state using 'pulumi stack export' to export your stack to a file and editing it. Once this is complete, you can use 'pulumi stack import' to import the edited stack.

Error: Resource URN ambiguously referred to multiple resources:
  touched-walleye-1
  touched-walleye-2
  touched-walleye-3
  touched-walleye-4

```

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
