### PR TITLE
Change python output model

### DIFF
--- a/pkg/codegen/testing/test/testdata/output-funcs/python-extras/tests/test_codegen.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python-extras/tests/test_codegen.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import json
+
 import pytest
 
 import pulumi
@@ -215,15 +216,6 @@ def test_list_storage_accounts(my_mocks):
         )])
 
 
-@pulumi.runtime.test
-def test_preview_with_unknowns(my_preview_mocks):
-
-    def check(r):
-        assert False, 'check() should not be called when args contain unknowns'
-
-    return list_storage_account_keys_output(account_name=unknown()).apply(check)
-
-
 def jstr(x):
     return json.dumps(x, sort_keys=True)
 
@@ -234,14 +226,3 @@ def r(x):
 
 def out(x):
     return pulumi.Output.from_input(x).apply(lambda x: x)
-
-
-def unknown():
-    is_known_fut: asyncio.Future[bool] = asyncio.Future()
-    is_secret_fut: asyncio.Future[bool] = asyncio.Future()
-    is_known_fut.set_result(False)
-    is_secret_fut.set_result(False)
-
-    value_fut: asyncio.Future[Any] = asyncio.Future()
-    value_fut.set_result(pulumi.UNKNOWN)
-    return pulumi.Output(set(), value_fut, is_known_fut, is_secret_fut)

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -43,7 +43,7 @@ from .runtime.resource import (
     convert_providers,
 )
 from .runtime.settings import get_root_resource
-from .output import _is_prompt, _map_input, _map2_input, T, Output
+from .output import _is_prompt, _map_input, _map2_input, T, Output, OutputData
 from . import urn as urn_util
 from . import log
 
@@ -1115,13 +1115,9 @@ class DependencyResource(CustomResource):
     def __init__(self, urn: str) -> None:
         super().__init__(t="", name="", props={}, opts=None, dependency=True)
 
-        urn_future: asyncio.Future[str] = asyncio.Future()
-        urn_known: asyncio.Future[bool] = asyncio.Future()
-        urn_secret: asyncio.Future[bool] = asyncio.Future()
-        urn_future.set_result(urn)
-        urn_known.set_result(True)
-        urn_secret.set_result(False)
-        self.__dict__["urn"] = Output({self}, urn_future, urn_known, urn_secret)
+        urn_future: asyncio.Future[OutputData] = asyncio.Future()
+        urn_future.set_result(OutputData({self}, urn, False))
+        self.__dict__["urn"] = Output(urn_future)
 
 
 class DependencyProviderResource(ProviderResource):
@@ -1140,21 +1136,13 @@ class DependencyProviderResource(ProviderResource):
 
         super().__init__(pkg=pkg, name="", props={}, opts=None, dependency=True)
 
-        urn_future: asyncio.Future[str] = asyncio.Future()
-        urn_known: asyncio.Future[bool] = asyncio.Future()
-        urn_secret: asyncio.Future[bool] = asyncio.Future()
-        urn_future.set_result(ref_urn)
-        urn_known.set_result(True)
-        urn_secret.set_result(False)
-        self.__dict__["urn"] = Output({self}, urn_future, urn_known, urn_secret)
+        urn_future: asyncio.Future[OutputData] = asyncio.Future()
+        urn_future.set_result(OutputData({self}, ref_urn, False))
+        self.__dict__["urn"] = Output(urn_future)
 
-        id_future: asyncio.Future[str] = asyncio.Future()
-        id_known: asyncio.Future[bool] = asyncio.Future()
-        id_secret: asyncio.Future[bool] = asyncio.Future()
-        id_future.set_result(ref_id)
-        id_known.set_result(True)
-        id_secret.set_result(False)
-        self.__dict__["id"] = Output({self}, id_future, id_known, id_secret)
+        id_future: asyncio.Future[OutputData] = asyncio.Future()
+        id_future.set_result(OutputData({self}, ref_id, False))
+        self.__dict__["id"] = Output(id_future)
 
 
 def export(name: str, value: Any):

--- a/sdk/python/lib/pulumi/runtime/sync_await.py
+++ b/sdk/python/lib/pulumi/runtime/sync_await.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import asyncio
 import sys
-from typing import Any, Awaitable
+from typing import TypeVar, Awaitable
 
 # If we are not running on Python 3.7 or later, we need to swap the Python implementation of Task in for the C
 # implementation in order to support synchronous invokes.
@@ -38,7 +38,10 @@ else:
     _get_current_task = asyncio.current_task  # type: ignore
 
 
-def _sync_await(awaitable: Awaitable[Any]) -> Any:
+T = TypeVar("T")
+
+
+def _sync_await(awaitable: Awaitable[T]) -> T:
     """
     _sync_await waits for the given future to complete by effectively yielding the current task and pumping the event
     loop.

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -9,7 +9,7 @@ pyyaml~=6.0
 
 # Dev packages only needed during development.
 pylint==2.15.5
-mypy==0.991
+mypy==1.0.0
 pytest
 pytest-timeout
 types-six


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This totally reworks the internals of Outputs in the Python SDK to be easier to reason about.

Previously an Output was four awaitables, `secret: Awaitable[bool]`, `resources: Awaitable[set[Resource]]`, `known: Awaitable[bool]`, and `value: Awaitable[T_co]`.
Reasoning about the interaction of four awaitables was tricky, and creating an Output meant setting all four awaitables at the same time correctly as well. Furthermore the typing for `value` was wrong as it could also be set to `UNKNOWN` of the `Unknown` type.

This reworks the internals to be a single `Awaitable[OutputData]` where the `OutputData` class is a record of the the information previously split across the four awaitables. It also simplfies the information by removing the `known` field and instead correctly typing the `value` field as `Union[T_co, Unknown]`. We use `isinstance(value, Unknown)` checks to decided if a value is known for when that logic is needed (e.g. for deciding if we should run apply or not).

This also paves the way for exposing OutputData via an advanced awaitOutput method like we have in the Go SDK. I haven't added that here, there's enough to discuss and cover just redoing the internals, but it should be a small change to add.

Fixes https://github.com/pulumi/pulumi/issues/12083

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - Covered by existing tests
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - Not user facing, unless we want to warn about the removal of `run_with_unknowns`?
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
