### PR TITLE
pkg/codegen/go: Prefer contract.Assertf over contract.Assert

### DIFF
--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -101,7 +101,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 func (d *DocLanguageHelper) GeneratePackagesMap(pkg *schema.Package, tool string, goInfo GoPackageInfo) {
 	var err error
 	d.packages, err = generatePackageContextMap(tool, pkg.Reference(), goInfo, nil)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "Could not generate package context map for %q", pkg.Name)
 }
 
 // GetPropertyName returns the property name specific to Go.

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -277,7 +277,7 @@ func getPackages(tool string, pkg *schema.Package, cache *Cache) map[string]*pkg
 		goPkgInfo = goInfo
 	}
 	v, err := generatePackageContextMap(tool, pkg.Reference(), goPkgInfo, cache)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "Could not generate package context map")
 	packageContexts.Store(pkg, v)
 	return v
 }
@@ -289,7 +289,7 @@ func (g *generator) collectScopeRoots(n pcl.Node) {
 		}
 		return n, nil
 	})
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "Expcted no diagnostics, got %d", len(diags))
 }
 
 // genPreamble generates package decl, imports, and opens the main func
@@ -402,7 +402,7 @@ func (g *generator) collectImports(
 					tokenRange := tokenArg.SyntaxNode().Range()
 					pkg, mod, name, diagnostics := pcl.DecomposeToken(token, tokenRange)
 
-					contract.Assert(len(diagnostics) == 0)
+					contract.Assertf(len(diagnostics) == 0, "Expected no diagnostics, got %d", len(diagnostics))
 
 					vPath, err := g.getVersionPath(program, pkg)
 					if err != nil {
@@ -420,7 +420,7 @@ func (g *generator) collectImports(
 			}
 			return n, nil
 		})
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "Expected no diagnostics, got %d", len(diags))
 
 		diags = n.VisitExpressions(nil, func(n model.Expression) (model.Expression, hcl.Diagnostics) {
 			if call, ok := n.(*model.FunctionCallExpression); ok {
@@ -435,7 +435,7 @@ func (g *generator) collectImports(
 			}
 			return n, nil
 		})
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "Expected no diagnostics, got %d", len(diags))
 	}
 }
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -712,7 +712,7 @@ func (g *generator) genTemplateExpression(w io.Writer, expr *model.TemplateExpre
 		g.genStringLiteral(w, fmtStr.String())
 	}
 	_, err := args.WriteTo(w)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "Failed to write arguments")
 	g.Fgenf(w, ")")
 }
 

--- a/pkg/codegen/go/utilities.go
+++ b/pkg/codegen/go/utilities.go
@@ -150,6 +150,6 @@ func fieldName(pkg *pkgContext, r *schema.Resource, p *schema.Property) string {
 	}
 
 	res := s + "_"
-	contract.Assert(!isReservedResourceField(name, res))
+	contract.Assertf(!isReservedResourceField(name, res), "Name %q is reserved on resource %q", name, res)
 	return res
 }


### PR DESCRIPTION
Migrates uses of contract.{Assert, AssertNoError} in pkg/codegen/go
to use Assertf and AssertNoErrorf so that
we write more meaningful messages when these contracts are violated.

Incremental step towards deprecating the non-f variants.

Refs #12132