### PR TITLE
Move gen-completion away from Hidden Command block

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -335,6 +335,7 @@ func NewPulumiCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				newVersionCmd(),
 				newAboutCmd(),
+				newGenCompletionCmd(cmd),
 			},
 		},
 
@@ -342,7 +343,6 @@ func NewPulumiCmd() *cobra.Command {
 		{
 			Name: "Hidden Commands",
 			Commands: []*cobra.Command{
-				newGenCompletionCmd(cmd),
 				newGenMarkdownCmd(cmd),
 			},
 		},


### PR DESCRIPTION
The `gen-completion` command was unhidden in https://github.com/pulumi/pulumi/pull/10218 but the command wasn't actually moved away from the hidden command group.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When running `pulumi --help`, the `gen-completion` command appears under a `Hidden Commands` section.
```
Hidden Commands:
  gen-completion 
```

This PR moves the command to the `Other Commands` section.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
