### PR TITLE
pkg/cmd: Prefer contract.Assertf over contract.Assert

### DIFF
--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -222,7 +222,7 @@ func newDestroyCmd() *cobra.Command {
 			var protectedCount int
 			var targetUrns []string = *targets
 			if excludeProtected {
-				contract.Assert(len(targetUrns) == 0)
+				contract.Assertf(len(targetUrns) == 0, "Expected no target URNs, got %d", len(targetUrns))
 				targetUrns, protectedCount, err = handleExcludeProtected(ctx, s)
 				if err != nil {
 					return result.FromError(err)

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -280,7 +280,9 @@ func printPolicyPackNextSteps(proj *workspace.PolicyPackProject, root string, ge
 		usageCommands = append(usageCommands, "pulumi policy publish [org-name]")
 	}
 
-	contract.Assert(len(usageCommandPreambles) == len(usageCommands))
+	contract.Assertf(len(usageCommandPreambles) == len(usageCommands),
+		"Number of command preambles (%d) must match number of commands (%d)",
+		len(usageCommandPreambles), len(usageCommands))
 
 	if len(usageCommands) == 1 {
 		usageMsg := fmt.Sprintf("Once you're done editing your Policy Pack, to %s `%s`", usageCommandPreambles[0],

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -297,7 +297,7 @@ func newPreviewCmd() *cobra.Command {
 		&planFilePath, "save-plan", "",
 		"[EXPERIMENTAL] Save the operations proposed by the preview to a plan file at the given path")
 	if !hasExperimentalCommands() {
-		contract.AssertNoError(cmd.PersistentFlags().MarkHidden("save-plan"))
+		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("save-plan"), `Could not mark "save-plan" as hidden`)
 	}
 	cmd.Flags().BoolVarP(
 		&showSecrets, "show-secrets", "", false, "Emit secrets in plaintext in the plan file. Defaults to `false`")

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -614,8 +614,9 @@ func getLatestBrewFormulaVersion() (semver.Version, bool, error) {
 		return semver.Version{}, false, nil
 	}
 
-	url, err := url.Parse("https://formulae.brew.sh/api/formula/pulumi.json")
-	contract.AssertNoError(err)
+	const formulaJSON = "https://formulae.brew.sh/api/formula/pulumi.json"
+	url, err := url.Parse(formulaJSON)
+	contract.AssertNoErrorf(err, "Could not parse URL %q", formulaJSON)
 
 	resp, err := httputil.DoWithRetry(&http.Request{
 		Method: http.MethodGet,

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -92,7 +92,7 @@ func newStackSelectCmd() *cobra.Command {
 				return err
 			}
 
-			contract.Assert(stack != nil)
+			contract.Assertf(stack != nil, "must select a stack")
 			return state.SetCurrentStack(stack.Ref().String())
 
 		}),

--- a/pkg/cmd/pulumi/state_unprotect.go
+++ b/pkg/cmd/pulumi/state_unprotect.go
@@ -78,7 +78,7 @@ func unprotectAllResources(ctx context.Context, stackName string, showPrompt boo
 
 		for _, res := range snap.Resources {
 			err := edit.UnprotectResource(snap, res)
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "Unable to unprotect resource %q", res.URN)
 		}
 
 		return nil

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -598,7 +598,7 @@ func newUpCmd() *cobra.Command {
 			"perform operations that exceed its plan (e.g. replacements instead of updates, or updates instead"+
 			"of sames).")
 	if !hasExperimentalCommands() {
-		contract.AssertNoError(cmd.PersistentFlags().MarkHidden("plan"))
+		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("plan"), `Could not mark "plan" as hidden`)
 	}
 
 	// Remote flags

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -991,13 +991,13 @@ func log3rdPartySecretsProviderDecryptionEvent(ctx context.Context, backend back
 				id := backend.(httpstate.Stack).StackIdentifier()
 				// we don't really care if these logging calls fail as they should not stop the execution
 				if secretName != "" {
-					contract.Assert(commandName == "")
+					contract.Assertf(commandName == "", "Command name must be empty if secret name is set")
 					err := client.Log3rdPartySecretsProviderDecryptionEvent(ctx, id, secretName)
 					contract.IgnoreError(err)
 				}
 
 				if commandName != "" {
-					contract.Assert(secretName == "")
+					contract.Assertf(secretName == "", "Secret name must be empty if command name is set")
 					err := client.LogBulk3rdPartySecretsProviderDecryptionEvent(ctx, id, commandName)
 					contract.IgnoreError(err)
 				}


### PR DESCRIPTION
Migrates uses of contract.{Assert, AssertNoError} in pkg/cmd
to use Assertf and AssertNoErrorf so that
we write more meaningful messages when these contracts are violated.

Incremental step towards deprecating the non-f variants.

Refs #12103
