### PR TITLE
`pulumi login` to support google oauth access tokens for GCS buckets

### DIFF
--- a/changelog/pending/20230208--backend-filestate--pulumi-login-to-support-google-oauth-access-tokens-via-environment-variable.yaml
+++ b/changelog/pending/20230208--backend-filestate--pulumi-login-to-support-google-oauth-access-tokens-via-environment-variable.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: backend/filestate
-  description: pulumi login to support google oauth access tokens via environment variable
+  description: pulumi login gs:// to support google oauth access tokens via environment variable for Google Cloud Storage backends

--- a/changelog/pending/20230208--backend-filestate--pulumi-login-to-support-google-oauth-access-tokens-via-environment-variable.yaml
+++ b/changelog/pending/20230208--backend-filestate--pulumi-login-to-support-google-oauth-access-tokens-via-environment-variable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/filestate
+  description: pulumi login to support google oauth access tokens via environment variable

--- a/pkg/authhelpers/gcpauth.go
+++ b/pkg/authhelpers/gcpauth.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"cloud.google.com/go/storage"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	"gocloud.dev/blob/gcsblob"
@@ -37,6 +38,15 @@ func ResolveGoogleCredentials(ctx context.Context, scope string) (*google.Creden
 			return nil, fmt.Errorf("unable to parse credentials from $GOOGLE_CREDENTIALS: %w", err)
 		}
 		return credentials, nil
+	}
+
+	if creds := os.Getenv("GOOGLE_OAUTH_ACCESS_TOKEN"); creds != "" {
+		// We try $GOOGLE_OAUTH_ACCESS_TOKEN before gcp.DefaultCredentials
+		// so that users can override the default creds
+
+		return &google.Credentials{
+			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: creds}),
+		}, nil
 	}
 
 	// DefaultCredentials will attempt to load creds in the following order:

--- a/pkg/authhelpers/gcpauth.go
+++ b/pkg/authhelpers/gcpauth.go
@@ -40,6 +40,10 @@ func ResolveGoogleCredentials(ctx context.Context, scope string) (*google.Creden
 		return credentials, nil
 	}
 
+	// GOOGLE_OAUTH_ACCESS_TOKEN aren't part of the gcloud standard authorization variables
+	// but the GCP terraform provider uses this variable to allow users to authenticate
+	// with a temporary access token obtained from the Google Authorization Server instead of just a file path or credentials.json.
+	// https://www.terraform.io/docs/backends/types/gcs.html
 	if creds := os.Getenv("GOOGLE_OAUTH_ACCESS_TOKEN"); creds != "" {
 		// We try $GOOGLE_OAUTH_ACCESS_TOKEN before gcp.DefaultCredentials
 		// so that users can override the default creds

--- a/pkg/authhelpers/gcpauth.go
+++ b/pkg/authhelpers/gcpauth.go
@@ -40,7 +40,7 @@ func ResolveGoogleCredentials(ctx context.Context, scope string) (*google.Creden
 		return credentials, nil
 	}
 
-	// GOOGLE_OAUTH_ACCESS_TOKEN aren't part of the gcloud standard authorization variables
+	// GOOGLE_OAUTH_ACCESS_TOKEN isnt't part of the gcloud standard authorization variables
 	// but the GCP terraform provider uses this variable to allow users to authenticate
 	// with a temporary access token obtained from the Google Authorization Server instead of just a file path or credentials.json.
 	// https://www.terraform.io/docs/backends/types/gcs.html

--- a/pkg/authhelpers/gcpauth.go
+++ b/pkg/authhelpers/gcpauth.go
@@ -42,7 +42,8 @@ func ResolveGoogleCredentials(ctx context.Context, scope string) (*google.Creden
 
 	// GOOGLE_OAUTH_ACCESS_TOKEN isnt't part of the gcloud standard authorization variables
 	// but the GCP terraform provider uses this variable to allow users to authenticate
-	// with a temporary access token obtained from the Google Authorization Server instead of just a file path or credentials.json.
+	// with a temporary access token obtained from the Google Authorization Server instead
+	// of just a file path or credentials.json.
 	// https://www.terraform.io/docs/backends/types/gcs.html
 	if creds := os.Getenv("GOOGLE_OAUTH_ACCESS_TOKEN"); creds != "" {
 		// We try $GOOGLE_OAUTH_ACCESS_TOKEN before gcp.DefaultCredentials


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
`pulumi login gs://....` now supports the use of google access tokens. If the environment variable `GOOGLE_OAUTH_ACCESS_TOKEN` is set during a `pulumi login gs://...` pulumi will utilize the provided token to login to the bucket, assuming this has not been pre-empted by another auth type.

Fixes  [#12067](https://github.com/pulumi/pulumi/issues/12067)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
