### PR TITLE
edit.DeleteResource now deletes by reference rather than by URN

### DIFF
--- a/changelog/pending/20230208--engine--fixes-an-issue-where-pulumi-state-delete-would-delete-all-matching-urns-in-interactive-mode.yaml
+++ b/changelog/pending/20230208--engine--fixes-an-issue-where-pulumi-state-delete-would-delete-all-matching-urns-in-interactive-mode.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: This fixes an issue where 'pulumi state delete ' would prompt the user to disambiguate between multiple resources in state with the same URN and proceed to delete all of them. With this change, dependency checks are performed only if the deletion will lead to no resources possessing the URN. The targetDependents flag will only target dependents if the deleted resource will orphan the dependents.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
This PR fixes an issue where 'pulumi state delete <urn>' would prompt the user to disambiguate between multiple resources in state with the same URN and proceed to delete all of them. With this change, dependency checks are performed only if the deletion will lead to no resources possessing the URN. The targetDependents flag will only target dependents if the deleted resource will orphan the dependents.


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12077 
Fixes #12110 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
