### PR TITLE
Change resource binding for optional fields

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -333,7 +333,8 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 	case *schema.InputType:
 		inputType := "Input"
 		elem := t.ElementType
-		switch e := t.ElementType.(type) {
+
+		switch e := elem.(type) {
 		case *schema.ArrayType:
 			inputType, elem = "InputList", codegen.PlainType(e.ElementType)
 		case *schema.MapType:

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2338,6 +2338,13 @@ func (mod *modContext) genPropDocstring(w io.Writer, name string, prop *schema.P
 func (mod *modContext) typeString(t schema.Type, input, acceptMapping bool) string {
 	switch t := t.(type) {
 	case *schema.OptionalType:
+		// Special case Optional[Input[Optional[T]]] to just Input[Optional[T]]
+		if innerInput, ok := t.ElementType.(*schema.InputType); ok {
+			if _, ok := innerInput.ElementType.(*schema.OptionalType); ok {
+				return mod.typeString(innerInput, input, acceptMapping)
+			}
+		}
+
 		return fmt.Sprintf("Optional[%s]", mod.typeString(t.ElementType, input, acceptMapping))
 	case *schema.InputType:
 		typ := mod.typeString(codegen.SimplifyInputUnion(t.ElementType), input, acceptMapping)

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1205,9 +1205,7 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 	specs = make(map[string]PropertySpec, len(props))
 	for _, p := range props {
 		typ := p.Type
-		if t, optional := typ.(*OptionalType); optional {
-			typ = t.ElementType
-		} else {
+		if _, optional := typ.(*OptionalType); !optional {
 			required = append(required, p.Name)
 		}
 
@@ -1252,6 +1250,10 @@ func (pkg *Package) marshalProperties(props []*Property, plain bool) (required [
 // require `Plain` annotations (hence the odd-looking `Plain: !plain` fields below).
 func (pkg *Package) marshalType(t Type, plain bool) TypeSpec {
 	switch t := t.(type) {
+	case *OptionalType:
+		// Schema's can't actually contain optional types but if they we're optional we will have marked it as
+		// such elsewhere and can just drop these parts.
+		return pkg.marshalType(t.ElementType, plain)
 	case *InputType:
 		el := pkg.marshalType(t.ElementType, plain)
 		el.Plain = false

--- a/pkg/codegen/testing/test/testdata/aws-eks-pp/go/aws-eks.go
+++ b/pkg/codegen/testing/test/testdata/aws-eks-pp/go/aws-eks.go
@@ -14,11 +14,11 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		eksVpc, err := ec2.NewVpc(ctx, "eksVpc", &ec2.VpcArgs{
-			CidrBlock:          pulumi.String("10.100.0.0/16"),
-			InstanceTenancy:    pulumi.String("default"),
-			EnableDnsHostnames: pulumi.Bool(true),
-			EnableDnsSupport:   pulumi.Bool(true),
-			Tags: pulumi.StringMap{
+			CidrBlock:          "10.100.0.0/16",
+			InstanceTenancy:    "default",
+			EnableDnsHostnames: true,
+			EnableDnsSupport:   true,
+			Tags: map[string]pulumi.String{
 				"Name": pulumi.String("pulumi-eks-vpc"),
 			},
 		})
@@ -27,7 +27,7 @@ func main() {
 		}
 		eksIgw, err := ec2.NewInternetGateway(ctx, "eksIgw", &ec2.InternetGatewayArgs{
 			VpcId: eksVpc.ID(),
-			Tags: pulumi.StringMap{
+			Tags: map[string]pulumi.String{
 				"Name": pulumi.String("pulumi-vpc-ig"),
 			},
 		})
@@ -36,13 +36,13 @@ func main() {
 		}
 		eksRouteTable, err := ec2.NewRouteTable(ctx, "eksRouteTable", &ec2.RouteTableArgs{
 			VpcId: eksVpc.ID(),
-			Routes: ec2.RouteTableRouteArray{
-				&ec2.RouteTableRouteArgs{
-					CidrBlock: pulumi.String("0.0.0.0/0"),
+			Routes: []ec2.RouteTableRouteArgs{
+				{
+					CidrBlock: "0.0.0.0/0",
 					GatewayId: eksIgw.ID(),
 				},
 			},
-			Tags: pulumi.StringMap{
+			Tags: map[string]pulumi.String{
 				"Name": pulumi.String("pulumi-vpc-rt"),
 			},
 		})
@@ -56,12 +56,12 @@ func main() {
 		var vpcSubnet []*ec2.Subnet
 		for key0, val0 := range zones.Names {
 			__res, err := ec2.NewSubnet(ctx, fmt.Sprintf("vpcSubnet-%v", key0), &ec2.SubnetArgs{
-				AssignIpv6AddressOnCreation: pulumi.Bool(false),
+				AssignIpv6AddressOnCreation: false,
 				VpcId:                       eksVpc.ID(),
-				MapPublicIpOnLaunch:         pulumi.Bool(true),
-				CidrBlock:                   pulumi.String(fmt.Sprintf("10.100.%v.0/24", key0)),
+				MapPublicIpOnLaunch:         true,
+				CidrBlock:                   fmt.Sprintf("10.100.%v.0/24", key0),
 				AvailabilityZone:            pulumi.String(val0),
-				Tags: pulumi.StringMap{
+				Tags: map[string]pulumi.String{
 					"Name": pulumi.String(fmt.Sprintf("pulumi-sn-%v", val0)),
 				},
 			})
@@ -88,28 +88,28 @@ func main() {
 		subnetIds := splat0
 		eksSecurityGroup, err := ec2.NewSecurityGroup(ctx, "eksSecurityGroup", &ec2.SecurityGroupArgs{
 			VpcId:       eksVpc.ID(),
-			Description: pulumi.String("Allow all HTTP(s) traffic to EKS Cluster"),
-			Tags: pulumi.StringMap{
+			Description: "Allow all HTTP(s) traffic to EKS Cluster",
+			Tags: map[string]pulumi.String{
 				"Name": pulumi.String("pulumi-cluster-sg"),
 			},
-			Ingress: ec2.SecurityGroupIngressArray{
-				&ec2.SecurityGroupIngressArgs{
-					CidrBlocks: pulumi.StringArray{
+			Ingress: []ec2.SecurityGroupIngressArgs{
+				{
+					CidrBlocks: []pulumi.String{
 						pulumi.String("0.0.0.0/0"),
 					},
 					FromPort:    pulumi.Int(443),
 					ToPort:      pulumi.Int(443),
 					Protocol:    pulumi.String("tcp"),
-					Description: pulumi.String("Allow pods to communicate with the cluster API Server."),
+					Description: "Allow pods to communicate with the cluster API Server.",
 				},
-				&ec2.SecurityGroupIngressArgs{
-					CidrBlocks: pulumi.StringArray{
+				{
+					CidrBlocks: []pulumi.String{
 						pulumi.String("0.0.0.0/0"),
 					},
 					FromPort:    pulumi.Int(80),
 					ToPort:      pulumi.Int(80),
 					Protocol:    pulumi.String("tcp"),
-					Description: pulumi.String("Allow internet access to pods"),
+					Description: "Allow internet access to pods",
 				},
 			},
 		})
@@ -199,14 +199,14 @@ func main() {
 		}
 		eksCluster, err := eks.NewCluster(ctx, "eksCluster", &eks.ClusterArgs{
 			RoleArn: eksRole.Arn,
-			Tags: pulumi.StringMap{
+			Tags: map[string]pulumi.String{
 				"Name": pulumi.String("pulumi-eks-cluster"),
 			},
 			VpcConfig: &eks.ClusterVpcConfigArgs{
-				PublicAccessCidrs: pulumi.StringArray{
+				PublicAccessCidrs: []pulumi.String{
 					pulumi.String("0.0.0.0/0"),
 				},
-				SecurityGroupIds: pulumi.StringArray{
+				SecurityGroupIds: []pulumi.String{
 					eksSecurityGroup.ID(),
 				},
 				SubnetIds: subnetIds,
@@ -217,10 +217,10 @@ func main() {
 		}
 		_, err = eks.NewNodeGroup(ctx, "nodeGroup", &eks.NodeGroupArgs{
 			ClusterName:   eksCluster.Name,
-			NodeGroupName: pulumi.String("pulumi-eks-nodegroup"),
+			NodeGroupName: "pulumi-eks-nodegroup",
 			NodeRoleArn:   ec2Role.Arn,
 			SubnetIds:     subnetIds,
-			Tags: pulumi.StringMap{
+			Tags: map[string]pulumi.String{
 				"Name": pulumi.String("pulumi-cluster-nodeGroup"),
 			},
 			ScalingConfig: &eks.NodeGroupScalingConfigArgs{

--- a/pkg/codegen/testing/test/testdata/aws-fargate-pp/dotnet/aws-fargate.cs
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-pp/dotnet/aws-fargate.cs
@@ -147,14 +147,14 @@ return await Deployment.RunAsync(() =>
         DesiredCount = 5,
         LaunchType = "FARGATE",
         TaskDefinition = appTask.Arn,
-        NetworkConfiguration = new Aws.Ecs.Inputs.ServiceNetworkConfigurationArgs
+        NetworkConfiguration = 
         {
-            AssignPublicIp = true,
-            Subnets = subnets.Apply(getSubnetIdsResult => getSubnetIdsResult.Ids),
-            SecurityGroups = new[]
+            { "assignPublicIp", true },
+            { "subnets", subnets.Apply(getSubnetIdsResult => getSubnetIdsResult.Ids) },
+            { "securityGroups", new[]
             {
                 webSecurityGroup.Id,
-            },
+            } },
         },
         LoadBalancers = new[]
         {

--- a/pkg/codegen/testing/test/testdata/aws-fargate-pp/python/aws-fargate.py
+++ b/pkg/codegen/testing/test/testdata/aws-fargate-pp/python/aws-fargate.py
@@ -74,11 +74,11 @@ app_service = aws.ecs.Service("appService",
     desired_count=5,
     launch_type="FARGATE",
     task_definition=app_task.arn,
-    network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
-        assign_public_ip=True,
-        subnets=subnets.ids,
-        security_groups=[web_security_group.id],
-    ),
+    network_configuration={
+        "assignPublicIp": True,
+        "subnets": subnets.ids,
+        "securityGroups": [web_security_group.id],
+    },
     load_balancers=[aws.ecs.ServiceLoadBalancerArgs(
         target_group_arn=web_target_group.arn,
         container_name="my-app",

--- a/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/go/aws-iam-policy.go
+++ b/pkg/codegen/testing/test/testdata/aws-iam-policy-pp/go/aws-iam-policy.go
@@ -37,8 +37,8 @@ func main() {
 		}
 		json0 := string(tmpJSON0)
 		policy, err := iam.NewPolicy(ctx, "policy", &iam.PolicyArgs{
-			Path:        pulumi.String("/"),
-			Description: pulumi.String("My test policy"),
+			Path:        "/",
+			Description: "My test policy",
 			Policy:      pulumi.String(json0),
 		})
 		if err != nil {

--- a/pkg/codegen/testing/test/testdata/aws-lambda-pp/python/aws-lambda.py
+++ b/pkg/codegen/testing/test/testdata/aws-lambda-pp/python/aws-lambda.py
@@ -7,8 +7,8 @@ test_lambda = aws.lambda_.Function("testLambda",
     role=iam_for_lambda.arn,
     handler="index.test",
     runtime="nodejs12.x",
-    environment=aws.lambda_.FunctionEnvironmentArgs(
-        variables={
+    environment={
+        "variables": {
             "foo": "bar",
         },
-    ))
+    })

--- a/pkg/codegen/testing/test/testdata/aws-optionals-pp/go/aws-optionals.go
+++ b/pkg/codegen/testing/test/testdata/aws-optionals-pp/go/aws-optionals.go
@@ -25,8 +25,8 @@ func main() {
 			return err
 		}
 		_, err = iam.NewPolicy(ctx, "example", &iam.PolicyArgs{
-			Name:   pulumi.String("example_policy"),
-			Path:   pulumi.String("/"),
+			Name:   "example_policy",
+			Path:   "/",
 			Policy: pulumi.String(policyDocument.Json),
 		})
 		if err != nil {

--- a/pkg/codegen/testing/test/testdata/aws-resource-options-4.26-pp/go/aws-resource-options-4.26.go
+++ b/pkg/codegen/testing/test/testdata/aws-resource-options-4.26-pp/go/aws-resource-options-4.26.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		provider, err := aws.NewProvider(ctx, "provider", &aws.ProviderArgs{
-			Region: pulumi.String("us-west-2"),
+			Region: "us-west-2",
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/aws-resource-options-5.16.2-pp/go/aws-resource-options-5.16.2.go
+++ b/pkg/codegen/testing/test/testdata/aws-resource-options-5.16.2-pp/go/aws-resource-options-5.16.2.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		provider, err := aws.NewProvider(ctx, "provider", &aws.ProviderArgs{
-			Region: pulumi.String("us-west-2"),
+			Region: "us-west-2",
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/dotnet/aws-s3-folder.cs
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/dotnet/aws-s3-folder.cs
@@ -10,9 +10,9 @@ return await Deployment.RunAsync(() =>
     // Create a bucket and expose a website index document
     var siteBucket = new Aws.S3.Bucket("siteBucket", new()
     {
-        Website = new Aws.S3.Inputs.BucketWebsiteArgs
+        Website = 
         {
-            IndexDocument = "index.html",
+            { "indexDocument", "index.html" },
         },
     });
 

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/go/aws-s3-folder.go
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/go/aws-s3-folder.go
@@ -13,8 +13,8 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		siteBucket, err := s3.NewBucket(ctx, "siteBucket", &s3.BucketArgs{
-			Website: &s3.BucketWebsiteArgs{
-				IndexDocument: pulumi.String("index.html"),
+			Website: &*s3.BucketWebsiteArgs{
+				IndexDocument: "index.html",
 			},
 		})
 		if err != nil {

--- a/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/python/aws-s3-folder.py
+++ b/pkg/codegen/testing/test/testdata/aws-s3-folder-pp/python/aws-s3-folder.py
@@ -4,9 +4,9 @@ import os
 import pulumi_aws as aws
 
 # Create a bucket and expose a website index document
-site_bucket = aws.s3.Bucket("siteBucket", website=aws.s3.BucketWebsiteArgs(
-    index_document="index.html",
-))
+site_bucket = aws.s3.Bucket("siteBucket", website={
+    "indexDocument": "index.html",
+})
 site_dir = "www"
 # For each file in the directory, create an S3 object stored in `siteBucket`
 files = []

--- a/pkg/codegen/testing/test/testdata/aws-s3-logging-pp/go/aws-s3-logging.go
+++ b/pkg/codegen/testing/test/testdata/aws-s3-logging-pp/go/aws-s3-logging.go
@@ -12,8 +12,8 @@ func main() {
 			return err
 		}
 		bucket, err := s3.NewBucket(ctx, "bucket", &s3.BucketArgs{
-			Loggings: s3.BucketLoggingArray{
-				&s3.BucketLoggingArgs{
+			Loggings: []s3.BucketLoggingArgs{
+				{
 					TargetBucket: logs.Bucket,
 				},
 			},

--- a/pkg/codegen/testing/test/testdata/aws-webserver-pp/go/aws-webserver.go
+++ b/pkg/codegen/testing/test/testdata/aws-webserver-pp/go/aws-webserver.go
@@ -11,12 +11,12 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		securityGroup, err := ec2.NewSecurityGroup(ctx, "securityGroup", &ec2.SecurityGroupArgs{
-			Ingress: ec2.SecurityGroupIngressArray{
-				&ec2.SecurityGroupIngressArgs{
+			Ingress: []ec2.SecurityGroupIngressArgs{
+				{
 					Protocol: pulumi.String("tcp"),
 					FromPort: pulumi.Int(0),
 					ToPort:   pulumi.Int(0),
-					CidrBlocks: pulumi.StringArray{
+					CidrBlocks: []pulumi.String{
 						pulumi.String("0.0.0.0/0"),
 					},
 				},
@@ -43,15 +43,15 @@ func main() {
 			return err
 		}
 		server, err := ec2.NewInstance(ctx, "server", &ec2.InstanceArgs{
-			Tags: pulumi.StringMap{
+			Tags: map[string]pulumi.String{
 				"Name": pulumi.String("web-server-www"),
 			},
-			InstanceType: pulumi.String("t2.micro"),
-			SecurityGroups: pulumi.StringArray{
+			InstanceType: "t2.micro",
+			SecurityGroups: []pulumi.String{
 				securityGroup.Name,
 			},
 			Ami:      pulumi.String(ami.Id),
-			UserData: pulumi.String(fmt.Sprintf("#!/bin/bash\necho \"Hello, World!\" > index.html\nnohup python -m SimpleHTTPServer 80 &\n")),
+			UserData: fmt.Sprintf("#!/bin/bash\necho \"Hello, World!\" > index.html\nnohup python -m SimpleHTTPServer 80 &\n"),
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/azure-native-pp/dotnet/azure-native.cs
+++ b/pkg/codegen/testing/test/testdata/azure-native-pp/dotnet/azure-native.cs
@@ -11,13 +11,13 @@ return await Deployment.RunAsync(() =>
         {
             new AzureNative.Network.Inputs.RoutingRuleArgs
             {
-                RouteConfiguration = new AzureNative.Network.Inputs.ForwardingConfigurationArgs
+                RouteConfiguration = 
                 {
-                    OdataType = "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-                    BackendPool = new AzureNative.Network.Inputs.SubResourceArgs
+                    { "odataType", "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration" },
+                    { "backendPool", 
                     {
-                        Id = "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/frontDoors/frontDoor1/backendPools/backendPool1",
-                    },
+                        { "id", "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/frontDoors/frontDoor1/backendPools/backendPool1" },
+                    } },
                 },
             },
         },
@@ -26,9 +26,9 @@ return await Deployment.RunAsync(() =>
     var endpoint = new AzureNative.Cdn.Endpoint("endpoint", new()
     {
         Origins = new[] {},
-        DeliveryPolicy = new AzureNative.Cdn.Inputs.EndpointPropertiesUpdateParametersDeliveryPolicyArgs
+        DeliveryPolicy = 
         {
-            Rules = new[]
+            { "rules", new[]
             {
                 new AzureNative.Cdn.Inputs.DeliveryRuleArgs
                 {
@@ -89,7 +89,7 @@ return await Deployment.RunAsync(() =>
                     Name = "rule1",
                     Order = 1,
                 },
-            },
+            } },
         },
         EndpointName = "endpoint1",
         IsCompressionEnabled = true,

--- a/pkg/codegen/testing/test/testdata/azure-native-pp/python/azure-native.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-pp/python/azure-native.py
@@ -4,17 +4,17 @@ import pulumi_azure_native as azure_native
 front_door = azure_native.network.FrontDoor("frontDoor",
     resource_group_name="someGroupName",
     routing_rules=[azure_native.network.RoutingRuleArgs(
-        route_configuration=azure_native.network.ForwardingConfigurationArgs(
-            odata_type="#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-            backend_pool=azure_native.network.SubResourceArgs(
-                id="/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/frontDoors/frontDoor1/backendPools/backendPool1",
-            ),
-        ),
+        route_configuration={
+            "odataType": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+            "backendPool": {
+                "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/frontDoors/frontDoor1/backendPools/backendPool1",
+            },
+        },
     )])
 endpoint = azure_native.cdn.Endpoint("endpoint",
     origins=[],
-    delivery_policy=azure_native.cdn.EndpointPropertiesUpdateParametersDeliveryPolicyArgs(
-        rules=[azure_native.cdn.DeliveryRuleArgs(
+    delivery_policy={
+        "rules": [azure_native.cdn.DeliveryRuleArgs(
             actions=[
                 azure_native.cdn.DeliveryRuleCacheExpirationActionArgs(
                     name="CacheExpiration",
@@ -59,7 +59,7 @@ endpoint = azure_native.cdn.Endpoint("endpoint",
             name="rule1",
             order=1,
         )],
-    ),
+    },
     endpoint_name="endpoint1",
     is_compression_enabled=True,
     is_http_allowed=True,

--- a/pkg/codegen/testing/test/testdata/azure-sa-pp/go/azure-sa.go
+++ b/pkg/codegen/testing/test/testdata/azure-sa-pp/go/azure-sa.go
@@ -32,7 +32,7 @@ func main() {
 		}
 		storageAccountResource, err := storage.NewAccount(ctx, "storageAccountResource", &storage.AccountArgs{
 			Name:                   pulumi.String(storageAccountNameParam),
-			AccountKind:            pulumi.String("StorageV2"),
+			AccountKind:            "StorageV2",
 			Location:               pulumi.String(locationParam),
 			ResourceGroupName:      pulumi.String(resourceGroupNameParam),
 			AccountTier:            pulumi.String(storageAccountTierParam),

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/docs/submodule1/moduleresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                    <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                   <span class="nx">thing</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.TopLevelArgs]</span> = None<span class="p">)</span>
+                   <span class="nx">thing</span><span class="p">:</span> <span class="nx">Optional[Optional[_root_inputs.TopLevelArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                    <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ModuleResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_csharp" style="color: inherit; text-decoration: inherit;">Thing</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#toplevel">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Inputs.<wbr>Top<wbr>Level<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Inputs.<wbr>Top<wbr>Level<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -239,7 +239,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_go" style="color: inherit; text-decoration: inherit;">Thing</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#toplevel">Top<wbr>Level<wbr>Args</a></span>
+        <span class="property-type">Top<wbr>Level<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_java" style="color: inherit; text-decoration: inherit;">thing</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#toplevel">Top<wbr>Level<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Top<wbr>Level<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_nodejs" style="color: inherit; text-decoration: inherit;">thing</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#toplevel">Top<wbr>Level<wbr>Args</a></span>
+        <span class="property-type">Top<wbr>Level<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_python" style="color: inherit; text-decoration: inherit;">thing</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#toplevel">Top<wbr>Level<wbr>Args</a></span>
+        <span class="property-type">Top<wbr>Level<wbr>Args]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -295,7 +295,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#thing_yaml" style="color: inherit; text-decoration: inherit;">thing</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#toplevel">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Inputs/TopLevelArgs.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Inputs/TopLevelArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.FooBar.Inputs
     public sealed class TopLevelArgs : global::Pulumi.ResourceArgs
     {
         [Input("buzz")]
-        public Input<string>? Buzz { get; set; }
+        public Input<string?>? Buzz { get; set; }
 
         public TopLevelArgs()
         {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Submodule1/ModuleResource.cs
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Submodule1/ModuleResource.cs
@@ -61,7 +61,7 @@ namespace Pulumi.FooBar.Submodule1
     public sealed class ModuleResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("thing")]
-        public Input<Pulumi.FooBar.Inputs.TopLevelArgs>? Thing { get; set; }
+        public Input<Pulumi.FooBar.Inputs.TopLevelArgs?>? Thing { get; set; }
 
         public ModuleResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/pulumiTypes.go
@@ -26,7 +26,7 @@ type TopLevelInput interface {
 }
 
 type TopLevelArgs struct {
-	Buzz pulumi.StringPtrInput `pulumi:"buzz"`
+	Buzz *string `pulumi:"buzz"`
 }
 
 func (TopLevelArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
@@ -61,7 +61,7 @@ type moduleResourceArgs struct {
 
 // The set of arguments for constructing a ModuleResource resource.
 type ModuleResourceArgs struct {
-	Thing foo.TopLevelPtrInput
+	Thing *foo.TopLevelArgs
 }
 
 func (ModuleResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/submodule1/moduleResource.ts
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/submodule1/moduleResource.ts
@@ -59,5 +59,5 @@ export class ModuleResource extends pulumi.CustomResource {
  * The set of arguments for constructing a ModuleResource resource.
  */
 export interface ModuleResourceArgs {
-    thing?: pulumi.Input<inputs.TopLevelArgs>;
+    thing?: pulumi.Input<inputs.TopLevelArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/nodejs/types/input.ts
@@ -6,5 +6,5 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 
 export interface TopLevelArgs {
-    buzz?: pulumi.Input<string>;
+    buzz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/_inputs.py
@@ -16,17 +16,17 @@ __all__ = [
 @pulumi.input_type
 class TopLevelArgs:
     def __init__(__self__, *,
-                 buzz: Optional[pulumi.Input[str]] = None):
+                 buzz: pulumi.Input[Optional[str]] = None):
         if buzz is not None:
             pulumi.set(__self__, "buzz", buzz)
 
     @property
     @pulumi.getter
-    def buzz(self) -> Optional[pulumi.Input[str]]:
+    def buzz(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "buzz")
 
     @buzz.setter
-    def buzz(self, value: Optional[pulumi.Input[str]]):
+    def buzz(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "buzz", value)
 
 

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/pulumi_foo_bar/submodule1/module_resource.py
@@ -16,7 +16,7 @@ __all__ = ['ModuleResourceArgs', 'ModuleResource']
 @pulumi.input_type
 class ModuleResourceArgs:
     def __init__(__self__, *,
-                 thing: Optional[pulumi.Input['_root_inputs.TopLevelArgs']] = None):
+                 thing: pulumi.Input[Optional['_root_inputs.TopLevelArgs']] = None):
         """
         The set of arguments for constructing a ModuleResource resource.
         """
@@ -25,11 +25,11 @@ class ModuleResourceArgs:
 
     @property
     @pulumi.getter
-    def thing(self) -> Optional[pulumi.Input['_root_inputs.TopLevelArgs']]:
+    def thing(self) -> pulumi.Input[Optional['_root_inputs.TopLevelArgs']]:
         return pulumi.get(self, "thing")
 
     @thing.setter
-    def thing(self, value: Optional[pulumi.Input['_root_inputs.TopLevelArgs']]):
+    def thing(self, value: pulumi.Input[Optional['_root_inputs.TopLevelArgs']]):
         pulumi.set(self, "thing", value)
 
 
@@ -38,7 +38,7 @@ class ModuleResource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 thing: Optional[pulumi.Input[pulumi.InputType['_root_inputs.TopLevelArgs']]] = None,
+                 thing: pulumi.Input[Optional[pulumi.InputType['_root_inputs.TopLevelArgs']]] = None,
                  __props__=None):
         """
         Create a ModuleResource resource with the given unique name, props, and options.
@@ -68,7 +68,7 @@ class ModuleResource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 thing: Optional[pulumi.Input[pulumi.InputType['_root_inputs.TopLevelArgs']]] = None,
+                 thing: pulumi.Input[Optional[pulumi.InputType['_root_inputs.TopLevelArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/nursery/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">,</span>
+            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Optional[Mapping[str, TreeSize]]]</span> = None<span class="p">,</span>
             <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
@@ -235,7 +235,7 @@ The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-o
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;</span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;?</span>
     </dt>
     <dd><p>The sizes of trees available</p>
 </dd></dl>
@@ -307,7 +307,7 @@ The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-o
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: Tree<wbr>Size}</span>
+        <span class="property-type">{[key: string]: Tree<wbr>Size} | undefined</span>
     </dt>
     <dd><p>The sizes of trees available</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/docs/tree/v1/rubbertree/_index.md
@@ -32,10 +32,10 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
+               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[Optional[_root_inputs.ContainerArgs]]</span> = None<span class="p">,</span>
                <span class="nx">diameter</span><span class="p">:</span> <span class="nx">Optional[Diameter]</span> = None<span class="p">,</span>
-               <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">,</span>
-               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">,</span>
+               <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Optional[Union[Farm, str]]]</span> = None<span class="p">,</span>
+               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[Optional[TreeSize]]</span> = None<span class="p">,</span>
                <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
@@ -245,7 +245,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -253,7 +253,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
+        <span class="property-type">Union&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm, string&gt;?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -261,7 +261,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size</a></span>
+        <span class="property-type">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -291,7 +291,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -299,7 +299,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -307,7 +307,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -337,7 +337,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_java" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Container<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -345,7 +345,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_java" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | String</span>
+        <span class="property-type">Optional&lt;Either&lt;Farm,String&gt;&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -353,7 +353,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_java" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Optional&lt;Tree<wbr>Size&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -383,7 +383,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -391,7 +391,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">Farm | string | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -399,7 +399,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -429,7 +429,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -437,7 +437,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | str</span>
+        <span class="property-type">Union[Farm, str]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -445,7 +445,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -475,7 +475,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_yaml" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -483,7 +483,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_yaml" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34;</a> | String</span>
+        <span class="property-type">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34; | String</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -491,7 +491,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_yaml" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">&#34;small&#34; | &#34;medium&#34; | &#34;large&#34;</a></span>
+        <span class="property-type">&#34;small&#34; | &#34;medium&#34; | &#34;large&#34;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -615,7 +615,7 @@ Get an existing RubberTree resource's state with the given name, ID, and optiona
 <span class="k">def </span><span class="nf">get</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">id</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">) -&gt;</span> RubberTree</code></pre></div>
+        <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Optional[Union[Farm, str]]]</span> = None<span class="p">) -&gt;</span> RubberTree</code></pre></div>
 </pulumi-choosable>
 </div>
 
@@ -789,7 +789,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
+        <span class="property-type">Union&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm, string&gt;?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -803,7 +803,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">string</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -817,7 +817,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_java" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | String</span>
+        <span class="property-type">Optional&lt;Either&lt;Farm,String&gt;&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -831,7 +831,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">Farm | string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -845,7 +845,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | str</span>
+        <span class="property-type">Union[Farm, str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -859,7 +859,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_yaml" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34;</a> | String</span>
+        <span class="property-type">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34; | String</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Inputs/ContainerArgs.cs
@@ -13,20 +13,20 @@ namespace Pulumi.Plant.Inputs
     public sealed class ContainerArgs : global::Pulumi.ResourceArgs
     {
         [Input("brightness")]
-        public Input<Pulumi.Plant.ContainerBrightness>? Brightness { get; set; }
+        public Input<Pulumi.Plant.ContainerBrightness?>? Brightness { get; set; }
 
         [Input("color")]
-        public InputUnion<Pulumi.Plant.ContainerColor, string>? Color { get; set; }
+        public Input<Union<Input<Pulumi.Plant.ContainerColor>, Input<string>>?>? Color { get; set; }
 
         [Input("material")]
-        public Input<string>? Material { get; set; }
+        public Input<string?>? Material { get; set; }
 
         [Input("size", required: true)]
         public Input<Pulumi.Plant.ContainerSize> Size { get; set; } = null!;
 
         public ContainerArgs()
         {
-            Brightness = Pulumi.Plant.ContainerBrightness.One;
+            Brightness = 1;
         }
         public static new ContainerArgs Empty => new ContainerArgs();
     }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/Nursery.cs
@@ -56,17 +56,11 @@ namespace Pulumi.Plant.Tree.V1
 
     public sealed class NurseryArgs : global::Pulumi.ResourceArgs
     {
-        [Input("sizes")]
-        private InputMap<Pulumi.Plant.Tree.V1.TreeSize>? _sizes;
-
         /// <summary>
         /// The sizes of trees available
         /// </summary>
-        public InputMap<Pulumi.Plant.Tree.V1.TreeSize> Sizes
-        {
-            get => _sizes ?? (_sizes = new InputMap<Pulumi.Plant.Tree.V1.TreeSize>());
-            set => _sizes = value;
-        }
+        [Input("sizes")]
+        public Input<ImmutableDictionary<string, Input<Pulumi.Plant.Tree.V1.TreeSize>>?>? Sizes { get; set; }
 
         [Input("varieties", required: true)]
         private InputList<Pulumi.Plant.Tree.V1.RubberTreeVariety>? _varieties;

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Tree/V1/RubberTree.cs
@@ -74,16 +74,16 @@ namespace Pulumi.Plant.Tree.V1
     public sealed class RubberTreeArgs : global::Pulumi.ResourceArgs
     {
         [Input("container")]
-        public Input<Pulumi.Plant.Inputs.ContainerArgs>? Container { get; set; }
+        public Input<Pulumi.Plant.Inputs.ContainerArgs?>? Container { get; set; }
 
         [Input("diameter", required: true)]
         public Input<Pulumi.Plant.Tree.V1.Diameter> Diameter { get; set; } = null!;
 
         [Input("farm")]
-        public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+        public Input<Union<Input<Pulumi.Plant.Tree.V1.Farm>, Input<string>>?>? Farm { get; set; }
 
         [Input("size")]
-        public Input<Pulumi.Plant.Tree.V1.TreeSize>? Size { get; set; }
+        public Input<Pulumi.Plant.Tree.V1.TreeSize?>? Size { get; set; }
 
         [Input("type", required: true)]
         public Input<Pulumi.Plant.Tree.V1.RubberTreeVariety> Type { get; set; } = null!;
@@ -92,7 +92,7 @@ namespace Pulumi.Plant.Tree.V1
         {
             Diameter = Pulumi.Plant.Tree.V1.Diameter.Sixinch;
             Farm = "(unknown)";
-            Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
+            Size = "medium";
             Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
         }
         public static new RubberTreeArgs Empty => new RubberTreeArgs();
@@ -101,7 +101,7 @@ namespace Pulumi.Plant.Tree.V1
     public sealed class RubberTreeState : global::Pulumi.ResourceArgs
     {
         [Input("farm")]
-        public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+        public Input<Union<Input<Pulumi.Plant.Tree.V1.Farm>, Input<string>>?>? Farm { get; set; }
 
         public RubberTreeState()
         {

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/pulumiTypes.go
@@ -42,10 +42,10 @@ type ContainerInput interface {
 }
 
 type ContainerArgs struct {
-	Brightness ContainerBrightnessPtrInput `pulumi:"brightness"`
-	Color      pulumi.StringPtrInput       `pulumi:"color"`
-	Material   pulumi.StringPtrInput       `pulumi:"material"`
-	Size       ContainerSizeInput          `pulumi:"size"`
+	Brightness *ContainerBrightness `pulumi:"brightness"`
+	Color      *string              `pulumi:"color"`
+	Material   *string              `pulumi:"material"`
+	Size       ContainerSizeInput   `pulumi:"size"`
 }
 
 // Defaults sets the appropriate defaults for ContainerArgs
@@ -55,7 +55,7 @@ func (val *ContainerArgs) Defaults() *ContainerArgs {
 	}
 	tmp := *val
 	if tmp.Brightness == nil {
-		tmp.Brightness = ContainerBrightness(1.0)
+		tmp.Brightness = *ContainerBrightness(1.0)
 	}
 	return &tmp
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
@@ -66,7 +66,7 @@ type nurseryArgs struct {
 // The set of arguments for constructing a Nursery resource.
 type NurseryArgs struct {
 	// The sizes of trees available
-	Sizes TreeSizeMapInput
+	Sizes map[string]TreeSizeInput
 	// The varieties available
 	Varieties RubberTreeVarietyArrayInput
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
@@ -29,20 +29,19 @@ func NewRubberTree(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Container != nil {
-		args.Container = args.Container.ToContainerPtrOutput().ApplyT(func(v *plantprovider.Container) *plantprovider.Container { return v.Defaults() }).(plantprovider.ContainerPtrOutput)
-	}
 	if args.Diameter == nil {
-		args.Diameter = Diameter(6.0)
+		diameter_ := Diameter(6.0)
+		args.Diameter = &diameter_
 	}
 	if args.Farm == nil {
-		args.Farm = pulumi.StringPtr("(unknown)")
+		args.Farm = *string("(unknown)")
 	}
 	if args.Size == nil {
-		args.Size = TreeSize("medium")
+		args.Size = *TreeSize("medium")
 	}
 	if args.Type == nil {
-		args.Type = RubberTreeVariety("Burgundy")
+		type_ := RubberTreeVariety("Burgundy")
+		args.Type = &type_
 	}
 	var resource RubberTree
 	err := ctx.RegisterResource("plant:tree/v1:RubberTree", name, args, &resource, opts...)
@@ -70,7 +69,7 @@ type rubberTreeState struct {
 }
 
 type RubberTreeState struct {
-	Farm pulumi.StringPtrInput
+	Farm *string
 }
 
 func (RubberTreeState) ElementType() reflect.Type {
@@ -87,10 +86,10 @@ type rubberTreeArgs struct {
 
 // The set of arguments for constructing a RubberTree resource.
 type RubberTreeArgs struct {
-	Container plantprovider.ContainerPtrInput
+	Container *plantprovider.ContainerArgs
 	Diameter  DiameterInput
-	Farm      pulumi.StringPtrInput
-	Size      TreeSizePtrInput
+	Farm      *string
+	Size      *TreeSize
 	Type      RubberTreeVarietyInput
 }
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/tree/v1/nursery.ts
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/tree/v1/nursery.ts
@@ -65,7 +65,7 @@ export interface NurseryArgs {
     /**
      * The sizes of trees available
      */
-    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>}>;
+    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>} | undefined>;
     /**
      * The varieties available
      */

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/tree/v1/rubberTree.ts
@@ -75,16 +75,16 @@ export class RubberTree extends pulumi.CustomResource {
 }
 
 export interface RubberTreeState {
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    farm?: pulumi.Input<pulumi.Input<enums.tree.v1.Farm> | pulumi.Input<string> | undefined>;
 }
 
 /**
  * The set of arguments for constructing a RubberTree resource.
  */
 export interface RubberTreeArgs {
-    container?: pulumi.Input<inputs.ContainerArgs>;
+    container?: pulumi.Input<inputs.ContainerArgs | undefined>;
     diameter: pulumi.Input<enums.tree.v1.Diameter>;
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
-    size?: pulumi.Input<enums.tree.v1.TreeSize>;
+    farm?: pulumi.Input<pulumi.Input<enums.tree.v1.Farm> | pulumi.Input<string> | undefined>;
+    size?: pulumi.Input<enums.tree.v1.TreeSize | undefined>;
     type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
 }

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/nodejs/types/input.ts
@@ -9,9 +9,9 @@ import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
 export interface ContainerArgs {
-    brightness?: pulumi.Input<enums.ContainerBrightness>;
-    color?: pulumi.Input<enums.ContainerColor | string>;
-    material?: pulumi.Input<string>;
+    brightness?: pulumi.Input<enums.ContainerBrightness | undefined>;
+    color?: pulumi.Input<pulumi.Input<enums.ContainerColor> | pulumi.Input<string> | undefined>;
+    material?: pulumi.Input<string | undefined>;
     size: pulumi.Input<enums.ContainerSize>;
 }
 /**

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/_inputs.py
@@ -18,9 +18,9 @@ __all__ = [
 class ContainerArgs:
     def __init__(__self__, *,
                  size: pulumi.Input['ContainerSize'],
-                 brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
-                 color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
-                 material: Optional[pulumi.Input[str]] = None):
+                 brightness: pulumi.Input[Optional['ContainerBrightness']] = None,
+                 color: pulumi.Input[Optional[Union['ContainerColor', str]]] = None,
+                 material: pulumi.Input[Optional[str]] = None):
         pulumi.set(__self__, "size", size)
         if brightness is None:
             brightness = 1
@@ -42,29 +42,29 @@ class ContainerArgs:
 
     @property
     @pulumi.getter
-    def brightness(self) -> Optional[pulumi.Input['ContainerBrightness']]:
+    def brightness(self) -> pulumi.Input[Optional['ContainerBrightness']]:
         return pulumi.get(self, "brightness")
 
     @brightness.setter
-    def brightness(self, value: Optional[pulumi.Input['ContainerBrightness']]):
+    def brightness(self, value: pulumi.Input[Optional['ContainerBrightness']]):
         pulumi.set(self, "brightness", value)
 
     @property
     @pulumi.getter
-    def color(self) -> Optional[pulumi.Input[Union['ContainerColor', str]]]:
+    def color(self) -> pulumi.Input[Optional[Union['ContainerColor', str]]]:
         return pulumi.get(self, "color")
 
     @color.setter
-    def color(self, value: Optional[pulumi.Input[Union['ContainerColor', str]]]):
+    def color(self, value: pulumi.Input[Optional[Union['ContainerColor', str]]]):
         pulumi.set(self, "color", value)
 
     @property
     @pulumi.getter
-    def material(self) -> Optional[pulumi.Input[str]]:
+    def material(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "material")
 
     @material.setter
-    def material(self, value: Optional[pulumi.Input[str]]):
+    def material(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "material", value)
 
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -16,11 +16,11 @@ __all__ = ['NurseryArgs', 'Nursery']
 class NurseryArgs:
     def __init__(__self__, *,
                  varieties: pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]],
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None):
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None):
         """
         The set of arguments for constructing a Nursery resource.
         :param pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]] varieties: The varieties available
-        :param pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]] sizes: The sizes of trees available
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] sizes: The sizes of trees available
         """
         pulumi.set(__self__, "varieties", varieties)
         if sizes is not None:
@@ -40,14 +40,14 @@ class NurseryArgs:
 
     @property
     @pulumi.getter
-    def sizes(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]]:
+    def sizes(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]]:
         """
         The sizes of trees available
         """
         return pulumi.get(self, "sizes")
 
     @sizes.setter
-    def sizes(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]]):
+    def sizes(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]]):
         pulumi.set(self, "sizes", value)
 
 
@@ -56,14 +56,14 @@ class Nursery(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
         """
         Create a Nursery resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]] sizes: The sizes of trees available
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] sizes: The sizes of trees available
         :param pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]] varieties: The varieties available
         """
         ...
@@ -89,7 +89,7 @@ class Nursery(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -20,9 +20,9 @@ class RubberTreeArgs:
     def __init__(__self__, *,
                  diameter: pulumi.Input['Diameter'],
                  type: pulumi.Input['RubberTreeVariety'],
-                 container: Optional[pulumi.Input['_root_inputs.ContainerArgs']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None):
+                 container: pulumi.Input[Optional['_root_inputs.ContainerArgs']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None):
         """
         The set of arguments for constructing a RubberTree resource.
         """
@@ -63,36 +63,36 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
-    def container(self) -> Optional[pulumi.Input['_root_inputs.ContainerArgs']]:
+    def container(self) -> pulumi.Input[Optional['_root_inputs.ContainerArgs']]:
         return pulumi.get(self, "container")
 
     @container.setter
-    def container(self, value: Optional[pulumi.Input['_root_inputs.ContainerArgs']]):
+    def container(self, value: pulumi.Input[Optional['_root_inputs.ContainerArgs']]):
         pulumi.set(self, "container", value)
 
     @property
     @pulumi.getter
-    def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+    def farm(self) -> pulumi.Input[Optional[Union['Farm', str]]]:
         return pulumi.get(self, "farm")
 
     @farm.setter
-    def farm(self, value: Optional[pulumi.Input[Union['Farm', str]]]):
+    def farm(self, value: pulumi.Input[Optional[Union['Farm', str]]]):
         pulumi.set(self, "farm", value)
 
     @property
     @pulumi.getter
-    def size(self) -> Optional[pulumi.Input['TreeSize']]:
+    def size(self) -> pulumi.Input[Optional['TreeSize']]:
         return pulumi.get(self, "size")
 
     @size.setter
-    def size(self, value: Optional[pulumi.Input['TreeSize']]):
+    def size(self, value: pulumi.Input[Optional['TreeSize']]):
         pulumi.set(self, "size", value)
 
 
 @pulumi.input_type
 class _RubberTreeState:
     def __init__(__self__, *,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None):
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None):
         """
         Input properties used for looking up and filtering RubberTree resources.
         """
@@ -103,11 +103,11 @@ class _RubberTreeState:
 
     @property
     @pulumi.getter
-    def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+    def farm(self) -> pulumi.Input[Optional[Union['Farm', str]]]:
         return pulumi.get(self, "farm")
 
     @farm.setter
-    def farm(self, value: Optional[pulumi.Input[Union['Farm', str]]]):
+    def farm(self, value: pulumi.Input[Optional[Union['Farm', str]]]):
         pulumi.set(self, "farm", value)
 
 
@@ -116,10 +116,10 @@ class RubberTree(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 container: Optional[pulumi.Input[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
+                 container: pulumi.Input[Optional[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
                  diameter: Optional[pulumi.Input['Diameter']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
         """
@@ -150,10 +150,10 @@ class RubberTree(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 container: Optional[pulumi.Input[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
+                 container: pulumi.Input[Optional[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
                  diameter: Optional[pulumi.Input['Diameter']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -191,7 +191,7 @@ class RubberTree(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            farm: Optional[pulumi.Input[Union['Farm', str]]] = None) -> 'RubberTree':
+            farm: pulumi.Input[Optional[Union['Farm', str]]] = None) -> 'RubberTree':
         """
         Get an existing RubberTree resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/nursery/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">,</span>
+            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Optional[Mapping[str, TreeSize]]]</span> = None<span class="p">,</span>
             <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
@@ -235,7 +235,7 @@ The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-o
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;</span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;?</span>
     </dt>
     <dd><p>The sizes of trees available</p>
 </dd></dl>
@@ -307,7 +307,7 @@ The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-o
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: Tree<wbr>Size}</span>
+        <span class="property-type">{[key: string]: Tree<wbr>Size} | undefined</span>
     </dt>
     <dd><p>The sizes of trees available</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/different-enum/docs/tree/v1/rubbertree/_index.md
@@ -32,10 +32,10 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
+               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[Optional[_root_inputs.ContainerArgs]]</span> = None<span class="p">,</span>
                <span class="nx">diameter</span><span class="p">:</span> <span class="nx">Optional[Diameter]</span> = None<span class="p">,</span>
-               <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">,</span>
-               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">,</span>
+               <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Optional[Union[Farm, str]]]</span> = None<span class="p">,</span>
+               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[Optional[TreeSize]]</span> = None<span class="p">,</span>
                <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
@@ -245,7 +245,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -253,7 +253,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
+        <span class="property-type">Union&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm, string&gt;?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -261,7 +261,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size</a></span>
+        <span class="property-type">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -291,7 +291,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -299,7 +299,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -307,7 +307,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -337,7 +337,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_java" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Container<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -345,7 +345,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_java" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | String</span>
+        <span class="property-type">Optional&lt;Either&lt;Farm,String&gt;&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -353,7 +353,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_java" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Optional&lt;Tree<wbr>Size&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -383,7 +383,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -391,7 +391,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">Farm | string | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -399,7 +399,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -429,7 +429,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -437,7 +437,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | str</span>
+        <span class="property-type">Union[Farm, str]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -445,7 +445,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -475,7 +475,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_yaml" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -483,7 +483,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_yaml" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34;</a> | String</span>
+        <span class="property-type">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34; | String</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -491,7 +491,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_yaml" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">&#34;small&#34; | &#34;medium&#34; | &#34;large&#34;</a></span>
+        <span class="property-type">&#34;small&#34; | &#34;medium&#34; | &#34;large&#34;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -615,7 +615,7 @@ Get an existing RubberTree resource's state with the given name, ID, and optiona
 <span class="k">def </span><span class="nf">get</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">id</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">) -&gt;</span> RubberTree</code></pre></div>
+        <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Optional[Union[Farm, str]]]</span> = None<span class="p">) -&gt;</span> RubberTree</code></pre></div>
 </pulumi-choosable>
 </div>
 
@@ -789,7 +789,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
+        <span class="property-type">Union&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm, string&gt;?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -803,7 +803,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">string</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -817,7 +817,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_java" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | String</span>
+        <span class="property-type">Optional&lt;Either&lt;Farm,String&gt;&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -831,7 +831,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">Farm | string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -845,7 +845,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | str</span>
+        <span class="property-type">Union[Farm, str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -859,7 +859,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_yaml" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34;</a> | String</span>
+        <span class="property-type">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34; | String</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Inputs/ContainerArgs.cs
@@ -13,20 +13,20 @@ namespace Pulumi.Plant.Inputs
     public sealed class ContainerArgs : global::Pulumi.ResourceArgs
     {
         [Input("brightness")]
-        public Input<Pulumi.Plant.ContainerBrightness>? Brightness { get; set; }
+        public Input<Pulumi.Plant.ContainerBrightness?>? Brightness { get; set; }
 
         [Input("color")]
-        public InputUnion<Pulumi.Plant.ContainerColor, string>? Color { get; set; }
+        public Input<Union<Input<Pulumi.Plant.ContainerColor>, Input<string>>?>? Color { get; set; }
 
         [Input("material")]
-        public Input<string>? Material { get; set; }
+        public Input<string?>? Material { get; set; }
 
         [Input("size", required: true)]
         public Input<Pulumi.Plant.ContainerSize> Size { get; set; } = null!;
 
         public ContainerArgs()
         {
-            Brightness = Pulumi.Plant.ContainerBrightness.One;
+            Brightness = 1;
         }
         public static new ContainerArgs Empty => new ContainerArgs();
     }

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/Nursery.cs
@@ -56,17 +56,11 @@ namespace Pulumi.Plant.Tree.V1
 
     public sealed class NurseryArgs : global::Pulumi.ResourceArgs
     {
-        [Input("sizes")]
-        private InputMap<Pulumi.Plant.Tree.V1.TreeSize>? _sizes;
-
         /// <summary>
         /// The sizes of trees available
         /// </summary>
-        public InputMap<Pulumi.Plant.Tree.V1.TreeSize> Sizes
-        {
-            get => _sizes ?? (_sizes = new InputMap<Pulumi.Plant.Tree.V1.TreeSize>());
-            set => _sizes = value;
-        }
+        [Input("sizes")]
+        public Input<ImmutableDictionary<string, Input<Pulumi.Plant.Tree.V1.TreeSize>>?>? Sizes { get; set; }
 
         [Input("varieties", required: true)]
         private InputList<Pulumi.Plant.Tree.V1.RubberTreeVariety>? _varieties;

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Tree/V1/RubberTree.cs
@@ -74,16 +74,16 @@ namespace Pulumi.Plant.Tree.V1
     public sealed class RubberTreeArgs : global::Pulumi.ResourceArgs
     {
         [Input("container")]
-        public Input<Pulumi.Plant.Inputs.ContainerArgs>? Container { get; set; }
+        public Input<Pulumi.Plant.Inputs.ContainerArgs?>? Container { get; set; }
 
         [Input("diameter", required: true)]
         public Input<Pulumi.Other.Tree.V1.Diameter> Diameter { get; set; } = null!;
 
         [Input("farm")]
-        public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+        public Input<Union<Input<Pulumi.Plant.Tree.V1.Farm>, Input<string>>?>? Farm { get; set; }
 
         [Input("size")]
-        public Input<Pulumi.Plant.Tree.V1.TreeSize>? Size { get; set; }
+        public Input<Pulumi.Plant.Tree.V1.TreeSize?>? Size { get; set; }
 
         [Input("type", required: true)]
         public Input<Pulumi.Plant.Tree.V1.RubberTreeVariety> Type { get; set; } = null!;
@@ -92,7 +92,7 @@ namespace Pulumi.Plant.Tree.V1
         {
             Diameter = Pulumi.Plant.Tree.V1.Diameter.Sixinch;
             Farm = "(unknown)";
-            Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
+            Size = "medium";
             Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
         }
         public static new RubberTreeArgs Empty => new RubberTreeArgs();
@@ -101,7 +101,7 @@ namespace Pulumi.Plant.Tree.V1
     public sealed class RubberTreeState : global::Pulumi.ResourceArgs
     {
         [Input("farm")]
-        public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+        public Input<Union<Input<Pulumi.Plant.Tree.V1.Farm>, Input<string>>?>? Farm { get; set; }
 
         public RubberTreeState()
         {

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/pulumiTypes.go
@@ -42,10 +42,10 @@ type ContainerInput interface {
 }
 
 type ContainerArgs struct {
-	Brightness ContainerBrightnessPtrInput `pulumi:"brightness"`
-	Color      pulumi.StringPtrInput       `pulumi:"color"`
-	Material   pulumi.StringPtrInput       `pulumi:"material"`
-	Size       ContainerSizeInput          `pulumi:"size"`
+	Brightness *ContainerBrightness `pulumi:"brightness"`
+	Color      *string              `pulumi:"color"`
+	Material   *string              `pulumi:"material"`
+	Size       ContainerSizeInput   `pulumi:"size"`
 }
 
 // Defaults sets the appropriate defaults for ContainerArgs
@@ -55,7 +55,7 @@ func (val *ContainerArgs) Defaults() *ContainerArgs {
 	}
 	tmp := *val
 	if tmp.Brightness == nil {
-		tmp.Brightness = ContainerBrightness(1.0)
+		tmp.Brightness = *ContainerBrightness(1.0)
 	}
 	return &tmp
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/nursery.go
@@ -66,7 +66,7 @@ type nurseryArgs struct {
 // The set of arguments for constructing a Nursery resource.
 type NurseryArgs struct {
 	// The sizes of trees available
-	Sizes TreeSizeMapInput
+	Sizes map[string]TreeSizeInput
 	// The varieties available
 	Varieties RubberTreeVarietyArrayInput
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/different-enum/go/plant/tree/v1/rubberTree.go
@@ -29,20 +29,19 @@ func NewRubberTree(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Container != nil {
-		args.Container = args.Container.ToContainerPtrOutput().ApplyT(func(v *plant.Container) *plant.Container { return v.Defaults() }).(plant.ContainerPtrOutput)
-	}
 	if args.Diameter == nil {
-		args.Diameter = Diameter(6.0)
+		diameter_ := Diameter(6.0)
+		args.Diameter = &diameter_
 	}
 	if args.Farm == nil {
-		args.Farm = pulumi.StringPtr("(unknown)")
+		args.Farm = *string("(unknown)")
 	}
 	if args.Size == nil {
-		args.Size = TreeSize("medium")
+		args.Size = *TreeSize("medium")
 	}
 	if args.Type == nil {
-		args.Type = RubberTreeVariety("Burgundy")
+		type_ := RubberTreeVariety("Burgundy")
+		args.Type = &type_
 	}
 	var resource RubberTree
 	err := ctx.RegisterResource("plant:tree/v1:RubberTree", name, args, &resource, opts...)
@@ -70,7 +69,7 @@ type rubberTreeState struct {
 }
 
 type RubberTreeState struct {
-	Farm pulumi.StringPtrInput
+	Farm *string
 }
 
 func (RubberTreeState) ElementType() reflect.Type {
@@ -87,10 +86,10 @@ type rubberTreeArgs struct {
 
 // The set of arguments for constructing a RubberTree resource.
 type RubberTreeArgs struct {
-	Container plant.ContainerPtrInput
+	Container *plant.ContainerArgs
 	Diameter  DiameterInput
-	Farm      pulumi.StringPtrInput
-	Size      TreeSizePtrInput
+	Farm      *string
+	Size      *TreeSize
 	Type      RubberTreeVarietyInput
 }
 

--- a/pkg/codegen/testing/test/testdata/different-enum/nodejs/tree/v1/nursery.ts
+++ b/pkg/codegen/testing/test/testdata/different-enum/nodejs/tree/v1/nursery.ts
@@ -65,7 +65,7 @@ export interface NurseryArgs {
     /**
      * The sizes of trees available
      */
-    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>}>;
+    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>} | undefined>;
     /**
      * The varieties available
      */

--- a/pkg/codegen/testing/test/testdata/different-enum/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/testing/test/testdata/different-enum/nodejs/tree/v1/rubberTree.ts
@@ -75,16 +75,16 @@ export class RubberTree extends pulumi.CustomResource {
 }
 
 export interface RubberTreeState {
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    farm?: pulumi.Input<pulumi.Input<enums.tree.v1.Farm> | pulumi.Input<string> | undefined>;
 }
 
 /**
  * The set of arguments for constructing a RubberTree resource.
  */
 export interface RubberTreeArgs {
-    container?: pulumi.Input<inputs.ContainerArgs>;
+    container?: pulumi.Input<inputs.ContainerArgs | undefined>;
     diameter: pulumi.Input<enums.tree.v1.Diameter>;
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
-    size?: pulumi.Input<enums.tree.v1.TreeSize>;
+    farm?: pulumi.Input<pulumi.Input<enums.tree.v1.Farm> | pulumi.Input<string> | undefined>;
+    size?: pulumi.Input<enums.tree.v1.TreeSize | undefined>;
     type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
 }

--- a/pkg/codegen/testing/test/testdata/different-enum/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/different-enum/nodejs/types/input.ts
@@ -9,9 +9,9 @@ import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
 export interface ContainerArgs {
-    brightness?: pulumi.Input<enums.ContainerBrightness>;
-    color?: pulumi.Input<enums.ContainerColor | string>;
-    material?: pulumi.Input<string>;
+    brightness?: pulumi.Input<enums.ContainerBrightness | undefined>;
+    color?: pulumi.Input<pulumi.Input<enums.ContainerColor> | pulumi.Input<string> | undefined>;
+    material?: pulumi.Input<string | undefined>;
     size: pulumi.Input<enums.ContainerSize>;
 }
 /**

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/_inputs.py
@@ -18,9 +18,9 @@ __all__ = [
 class ContainerArgs:
     def __init__(__self__, *,
                  size: pulumi.Input['ContainerSize'],
-                 brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
-                 color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
-                 material: Optional[pulumi.Input[str]] = None):
+                 brightness: pulumi.Input[Optional['ContainerBrightness']] = None,
+                 color: pulumi.Input[Optional[Union['ContainerColor', str]]] = None,
+                 material: pulumi.Input[Optional[str]] = None):
         pulumi.set(__self__, "size", size)
         if brightness is None:
             brightness = 1
@@ -42,29 +42,29 @@ class ContainerArgs:
 
     @property
     @pulumi.getter
-    def brightness(self) -> Optional[pulumi.Input['ContainerBrightness']]:
+    def brightness(self) -> pulumi.Input[Optional['ContainerBrightness']]:
         return pulumi.get(self, "brightness")
 
     @brightness.setter
-    def brightness(self, value: Optional[pulumi.Input['ContainerBrightness']]):
+    def brightness(self, value: pulumi.Input[Optional['ContainerBrightness']]):
         pulumi.set(self, "brightness", value)
 
     @property
     @pulumi.getter
-    def color(self) -> Optional[pulumi.Input[Union['ContainerColor', str]]]:
+    def color(self) -> pulumi.Input[Optional[Union['ContainerColor', str]]]:
         return pulumi.get(self, "color")
 
     @color.setter
-    def color(self, value: Optional[pulumi.Input[Union['ContainerColor', str]]]):
+    def color(self, value: pulumi.Input[Optional[Union['ContainerColor', str]]]):
         pulumi.set(self, "color", value)
 
     @property
     @pulumi.getter
-    def material(self) -> Optional[pulumi.Input[str]]:
+    def material(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "material")
 
     @material.setter
-    def material(self, value: Optional[pulumi.Input[str]]):
+    def material(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "material", value)
 
 

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/nursery.py
@@ -16,11 +16,11 @@ __all__ = ['NurseryArgs', 'Nursery']
 class NurseryArgs:
     def __init__(__self__, *,
                  varieties: pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]],
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None):
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None):
         """
         The set of arguments for constructing a Nursery resource.
         :param pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]] varieties: The varieties available
-        :param pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]] sizes: The sizes of trees available
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] sizes: The sizes of trees available
         """
         pulumi.set(__self__, "varieties", varieties)
         if sizes is not None:
@@ -40,14 +40,14 @@ class NurseryArgs:
 
     @property
     @pulumi.getter
-    def sizes(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]]:
+    def sizes(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]]:
         """
         The sizes of trees available
         """
         return pulumi.get(self, "sizes")
 
     @sizes.setter
-    def sizes(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]]):
+    def sizes(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]]):
         pulumi.set(self, "sizes", value)
 
 
@@ -56,14 +56,14 @@ class Nursery(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
         """
         Create a Nursery resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]] sizes: The sizes of trees available
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] sizes: The sizes of trees available
         :param pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]] varieties: The varieties available
         """
         ...
@@ -89,7 +89,7 @@ class Nursery(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -20,9 +20,9 @@ class RubberTreeArgs:
     def __init__(__self__, *,
                  diameter: pulumi.Input['Diameter'],
                  type: pulumi.Input['RubberTreeVariety'],
-                 container: Optional[pulumi.Input['_root_inputs.ContainerArgs']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None):
+                 container: pulumi.Input[Optional['_root_inputs.ContainerArgs']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None):
         """
         The set of arguments for constructing a RubberTree resource.
         """
@@ -63,36 +63,36 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
-    def container(self) -> Optional[pulumi.Input['_root_inputs.ContainerArgs']]:
+    def container(self) -> pulumi.Input[Optional['_root_inputs.ContainerArgs']]:
         return pulumi.get(self, "container")
 
     @container.setter
-    def container(self, value: Optional[pulumi.Input['_root_inputs.ContainerArgs']]):
+    def container(self, value: pulumi.Input[Optional['_root_inputs.ContainerArgs']]):
         pulumi.set(self, "container", value)
 
     @property
     @pulumi.getter
-    def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+    def farm(self) -> pulumi.Input[Optional[Union['Farm', str]]]:
         return pulumi.get(self, "farm")
 
     @farm.setter
-    def farm(self, value: Optional[pulumi.Input[Union['Farm', str]]]):
+    def farm(self, value: pulumi.Input[Optional[Union['Farm', str]]]):
         pulumi.set(self, "farm", value)
 
     @property
     @pulumi.getter
-    def size(self) -> Optional[pulumi.Input['TreeSize']]:
+    def size(self) -> pulumi.Input[Optional['TreeSize']]:
         return pulumi.get(self, "size")
 
     @size.setter
-    def size(self, value: Optional[pulumi.Input['TreeSize']]):
+    def size(self, value: pulumi.Input[Optional['TreeSize']]):
         pulumi.set(self, "size", value)
 
 
 @pulumi.input_type
 class _RubberTreeState:
     def __init__(__self__, *,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None):
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None):
         """
         Input properties used for looking up and filtering RubberTree resources.
         """
@@ -103,11 +103,11 @@ class _RubberTreeState:
 
     @property
     @pulumi.getter
-    def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+    def farm(self) -> pulumi.Input[Optional[Union['Farm', str]]]:
         return pulumi.get(self, "farm")
 
     @farm.setter
-    def farm(self, value: Optional[pulumi.Input[Union['Farm', str]]]):
+    def farm(self, value: pulumi.Input[Optional[Union['Farm', str]]]):
         pulumi.set(self, "farm", value)
 
 
@@ -116,10 +116,10 @@ class RubberTree(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 container: Optional[pulumi.Input[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
+                 container: pulumi.Input[Optional[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
                  diameter: Optional[pulumi.Input['Diameter']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
         """
@@ -150,10 +150,10 @@ class RubberTree(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 container: Optional[pulumi.Input[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
+                 container: pulumi.Input[Optional[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
                  diameter: Optional[pulumi.Input['Diameter']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -191,7 +191,7 @@ class RubberTree(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            farm: Optional[pulumi.Input[Union['Farm', str]]] = None) -> 'RubberTree':
+            farm: pulumi.Input[Optional[Union['Farm', str]]] = None) -> 'RubberTree':
         """
         Get an existing RubberTree resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/pkg/codegen/testing/test/testdata/discriminated-union-pp/python/discriminated-union.py
+++ b/pkg/codegen/testing/test/testdata/discriminated-union-pp/python/discriminated-union.py
@@ -10,12 +10,12 @@ server = azure_native.dbforpostgresql.Server("server",
     ),
     resource_group_name="TargetResourceGroup",
     server_name="targetserver",
-    sku=azure_native.dbforpostgresql.SkuArgs(
-        capacity=2,
-        family="Gen5",
-        name="B_Gen5_2",
-        tier="Basic",
-    ),
+    sku={
+        "capacity": 2,
+        "family": "Gen5",
+        "name": "B_Gen5_2",
+        "tier": "Basic",
+    },
     tags={
         "ElasticServer": "1",
     })

--- a/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/enum-reference/docs/myModule/iamresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">IamResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                <span class="nx">config</span><span class="p">:</span> <span class="nx">Optional[pulumi_google_native.iam.v1.AuditConfigArgs]</span> = None<span class="p">)</span>
+                <span class="nx">config</span><span class="p">:</span> <span class="nx">Optional[Optional[pulumi_google_native.iam.v1.AuditConfigArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">IamResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[IamResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_csharp" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#auditconfig">Pulumi.<wbr>Google<wbr>Native.<wbr>IAM.<wbr>V1.<wbr>Inputs.<wbr>Audit<wbr>Config<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Google<wbr>Native.<wbr>IAM.<wbr>V1.<wbr>Inputs.<wbr>Audit<wbr>Config<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -239,7 +239,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_go" style="color: inherit; text-decoration: inherit;">Config</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#auditconfig">Audit<wbr>Config<wbr>Args</a></span>
+        <span class="property-type">Audit<wbr>Config<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_java" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#auditconfig">Audit<wbr>Config<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Audit<wbr>Config<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_nodejs" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#auditconfig">pulumi<wbr>Google<wbr>Native.types.input.iam.v1.<wbr>Audit<wbr>Config<wbr>Args</a></span>
+        <span class="property-type">pulumi<wbr>Google<wbr>Native.types.input.iam.v1.<wbr>Audit<wbr>Config<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_python" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#auditconfig">Audit<wbr>Config<wbr>Args</a></span>
+        <span class="property-type">Audit<wbr>Config<wbr>Args]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -295,7 +295,7 @@ The IamResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#config_yaml" style="color: inherit; text-decoration: inherit;">config</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#auditconfig">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/MyModule/IamResource.cs
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/MyModule/IamResource.cs
@@ -40,7 +40,7 @@ namespace Pulumi.Example.MyModule
     public sealed class IamResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
-        public Input<Pulumi.GoogleNative.IAM.V1.Inputs.AuditConfigArgs>? Config { get; set; }
+        public Input<Pulumi.GoogleNative.IAM.V1.Inputs.AuditConfigArgs?>? Config { get; set; }
 
         public IamResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/enum-reference/go/example/mymodule/iamResource.go
+++ b/pkg/codegen/testing/test/testdata/enum-reference/go/example/mymodule/iamResource.go
@@ -36,7 +36,7 @@ type iamResourceArgs struct {
 
 // The set of arguments for constructing a IamResource resource.
 type IamResourceArgs struct {
-	Config *iam.AuditConfigInput
+	Config *iam.AuditConfigArgs
 }
 
 func (IamResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/enum-reference/nodejs/mymodule/iamResource.ts
+++ b/pkg/codegen/testing/test/testdata/enum-reference/nodejs/mymodule/iamResource.ts
@@ -45,5 +45,5 @@ export class IamResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a IamResource resource.
  */
 export interface IamResourceArgs {
-    config?: pulumi.Input<pulumiGoogleNative.types.input.iam.v1.AuditConfigArgs>;
+    config?: pulumi.Input<pulumiGoogleNative.types.input.iam.v1.AuditConfigArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/mymodule/iam_resource.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/pulumi_example/mymodule/iam_resource.py
@@ -15,7 +15,7 @@ __all__ = ['IamResourceArgs', 'IamResource']
 @pulumi.input_type
 class IamResourceArgs:
     def __init__(__self__, *,
-                 config: Optional[pulumi.Input['pulumi_google_native.iam.v1.AuditConfigArgs']] = None):
+                 config: pulumi.Input[Optional['pulumi_google_native.iam.v1.AuditConfigArgs']] = None):
         """
         The set of arguments for constructing a IamResource resource.
         """
@@ -24,11 +24,11 @@ class IamResourceArgs:
 
     @property
     @pulumi.getter
-    def config(self) -> Optional[pulumi.Input['pulumi_google_native.iam.v1.AuditConfigArgs']]:
+    def config(self) -> pulumi.Input[Optional['pulumi_google_native.iam.v1.AuditConfigArgs']]:
         return pulumi.get(self, "config")
 
     @config.setter
-    def config(self, value: Optional[pulumi.Input['pulumi_google_native.iam.v1.AuditConfigArgs']]):
+    def config(self, value: pulumi.Input[Optional['pulumi_google_native.iam.v1.AuditConfigArgs']]):
         pulumi.set(self, "config", value)
 
 
@@ -37,7 +37,7 @@ class IamResource(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 config: Optional[pulumi.Input[pulumi.InputType['pulumi_google_native.iam.v1.AuditConfigArgs']]] = None,
+                 config: pulumi.Input[Optional[pulumi.InputType['pulumi_google_native.iam.v1.AuditConfigArgs']]] = None,
                  __props__=None):
         """
         Create a IamResource resource with the given unique name, props, and options.
@@ -67,7 +67,7 @@ class IamResource(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 config: Optional[pulumi.Input[pulumi.InputType['pulumi_google_native.iam.v1.AuditConfigArgs']]] = None,
+                 config: pulumi.Input[Optional[pulumi.InputType['pulumi_google_native.iam.v1.AuditConfigArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-enum/docs/component/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-              <span class="nx">local_enum</span><span class="p">:</span> <span class="nx">Optional[_local.MyEnum]</span> = None<span class="p">,</span>
-              <span class="nx">remote_enum</span><span class="p">:</span> <span class="nx">Optional[_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem]</span> = None<span class="p">)</span>
+              <span class="nx">local_enum</span><span class="p">:</span> <span class="nx">Optional[Optional[_local.MyEnum]]</span> = None<span class="p">,</span>
+              <span class="nx">remote_enum</span><span class="p">:</span> <span class="nx">Optional[Optional[_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ComponentArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#localenum_csharp" style="color: inherit; text-decoration: inherit;">Local<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#myenum">Pulumi.<wbr>Example.<wbr>Local.<wbr>My<wbr>Enum</a></span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Local.<wbr>My<wbr>Enum?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#remoteenum_csharp" style="color: inherit; text-decoration: inherit;">Remote<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Pulumi.<wbr>Google<wbr>Native.<wbr>Accesscontextmanager/v1.<wbr>Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
+        <span class="property-type">Pulumi.<wbr>Google<wbr>Native.<wbr>Accesscontextmanager/v1.<wbr>Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -248,7 +248,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#localenum_go" style="color: inherit; text-decoration: inherit;">Local<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#myenum">My<wbr>Enum</a></span>
+        <span class="property-type">My<wbr>Enum</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -256,7 +256,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#remoteenum_go" style="color: inherit; text-decoration: inherit;">Remote<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
+        <span class="property-type">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#localenum_java" style="color: inherit; text-decoration: inherit;">local<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#myenum">My<wbr>Enum</a></span>
+        <span class="property-type">Optional&lt;My<wbr>Enum&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#remoteenum_java" style="color: inherit; text-decoration: inherit;">remote<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
+        <span class="property-type">Optional&lt;Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#localenum_nodejs" style="color: inherit; text-decoration: inherit;">local<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#myenum">local<wbr>My<wbr>Enum</a></span>
+        <span class="property-type">local<wbr>My<wbr>Enum | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#remoteenum_nodejs" style="color: inherit; text-decoration: inherit;">remote<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">pulumi<wbr>Google<wbr>Nativeaccesscontextmanagerv1Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
+        <span class="property-type">pulumi<wbr>Google<wbr>Nativeaccesscontextmanagerv1Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#local_enum_python" style="color: inherit; text-decoration: inherit;">local_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#myenum">My<wbr>Enum</a></span>
+        <span class="property-type">My<wbr>Enum]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#remote_enum_python" style="color: inherit; text-decoration: inherit;">remote_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item</a></span>
+        <span class="property-type">Device<wbr>Policy<wbr>Allowed<wbr>Device<wbr>Management<wbr>Levels<wbr>Item]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -336,7 +336,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#localenum_yaml" style="color: inherit; text-decoration: inherit;">local<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#myenum">3.1415 | 1e-07</a></span>
+        <span class="property-type">3.1415 | 1e-07</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -344,7 +344,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#remoteenum_yaml" style="color: inherit; text-decoration: inherit;">remote<wbr>Enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#devicepolicyalloweddevicemanagementlevelsitem">&#34;MANAGEMENT_UNSPECIFIED&#34; | &#34;NONE&#34; | &#34;BASIC&#34; | &#34;COMPLETE&#34;</a></span>
+        <span class="property-type">&#34;MANAGEMENT_UNSPECIFIED&#34; | &#34;NONE&#34; | &#34;BASIC&#34; | &#34;COMPLETE&#34;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/external-enum/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-enum/go/example/component.go
@@ -64,8 +64,8 @@ type componentArgs struct {
 
 // The set of arguments for constructing a Component resource.
 type ComponentArgs struct {
-	LocalEnum  local.MyEnumPtrInput
-	RemoteEnum accesscontextmanager.DevicePolicyAllowedDeviceManagementLevelsItemPtrInput
+	LocalEnum  *local.MyEnum
+	RemoteEnum *accesscontextmanager.DevicePolicyAllowedDeviceManagementLevelsItem
 }
 
 func (ComponentArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-enum/nodejs/component.ts
+++ b/pkg/codegen/testing/test/testdata/external-enum/nodejs/component.ts
@@ -65,6 +65,6 @@ export class Component extends pulumi.CustomResource {
  * The set of arguments for constructing a Component resource.
  */
 export interface ComponentArgs {
-    localEnum?: pulumi.Input<enums.local.MyEnum>;
-    remoteEnum?: pulumi.Input<pulumiGoogleNative.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem>;
+    localEnum?: pulumi.Input<enums.local.MyEnum | undefined>;
+    remoteEnum?: pulumi.Input<pulumiGoogleNative.accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/pulumi_example/component.py
@@ -16,8 +16,8 @@ __all__ = ['ComponentArgs', 'Component']
 @pulumi.input_type
 class ComponentArgs:
     def __init__(__self__, *,
-                 local_enum: Optional[pulumi.Input['_local.MyEnum']] = None,
-                 remote_enum: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None):
+                 local_enum: pulumi.Input[Optional['_local.MyEnum']] = None,
+                 remote_enum: pulumi.Input[Optional['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None):
         """
         The set of arguments for constructing a Component resource.
         """
@@ -28,20 +28,20 @@ class ComponentArgs:
 
     @property
     @pulumi.getter(name="localEnum")
-    def local_enum(self) -> Optional[pulumi.Input['_local.MyEnum']]:
+    def local_enum(self) -> pulumi.Input[Optional['_local.MyEnum']]:
         return pulumi.get(self, "local_enum")
 
     @local_enum.setter
-    def local_enum(self, value: Optional[pulumi.Input['_local.MyEnum']]):
+    def local_enum(self, value: pulumi.Input[Optional['_local.MyEnum']]):
         pulumi.set(self, "local_enum", value)
 
     @property
     @pulumi.getter(name="remoteEnum")
-    def remote_enum(self) -> Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]:
+    def remote_enum(self) -> pulumi.Input[Optional['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]:
         return pulumi.get(self, "remote_enum")
 
     @remote_enum.setter
-    def remote_enum(self, value: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]):
+    def remote_enum(self, value: pulumi.Input[Optional['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']]):
         pulumi.set(self, "remote_enum", value)
 
 
@@ -50,8 +50,8 @@ class Component(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 local_enum: Optional[pulumi.Input['_local.MyEnum']] = None,
-                 remote_enum: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
+                 local_enum: pulumi.Input[Optional['_local.MyEnum']] = None,
+                 remote_enum: pulumi.Input[Optional['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
                  __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -81,8 +81,8 @@ class Component(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 local_enum: Optional[pulumi.Input['_local.MyEnum']] = None,
-                 remote_enum: Optional[pulumi.Input['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
+                 local_enum: pulumi.Input[Optional['_local.MyEnum']] = None,
+                 remote_enum: pulumi.Input[Optional['_accesscontextmanager.v1.DevicePolicyAllowedDeviceManagementLevelsItem']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-go-import-aliases/go/example/component.go
@@ -113,7 +113,7 @@ type ComponentArgs struct {
 	TypeLocalInsteadOfRemoteAlias     gcpiamv1.AuditConfigInput
 	TypeNoAlias                       s3.BucketWebsiteInput
 	TypeRemoteAlias                   dns.DnsKeySpecInput
-	TypeRemoteEnum                    accesscontextmanager.DevicePolicyAllowedDeviceManagementLevelsItemPtrInput
+	TypeRemoteEnum                    *accesscontextmanager.DevicePolicyAllowedDeviceManagementLevelsItem
 }
 
 func (ComponentArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/pulumi_example/cloudtrail/trail.py
@@ -15,8 +15,8 @@ __all__ = ['TrailArgs', 'Trail']
 @pulumi.input_type
 class TrailArgs:
     def __init__(__self__, *,
-                 advanced_event_selectors: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]] = None,
-                 trail: Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']] = None):
+                 advanced_event_selectors: pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]] = None,
+                 trail: pulumi.Input[Optional['pulumi_aws.cloudtrail.Trail']] = None):
         """
         The set of arguments for constructing a Trail resource.
         """
@@ -27,20 +27,20 @@ class TrailArgs:
 
     @property
     @pulumi.getter(name="advancedEventSelectors")
-    def advanced_event_selectors(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]:
+    def advanced_event_selectors(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]:
         return pulumi.get(self, "advanced_event_selectors")
 
     @advanced_event_selectors.setter
-    def advanced_event_selectors(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]):
+    def advanced_event_selectors(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]):
         pulumi.set(self, "advanced_event_selectors", value)
 
     @property
     @pulumi.getter
-    def trail(self) -> Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']]:
+    def trail(self) -> pulumi.Input[Optional['pulumi_aws.cloudtrail.Trail']]:
         return pulumi.get(self, "trail")
 
     @trail.setter
-    def trail(self, value: Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']]):
+    def trail(self, value: pulumi.Input[Optional['pulumi_aws.cloudtrail.Trail']]):
         pulumi.set(self, "trail", value)
 
 
@@ -49,8 +49,8 @@ class Trail(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 advanced_event_selectors: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]] = None,
-                 trail: Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']] = None,
+                 advanced_event_selectors: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]] = None,
+                 trail: pulumi.Input[Optional['pulumi_aws.cloudtrail.Trail']] = None,
                  __props__=None):
         """
         Create a Trail resource with the given unique name, props, and options.
@@ -80,8 +80,8 @@ class Trail(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 advanced_event_selectors: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]] = None,
-                 trail: Optional[pulumi.Input['pulumi_aws.cloudtrail.Trail']] = None,
+                 advanced_event_selectors: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.cloudtrail.TrailAdvancedEventSelectorArgs']]]]] = None,
+                 trail: pulumi.Input[Optional['pulumi_aws.cloudtrail.Trail']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/argfunction/_index.md
@@ -45,7 +45,7 @@ function </span>argFunctionOutput<span class="p">(</span><span class="nx">args</
 ><span class="k">def </span>arg_function<span class="p">(</span><span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[pulumi_random.RandomPet]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ArgFunctionResult</span
 ><span class="k">
-def </span>arg_function_output<span class="p">(</span><span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[pulumi_random.RandomPet]]</span> = None<span class="p">,</span>
+def </span>arg_function_output<span class="p">(</span><span class="nx">name</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[pulumi_random.RandomPet]]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ArgFunctionResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/cat/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Cat</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">age</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
-        <span class="nx">pet</span><span class="p">:</span> <span class="nx">Optional[PetArgs]</span> = None<span class="p">)</span>
+        <span class="nx">age</span><span class="p">:</span> <span class="nx">Optional[Optional[int]]</span> = None<span class="p">,</span>
+        <span class="nx">pet</span><span class="p">:</span> <span class="nx">Optional[Optional[PetArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Cat</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[CatArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">int</span>
+        <span class="property-type">int?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_csharp" style="color: inherit; text-decoration: inherit;">Pet</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
+        <span class="property-type">Pet<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -256,7 +256,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_go" style="color: inherit; text-decoration: inherit;">Pet</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
+        <span class="property-type">Pet<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_java" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Integer</span>
+        <span class="property-type">Optional&lt;Integer&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_java" style="color: inherit; text-decoration: inherit;">pet</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Pet<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">number</span>
+        <span class="property-type">number | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_nodejs" style="color: inherit; text-decoration: inherit;">pet</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
+        <span class="property-type">Pet<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">int</span>
+        <span class="property-type">Optional[int]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_python" style="color: inherit; text-decoration: inherit;">pet</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Pet<wbr>Args</a></span>
+        <span class="property-type">Pet<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -344,7 +344,7 @@ The Cat resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pet_yaml" style="color: inherit; text-decoration: inherit;">pet</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/docs/component/_index.md
@@ -32,9 +32,9 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">,</span>
-              <span class="nx">metadata_array</span><span class="p">:</span> <span class="nx">Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
-              <span class="nx">metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">metadata_array</span><span class="p">:</span> <span class="nx">Optional[Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]]</span> = None<span class="p">,</span>
+              <span class="nx">metadata_map</span><span class="p">:</span> <span class="nx">Optional[Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]]</span> = None<span class="p">,</span>
               <span class="nx">required_metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">,</span>
               <span class="nx">required_metadata_array</span><span class="p">:</span> <span class="nx">Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
               <span class="nx">required_metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">)</span>
@@ -254,7 +254,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_csharp" style="color: inherit; text-decoration: inherit;">Metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -262,7 +262,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">List&lt;Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -270,7 +270,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatamap_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -308,7 +308,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_go" style="color: inherit; text-decoration: inherit;">Metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Meta<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -316,7 +316,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Meta<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -362,7 +362,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_java" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Object<wbr>Meta<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -370,7 +370,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_java" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">List&lt;Object<wbr>Meta<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Object<wbr>Meta<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -416,7 +416,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_nodejs" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta</a></span>
+        <span class="property-type">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -424,7 +424,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta[]</a></span>
+        <span class="property-type">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta[] | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -432,7 +432,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadatamap_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta}</span>
+        <span class="property-type">{[key: string]: pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta} | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -470,7 +470,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_python" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Meta<wbr>Args]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -478,7 +478,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_array_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args]</a></span>
+        <span class="property-type">Object<wbr>Meta<wbr>Args]]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -486,7 +486,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_map_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>map</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Object<wbr>Meta<wbr>Args]</span>
+        <span class="property-type">Object<wbr>Meta<wbr>Args]]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -524,7 +524,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadata_yaml" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -532,7 +532,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#metadataarray_yaml" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">List&lt;Property Map&gt;</a></span>
+        <span class="property-type">List&lt;Property Map&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/ArgFunction.cs
@@ -33,7 +33,7 @@ namespace Pulumi.Example
     public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("name")]
-        public Input<Pulumi.Random.RandomPet>? Name { get; set; }
+        public Input<Pulumi.Random.RandomPet?>? Name { get; set; }
 
         public ArgFunctionInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Cat.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Cat.cs
@@ -61,10 +61,10 @@ namespace Pulumi.Example
     public sealed class CatArgs : global::Pulumi.ResourceArgs
     {
         [Input("age")]
-        public Input<int>? Age { get; set; }
+        public Input<int?>? Age { get; set; }
 
         [Input("pet")]
-        public Input<Inputs.PetArgs>? Pet { get; set; }
+        public Input<Inputs.PetArgs?>? Pet { get; set; }
 
         public CatArgs()
         {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Component.cs
@@ -67,23 +67,13 @@ namespace Pulumi.Example
     public sealed class ComponentArgs : global::Pulumi.ResourceArgs
     {
         [Input("metadata")]
-        public Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? Metadata { get; set; }
+        public Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs?>? Metadata { get; set; }
 
         [Input("metadataArray")]
-        private InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? _metadataArray;
-        public InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> MetadataArray
-        {
-            get => _metadataArray ?? (_metadataArray = new InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>());
-            set => _metadataArray = value;
-        }
+        public Input<ImmutableArray<Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>>>? MetadataArray { get; set; }
 
         [Input("metadataMap")]
-        private InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? _metadataMap;
-        public InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> MetadataMap
-        {
-            get => _metadataMap ?? (_metadataMap = new InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>());
-            set => _metadataMap = value;
-        }
+        public Input<ImmutableDictionary<string, Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>>?>? MetadataMap { get; set; }
 
         [Input("requiredMetadata", required: true)]
         public Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> RequiredMetadata { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
@@ -13,26 +13,16 @@ namespace Pulumi.Example.Inputs
     public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("age")]
-        public Input<int>? Age { get; set; }
+        public Input<int?>? Age { get; set; }
 
         [Input("name")]
-        public Input<Pulumi.Random.RandomPet>? Name { get; set; }
+        public Input<Pulumi.Random.RandomPet?>? Name { get; set; }
 
         [Input("nameArray")]
-        private InputList<Pulumi.Random.RandomPet>? _nameArray;
-        public InputList<Pulumi.Random.RandomPet> NameArray
-        {
-            get => _nameArray ?? (_nameArray = new InputList<Pulumi.Random.RandomPet>());
-            set => _nameArray = value;
-        }
+        public Input<ImmutableArray<Input<Pulumi.Random.RandomPet>>>? NameArray { get; set; }
 
         [Input("nameMap")]
-        private InputMap<Pulumi.Random.RandomPet>? _nameMap;
-        public InputMap<Pulumi.Random.RandomPet> NameMap
-        {
-            get => _nameMap ?? (_nameMap = new InputMap<Pulumi.Random.RandomPet>());
-            set => _nameMap = value;
-        }
+        public Input<ImmutableDictionary<string, Input<Pulumi.Random.RandomPet>>?>? NameMap { get; set; }
 
         [Input("requiredName", required: true)]
         public Input<Pulumi.Random.RandomPet> RequiredName { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/argFunction.go
@@ -42,7 +42,7 @@ func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...
 }
 
 type ArgFunctionOutputArgs struct {
-	Name random.RandomPetInput `pulumi:"name"`
+	Name *random.RandomPet `pulumi:"name"`
 }
 
 func (ArgFunctionOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/cat.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/cat.go
@@ -61,8 +61,8 @@ type catArgs struct {
 
 // The set of arguments for constructing a Cat resource.
 type CatArgs struct {
-	Age pulumi.IntPtrInput
-	Pet PetPtrInput
+	Age *int
+	Pet *PetArgs
 }
 
 func (CatArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/component.go
@@ -81,9 +81,9 @@ type componentArgs struct {
 
 // The set of arguments for constructing a Component resource.
 type ComponentArgs struct {
-	Metadata              metav1.ObjectMetaPtrInput
-	MetadataArray         metav1.ObjectMetaArrayInput
-	MetadataMap           metav1.ObjectMetaMapInput
+	Metadata              *metav1.ObjectMetaArgs
+	MetadataArray         []metav1.ObjectMetaInput
+	MetadataMap           map[string]metav1.ObjectMetaInput
 	RequiredMetadata      metav1.ObjectMetaInput
 	RequiredMetadataArray metav1.ObjectMetaArrayInput
 	RequiredMetadataMap   metav1.ObjectMetaMapInput

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/go/example/pulumiTypes.go
@@ -33,13 +33,13 @@ type PetInput interface {
 }
 
 type PetArgs struct {
-	Age               pulumi.IntPtrInput         `pulumi:"age"`
-	Name              random.RandomPetInput      `pulumi:"name"`
-	NameArray         random.RandomPetArrayInput `pulumi:"nameArray"`
-	NameMap           random.RandomPetMapInput   `pulumi:"nameMap"`
-	RequiredName      random.RandomPetInput      `pulumi:"requiredName"`
-	RequiredNameArray random.RandomPetArrayInput `pulumi:"requiredNameArray"`
-	RequiredNameMap   random.RandomPetMapInput   `pulumi:"requiredNameMap"`
+	Age               *int                             `pulumi:"age"`
+	Name              *random.RandomPet                `pulumi:"name"`
+	NameArray         []random.RandomPetInput          `pulumi:"nameArray"`
+	NameMap           map[string]random.RandomPetInput `pulumi:"nameMap"`
+	RequiredName      random.RandomPetInput            `pulumi:"requiredName"`
+	RequiredNameArray random.RandomPetArrayInput       `pulumi:"requiredNameArray"`
+	RequiredNameMap   random.RandomPetMapInput         `pulumi:"requiredNameMap"`
 }
 
 func (PetArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/argFunction.ts
@@ -27,5 +27,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    name?: pulumi.Input<pulumiRandom.RandomPet>;
+    name?: pulumi.Input<pulumiRandom.RandomPet | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/cat.ts
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/cat.ts
@@ -63,6 +63,6 @@ export class Cat extends pulumi.CustomResource {
  * The set of arguments for constructing a Cat resource.
  */
 export interface CatArgs {
-    age?: pulumi.Input<number>;
-    pet?: pulumi.Input<inputs.PetArgs>;
+    age?: pulumi.Input<number | undefined>;
+    pet?: pulumi.Input<inputs.PetArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/component.ts
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/component.ts
@@ -81,9 +81,9 @@ export class Component extends pulumi.CustomResource {
  * The set of arguments for constructing a Component resource.
  */
 export interface ComponentArgs {
-    metadata?: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>;
-    metadataArray?: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>[]>;
-    metadataMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>}>;
+    metadata?: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta | undefined>;
+    metadataArray?: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>[] | undefined>;
+    metadataMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>} | undefined>;
     requiredMetadata: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>;
     requiredMetadataArray: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>[]>;
     requiredMetadataMap: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMeta>}>;

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/nodejs/types/input.ts
@@ -8,10 +8,10 @@ import * as outputs from "../types/output";
 import * as pulumiRandom from "@pulumi/random";
 
 export interface PetArgs {
-    age?: pulumi.Input<number>;
-    name?: pulumi.Input<pulumiRandom.RandomPet>;
-    nameArray?: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[]>;
-    nameMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>}>;
+    age?: pulumi.Input<number | undefined>;
+    name?: pulumi.Input<pulumiRandom.RandomPet | undefined>;
+    nameArray?: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[] | undefined>;
+    nameMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>} | undefined>;
     requiredName: pulumi.Input<pulumiRandom.RandomPet>;
     requiredNameArray: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[]>;
     requiredNameMap: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>}>;

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
@@ -20,10 +20,10 @@ class PetArgs:
                  required_name: pulumi.Input['pulumi_random.RandomPet'],
                  required_name_array: pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]],
                  required_name_map: pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]],
-                 age: Optional[pulumi.Input[int]] = None,
-                 name: Optional[pulumi.Input['pulumi_random.RandomPet']] = None,
-                 name_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]] = None,
-                 name_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]] = None):
+                 age: pulumi.Input[Optional[int]] = None,
+                 name: pulumi.Input[Optional['pulumi_random.RandomPet']] = None,
+                 name_array: pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_random.RandomPet']]]] = None,
+                 name_map: pulumi.Input[Optional[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]] = None):
         pulumi.set(__self__, "required_name", required_name)
         pulumi.set(__self__, "required_name_array", required_name_array)
         pulumi.set(__self__, "required_name_map", required_name_map)
@@ -65,38 +65,38 @@ class PetArgs:
 
     @property
     @pulumi.getter
-    def age(self) -> Optional[pulumi.Input[int]]:
+    def age(self) -> pulumi.Input[Optional[int]]:
         return pulumi.get(self, "age")
 
     @age.setter
-    def age(self, value: Optional[pulumi.Input[int]]):
+    def age(self, value: pulumi.Input[Optional[int]]):
         pulumi.set(self, "age", value)
 
     @property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input['pulumi_random.RandomPet']]:
+    def name(self) -> pulumi.Input[Optional['pulumi_random.RandomPet']]:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input['pulumi_random.RandomPet']]):
+    def name(self, value: pulumi.Input[Optional['pulumi_random.RandomPet']]):
         pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="nameArray")
-    def name_array(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]]:
+    def name_array(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_random.RandomPet']]]]:
         return pulumi.get(self, "name_array")
 
     @name_array.setter
-    def name_array(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]]):
+    def name_array(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_random.RandomPet']]]]):
         pulumi.set(self, "name_array", value)
 
     @property
     @pulumi.getter(name="nameMap")
-    def name_map(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]]:
+    def name_map(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]]:
         return pulumi.get(self, "name_map")
 
     @name_map.setter
-    def name_map(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]]):
+    def name_map(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]]):
         pulumi.set(self, "name_map", value)
 
 

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
@@ -54,7 +54,7 @@ def arg_function(name: Optional['pulumi_random.RandomPet'] = None,
 
 
 @_utilities.lift_output_func(arg_function)
-def arg_function_output(name: Optional[pulumi.Input[Optional['pulumi_random.RandomPet']]] = None,
+def arg_function_output(name: pulumi.Input[Optional['pulumi_random.RandomPet']] = None,
                         opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ArgFunctionResult]:
     """
     Use this data source to access information about an existing resource.

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/cat.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/cat.py
@@ -16,8 +16,8 @@ __all__ = ['CatArgs', 'Cat']
 @pulumi.input_type
 class CatArgs:
     def __init__(__self__, *,
-                 age: Optional[pulumi.Input[int]] = None,
-                 pet: Optional[pulumi.Input['PetArgs']] = None):
+                 age: pulumi.Input[Optional[int]] = None,
+                 pet: pulumi.Input[Optional['PetArgs']] = None):
         """
         The set of arguments for constructing a Cat resource.
         """
@@ -28,20 +28,20 @@ class CatArgs:
 
     @property
     @pulumi.getter
-    def age(self) -> Optional[pulumi.Input[int]]:
+    def age(self) -> pulumi.Input[Optional[int]]:
         return pulumi.get(self, "age")
 
     @age.setter
-    def age(self, value: Optional[pulumi.Input[int]]):
+    def age(self, value: pulumi.Input[Optional[int]]):
         pulumi.set(self, "age", value)
 
     @property
     @pulumi.getter
-    def pet(self) -> Optional[pulumi.Input['PetArgs']]:
+    def pet(self) -> pulumi.Input[Optional['PetArgs']]:
         return pulumi.get(self, "pet")
 
     @pet.setter
-    def pet(self, value: Optional[pulumi.Input['PetArgs']]):
+    def pet(self, value: pulumi.Input[Optional['PetArgs']]):
         pulumi.set(self, "pet", value)
 
 
@@ -50,8 +50,8 @@ class Cat(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 age: Optional[pulumi.Input[int]] = None,
-                 pet: Optional[pulumi.Input[pulumi.InputType['PetArgs']]] = None,
+                 age: pulumi.Input[Optional[int]] = None,
+                 pet: pulumi.Input[Optional[pulumi.InputType['PetArgs']]] = None,
                  __props__=None):
         """
         Create a Cat resource with the given unique name, props, and options.
@@ -81,8 +81,8 @@ class Cat(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 age: Optional[pulumi.Input[int]] = None,
-                 pet: Optional[pulumi.Input[pulumi.InputType['PetArgs']]] = None,
+                 age: pulumi.Input[Optional[int]] = None,
+                 pet: pulumi.Input[Optional[pulumi.InputType['PetArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -19,9 +19,9 @@ class ComponentArgs:
                  required_metadata: pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs'],
                  required_metadata_array: pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]],
                  required_metadata_map: pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]],
-                 metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None,
-                 metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
-                 metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None):
+                 metadata: pulumi.Input[Optional['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None,
+                 metadata_array: pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
+                 metadata_map: pulumi.Input[Optional[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None):
         """
         The set of arguments for constructing a Component resource.
         """
@@ -64,29 +64,29 @@ class ComponentArgs:
 
     @property
     @pulumi.getter
-    def metadata(self) -> Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]:
+    def metadata(self) -> pulumi.Input[Optional['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]:
         return pulumi.get(self, "metadata")
 
     @metadata.setter
-    def metadata(self, value: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]):
+    def metadata(self, value: pulumi.Input[Optional['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
     @property
     @pulumi.getter(name="metadataArray")
-    def metadata_array(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]:
+    def metadata_array(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]:
         return pulumi.get(self, "metadata_array")
 
     @metadata_array.setter
-    def metadata_array(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]):
+    def metadata_array(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]):
         pulumi.set(self, "metadata_array", value)
 
     @property
     @pulumi.getter(name="metadataMap")
-    def metadata_map(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]:
+    def metadata_map(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]:
         return pulumi.get(self, "metadata_map")
 
     @metadata_map.setter
-    def metadata_map(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]):
+    def metadata_map(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]):
         pulumi.set(self, "metadata_map", value)
 
 
@@ -95,9 +95,9 @@ class Component(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
-                 metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
-                 metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 metadata: pulumi.Input[Optional[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
+                 metadata_array: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 metadata_map: pulumi.Input[Optional[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  required_metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
                  required_metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  required_metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
@@ -130,9 +130,9 @@ class Component(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
-                 metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
-                 metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 metadata: pulumi.Input[Optional[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
+                 metadata_array: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 metadata_map: pulumi.Input[Optional[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  required_metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
                  required_metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  required_metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,

--- a/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/consumer.go
+++ b/pkg/codegen/testing/test/testdata/go-nested-collections/go/repro/overlap/consumer.go
@@ -59,8 +59,8 @@ type consumerArgs struct {
 
 // The set of arguments for constructing a Consumer resource.
 type ConsumerArgs struct {
-	Typ  SomeTypeMapInput
-	TypM SomeTypeMapInput
+	Typ  map[string]SomeTypeInput
+	TypM *SomeTypeMap
 }
 
 func (ConsumerArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/go-plain-ref-repro/go/repro/ecs/pulumiTypes.go
@@ -27,8 +27,8 @@ type TaskDefinitionContainerDefinitionInput interface {
 }
 
 type TaskDefinitionContainerDefinitionArgs struct {
-	Command pulumi.StringArrayInput `pulumi:"command"`
-	Cpu     pulumi.IntPtrInput      `pulumi:"cpu"`
+	Command []pulumi.StringInput `pulumi:"command"`
+	Cpu     *int                 `pulumi:"cpu"`
 }
 
 func (TaskDefinitionContainerDefinitionArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/invalid-go-sprintf-pp/go/invalid-go-sprintf.go
+++ b/pkg/codegen/testing/test/testdata/invalid-go-sprintf-pp/go/invalid-go-sprintf.go
@@ -11,10 +11,10 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := appsv1.NewDeployment(ctx, "argocd_serverDeployment", &appsv1.DeploymentArgs{
-			ApiVersion: pulumi.String("apps/v1"),
-			Kind:       pulumi.String("Deployment"),
-			Metadata: &metav1.ObjectMetaArgs{
-				Labels: pulumi.StringMap{
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			Metadata: &*metav1.ObjectMetaArgs{
+				Labels: map[string]pulumi.String{
 					"app.kubernetes.io/component":    pulumi.String("server"),
 					"aws:region":                     pulumi.String("us-west-2"),
 					fmt.Sprintf("key%vpercent", "%"): pulumi.String("percent"),
@@ -30,7 +30,7 @@ func main() {
 					"key=>geq":                       pulumi.String("geq"),
 					"key==eq":                        pulumi.String("equal"),
 				},
-				Name: pulumi.String("argocd-server"),
+				Name: "argocd-server",
 			},
 		})
 		if err != nil {

--- a/pkg/codegen/testing/test/testdata/kubernetes-operator-pp/dotnet/kubernetes-operator.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-operator-pp/dotnet/kubernetes-operator.cs
@@ -8,40 +8,40 @@ return await Deployment.RunAsync(() =>
     {
         ApiVersion = "apps/v1",
         Kind = "Deployment",
-        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        Metadata = 
         {
-            Name = "pulumi-kubernetes-operator",
+            { "name", "pulumi-kubernetes-operator" },
         },
-        Spec = new Kubernetes.Types.Inputs.Apps.V1.DeploymentSpecArgs
+        Spec = 
         {
-            Replicas = 1,
-            Selector = new Kubernetes.Types.Inputs.Meta.V1.LabelSelectorArgs
+            { "replicas", 1 },
+            { "selector", new Kubernetes.Types.Inputs.Meta.V1.LabelSelectorArgs
             {
                 MatchLabels = 
                 {
                     { "name", "pulumi-kubernetes-operator" },
                 },
-            },
-            Template = new Kubernetes.Types.Inputs.Core.V1.PodTemplateSpecArgs
+            } },
+            { "template", new Kubernetes.Types.Inputs.Core.V1.PodTemplateSpecArgs
             {
-                Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+                Metadata = 
                 {
-                    Labels = 
+                    { "labels", 
                     {
                         { "name", "pulumi-kubernetes-operator" },
-                    },
+                    } },
                 },
-                Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
+                Spec = 
                 {
-                    ServiceAccountName = "pulumi-kubernetes-operator",
-                    ImagePullSecrets = new[]
+                    { "serviceAccountName", "pulumi-kubernetes-operator" },
+                    { "imagePullSecrets", new[]
                     {
                         new Kubernetes.Types.Inputs.Core.V1.LocalObjectReferenceArgs
                         {
                             Name = "pulumi-kubernetes-operator",
                         },
-                    },
-                    Containers = new[]
+                    } },
+                    { "containers", new[]
                     {
                         new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
                         {
@@ -61,23 +61,23 @@ return await Deployment.RunAsync(() =>
                                 new Kubernetes.Types.Inputs.Core.V1.EnvVarArgs
                                 {
                                     Name = "WATCH_NAMESPACE",
-                                    ValueFrom = new Kubernetes.Types.Inputs.Core.V1.EnvVarSourceArgs
+                                    ValueFrom = 
                                     {
-                                        FieldRef = new Kubernetes.Types.Inputs.Core.V1.ObjectFieldSelectorArgs
+                                        { "fieldRef", 
                                         {
-                                            FieldPath = "metadata.namespace",
-                                        },
+                                            { "fieldPath", "metadata.namespace" },
+                                        } },
                                     },
                                 },
                                 new Kubernetes.Types.Inputs.Core.V1.EnvVarArgs
                                 {
                                     Name = "POD_NAME",
-                                    ValueFrom = new Kubernetes.Types.Inputs.Core.V1.EnvVarSourceArgs
+                                    ValueFrom = 
                                     {
-                                        FieldRef = new Kubernetes.Types.Inputs.Core.V1.ObjectFieldSelectorArgs
+                                        { "fieldRef", 
                                         {
-                                            FieldPath = "metadata.name",
-                                        },
+                                            { "fieldPath", "metadata.name" },
+                                        } },
                                     },
                                 },
                                 new Kubernetes.Types.Inputs.Core.V1.EnvVarArgs
@@ -87,9 +87,9 @@ return await Deployment.RunAsync(() =>
                                 },
                             },
                         },
-                    },
+                    } },
                 },
-            },
+            } },
         },
     });
 
@@ -97,10 +97,10 @@ return await Deployment.RunAsync(() =>
     {
         ApiVersion = "rbac.authorization.k8s.io/v1",
         Kind = "Role",
-        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        Metadata = 
         {
-            CreationTimestamp = null,
-            Name = "pulumi-kubernetes-operator",
+            { "creationTimestamp", null },
+            { "name", "pulumi-kubernetes-operator" },
         },
         Rules = new[]
         {
@@ -250,9 +250,9 @@ return await Deployment.RunAsync(() =>
     {
         Kind = "RoleBinding",
         ApiVersion = "rbac.authorization.k8s.io/v1",
-        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        Metadata = 
         {
-            Name = "pulumi-kubernetes-operator",
+            { "name", "pulumi-kubernetes-operator" },
         },
         Subjects = new[]
         {
@@ -274,9 +274,9 @@ return await Deployment.RunAsync(() =>
     {
         ApiVersion = "v1",
         Kind = "ServiceAccount",
-        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        Metadata = 
         {
-            Name = "pulumi-kubernetes-operator",
+            { "name", "pulumi-kubernetes-operator" },
         },
     });
 

--- a/pkg/codegen/testing/test/testdata/kubernetes-operator-pp/go/kubernetes-operator.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-operator-pp/go/kubernetes-operator.go
@@ -11,62 +11,62 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := appsv1.NewDeployment(ctx, "pulumi_kubernetes_operatorDeployment", &appsv1.DeploymentArgs{
-			ApiVersion: pulumi.String("apps/v1"),
-			Kind:       pulumi.String("Deployment"),
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String("pulumi-kubernetes-operator"),
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			Metadata: &*metav1.ObjectMetaArgs{
+				Name: "pulumi-kubernetes-operator",
 			},
-			Spec: &appsv1.DeploymentSpecArgs{
-				Replicas: pulumi.Int(1),
+			Spec: &*appsv1.DeploymentSpecArgs{
+				Replicas: 1,
 				Selector: &metav1.LabelSelectorArgs{
-					MatchLabels: pulumi.StringMap{
+					MatchLabels: map[string]pulumi.String{
 						"name": pulumi.String("pulumi-kubernetes-operator"),
 					},
 				},
 				Template: &corev1.PodTemplateSpecArgs{
-					Metadata: &metav1.ObjectMetaArgs{
-						Labels: pulumi.StringMap{
+					Metadata: &*metav1.ObjectMetaArgs{
+						Labels: map[string]pulumi.String{
 							"name": pulumi.String("pulumi-kubernetes-operator"),
 						},
 					},
-					Spec: &corev1.PodSpecArgs{
-						ServiceAccountName: pulumi.String("pulumi-kubernetes-operator"),
-						ImagePullSecrets: corev1.LocalObjectReferenceArray{
-							&corev1.LocalObjectReferenceArgs{
-								Name: pulumi.String("pulumi-kubernetes-operator"),
+					Spec: &*corev1.PodSpecArgs{
+						ServiceAccountName: "pulumi-kubernetes-operator",
+						ImagePullSecrets: []corev1.LocalObjectReferenceArgs{
+							{
+								Name: "pulumi-kubernetes-operator",
 							},
 						},
 						Containers: corev1.ContainerArray{
 							&corev1.ContainerArgs{
 								Name:  pulumi.String("pulumi-kubernetes-operator"),
-								Image: pulumi.String("pulumi/pulumi-kubernetes-operator:v0.0.2"),
-								Command: pulumi.StringArray{
+								Image: "pulumi/pulumi-kubernetes-operator:v0.0.2",
+								Command: []pulumi.String{
 									pulumi.String("pulumi-kubernetes-operator"),
 								},
-								Args: pulumi.StringArray{
+								Args: []pulumi.String{
 									pulumi.String("--zap-level=debug"),
 								},
-								ImagePullPolicy: pulumi.String("Always"),
-								Env: corev1.EnvVarArray{
-									&corev1.EnvVarArgs{
+								ImagePullPolicy: "Always",
+								Env: []corev1.EnvVarArgs{
+									{
 										Name: pulumi.String("WATCH_NAMESPACE"),
-										ValueFrom: &corev1.EnvVarSourceArgs{
-											FieldRef: &corev1.ObjectFieldSelectorArgs{
+										ValueFrom: {
+											FieldRef: {
 												FieldPath: pulumi.String("metadata.namespace"),
 											},
 										},
 									},
-									&corev1.EnvVarArgs{
+									{
 										Name: pulumi.String("POD_NAME"),
-										ValueFrom: &corev1.EnvVarSourceArgs{
-											FieldRef: &corev1.ObjectFieldSelectorArgs{
+										ValueFrom: {
+											FieldRef: {
 												FieldPath: pulumi.String("metadata.name"),
 											},
 										},
 									},
-									&corev1.EnvVarArgs{
+									{
 										Name:  pulumi.String("OPERATOR_NAME"),
-										Value: pulumi.String("pulumi-kubernetes-operator"),
+										Value: "pulumi-kubernetes-operator",
 									},
 								},
 							},
@@ -79,18 +79,18 @@ func main() {
 			return err
 		}
 		_, err = rbacv1.NewRole(ctx, "pulumi_kubernetes_operatorRole", &rbacv1.RoleArgs{
-			ApiVersion: pulumi.String("rbac.authorization.k8s.io/v1"),
-			Kind:       pulumi.String("Role"),
-			Metadata: &metav1.ObjectMetaArgs{
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+			Metadata: &*metav1.ObjectMetaArgs{
 				CreationTimestamp: nil,
-				Name:              pulumi.String("pulumi-kubernetes-operator"),
+				Name:              "pulumi-kubernetes-operator",
 			},
-			Rules: rbacv1.PolicyRuleArray{
-				&rbacv1.PolicyRuleArgs{
-					ApiGroups: pulumi.StringArray{
+			Rules: []rbacv1.PolicyRuleArgs{
+				{
+					ApiGroups: []pulumi.String{
 						pulumi.String(""),
 					},
-					Resources: pulumi.StringArray{
+					Resources: []pulumi.String{
 						pulumi.String("pods"),
 						pulumi.String("services"),
 						pulumi.String("services/finalizers"),
@@ -110,11 +110,11 @@ func main() {
 						pulumi.String("watch"),
 					},
 				},
-				&rbacv1.PolicyRuleArgs{
-					ApiGroups: pulumi.StringArray{
+				{
+					ApiGroups: []pulumi.String{
 						pulumi.String("apps"),
 					},
-					Resources: pulumi.StringArray{
+					Resources: []pulumi.String{
 						pulumi.String("deployments"),
 						pulumi.String("daemonsets"),
 						pulumi.String("replicasets"),
@@ -130,11 +130,11 @@ func main() {
 						pulumi.String("watch"),
 					},
 				},
-				&rbacv1.PolicyRuleArgs{
-					ApiGroups: pulumi.StringArray{
+				{
+					ApiGroups: []pulumi.String{
 						pulumi.String("monitoring.coreos.com"),
 					},
-					Resources: pulumi.StringArray{
+					Resources: []pulumi.String{
 						pulumi.String("servicemonitors"),
 					},
 					Verbs: pulumi.StringArray{
@@ -142,36 +142,36 @@ func main() {
 						pulumi.String("create"),
 					},
 				},
-				&rbacv1.PolicyRuleArgs{
-					ApiGroups: pulumi.StringArray{
+				{
+					ApiGroups: []pulumi.String{
 						pulumi.String("apps"),
 					},
-					ResourceNames: pulumi.StringArray{
+					ResourceNames: []pulumi.String{
 						pulumi.String("pulumi-kubernetes-operator"),
 					},
-					Resources: pulumi.StringArray{
+					Resources: []pulumi.String{
 						pulumi.String("deployments/finalizers"),
 					},
 					Verbs: pulumi.StringArray{
 						pulumi.String("update"),
 					},
 				},
-				&rbacv1.PolicyRuleArgs{
-					ApiGroups: pulumi.StringArray{
+				{
+					ApiGroups: []pulumi.String{
 						pulumi.String(""),
 					},
-					Resources: pulumi.StringArray{
+					Resources: []pulumi.String{
 						pulumi.String("pods"),
 					},
 					Verbs: pulumi.StringArray{
 						pulumi.String("get"),
 					},
 				},
-				&rbacv1.PolicyRuleArgs{
-					ApiGroups: pulumi.StringArray{
+				{
+					ApiGroups: []pulumi.String{
 						pulumi.String("apps"),
 					},
-					Resources: pulumi.StringArray{
+					Resources: []pulumi.String{
 						pulumi.String("replicasets"),
 						pulumi.String("deployments"),
 					},
@@ -179,11 +179,11 @@ func main() {
 						pulumi.String("get"),
 					},
 				},
-				&rbacv1.PolicyRuleArgs{
-					ApiGroups: pulumi.StringArray{
+				{
+					ApiGroups: []pulumi.String{
 						pulumi.String("pulumi.com"),
 					},
-					Resources: pulumi.StringArray{
+					Resources: []pulumi.String{
 						pulumi.String("*"),
 					},
 					Verbs: pulumi.StringArray{
@@ -202,13 +202,13 @@ func main() {
 			return err
 		}
 		_, err = rbacv1.NewRoleBinding(ctx, "pulumi_kubernetes_operatorRoleBinding", &rbacv1.RoleBindingArgs{
-			Kind:       pulumi.String("RoleBinding"),
-			ApiVersion: pulumi.String("rbac.authorization.k8s.io/v1"),
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String("pulumi-kubernetes-operator"),
+			Kind:       "RoleBinding",
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Metadata: &*metav1.ObjectMetaArgs{
+				Name: "pulumi-kubernetes-operator",
 			},
-			Subjects: rbacv1.SubjectArray{
-				&rbacv1.SubjectArgs{
+			Subjects: []rbacv1.SubjectArgs{
+				{
 					Kind: pulumi.String("ServiceAccount"),
 					Name: pulumi.String("pulumi-kubernetes-operator"),
 				},
@@ -223,10 +223,10 @@ func main() {
 			return err
 		}
 		_, err = corev1.NewServiceAccount(ctx, "pulumi_kubernetes_operatorServiceAccount", &corev1.ServiceAccountArgs{
-			ApiVersion: pulumi.String("v1"),
-			Kind:       pulumi.String("ServiceAccount"),
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String("pulumi-kubernetes-operator"),
+			ApiVersion: "v1",
+			Kind:       "ServiceAccount",
+			Metadata: &*metav1.ObjectMetaArgs{
+				Name: "pulumi-kubernetes-operator",
 			},
 		})
 		if err != nil {

--- a/pkg/codegen/testing/test/testdata/kubernetes-operator-pp/python/kubernetes-operator.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-operator-pp/python/kubernetes-operator.py
@@ -4,28 +4,28 @@ import pulumi_kubernetes as kubernetes
 pulumi_kubernetes_operator_deployment = kubernetes.apps.v1.Deployment("pulumi_kubernetes_operatorDeployment",
     api_version="apps/v1",
     kind="Deployment",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name="pulumi-kubernetes-operator",
-    ),
-    spec=kubernetes.apps.v1.DeploymentSpecArgs(
-        replicas=1,
-        selector=kubernetes.meta.v1.LabelSelectorArgs(
+    metadata={
+        "name": "pulumi-kubernetes-operator",
+    },
+    spec={
+        "replicas": 1,
+        "selector": kubernetes.meta.v1.LabelSelectorArgs(
             match_labels={
                 "name": "pulumi-kubernetes-operator",
             },
         ),
-        template=kubernetes.core.v1.PodTemplateSpecArgs(
-            metadata=kubernetes.meta.v1.ObjectMetaArgs(
-                labels={
+        "template": kubernetes.core.v1.PodTemplateSpecArgs(
+            metadata={
+                "labels": {
                     "name": "pulumi-kubernetes-operator",
                 },
-            ),
-            spec=kubernetes.core.v1.PodSpecArgs(
-                service_account_name="pulumi-kubernetes-operator",
-                image_pull_secrets=[kubernetes.core.v1.LocalObjectReferenceArgs(
+            },
+            spec={
+                "serviceAccountName": "pulumi-kubernetes-operator",
+                "imagePullSecrets": [kubernetes.core.v1.LocalObjectReferenceArgs(
                     name="pulumi-kubernetes-operator",
                 )],
-                containers=[kubernetes.core.v1.ContainerArgs(
+                "containers": [kubernetes.core.v1.ContainerArgs(
                     name="pulumi-kubernetes-operator",
                     image="pulumi/pulumi-kubernetes-operator:v0.0.2",
                     command=["pulumi-kubernetes-operator"],
@@ -34,19 +34,19 @@ pulumi_kubernetes_operator_deployment = kubernetes.apps.v1.Deployment("pulumi_ku
                     env=[
                         kubernetes.core.v1.EnvVarArgs(
                             name="WATCH_NAMESPACE",
-                            value_from=kubernetes.core.v1.EnvVarSourceArgs(
-                                field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
-                                    field_path="metadata.namespace",
-                                ),
-                            ),
+                            value_from={
+                                "fieldRef": {
+                                    "fieldPath": "metadata.namespace",
+                                },
+                            },
                         ),
                         kubernetes.core.v1.EnvVarArgs(
                             name="POD_NAME",
-                            value_from=kubernetes.core.v1.EnvVarSourceArgs(
-                                field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
-                                    field_path="metadata.name",
-                                ),
-                            ),
+                            value_from={
+                                "fieldRef": {
+                                    "fieldPath": "metadata.name",
+                                },
+                            },
                         ),
                         kubernetes.core.v1.EnvVarArgs(
                             name="OPERATOR_NAME",
@@ -54,16 +54,16 @@ pulumi_kubernetes_operator_deployment = kubernetes.apps.v1.Deployment("pulumi_ku
                         ),
                     ],
                 )],
-            ),
+            },
         ),
-    ))
+    })
 pulumi_kubernetes_operator_role = kubernetes.rbac.v1.Role("pulumi_kubernetes_operatorRole",
     api_version="rbac.authorization.k8s.io/v1",
     kind="Role",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        creation_timestamp=None,
-        name="pulumi-kubernetes-operator",
-    ),
+    metadata={
+        "creationTimestamp": None,
+        "name": "pulumi-kubernetes-operator",
+    },
     rules=[
         kubernetes.rbac.v1.PolicyRuleArgs(
             api_groups=[""],
@@ -149,9 +149,9 @@ pulumi_kubernetes_operator_role = kubernetes.rbac.v1.Role("pulumi_kubernetes_ope
 pulumi_kubernetes_operator_role_binding = kubernetes.rbac.v1.RoleBinding("pulumi_kubernetes_operatorRoleBinding",
     kind="RoleBinding",
     api_version="rbac.authorization.k8s.io/v1",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name="pulumi-kubernetes-operator",
-    ),
+    metadata={
+        "name": "pulumi-kubernetes-operator",
+    },
     subjects=[kubernetes.rbac.v1.SubjectArgs(
         kind="ServiceAccount",
         name="pulumi-kubernetes-operator",
@@ -164,6 +164,6 @@ pulumi_kubernetes_operator_role_binding = kubernetes.rbac.v1.RoleBinding("pulumi
 pulumi_kubernetes_operator_service_account = kubernetes.core.v1.ServiceAccount("pulumi_kubernetes_operatorServiceAccount",
     api_version="v1",
     kind="ServiceAccount",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name="pulumi-kubernetes-operator",
-    ))
+    metadata={
+        "name": "pulumi-kubernetes-operator",
+    })

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/dotnet/kubernetes-pod.cs
@@ -7,14 +7,14 @@ return await Deployment.RunAsync(() =>
     var bar = new Kubernetes.Core.V1.Pod("bar", new()
     {
         ApiVersion = "v1",
-        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        Metadata = 
         {
-            Namespace = "foo",
-            Name = "bar",
+            { "namespace", "foo" },
+            { "name", "bar" },
         },
-        Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
+        Spec = 
         {
-            Containers = new[]
+            { "containers", new[]
             {
                 new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
                 {
@@ -27,13 +27,13 @@ return await Deployment.RunAsync(() =>
                             ContainerPortValue = 80,
                         },
                     },
-                    Resources = new Kubernetes.Types.Inputs.Core.V1.ResourceRequirementsArgs
+                    Resources = 
                     {
-                        Limits = 
+                        { "limits", 
                         {
                             { "memory", "20Mi" },
                             { "cpu", "0.2" },
-                        },
+                        } },
                     },
                 },
                 new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
@@ -47,16 +47,16 @@ return await Deployment.RunAsync(() =>
                             ContainerPortValue = 80,
                         },
                     },
-                    Resources = new Kubernetes.Types.Inputs.Core.V1.ResourceRequirementsArgs
+                    Resources = 
                     {
-                        Limits = 
+                        { "limits", 
                         {
                             { "memory", "20Mi" },
                             { "cpu", "0.2" },
-                        },
+                        } },
                     },
                 },
-            },
+            } },
         },
     });
 

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/go/kubernetes-pod.go
@@ -9,38 +9,38 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		bar, err := corev1.NewPod(ctx, "bar", &corev1.PodArgs{
-			ApiVersion: pulumi.String("v1"),
-			Metadata: &metav1.ObjectMetaArgs{
-				Namespace: pulumi.String("foo"),
-				Name:      pulumi.String("bar"),
+			ApiVersion: "v1",
+			Metadata: &*metav1.ObjectMetaArgs{
+				Namespace: "foo",
+				Name:      "bar",
 			},
-			Spec: &corev1.PodSpecArgs{
-				Containers: []corev1.ContainerArgs{
-					{
+			Spec: &*corev1.PodSpecArgs{
+				Containers: corev1.ContainerArray{
+					&corev1.ContainerArgs{
 						Name:  pulumi.String("nginx"),
-						Image: pulumi.String("nginx:1.14-alpine"),
-						Ports: corev1.ContainerPortArray{
+						Image: "nginx:1.14-alpine",
+						Ports: []corev1.ContainerPortArgs{
 							{
 								ContainerPort: pulumi.Int(80),
 							},
 						},
-						Resources: {
-							Limits: {
+						Resources: &*corev1.ResourceRequirementsArgs{
+							Limits: map[string]pulumi.String{
 								"memory": pulumi.String("20Mi"),
 								"cpu":    pulumi.String("0.2"),
 							},
 						},
 					},
-					{
+					&corev1.ContainerArgs{
 						Name:  pulumi.String("nginx2"),
-						Image: pulumi.String("nginx:1.14-alpine"),
-						Ports: corev1.ContainerPortArray{
+						Image: "nginx:1.14-alpine",
+						Ports: []corev1.ContainerPortArgs{
 							{
 								ContainerPort: pulumi.Int(80),
 							},
 						},
-						Resources: {
-							Limits: {
+						Resources: &*corev1.ResourceRequirementsArgs{
+							Limits: map[string]pulumi.String{
 								"memory": pulumi.String("20Mi"),
 								"cpu":    pulumi.String("0.2"),
 							},

--- a/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-pod-pp/python/kubernetes-pod.py
@@ -3,24 +3,24 @@ import pulumi_kubernetes as kubernetes
 
 bar = kubernetes.core.v1.Pod("bar",
     api_version="v1",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        namespace="foo",
-        name="bar",
-    ),
-    spec=kubernetes.core.v1.PodSpecArgs(
-        containers=[
+    metadata={
+        "namespace": "foo",
+        "name": "bar",
+    },
+    spec={
+        "containers": [
             kubernetes.core.v1.ContainerArgs(
                 name="nginx",
                 image="nginx:1.14-alpine",
                 ports=[kubernetes.core.v1.ContainerPortArgs(
                     container_port=80,
                 )],
-                resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                    limits={
+                resources={
+                    "limits": {
                         "memory": "20Mi",
                         "cpu": "0.2",
                     },
-                ),
+                },
             ),
             kubernetes.core.v1.ContainerArgs(
                 name="nginx2",
@@ -28,13 +28,13 @@ bar = kubernetes.core.v1.Pod("bar",
                 ports=[kubernetes.core.v1.ContainerPortArgs(
                     container_port=80,
                 )],
-                resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                    limits={
+                resources={
+                    "limits": {
                         "memory": "20Mi",
                         "cpu": "0.2",
                     },
-                ),
+                },
             ),
         ],
-    ))
+    })
 kind = bar.kind

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-pp/dotnet/kubernetes-template.cs
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-pp/dotnet/kubernetes-template.cs
@@ -8,48 +8,48 @@ return await Deployment.RunAsync(() =>
     {
         ApiVersion = "apps/v1",
         Kind = "Deployment",
-        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        Metadata = 
         {
-            Name = "argocd-server",
+            { "name", "argocd-server" },
         },
-        Spec = new Kubernetes.Types.Inputs.Apps.V1.DeploymentSpecArgs
+        Spec = 
         {
-            Selector = new Kubernetes.Types.Inputs.Meta.V1.LabelSelectorArgs
+            { "selector", new Kubernetes.Types.Inputs.Meta.V1.LabelSelectorArgs
             {
                 MatchLabels = 
                 {
                     { "app", "server" },
                 },
-            },
-            Replicas = 1,
-            Template = new Kubernetes.Types.Inputs.Core.V1.PodTemplateSpecArgs
+            } },
+            { "replicas", 1 },
+            { "template", new Kubernetes.Types.Inputs.Core.V1.PodTemplateSpecArgs
             {
-                Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+                Metadata = 
                 {
-                    Labels = 
+                    { "labels", 
                     {
                         { "app", "server" },
-                    },
+                    } },
                 },
-                Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
+                Spec = 
                 {
-                    Containers = new[]
+                    { "containers", new[]
                     {
                         new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
                         {
                             Name = "nginx",
                             Image = "nginx",
-                            ReadinessProbe = new Kubernetes.Types.Inputs.Core.V1.ProbeArgs
+                            ReadinessProbe = 
                             {
-                                HttpGet = new Kubernetes.Types.Inputs.Core.V1.HTTPGetActionArgs
+                                { "httpGet", 
                                 {
-                                    Port = 8080,
-                                },
+                                    { "port", 8080 },
+                                } },
                             },
                         },
-                    },
+                    } },
                 },
-            },
+            } },
         },
     });
 

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-pp/go/kubernetes-template.go
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-pp/go/kubernetes-template.go
@@ -10,31 +10,31 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := appsv1.NewDeployment(ctx, "argocd_serverDeployment", &appsv1.DeploymentArgs{
-			ApiVersion: pulumi.String("apps/v1"),
-			Kind:       pulumi.String("Deployment"),
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String("argocd-server"),
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			Metadata: &*metav1.ObjectMetaArgs{
+				Name: "argocd-server",
 			},
-			Spec: &appsv1.DeploymentSpecArgs{
+			Spec: &*appsv1.DeploymentSpecArgs{
 				Selector: &metav1.LabelSelectorArgs{
-					MatchLabels: pulumi.StringMap{
+					MatchLabels: map[string]pulumi.String{
 						"app": pulumi.String("server"),
 					},
 				},
-				Replicas: pulumi.Int(1),
+				Replicas: 1,
 				Template: &corev1.PodTemplateSpecArgs{
-					Metadata: &metav1.ObjectMetaArgs{
-						Labels: pulumi.StringMap{
+					Metadata: &*metav1.ObjectMetaArgs{
+						Labels: map[string]pulumi.String{
 							"app": pulumi.String("server"),
 						},
 					},
-					Spec: &corev1.PodSpecArgs{
+					Spec: &*corev1.PodSpecArgs{
 						Containers: corev1.ContainerArray{
 							&corev1.ContainerArgs{
 								Name:  pulumi.String("nginx"),
-								Image: pulumi.String("nginx"),
-								ReadinessProbe: &corev1.ProbeArgs{
-									HttpGet: &corev1.HTTPGetActionArgs{
+								Image: "nginx",
+								ReadinessProbe: &*corev1.ProbeArgs{
+									HttpGet: &*corev1.HTTPGetActionArgs{
 										Port: pulumi.Any(8080),
 									},
 								},

--- a/pkg/codegen/testing/test/testdata/kubernetes-template-pp/python/kubernetes-template.py
+++ b/pkg/codegen/testing/test/testdata/kubernetes-template-pp/python/kubernetes-template.py
@@ -4,32 +4,32 @@ import pulumi_kubernetes as kubernetes
 argocd_server_deployment = kubernetes.apps.v1.Deployment("argocd_serverDeployment",
     api_version="apps/v1",
     kind="Deployment",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name="argocd-server",
-    ),
-    spec=kubernetes.apps.v1.DeploymentSpecArgs(
-        selector=kubernetes.meta.v1.LabelSelectorArgs(
+    metadata={
+        "name": "argocd-server",
+    },
+    spec={
+        "selector": kubernetes.meta.v1.LabelSelectorArgs(
             match_labels={
                 "app": "server",
             },
         ),
-        replicas=1,
-        template=kubernetes.core.v1.PodTemplateSpecArgs(
-            metadata=kubernetes.meta.v1.ObjectMetaArgs(
-                labels={
+        "replicas": 1,
+        "template": kubernetes.core.v1.PodTemplateSpecArgs(
+            metadata={
+                "labels": {
                     "app": "server",
                 },
-            ),
-            spec=kubernetes.core.v1.PodSpecArgs(
-                containers=[kubernetes.core.v1.ContainerArgs(
+            },
+            spec={
+                "containers": [kubernetes.core.v1.ContainerArgs(
                     name="nginx",
                     image="nginx",
-                    readiness_probe=kubernetes.core.v1.ProbeArgs(
-                        http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                            port=8080,
-                        ),
-                    ),
+                    readiness_probe={
+                        "httpGet": {
+                            "port": 8080,
+                        },
+                    },
                 )],
-            ),
+            },
         ),
-    ))
+    })

--- a/pkg/codegen/testing/test/testdata/modpath-pp/go/modpath.go
+++ b/pkg/codegen/testing/test/testdata/modpath-pp/go/modpath.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := pkg.NewThing(ctx, "thing", &pkg.ThingArgs{
-			Idea: pulumi.String("myIdea"),
+			Idea: "myIdea",
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/docs/mod/component/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-              <span class="nx">local</span><span class="p">:</span> <span class="nx">Optional[Component2]</span> = None<span class="p">,</span>
-              <span class="nx">main</span><span class="p">:</span> <span class="nx">Optional[MainComponent]</span> = None<span class="p">)</span>
+              <span class="nx">local</span><span class="p">:</span> <span class="nx">Optional[Optional[Component2]]</span> = None<span class="p">,</span>
+              <span class="nx">main</span><span class="p">:</span> <span class="nx">Optional[Optional[MainComponent]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ComponentArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#local_csharp" style="color: inherit; text-decoration: inherit;">Local</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Example.<wbr>Mod.<wbr>Component2</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Mod.<wbr>Component2?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#main_csharp" style="color: inherit; text-decoration: inherit;">Main</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Example.<wbr>Main<wbr>Component</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Main<wbr>Component?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#local_java" style="color: inherit; text-decoration: inherit;">local</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Component2</span>
+        <span class="property-type">Optional&lt;Component2&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#main_java" style="color: inherit; text-decoration: inherit;">main</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Main<wbr>Component</span>
+        <span class="property-type">Optional&lt;Main<wbr>Component&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#local_nodejs" style="color: inherit; text-decoration: inherit;">local</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Component2</span>
+        <span class="property-type">Component2 | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#main_nodejs" style="color: inherit; text-decoration: inherit;">main</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Main<wbr>Component</span>
+        <span class="property-type">Main<wbr>Component | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Mod/Component.cs
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Mod/Component.cs
@@ -57,10 +57,10 @@ namespace Pulumi.Example.Mod
     public sealed class ComponentArgs : global::Pulumi.ResourceArgs
     {
         [Input("local")]
-        public Input<Pulumi.Example.Mod.Component2>? Local { get; set; }
+        public Input<Pulumi.Example.Mod.Component2?>? Local { get; set; }
 
         [Input("main")]
-        public Input<Pulumi.Example.MainComponent>? Main { get; set; }
+        public Input<Pulumi.Example.MainComponent?>? Main { get; set; }
 
         public ComponentArgs()
         {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mod/component.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/mod/component.go
@@ -60,8 +60,8 @@ type componentArgs struct {
 
 // The set of arguments for constructing a Component resource.
 type ComponentArgs struct {
-	Local Component2Input
-	Main  example.MainComponentInput
+	Local *Component2
+	Main  *example.MainComponent
 }
 
 func (ComponentArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/go/example/pulumiTypes.go
@@ -26,7 +26,7 @@ type ObjectInput interface {
 }
 
 type ObjectArgs struct {
-	Bar pulumi.StringPtrInput `pulumi:"bar"`
+	Bar *string `pulumi:"bar"`
 }
 
 func (ObjectArgs) ElementType() reflect.Type {
@@ -75,7 +75,7 @@ type ObjectInputTypeInput interface {
 }
 
 type ObjectInputTypeArgs struct {
-	Bar pulumi.StringPtrInput `pulumi:"bar"`
+	Bar *string `pulumi:"bar"`
 }
 
 func (ObjectInputTypeArgs) ElementType() reflect.Type {
@@ -124,7 +124,7 @@ type ResourceTypeInput interface {
 }
 
 type ResourceTypeArgs struct {
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 }
 
 func (ResourceTypeArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/naming-collisions/nodejs/mod/component.ts
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/nodejs/mod/component.ts
@@ -59,6 +59,6 @@ export class Component extends pulumi.CustomResource {
  * The set of arguments for constructing a Component resource.
  */
 export interface ComponentArgs {
-    local?: pulumi.Input<Component2>;
-    main?: pulumi.Input<MainComponent>;
+    local?: pulumi.Input<Component2 | undefined>;
+    main?: pulumi.Input<MainComponent | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/mod/component.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/pulumi_example/mod/component.py
@@ -16,8 +16,8 @@ __all__ = ['ComponentArgs', 'Component']
 @pulumi.input_type
 class ComponentArgs:
     def __init__(__self__, *,
-                 local: Optional[pulumi.Input['Component2']] = None,
-                 main: Optional[pulumi.Input['MainComponent']] = None):
+                 local: pulumi.Input[Optional['Component2']] = None,
+                 main: pulumi.Input[Optional['MainComponent']] = None):
         """
         The set of arguments for constructing a Component resource.
         """
@@ -28,20 +28,20 @@ class ComponentArgs:
 
     @property
     @pulumi.getter
-    def local(self) -> Optional[pulumi.Input['Component2']]:
+    def local(self) -> pulumi.Input[Optional['Component2']]:
         return pulumi.get(self, "local")
 
     @local.setter
-    def local(self, value: Optional[pulumi.Input['Component2']]):
+    def local(self, value: pulumi.Input[Optional['Component2']]):
         pulumi.set(self, "local", value)
 
     @property
     @pulumi.getter
-    def main(self) -> Optional[pulumi.Input['MainComponent']]:
+    def main(self) -> pulumi.Input[Optional['MainComponent']]:
         return pulumi.get(self, "main")
 
     @main.setter
-    def main(self, value: Optional[pulumi.Input['MainComponent']]):
+    def main(self, value: pulumi.Input[Optional['MainComponent']]):
         pulumi.set(self, "main", value)
 
 
@@ -50,8 +50,8 @@ class Component(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 local: Optional[pulumi.Input['Component2']] = None,
-                 main: Optional[pulumi.Input['MainComponent']] = None,
+                 local: pulumi.Input[Optional['Component2']] = None,
+                 main: pulumi.Input[Optional['MainComponent']] = None,
                  __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -81,8 +81,8 @@ class Component(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 local: Optional[pulumi.Input['Component2']] = None,
-                 main: Optional[pulumi.Input['MainComponent']] = None,
+                 local: pulumi.Input[Optional['Component2']] = None,
+                 main: pulumi.Input[Optional['MainComponent']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/docs/deeply/nested/module/resource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_java" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Deeply/nested/module/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Deeply/nested/module/Resource.cs
@@ -65,14 +65,14 @@ namespace Pulumi.FooBar.Deeply/nested/module
     public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
-        private Input<string>? _baz;
-        public Input<string>? Baz
+        private Input<string?>? _baz;
+        public Input<string?>? Baz
         {
             get => _baz;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _baz = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _baz = Output.Tuple<Input<string?>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
@@ -24,7 +24,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Baz != nil {
-		args.Baz = pulumi.ToSecret(args.Baz).(pulumi.StringPtrInput)
+		args.Baz = pulumi.ToSecret(args.Baz).(*string)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"baz",
@@ -67,7 +67,7 @@ type resourceArgs struct {
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Baz pulumi.StringPtrInput
+	Baz *string
 }
 
 func (ResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/nodejs/deeply/nested/module/resource.ts
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/nodejs/deeply/nested/module/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    baz?: pulumi.Input<string>;
+    baz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/module/resource.py
@@ -14,7 +14,7 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 baz: Optional[pulumi.Input[str]] = None):
+                 baz: pulumi.Input[Optional[str]] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
@@ -23,11 +23,11 @@ class ResourceArgs:
 
     @property
     @pulumi.getter
-    def baz(self) -> Optional[pulumi.Input[str]]:
+    def baz(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "baz")
 
     @baz.setter
-    def baz(self, value: Optional[pulumi.Input[str]]):
+    def baz(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "baz", value)
 
 
@@ -36,7 +36,7 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 baz: Optional[pulumi.Input[str]] = None,
+                 baz: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -66,7 +66,7 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 baz: Optional[pulumi.Input[str]] = None,
+                 baz: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/nested-module/docs/nested/module/resource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Nested/module/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Nested/module/Resource.cs
@@ -65,14 +65,14 @@ namespace Pulumi.Foo.Nested/module
     public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        private Input<string>? _bar;
-        public Input<string>? Bar
+        private Input<string?>? _bar;
+        public Input<string?>? Bar
         {
             get => _bar;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _bar = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _bar = Output.Tuple<Input<string?>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
+++ b/pkg/codegen/testing/test/testdata/nested-module/go/foo/nested/module/resource.go
@@ -24,7 +24,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Bar != nil {
-		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrInput)
+		args.Bar = pulumi.ToSecret(args.Bar).(*string)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"bar",
@@ -67,7 +67,7 @@ type resourceArgs struct {
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Bar pulumi.StringPtrInput
+	Bar *string
 }
 
 func (ResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/nested-module/nodejs/nested/module/resource.ts
+++ b/pkg/codegen/testing/test/testdata/nested-module/nodejs/nested/module/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/nested/module/resource.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/pulumi_foo/nested/module/resource.py
@@ -14,7 +14,7 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input[str]] = None):
+                 bar: pulumi.Input[Optional[str]] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
@@ -23,11 +23,11 @@ class ResourceArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[str]]:
+    def bar(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[str]]):
+    def bar(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "bar", value)
 
 
@@ -36,7 +36,7 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -66,7 +66,7 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/argfunction/_index.md
@@ -45,7 +45,7 @@ function </span>argFunctionOutput<span class="p">(</span><span class="nx">args</
 ><span class="k">def </span>arg_function<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ArgFunctionResult</span
 ><span class="k">
-def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Resource]]</span> = None<span class="p">,</span>
+def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Resource]]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ArgFunctionResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/barresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">BarResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">BarResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[BarResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The BarResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The BarResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The BarResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/fooresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">FooResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">FooResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[FooResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The FooResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The FooResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The FooResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/otherresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[OtherResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Other.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayfunction/_index.md
@@ -45,7 +45,7 @@ function </span>overlayFunctionOutput<span class="p">(</span><span class="nx">ar
 ><span class="k">def </span>overlay_function<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">,</span>
                      <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>OverlayFunctionResult</span
 ><span class="k">
-def </span>overlay_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Resource]]</span> = None<span class="p">,</span>
+def </span>overlay_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Resource]]</span> = None<span class="p">,</span>
                      <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[OverlayFunctionResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/overlayresource/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OverlayResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                     <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                    <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[EnumOverlay]</span> = None<span class="p">,</span>
-                    <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[ConfigMapOverlayArgs]</span> = None<span class="p">)</span>
+                    <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[EnumOverlay]]</span> = None<span class="p">,</span>
+                    <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[ConfigMapOverlayArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OverlayResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                     <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[OverlayResourceArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Other.<wbr>Example.<wbr>Enum<wbr>Overlay</a></span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Enum<wbr>Overlay?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Other.<wbr>Example.<wbr>Inputs.<wbr>Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Inputs.<wbr>Config<wbr>Map<wbr>Overlay<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -248,7 +248,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Enum<wbr>Overlay</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -256,7 +256,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Config<wbr>Map<wbr>Overlay<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Optional&lt;Enum<wbr>Overlay&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Config<wbr>Map<wbr>Overlay<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Enum<wbr>Overlay | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Config<wbr>Map<wbr>Overlay<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Enum<wbr>Overlay</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Config<wbr>Map<wbr>Overlay<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -336,7 +336,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_yaml" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">&#34;SOME_ENUM_VALUE&#34;</a></span>
+        <span class="property-type">&#34;SOME_ENUM_VALUE&#34;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -344,7 +344,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_yaml" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/resource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/other-owned/docs/typeuses/_index.md
@@ -32,9 +32,9 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">TypeUses</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[SomeOtherObjectArgs]</span> = None<span class="p">,</span>
-             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[ObjectWithNodeOptionalInputsArgs]</span> = None<span class="p">,</span>
-             <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[ObjectArgs]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[SomeOtherObjectArgs]]</span> = None<span class="p">,</span>
+             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Optional[ObjectWithNodeOptionalInputsArgs]]</span> = None<span class="p">,</span>
+             <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[ObjectArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">TypeUses</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[TypeUsesArgs]</a></span> = None<span class="p">,</span>
@@ -227,7 +227,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Other.<wbr>Example.<wbr>Inputs.<wbr>Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Inputs.<wbr>Some<wbr>Other<wbr>Object<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -235,7 +235,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Other.<wbr>Example.<wbr>Inputs.<wbr>Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Inputs.<wbr>Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -243,7 +243,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Other.<wbr>Example.<wbr>Inputs.<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Other.<wbr>Example.<wbr>Inputs.<wbr>Object<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -257,7 +257,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -265,7 +265,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -273,7 +273,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -287,7 +287,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Some<wbr>Other<wbr>Object<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -295,7 +295,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_java" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -303,7 +303,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Object<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -317,7 +317,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -325,7 +325,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -333,7 +333,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -347,7 +347,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -355,7 +355,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -363,7 +363,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -377,7 +377,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_yaml" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -385,7 +385,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_yaml" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -393,7 +393,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_yaml" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/ArgFunction.cs
@@ -34,7 +34,7 @@ namespace Other.Example
     public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
-        public Input<Other.Example.Resource>? Arg1 { get; set; }
+        public Input<Other.Example.Resource?>? Arg1 { get; set; }
 
         public ArgFunctionInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/BarResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/BarResource.cs
@@ -46,7 +46,7 @@ namespace Other.Example
     public sealed class BarResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<Other.Example.Resource>? Foo { get; set; }
+        public Input<Other.Example.Resource?>? Foo { get; set; }
 
         public BarResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/FooResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/FooResource.cs
@@ -46,7 +46,7 @@ namespace Other.Example
     public sealed class FooResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<Other.Example.Resource>? Foo { get; set; }
+        public Input<Other.Example.Resource?>? Foo { get; set; }
 
         public FooResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ConfigMapArgs.cs
@@ -14,7 +14,7 @@ namespace Other.Example.Inputs
     public sealed class ConfigMapArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
-        public Input<string>? Config { get; set; }
+        public Input<string?>? Config { get; set; }
 
         public ConfigMapArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectArgs.cs
@@ -14,42 +14,25 @@ namespace Other.Example.Inputs
     public sealed class ObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<string>? Bar { get; set; }
+        public Input<string?>? Bar { get; set; }
 
         [Input("configs")]
-        private InputList<Inputs.ConfigMapArgs>? _configs;
-        public InputList<Inputs.ConfigMapArgs> Configs
-        {
-            get => _configs ?? (_configs = new InputList<Inputs.ConfigMapArgs>());
-            set => _configs = value;
-        }
+        public Input<ImmutableArray<Input<Inputs.ConfigMapArgs>>>? Configs { get; set; }
 
         [Input("foo")]
-        public Input<Other.Example.Resource>? Foo { get; set; }
-
-        [Input("others")]
-        private InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>>? _others;
+        public Input<Other.Example.Resource?>? Foo { get; set; }
 
         /// <summary>
         /// List of lists of other objects
         /// </summary>
-        public InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>> Others
-        {
-            get => _others ?? (_others = new InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>>());
-            set => _others = value;
-        }
-
-        [Input("stillOthers")]
-        private InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>>? _stillOthers;
+        [Input("others")]
+        public Input<ImmutableArray<InputList<Inputs.SomeOtherObjectArgs>>>? Others { get; set; }
 
         /// <summary>
         /// Mapping from string to list of some other object
         /// </summary>
-        public InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>> StillOthers
-        {
-            get => _stillOthers ?? (_stillOthers = new InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>>());
-            set => _stillOthers = value;
-        }
+        [Input("stillOthers")]
+        public Input<ImmutableDictionary<string, InputList<Inputs.SomeOtherObjectArgs>>?>? StillOthers { get; set; }
 
         public ObjectArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -14,7 +14,7 @@ namespace Other.Example.Inputs
     public sealed class ObjectWithNodeOptionalInputsArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<int>? Bar { get; set; }
+        public Input<int?>? Bar { get; set; }
 
         [Input("foo", required: true)]
         public Input<string> Foo { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -14,7 +14,7 @@ namespace Other.Example.Inputs
     public sealed class SomeOtherObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
-        public Input<string>? Baz { get; set; }
+        public Input<string?>? Baz { get; set; }
 
         public SomeOtherObjectArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/OtherResource.cs
@@ -46,7 +46,7 @@ namespace Other.Example
     public sealed class OtherResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<Other.Example.Resource>? Foo { get; set; }
+        public Input<Other.Example.Resource?>? Foo { get; set; }
 
         public OtherResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Resource.cs
@@ -67,14 +67,14 @@ namespace Other.Example
     public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        private Input<string>? _bar;
-        public Input<string>? Bar
+        private Input<string?>? _bar;
+        public Input<string?>? Bar
         {
             get => _bar;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _bar = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _bar = Output.Tuple<Input<string?>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/TypeUses.cs
@@ -69,13 +69,13 @@ namespace Other.Example
     public sealed class TypeUsesArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<Inputs.SomeOtherObjectArgs>? Bar { get; set; }
+        public Input<Inputs.SomeOtherObjectArgs?>? Bar { get; set; }
 
         [Input("baz")]
-        public Input<Inputs.ObjectWithNodeOptionalInputsArgs>? Baz { get; set; }
+        public Input<Inputs.ObjectWithNodeOptionalInputsArgs?>? Baz { get; set; }
 
         [Input("foo")]
-        public Input<Inputs.ObjectArgs>? Foo { get; set; }
+        public Input<Inputs.ObjectArgs?>? Foo { get; set; }
 
         public TypeUsesArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/go/output-funcs-aws.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-aws-pp/go/output-funcs-aws.go
@@ -8,8 +8,8 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		aws_vpc, err := ec2.NewVpc(ctx, "aws_vpc", &ec2.VpcArgs{
-			CidrBlock:       pulumi.String("10.0.0.0/16"),
-			InstanceTenancy: pulumi.String("default"),
+			CidrBlock:       "10.0.0.0/16",
+			InstanceTenancy: "default",
 		})
 		if err != nil {
 			return err
@@ -33,14 +33,14 @@ func main() {
 		_, err = ec2.NewNetworkAclRule(ctx, "privateS3NetworkAclRule", &ec2.NetworkAclRuleArgs{
 			NetworkAclId: bar.ID(),
 			RuleNumber:   pulumi.Int(200),
-			Egress:       pulumi.Bool(false),
+			Egress:       false,
 			Protocol:     pulumi.String("tcp"),
 			RuleAction:   pulumi.String("allow"),
 			CidrBlock: privateS3PrefixList.ApplyT(func(privateS3PrefixList ec2.GetPrefixListResult) (string, error) {
 				return privateS3PrefixList.CidrBlocks[0], nil
 			}).(pulumi.StringOutput),
-			FromPort: pulumi.Int(443),
-			ToPort:   pulumi.Int(443),
+			FromPort: 443,
+			ToPort:   443,
 		})
 		if err != nil {
 			return err
@@ -49,8 +49,8 @@ func main() {
 			Owners: pulumi.StringArray{
 				bar.ID(),
 			},
-			Filters: ec2.GetAmiIdsFilterArray{
-				&ec2.GetAmiIdsFilterArgs{
+			Filters: []ec2.GetAmiIdsFilterArgs{
+				{
 					Name: bar.ID(),
 					Values: pulumi.StringArray{
 						pulumi.String("pulumi*"),

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listconfigurations/_index.md
@@ -51,8 +51,8 @@ function </span>listConfigurationsOutput<span class="p">(</span><span class="nx"
                         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ListConfigurationsResult</span
 ><span class="k">
 def </span>list_configurations_output<span class="p">(</span><span class="nx">configuration_filters</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Sequence[pulumi.Input[ConfigurationFiltersArgs]]]]</span> = None<span class="p">,</span>
-                        <span class="nx">customer_subscription_details</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[CustomerSubscriptionDetailsArgs]]</span> = None<span class="p">,</span>
-                        <span class="nx">skip_token</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+                        <span class="nx">customer_subscription_details</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[CustomerSubscriptionDetailsArgs]]</span> = None<span class="p">,</span>
+                        <span class="nx">skip_token</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ListConfigurationsResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/docs/listproductfamilies/_index.md
@@ -51,10 +51,10 @@ function </span>listProductFamiliesOutput<span class="p">(</span><span class="nx
                           <span class="nx">skip_token</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                           <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ListProductFamiliesResult</span
 ><span class="k">
-def </span>list_product_families_output<span class="p">(</span><span class="nx">customer_subscription_details</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[CustomerSubscriptionDetailsArgs]]</span> = None<span class="p">,</span>
-                          <span class="nx">expand</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>list_product_families_output<span class="p">(</span><span class="nx">customer_subscription_details</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[CustomerSubscriptionDetailsArgs]]</span> = None<span class="p">,</span>
+                          <span class="nx">expand</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                           <span class="nx">filterable_properties</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[FilterablePropertyArgs]]]]]]</span> = None<span class="p">,</span>
-                          <span class="nx">skip_token</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+                          <span class="nx">skip_token</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                           <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ListProductFamiliesResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFiltersArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/ConfigurationFiltersArgs.cs
@@ -15,17 +15,11 @@ namespace Pulumi.Myedgeorder.Inputs
     /// </summary>
     public sealed class ConfigurationFiltersArgs : global::Pulumi.ResourceArgs
     {
-        [Input("filterableProperty")]
-        private InputList<Inputs.FilterablePropertyArgs>? _filterableProperty;
-
         /// <summary>
         /// Filters specific to product
         /// </summary>
-        public InputList<Inputs.FilterablePropertyArgs> FilterableProperty
-        {
-            get => _filterableProperty ?? (_filterableProperty = new InputList<Inputs.FilterablePropertyArgs>());
-            set => _filterableProperty = value;
-        }
+        [Input("filterableProperty")]
+        public Input<ImmutableArray<Input<Inputs.FilterablePropertyArgs>>>? FilterableProperty { get; set; }
 
         /// <summary>
         /// Product hierarchy information

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetailsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionDetailsArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Myedgeorder.Inputs
         /// Location placement Id of a subscription
         /// </summary>
         [Input("locationPlacementId")]
-        public Input<string>? LocationPlacementId { get; set; }
+        public Input<string?>? LocationPlacementId { get; set; }
 
         /// <summary>
         /// Quota ID of a subscription
@@ -27,17 +27,11 @@ namespace Pulumi.Myedgeorder.Inputs
         [Input("quotaId", required: true)]
         public Input<string> QuotaId { get; set; } = null!;
 
-        [Input("registeredFeatures")]
-        private InputList<Inputs.CustomerSubscriptionRegisteredFeaturesArgs>? _registeredFeatures;
-
         /// <summary>
         /// List of registered feature flags for subscription
         /// </summary>
-        public InputList<Inputs.CustomerSubscriptionRegisteredFeaturesArgs> RegisteredFeatures
-        {
-            get => _registeredFeatures ?? (_registeredFeatures = new InputList<Inputs.CustomerSubscriptionRegisteredFeaturesArgs>());
-            set => _registeredFeatures = value;
-        }
+        [Input("registeredFeatures")]
+        public Input<ImmutableArray<Input<Inputs.CustomerSubscriptionRegisteredFeaturesArgs>>>? RegisteredFeatures { get; set; }
 
         public CustomerSubscriptionDetailsArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeaturesArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/CustomerSubscriptionRegisteredFeaturesArgs.cs
@@ -19,13 +19,13 @@ namespace Pulumi.Myedgeorder.Inputs
         /// Name of subscription registered feature
         /// </summary>
         [Input("name")]
-        public Input<string>? Name { get; set; }
+        public Input<string?>? Name { get; set; }
 
         /// <summary>
         /// State of subscription registered feature
         /// </summary>
         [Input("state")]
-        public Input<string>? State { get; set; }
+        public Input<string?>? State { get; set; }
 
         public CustomerSubscriptionRegisteredFeaturesArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformationArgs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Inputs/HierarchyInformationArgs.cs
@@ -19,25 +19,25 @@ namespace Pulumi.Myedgeorder.Inputs
         /// Represents configuration name that uniquely identifies configuration
         /// </summary>
         [Input("configurationName")]
-        public Input<string>? ConfigurationName { get; set; }
+        public Input<string?>? ConfigurationName { get; set; }
 
         /// <summary>
         /// Represents product family name that uniquely identifies product family
         /// </summary>
         [Input("productFamilyName")]
-        public Input<string>? ProductFamilyName { get; set; }
+        public Input<string?>? ProductFamilyName { get; set; }
 
         /// <summary>
         /// Represents product line name that uniquely identifies product line
         /// </summary>
         [Input("productLineName")]
-        public Input<string>? ProductLineName { get; set; }
+        public Input<string?>? ProductLineName { get; set; }
 
         /// <summary>
         /// Represents product name that uniquely identifies product
         /// </summary>
         [Input("productName")]
-        public Input<string>? ProductName { get; set; }
+        public Input<string?>? ProductName { get; set; }
 
         public HierarchyInformationArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListConfigurations.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListConfigurations.cs
@@ -77,13 +77,13 @@ namespace Pulumi.Myedgeorder
         /// Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
         /// </summary>
         [Input("customerSubscriptionDetails")]
-        public Input<Inputs.CustomerSubscriptionDetailsArgs>? CustomerSubscriptionDetails { get; set; }
+        public Input<Inputs.CustomerSubscriptionDetailsArgs?>? CustomerSubscriptionDetails { get; set; }
 
         /// <summary>
         /// $skipToken is supported on list of configurations, which provides the next page in the list of configurations.
         /// </summary>
         [Input("skipToken")]
-        public Input<string>? SkipToken { get; set; }
+        public Input<string?>? SkipToken { get; set; }
 
         public ListConfigurationsInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/ListProductFamilies.cs
@@ -71,13 +71,13 @@ namespace Pulumi.Myedgeorder
         /// Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
         /// </summary>
         [Input("customerSubscriptionDetails")]
-        public Input<Inputs.CustomerSubscriptionDetailsArgs>? CustomerSubscriptionDetails { get; set; }
+        public Input<Inputs.CustomerSubscriptionDetailsArgs?>? CustomerSubscriptionDetails { get; set; }
 
         /// <summary>
         /// $expand is supported on configurations parameter for product, which provides details on the configurations for the product.
         /// </summary>
         [Input("expand")]
-        public Input<string>? Expand { get; set; }
+        public Input<string?>? Expand { get; set; }
 
         [Input("filterableProperties", required: true)]
         private InputMap<ImmutableArray<Inputs.FilterablePropertyArgs>>? _filterableProperties;
@@ -95,7 +95,7 @@ namespace Pulumi.Myedgeorder
         /// $skipToken is supported on list of product families, which provides the next page in the list of product families.
         /// </summary>
         [Input("skipToken")]
-        public Input<string>? SkipToken { get; set; }
+        public Input<string?>? SkipToken { get; set; }
 
         public ListProductFamiliesInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listConfigurations.go
@@ -55,9 +55,9 @@ type ListConfigurationsOutputArgs struct {
 	// Holds details about product hierarchy information and filterable property.
 	ConfigurationFilters ConfigurationFiltersArrayInput `pulumi:"configurationFilters"`
 	// Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
-	CustomerSubscriptionDetails CustomerSubscriptionDetailsPtrInput `pulumi:"customerSubscriptionDetails"`
+	CustomerSubscriptionDetails *CustomerSubscriptionDetailsArgs `pulumi:"customerSubscriptionDetails"`
 	// $skipToken is supported on list of configurations, which provides the next page in the list of configurations.
-	SkipToken pulumi.StringPtrInput `pulumi:"skipToken"`
+	SkipToken *string `pulumi:"skipToken"`
 }
 
 func (ListConfigurationsOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/listProductFamilies.go
@@ -55,13 +55,13 @@ func ListProductFamiliesOutput(ctx *pulumi.Context, args ListProductFamiliesOutp
 
 type ListProductFamiliesOutputArgs struct {
 	// Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
-	CustomerSubscriptionDetails CustomerSubscriptionDetailsPtrInput `pulumi:"customerSubscriptionDetails"`
+	CustomerSubscriptionDetails *CustomerSubscriptionDetailsArgs `pulumi:"customerSubscriptionDetails"`
 	// $expand is supported on configurations parameter for product, which provides details on the configurations for the product.
-	Expand pulumi.StringPtrInput `pulumi:"expand"`
+	Expand *string `pulumi:"expand"`
 	// Dictionary of filterable properties on product family.
 	FilterableProperties FilterablePropertyArrayMapInput `pulumi:"filterableProperties"`
 	// $skipToken is supported on list of product families, which provides the next page in the list of product families.
-	SkipToken pulumi.StringPtrInput `pulumi:"skipToken"`
+	SkipToken *string `pulumi:"skipToken"`
 }
 
 func (ListProductFamiliesOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
@@ -232,7 +232,7 @@ type ConfigurationFiltersInput interface {
 // Configuration filters
 type ConfigurationFiltersArgs struct {
 	// Filters specific to product
-	FilterableProperty FilterablePropertyArrayInput `pulumi:"filterableProperty"`
+	FilterableProperty []FilterablePropertyInput `pulumi:"filterableProperty"`
 	// Product hierarchy information
 	HierarchyInformation HierarchyInformationInput `pulumi:"hierarchyInformation"`
 }
@@ -579,11 +579,11 @@ type CustomerSubscriptionDetailsInput interface {
 // Holds Customer subscription details. Clients can display available products to unregistered customers by explicitly passing subscription details
 type CustomerSubscriptionDetailsArgs struct {
 	// Location placement Id of a subscription
-	LocationPlacementId pulumi.StringPtrInput `pulumi:"locationPlacementId"`
+	LocationPlacementId *string `pulumi:"locationPlacementId"`
 	// Quota ID of a subscription
 	QuotaId pulumi.StringInput `pulumi:"quotaId"`
 	// List of registered feature flags for subscription
-	RegisteredFeatures CustomerSubscriptionRegisteredFeaturesArrayInput `pulumi:"registeredFeatures"`
+	RegisteredFeatures []CustomerSubscriptionRegisteredFeaturesInput `pulumi:"registeredFeatures"`
 }
 
 func (CustomerSubscriptionDetailsArgs) ElementType() reflect.Type {
@@ -757,9 +757,9 @@ type CustomerSubscriptionRegisteredFeaturesInput interface {
 // Represents subscription registered features
 type CustomerSubscriptionRegisteredFeaturesArgs struct {
 	// Name of subscription registered feature
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// State of subscription registered feature
-	State pulumi.StringPtrInput `pulumi:"state"`
+	State *string `pulumi:"state"`
 }
 
 func (CustomerSubscriptionRegisteredFeaturesArgs) ElementType() reflect.Type {
@@ -1297,13 +1297,13 @@ type HierarchyInformationInput interface {
 // Holds details about product hierarchy information
 type HierarchyInformationArgs struct {
 	// Represents configuration name that uniquely identifies configuration
-	ConfigurationName pulumi.StringPtrInput `pulumi:"configurationName"`
+	ConfigurationName *string `pulumi:"configurationName"`
 	// Represents product family name that uniquely identifies product family
-	ProductFamilyName pulumi.StringPtrInput `pulumi:"productFamilyName"`
+	ProductFamilyName *string `pulumi:"productFamilyName"`
 	// Represents product line name that uniquely identifies product line
-	ProductLineName pulumi.StringPtrInput `pulumi:"productLineName"`
+	ProductLineName *string `pulumi:"productLineName"`
 	// Represents product name that uniquely identifies product
-	ProductName pulumi.StringPtrInput `pulumi:"productName"`
+	ProductName *string `pulumi:"productName"`
 }
 
 func (HierarchyInformationArgs) ElementType() reflect.Type {
@@ -1379,13 +1379,13 @@ type HierarchyInformationResponseInput interface {
 // Holds details about product hierarchy information
 type HierarchyInformationResponseArgs struct {
 	// Represents configuration name that uniquely identifies configuration
-	ConfigurationName pulumi.StringPtrInput `pulumi:"configurationName"`
+	ConfigurationName *string `pulumi:"configurationName"`
 	// Represents product family name that uniquely identifies product family
-	ProductFamilyName pulumi.StringPtrInput `pulumi:"productFamilyName"`
+	ProductFamilyName *string `pulumi:"productFamilyName"`
 	// Represents product line name that uniquely identifies product line
-	ProductLineName pulumi.StringPtrInput `pulumi:"productLineName"`
+	ProductLineName *string `pulumi:"productLineName"`
 	// Represents product name that uniquely identifies product
-	ProductName pulumi.StringPtrInput `pulumi:"productName"`
+	ProductName *string `pulumi:"productName"`
 }
 
 func (HierarchyInformationResponseArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listConfigurations.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listConfigurations.ts
@@ -65,9 +65,9 @@ export interface ListConfigurationsOutputArgs {
     /**
      * Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
      */
-    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs>;
+    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs | undefined>;
     /**
      * $skipToken is supported on list of configurations, which provides the next page in the list of configurations.
      */
-    skipToken?: pulumi.Input<string>;
+    skipToken?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listProductFamilies.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/listProductFamilies.ts
@@ -66,11 +66,11 @@ export interface ListProductFamiliesOutputArgs {
     /**
      * Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
      */
-    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs>;
+    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs | undefined>;
     /**
      * $expand is supported on configurations parameter for product, which provides details on the configurations for the product.
      */
-    expand?: pulumi.Input<string>;
+    expand?: pulumi.Input<string | undefined>;
     /**
      * Dictionary of filterable properties on product family.
      */
@@ -78,5 +78,5 @@ export interface ListProductFamiliesOutputArgs {
     /**
      * $skipToken is supported on list of product families, which provides the next page in the list of product families.
      */
-    skipToken?: pulumi.Input<string>;
+    skipToken?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/nodejs/types/input.ts
@@ -27,7 +27,7 @@ export interface ConfigurationFiltersArgs {
     /**
      * Filters specific to product
      */
-    filterableProperty?: pulumi.Input<pulumi.Input<inputs.FilterablePropertyArgs>[]>;
+    filterableProperty?: pulumi.Input<pulumi.Input<inputs.FilterablePropertyArgs>[] | undefined>;
     /**
      * Product hierarchy information
      */
@@ -59,7 +59,7 @@ export interface CustomerSubscriptionDetailsArgs {
     /**
      * Location placement Id of a subscription
      */
-    locationPlacementId?: pulumi.Input<string>;
+    locationPlacementId?: pulumi.Input<string | undefined>;
     /**
      * Quota ID of a subscription
      */
@@ -67,7 +67,7 @@ export interface CustomerSubscriptionDetailsArgs {
     /**
      * List of registered feature flags for subscription
      */
-    registeredFeatures?: pulumi.Input<pulumi.Input<inputs.CustomerSubscriptionRegisteredFeaturesArgs>[]>;
+    registeredFeatures?: pulumi.Input<pulumi.Input<inputs.CustomerSubscriptionRegisteredFeaturesArgs>[] | undefined>;
 }
 
 /**
@@ -91,11 +91,11 @@ export interface CustomerSubscriptionRegisteredFeaturesArgs {
     /**
      * Name of subscription registered feature
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * State of subscription registered feature
      */
-    state?: pulumi.Input<string>;
+    state?: pulumi.Input<string | undefined>;
 }
 
 /**
@@ -155,18 +155,18 @@ export interface HierarchyInformationArgs {
     /**
      * Represents configuration name that uniquely identifies configuration
      */
-    configurationName?: pulumi.Input<string>;
+    configurationName?: pulumi.Input<string | undefined>;
     /**
      * Represents product family name that uniquely identifies product family
      */
-    productFamilyName?: pulumi.Input<string>;
+    productFamilyName?: pulumi.Input<string | undefined>;
     /**
      * Represents product line name that uniquely identifies product line
      */
-    productLineName?: pulumi.Input<string>;
+    productLineName?: pulumi.Input<string | undefined>;
     /**
      * Represents product name that uniquely identifies product
      */
-    productName?: pulumi.Input<string>;
+    productName?: pulumi.Input<string | undefined>;
 }
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
@@ -86,8 +86,8 @@ def list_configurations(configuration_filters: Optional[Sequence[pulumi.InputTyp
 
 @_utilities.lift_output_func(list_configurations)
 def list_configurations_output(configuration_filters: Optional[pulumi.Input[Sequence[pulumi.InputType['ConfigurationFilters']]]] = None,
-                               customer_subscription_details: Optional[pulumi.Input[Optional[pulumi.InputType['CustomerSubscriptionDetails']]]] = None,
-                               skip_token: Optional[pulumi.Input[Optional[str]]] = None,
+                               customer_subscription_details: pulumi.Input[Optional[pulumi.InputType['CustomerSubscriptionDetails']]] = None,
+                               skip_token: pulumi.Input[Optional[str]] = None,
                                opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ListConfigurationsResult]:
     """
     The list of configurations.

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
@@ -88,10 +88,10 @@ def list_product_families(customer_subscription_details: Optional[pulumi.InputTy
 
 
 @_utilities.lift_output_func(list_product_families)
-def list_product_families_output(customer_subscription_details: Optional[pulumi.Input[Optional[pulumi.InputType['CustomerSubscriptionDetails']]]] = None,
-                                 expand: Optional[pulumi.Input[Optional[str]]] = None,
+def list_product_families_output(customer_subscription_details: pulumi.Input[Optional[pulumi.InputType['CustomerSubscriptionDetails']]] = None,
+                                 expand: pulumi.Input[Optional[str]] = None,
                                  filterable_properties: Optional[pulumi.Input[Mapping[str, Sequence[pulumi.InputType['FilterableProperty']]]]] = None,
-                                 skip_token: Optional[pulumi.Input[Optional[str]]] = None,
+                                 skip_token: pulumi.Input[Optional[str]] = None,
                                  opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ListProductFamiliesResult]:
     """
     The list of product families.

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/getamiids/_index.md
@@ -53,11 +53,11 @@ function </span>getAmiIdsOutput<span class="p">(</span><span class="nx">args</sp
                 <span class="nx">sort_ascending</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetAmiIdsResult</span
 ><span class="k">
-def </span>get_ami_ids_output<span class="p">(</span><span class="nx">executable_users</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]</span> = None<span class="p">,</span>
-                <span class="nx">filters</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Sequence[pulumi.Input[GetAmiIdsFilterArgs]]]]</span> = None<span class="p">,</span>
-                <span class="nx">name_regex</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>get_ami_ids_output<span class="p">(</span><span class="nx">executable_users</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Sequence[pulumi.Input[str]]]]</span> = None<span class="p">,</span>
+                <span class="nx">filters</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Sequence[pulumi.Input[GetAmiIdsFilterArgs]]]]</span> = None<span class="p">,</span>
+                <span class="nx">name_regex</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                 <span class="nx">owners</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]</span> = None<span class="p">,</span>
-                <span class="nx">sort_ascending</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[bool]]</span> = None<span class="p">,</span>
+                <span class="nx">sort_ascending</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[bool]]</span> = None<span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetAmiIdsResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/docs/liststorageaccountkeys/_index.md
@@ -51,7 +51,7 @@ function </span>listStorageAccountKeysOutput<span class="p">(</span><span class=
                               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ListStorageAccountKeysResult</span
 ><span class="k">
 def </span>list_storage_account_keys_output<span class="p">(</span><span class="nx">account_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                              <span class="nx">expand</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+                              <span class="nx">expand</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                               <span class="nx">resource_group_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
                               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ListStorageAccountKeysResult]</span
 ></code></pre></div>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/GetAmiIds.cs
@@ -91,32 +91,20 @@ namespace Pulumi.Mypkg
 
     public sealed class GetAmiIdsInvokeArgs : global::Pulumi.InvokeArgs
     {
-        [Input("executableUsers")]
-        private InputList<string>? _executableUsers;
-
         /// <summary>
         /// Limit search to users with *explicit* launch
         /// permission on  the image. Valid items are the numeric account ID or `self`.
         /// </summary>
-        public InputList<string> ExecutableUsers
-        {
-            get => _executableUsers ?? (_executableUsers = new InputList<string>());
-            set => _executableUsers = value;
-        }
-
-        [Input("filters")]
-        private InputList<Inputs.GetAmiIdsFilterInputArgs>? _filters;
+        [Input("executableUsers")]
+        public Input<ImmutableArray<Input<string>>>? ExecutableUsers { get; set; }
 
         /// <summary>
         /// One or more name/value pairs to filter off of. There
         /// are several valid keys, for a full reference, check out
         /// [describe-images in the AWS CLI reference][1].
         /// </summary>
-        public InputList<Inputs.GetAmiIdsFilterInputArgs> Filters
-        {
-            get => _filters ?? (_filters = new InputList<Inputs.GetAmiIdsFilterInputArgs>());
-            set => _filters = value;
-        }
+        [Input("filters")]
+        public Input<ImmutableArray<Input<Inputs.GetAmiIdsFilterInputArgs>>>? Filters { get; set; }
 
         /// <summary>
         /// A regex string to apply to the AMI list returned
@@ -126,7 +114,7 @@ namespace Pulumi.Mypkg
         /// options to narrow down the list AWS returns.
         /// </summary>
         [Input("nameRegex")]
-        public Input<string>? NameRegex { get; set; }
+        public Input<string?>? NameRegex { get; set; }
 
         [Input("owners", required: true)]
         private InputList<string>? _owners;
@@ -144,7 +132,7 @@ namespace Pulumi.Mypkg
         /// Used to sort AMIs by creation time.
         /// </summary>
         [Input("sortAscending")]
-        public Input<bool>? SortAscending { get; set; }
+        public Input<bool?>? SortAscending { get; set; }
 
         public GetAmiIdsInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/ListStorageAccountKeys.cs
@@ -65,7 +65,7 @@ namespace Pulumi.Mypkg
         /// Specifies type of the key to be listed. Possible value is kerb.
         /// </summary>
         [Input("expand")]
-        public Input<string>? Expand { get; set; }
+        public Input<string?>? Expand { get; set; }
 
         /// <summary>
         /// The name of the resource group within the user's subscription. The name is case insensitive.

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/getAmiIds.go
@@ -72,21 +72,21 @@ func GetAmiIdsOutput(ctx *pulumi.Context, args GetAmiIdsOutputArgs, opts ...pulu
 type GetAmiIdsOutputArgs struct {
 	// Limit search to users with *explicit* launch
 	// permission on  the image. Valid items are the numeric account ID or `self`.
-	ExecutableUsers pulumi.StringArrayInput `pulumi:"executableUsers"`
+	ExecutableUsers []pulumi.StringInput `pulumi:"executableUsers"`
 	// One or more name/value pairs to filter off of. There
 	// are several valid keys, for a full reference, check out
 	// [describe-images in the AWS CLI reference][1].
-	Filters GetAmiIdsFilterArrayInput `pulumi:"filters"`
+	Filters []GetAmiIdsFilterInput `pulumi:"filters"`
 	// A regex string to apply to the AMI list returned
 	// by AWS. This allows more advanced filtering not supported from the AWS API.
 	// This filtering is done locally on what AWS returns, and could have a performance
 	// impact if the result is large. It is recommended to combine this with other
 	// options to narrow down the list AWS returns.
-	NameRegex pulumi.StringPtrInput `pulumi:"nameRegex"`
+	NameRegex *string `pulumi:"nameRegex"`
 	// List of AMI owners to limit search. At least 1 value must be specified. Valid values: an AWS account ID, `self` (the current account), or an AWS owner alias (e.g. `amazon`, `aws-marketplace`, `microsoft`).
 	Owners pulumi.StringArrayInput `pulumi:"owners"`
 	// Used to sort AMIs by creation time.
-	SortAscending pulumi.BoolPtrInput `pulumi:"sortAscending"`
+	SortAscending *bool `pulumi:"sortAscending"`
 }
 
 func (GetAmiIdsOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/go/mypkg/listStorageAccountKeys.go
@@ -53,7 +53,7 @@ type ListStorageAccountKeysOutputArgs struct {
 	// The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
 	AccountName pulumi.StringInput `pulumi:"accountName"`
 	// Specifies type of the key to be listed. Possible value is kerb.
-	Expand pulumi.StringPtrInput `pulumi:"expand"`
+	Expand *string `pulumi:"expand"`
 	// The name of the resource group within the user's subscription. The name is case insensitive.
 	ResourceGroupName pulumi.StringInput `pulumi:"resourceGroupName"`
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/getAmiIds.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/getAmiIds.ts
@@ -87,13 +87,13 @@ export interface GetAmiIdsOutputArgs {
      * Limit search to users with *explicit* launch
      * permission on  the image. Valid items are the numeric account ID or `self`.
      */
-    executableUsers?: pulumi.Input<pulumi.Input<string>[]>;
+    executableUsers?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * One or more name/value pairs to filter off of. There
      * are several valid keys, for a full reference, check out
      * [describe-images in the AWS CLI reference][1].
      */
-    filters?: pulumi.Input<pulumi.Input<inputs.GetAmiIdsFilterArgs>[]>;
+    filters?: pulumi.Input<pulumi.Input<inputs.GetAmiIdsFilterArgs>[] | undefined>;
     /**
      * A regex string to apply to the AMI list returned
      * by AWS. This allows more advanced filtering not supported from the AWS API.
@@ -101,7 +101,7 @@ export interface GetAmiIdsOutputArgs {
      * impact if the result is large. It is recommended to combine this with other
      * options to narrow down the list AWS returns.
      */
-    nameRegex?: pulumi.Input<string>;
+    nameRegex?: pulumi.Input<string | undefined>;
     /**
      * List of AMI owners to limit search. At least 1 value must be specified. Valid values: an AWS account ID, `self` (the current account), or an AWS owner alias (e.g. `amazon`, `aws-marketplace`, `microsoft`).
      */
@@ -109,5 +109,5 @@ export interface GetAmiIdsOutputArgs {
     /**
      * Used to sort AMIs by creation time.
      */
-    sortAscending?: pulumi.Input<boolean>;
+    sortAscending?: pulumi.Input<boolean | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
@@ -60,7 +60,7 @@ export interface ListStorageAccountKeysOutputArgs {
     /**
      * Specifies type of the key to be listed. Possible value is kerb.
      */
-    expand?: pulumi.Input<string>;
+    expand?: pulumi.Input<string | undefined>;
     /**
      * The name of the resource group within the user's subscription. The name is case insensitive.
      */

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
@@ -146,11 +146,11 @@ def get_ami_ids(executable_users: Optional[Sequence[str]] = None,
 
 
 @_utilities.lift_output_func(get_ami_ids)
-def get_ami_ids_output(executable_users: Optional[pulumi.Input[Optional[Sequence[str]]]] = None,
-                       filters: Optional[pulumi.Input[Optional[Sequence[pulumi.InputType['GetAmiIdsFilterArgs']]]]] = None,
-                       name_regex: Optional[pulumi.Input[Optional[str]]] = None,
+def get_ami_ids_output(executable_users: pulumi.Input[Optional[Sequence[str]]] = None,
+                       filters: pulumi.Input[Optional[Sequence[pulumi.InputType['GetAmiIdsFilterArgs']]]] = None,
+                       name_regex: pulumi.Input[Optional[str]] = None,
                        owners: Optional[pulumi.Input[Sequence[str]]] = None,
-                       sort_ascending: Optional[pulumi.Input[Optional[bool]]] = None,
+                       sort_ascending: pulumi.Input[Optional[bool]] = None,
                        opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetAmiIdsResult]:
     """
     Taken from pulumi-AWS to regress an issue

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
@@ -71,7 +71,7 @@ def list_storage_account_keys(account_name: Optional[str] = None,
 
 @_utilities.lift_output_func(list_storage_account_keys)
 def list_storage_account_keys_output(account_name: Optional[pulumi.Input[str]] = None,
-                                     expand: Optional[pulumi.Input[Optional[str]]] = None,
+                                     expand: pulumi.Input[Optional[str]] = None,
                                      resource_group_name: Optional[pulumi.Input[str]] = None,
                                      opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ListStorageAccountKeysResult]:
     """

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithalloptionalinputs/_index.md
@@ -48,8 +48,8 @@ function </span>funcWithAllOptionalInputsOutput<span class="p">(</span><span cla
                                   <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithAllOptionalInputsResult</span
 ><span class="k">
-def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
+                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithAllOptionalInputsResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdefaultvalue/_index.md
@@ -49,7 +49,7 @@ function </span>funcWithDefaultValueOutput<span class="p">(</span><span class="n
                             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithDefaultValueResult</span
 ><span class="k">
 def </span>func_with_default_value_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                            <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+                            <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithDefaultValueResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithdictparam/_index.md
@@ -48,8 +48,8 @@ function </span>funcWithDictParamOutput<span class="p">(</span><span class="nx">
                          <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                          <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithDictParamResult</span
 ><span class="k">
-def </span>func_with_dict_param_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]</span> = None<span class="p">,</span>
-                         <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>func_with_dict_param_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Mapping[str, pulumi.Input[str]]]]</span> = None<span class="p">,</span>
+                         <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                          <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithDictParamResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/funcwithlistparam/_index.md
@@ -48,8 +48,8 @@ function </span>funcWithListParamOutput<span class="p">(</span><span class="nx">
                          <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                          <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithListParamResult</span
 ><span class="k">
-def </span>func_with_list_param_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]</span> = None<span class="p">,</span>
-                         <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>func_with_list_param_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Sequence[pulumi.Input[str]]]]</span> = None<span class="p">,</span>
+                         <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                          <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithListParamResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getbastionshareablelink/_index.md
@@ -52,7 +52,7 @@ function </span>getBastionShareableLinkOutput<span class="p">(</span><span class
 ><span class="k">
 def </span>get_bastion_shareable_link_output<span class="p">(</span><span class="nx">bastion_host_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
                                <span class="nx">resource_group_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                               <span class="nx">vms</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Sequence[pulumi.Input[BastionShareableLinkArgs]]]]</span> = None<span class="p">,</span>
+                               <span class="nx">vms</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Sequence[pulumi.Input[BastionShareableLinkArgs]]]]</span> = None<span class="p">,</span>
                                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetBastionShareableLinkResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/getintegrationruntimeobjectmetadatum/_index.md
@@ -53,7 +53,7 @@ function </span>getIntegrationRuntimeObjectMetadatumOutput<span class="p">(</spa
 ><span class="k">
 def </span>get_integration_runtime_object_metadatum_output<span class="p">(</span><span class="nx">factory_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
                                              <span class="nx">integration_runtime_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                                             <span class="nx">metadata_path</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+                                             <span class="nx">metadata_path</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                                              <span class="nx">resource_group_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
                                              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetIntegrationRuntimeObjectMetadatumResult]</span
 ></code></pre></div>

--- a/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
+++ b/pkg/codegen/testing/test/testdata/output-funcs/docs/liststorageaccountkeys/_index.md
@@ -51,7 +51,7 @@ function </span>listStorageAccountKeysOutput<span class="p">(</span><span class=
                               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ListStorageAccountKeysResult</span
 ><span class="k">
 def </span>list_storage_account_keys_output<span class="p">(</span><span class="nx">account_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                              <span class="nx">expand</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+                              <span class="nx">expand</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                               <span class="nx">resource_group_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
                               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ListStorageAccountKeysResult]</span
 ></code></pre></div>

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithAllOptionalInputs.cs
@@ -51,13 +51,13 @@ namespace Pulumi.Mypkg
         /// Property A
         /// </summary>
         [Input("a")]
-        public Input<string>? A { get; set; }
+        public Input<string?>? A { get; set; }
 
         /// <summary>
         /// Property B
         /// </summary>
         [Input("b")]
-        public Input<string>? B { get; set; }
+        public Input<string?>? B { get; set; }
 
         public FuncWithAllOptionalInputsInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDefaultValue.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDefaultValue.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Mypkg
         public Input<string> A { get; set; } = null!;
 
         [Input("b")]
-        public Input<string>? B { get; set; }
+        public Input<string?>? B { get; set; }
 
         public FuncWithDefaultValueInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDictParam.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithDictParam.cs
@@ -47,15 +47,10 @@ namespace Pulumi.Mypkg
     public sealed class FuncWithDictParamInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("a")]
-        private InputMap<string>? _a;
-        public InputMap<string> A
-        {
-            get => _a ?? (_a = new InputMap<string>());
-            set => _a = value;
-        }
+        public Input<ImmutableDictionary<string, Input<string>>?>? A { get; set; }
 
         [Input("b")]
-        public Input<string>? B { get; set; }
+        public Input<string?>? B { get; set; }
 
         public FuncWithDictParamInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithListParam.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/FuncWithListParam.cs
@@ -47,15 +47,10 @@ namespace Pulumi.Mypkg
     public sealed class FuncWithListParamInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("a")]
-        private InputList<string>? _a;
-        public InputList<string> A
-        {
-            get => _a ?? (_a = new InputList<string>());
-            set => _a = value;
-        }
+        public Input<ImmutableArray<Input<string>>>? A { get; set; }
 
         [Input("b")]
-        public Input<string>? B { get; set; }
+        public Input<string?>? B { get; set; }
 
         public FuncWithListParamInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetBastionShareableLink.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetBastionShareableLink.cs
@@ -73,17 +73,11 @@ namespace Pulumi.Mypkg
         [Input("resourceGroupName", required: true)]
         public Input<string> ResourceGroupName { get; set; } = null!;
 
-        [Input("vms")]
-        private InputList<Inputs.BastionShareableLinkArgs>? _vms;
-
         /// <summary>
         /// List of VM references.
         /// </summary>
-        public InputList<Inputs.BastionShareableLinkArgs> Vms
-        {
-            get => _vms ?? (_vms = new InputList<Inputs.BastionShareableLinkArgs>());
-            set => _vms = value;
-        }
+        [Input("vms")]
+        public Input<ImmutableArray<Input<Inputs.BastionShareableLinkArgs>>>? Vms { get; set; }
 
         public GetBastionShareableLinkInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/GetIntegrationRuntimeObjectMetadatum.cs
@@ -77,7 +77,7 @@ namespace Pulumi.Mypkg
         /// Metadata path.
         /// </summary>
         [Input("metadataPath")]
-        public Input<string>? MetadataPath { get; set; }
+        public Input<string?>? MetadataPath { get; set; }
 
         /// <summary>
         /// The resource group name.

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/ListStorageAccountKeys.cs
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/ListStorageAccountKeys.cs
@@ -65,7 +65,7 @@ namespace Pulumi.Mypkg
         /// Specifies type of the key to be listed. Possible value is kerb.
         /// </summary>
         [Input("expand")]
-        public Input<string>? Expand { get; set; }
+        public Input<string?>? Expand { get; set; }
 
         /// <summary>
         /// The name of the resource group within the user's subscription. The name is case insensitive.

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithAllOptionalInputs.go
@@ -46,9 +46,9 @@ func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOption
 
 type FuncWithAllOptionalInputsOutputArgs struct {
 	// Property A
-	A pulumi.StringPtrInput `pulumi:"a"`
+	A *string `pulumi:"a"`
 	// Property B
-	B pulumi.StringPtrInput `pulumi:"b"`
+	B *string `pulumi:"b"`
 }
 
 func (FuncWithAllOptionalInputsOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDefaultValue.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDefaultValue.go
@@ -56,8 +56,8 @@ func FuncWithDefaultValueOutput(ctx *pulumi.Context, args FuncWithDefaultValueOu
 }
 
 type FuncWithDefaultValueOutputArgs struct {
-	A pulumi.StringInput    `pulumi:"a"`
-	B pulumi.StringPtrInput `pulumi:"b"`
+	A pulumi.StringInput `pulumi:"a"`
+	B *string            `pulumi:"b"`
 }
 
 func (FuncWithDefaultValueOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDictParam.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithDictParam.go
@@ -43,8 +43,8 @@ func FuncWithDictParamOutput(ctx *pulumi.Context, args FuncWithDictParamOutputAr
 }
 
 type FuncWithDictParamOutputArgs struct {
-	A pulumi.StringMapInput `pulumi:"a"`
-	B pulumi.StringPtrInput `pulumi:"b"`
+	A map[string]pulumi.StringInput `pulumi:"a"`
+	B *string                       `pulumi:"b"`
 }
 
 func (FuncWithDictParamOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithListParam.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/funcWithListParam.go
@@ -43,8 +43,8 @@ func FuncWithListParamOutput(ctx *pulumi.Context, args FuncWithListParamOutputAr
 }
 
 type FuncWithListParamOutputArgs struct {
-	A pulumi.StringArrayInput `pulumi:"a"`
-	B pulumi.StringPtrInput   `pulumi:"b"`
+	A []pulumi.StringInput `pulumi:"a"`
+	B *string              `pulumi:"b"`
 }
 
 func (FuncWithListParamOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getBastionShareableLink.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getBastionShareableLink.go
@@ -55,7 +55,7 @@ type GetBastionShareableLinkOutputArgs struct {
 	// The name of the resource group.
 	ResourceGroupName pulumi.StringInput `pulumi:"resourceGroupName"`
 	// List of VM references.
-	Vms BastionShareableLinkArrayInput `pulumi:"vms"`
+	Vms []BastionShareableLinkInput `pulumi:"vms"`
 }
 
 func (GetBastionShareableLinkOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/getIntegrationRuntimeObjectMetadatum.go
@@ -59,7 +59,7 @@ type GetIntegrationRuntimeObjectMetadatumOutputArgs struct {
 	// The integration runtime name.
 	IntegrationRuntimeName pulumi.StringInput `pulumi:"integrationRuntimeName"`
 	// Metadata path.
-	MetadataPath pulumi.StringPtrInput `pulumi:"metadataPath"`
+	MetadataPath *string `pulumi:"metadataPath"`
 	// The resource group name.
 	ResourceGroupName pulumi.StringInput `pulumi:"resourceGroupName"`
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/listStorageAccountKeys.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/listStorageAccountKeys.go
@@ -53,7 +53,7 @@ type ListStorageAccountKeysOutputArgs struct {
 	// The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
 	AccountName pulumi.StringInput `pulumi:"accountName"`
 	// Specifies type of the key to be listed. Possible value is kerb.
-	Expand pulumi.StringPtrInput `pulumi:"expand"`
+	Expand *string `pulumi:"expand"`
 	// The name of the resource group within the user's subscription. The name is case insensitive.
 	ResourceGroupName pulumi.StringInput `pulumi:"resourceGroupName"`
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/output-funcs/go/mypkg/pulumiTypes.go
@@ -136,13 +136,13 @@ type SsisEnvironmentReferenceResponseInput interface {
 // Ssis environment reference.
 type SsisEnvironmentReferenceResponseArgs struct {
 	// Environment folder name.
-	EnvironmentFolderName pulumi.StringPtrInput `pulumi:"environmentFolderName"`
+	EnvironmentFolderName *string `pulumi:"environmentFolderName"`
 	// Environment name.
-	EnvironmentName pulumi.StringPtrInput `pulumi:"environmentName"`
+	EnvironmentName *string `pulumi:"environmentName"`
 	// Environment reference id.
-	Id pulumi.Float64PtrInput `pulumi:"id"`
+	Id *float64 `pulumi:"id"`
 	// Reference type
-	ReferenceType pulumi.StringPtrInput `pulumi:"referenceType"`
+	ReferenceType *string `pulumi:"referenceType"`
 }
 
 func (SsisEnvironmentReferenceResponseArgs) ElementType() reflect.Type {
@@ -268,18 +268,18 @@ type SsisEnvironmentResponseInput interface {
 // Ssis environment.
 type SsisEnvironmentResponseArgs struct {
 	// Metadata description.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description *string `pulumi:"description"`
 	// Folder id which contains environment.
-	FolderId pulumi.Float64PtrInput `pulumi:"folderId"`
+	FolderId *float64 `pulumi:"folderId"`
 	// Metadata id.
-	Id pulumi.Float64PtrInput `pulumi:"id"`
+	Id *float64 `pulumi:"id"`
 	// Metadata name.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// The type of SSIS object metadata.
 	// Expected value is 'Environment'.
 	Type pulumi.StringInput `pulumi:"type"`
 	// Variable in environment
-	Variables SsisVariableResponseArrayInput `pulumi:"variables"`
+	Variables []SsisVariableResponseInput `pulumi:"variables"`
 }
 
 func (SsisEnvironmentResponseArgs) ElementType() reflect.Type {
@@ -367,11 +367,11 @@ type SsisFolderResponseInput interface {
 // Ssis folder.
 type SsisFolderResponseArgs struct {
 	// Metadata description.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description *string `pulumi:"description"`
 	// Metadata id.
-	Id pulumi.Float64PtrInput `pulumi:"id"`
+	Id *float64 `pulumi:"id"`
 	// Metadata name.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// The type of SSIS object metadata.
 	// Expected value is 'Folder'.
 	Type pulumi.StringInput `pulumi:"type"`
@@ -460,19 +460,19 @@ type SsisPackageResponseInput interface {
 // Ssis Package.
 type SsisPackageResponseArgs struct {
 	// Metadata description.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description *string `pulumi:"description"`
 	// Folder id which contains package.
-	FolderId pulumi.Float64PtrInput `pulumi:"folderId"`
+	FolderId *float64 `pulumi:"folderId"`
 	// Metadata id.
-	Id pulumi.Float64PtrInput `pulumi:"id"`
+	Id *float64 `pulumi:"id"`
 	// Metadata name.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Parameters in package
-	Parameters SsisParameterResponseArrayInput `pulumi:"parameters"`
+	Parameters []SsisParameterResponseInput `pulumi:"parameters"`
 	// Project id which contains package.
-	ProjectId pulumi.Float64PtrInput `pulumi:"projectId"`
+	ProjectId *float64 `pulumi:"projectId"`
 	// Project version which contains package.
-	ProjectVersion pulumi.Float64PtrInput `pulumi:"projectVersion"`
+	ProjectVersion *float64 `pulumi:"projectVersion"`
 	// The type of SSIS object metadata.
 	// Expected value is 'Package'.
 	Type pulumi.StringInput `pulumi:"type"`
@@ -588,29 +588,29 @@ type SsisParameterResponseInput interface {
 // Ssis parameter.
 type SsisParameterResponseArgs struct {
 	// Parameter type.
-	DataType pulumi.StringPtrInput `pulumi:"dataType"`
+	DataType *string `pulumi:"dataType"`
 	// Default value of parameter.
-	DefaultValue pulumi.StringPtrInput `pulumi:"defaultValue"`
+	DefaultValue *string `pulumi:"defaultValue"`
 	// Parameter description.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description *string `pulumi:"description"`
 	// Design default value of parameter.
-	DesignDefaultValue pulumi.StringPtrInput `pulumi:"designDefaultValue"`
+	DesignDefaultValue *string `pulumi:"designDefaultValue"`
 	// Parameter id.
-	Id pulumi.Float64PtrInput `pulumi:"id"`
+	Id *float64 `pulumi:"id"`
 	// Parameter name.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Whether parameter is required.
-	Required pulumi.BoolPtrInput `pulumi:"required"`
+	Required *bool `pulumi:"required"`
 	// Whether parameter is sensitive.
-	Sensitive pulumi.BoolPtrInput `pulumi:"sensitive"`
+	Sensitive *bool `pulumi:"sensitive"`
 	// Default sensitive value of parameter.
-	SensitiveDefaultValue pulumi.StringPtrInput `pulumi:"sensitiveDefaultValue"`
+	SensitiveDefaultValue *string `pulumi:"sensitiveDefaultValue"`
 	// Parameter value set.
-	ValueSet pulumi.BoolPtrInput `pulumi:"valueSet"`
+	ValueSet *bool `pulumi:"valueSet"`
 	// Parameter value type.
-	ValueType pulumi.StringPtrInput `pulumi:"valueType"`
+	ValueType *string `pulumi:"valueType"`
 	// Parameter reference variable.
-	Variable pulumi.StringPtrInput `pulumi:"variable"`
+	Variable *string `pulumi:"variable"`
 }
 
 func (SsisParameterResponseArgs) ElementType() reflect.Type {
@@ -780,22 +780,22 @@ type SsisProjectResponseInput interface {
 // Ssis project.
 type SsisProjectResponseArgs struct {
 	// Metadata description.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description *string `pulumi:"description"`
 	// Environment reference in project
-	EnvironmentRefs SsisEnvironmentReferenceResponseArrayInput `pulumi:"environmentRefs"`
+	EnvironmentRefs []SsisEnvironmentReferenceResponseInput `pulumi:"environmentRefs"`
 	// Folder id which contains project.
-	FolderId pulumi.Float64PtrInput `pulumi:"folderId"`
+	FolderId *float64 `pulumi:"folderId"`
 	// Metadata id.
-	Id pulumi.Float64PtrInput `pulumi:"id"`
+	Id *float64 `pulumi:"id"`
 	// Metadata name.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Parameters in project
-	Parameters SsisParameterResponseArrayInput `pulumi:"parameters"`
+	Parameters []SsisParameterResponseInput `pulumi:"parameters"`
 	// The type of SSIS object metadata.
 	// Expected value is 'Project'.
 	Type pulumi.StringInput `pulumi:"type"`
 	// Project version.
-	Version pulumi.Float64PtrInput `pulumi:"version"`
+	Version *float64 `pulumi:"version"`
 }
 
 func (SsisProjectResponseArgs) ElementType() reflect.Type {
@@ -898,19 +898,19 @@ type SsisVariableResponseInput interface {
 // Ssis variable.
 type SsisVariableResponseArgs struct {
 	// Variable type.
-	DataType pulumi.StringPtrInput `pulumi:"dataType"`
+	DataType *string `pulumi:"dataType"`
 	// Variable description.
-	Description pulumi.StringPtrInput `pulumi:"description"`
+	Description *string `pulumi:"description"`
 	// Variable id.
-	Id pulumi.Float64PtrInput `pulumi:"id"`
+	Id *float64 `pulumi:"id"`
 	// Variable name.
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 	// Whether variable is sensitive.
-	Sensitive pulumi.BoolPtrInput `pulumi:"sensitive"`
+	Sensitive *bool `pulumi:"sensitive"`
 	// Variable sensitive value.
-	SensitiveValue pulumi.StringPtrInput `pulumi:"sensitiveValue"`
+	SensitiveValue *string `pulumi:"sensitiveValue"`
 	// Variable value.
-	Value pulumi.StringPtrInput `pulumi:"value"`
+	Value *string `pulumi:"value"`
 }
 
 func (SsisVariableResponseArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithAllOptionalInputs.ts
@@ -42,9 +42,9 @@ export interface FuncWithAllOptionalInputsOutputArgs {
     /**
      * Property A
      */
-    a?: pulumi.Input<string>;
+    a?: pulumi.Input<string | undefined>;
     /**
      * Property B
      */
-    b?: pulumi.Input<string>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDefaultValue.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDefaultValue.ts
@@ -33,5 +33,5 @@ export function funcWithDefaultValueOutput(args: FuncWithDefaultValueOutputArgs,
 
 export interface FuncWithDefaultValueOutputArgs {
     a: pulumi.Input<string>;
-    b?: pulumi.Input<string>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDictParam.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithDictParam.ts
@@ -33,6 +33,6 @@ export function funcWithDictParamOutput(args?: FuncWithDictParamOutputArgs, opts
 }
 
 export interface FuncWithDictParamOutputArgs {
-    a?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    b?: pulumi.Input<string>;
+    a?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithListParam.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/funcWithListParam.ts
@@ -33,6 +33,6 @@ export function funcWithListParamOutput(args?: FuncWithListParamOutputArgs, opts
 }
 
 export interface FuncWithListParamOutputArgs {
-    a?: pulumi.Input<pulumi.Input<string>[]>;
-    b?: pulumi.Input<string>;
+    a?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getBastionShareableLink.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getBastionShareableLink.ts
@@ -64,5 +64,5 @@ export interface GetBastionShareableLinkOutputArgs {
     /**
      * List of VM references.
      */
-    vms?: pulumi.Input<pulumi.Input<inputs.BastionShareableLinkArgs>[]>;
+    vms?: pulumi.Input<pulumi.Input<inputs.BastionShareableLinkArgs>[] | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
@@ -73,7 +73,7 @@ export interface GetIntegrationRuntimeObjectMetadatumOutputArgs {
     /**
      * Metadata path.
      */
-    metadataPath?: pulumi.Input<string>;
+    metadataPath?: pulumi.Input<string | undefined>;
     /**
      * The resource group name.
      */

--- a/pkg/codegen/testing/test/testdata/output-funcs/nodejs/listStorageAccountKeys.ts
+++ b/pkg/codegen/testing/test/testdata/output-funcs/nodejs/listStorageAccountKeys.ts
@@ -60,7 +60,7 @@ export interface ListStorageAccountKeysOutputArgs {
     /**
      * Specifies type of the key to be listed. Possible value is kerb.
      */
-    expand?: pulumi.Input<string>;
+    expand?: pulumi.Input<string | undefined>;
     /**
      * The name of the resource group within the user's subscription. The name is case insensitive.
      */

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
@@ -59,8 +59,8 @@ def func_with_all_optional_inputs(a: Optional[str] = None,
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)
-def func_with_all_optional_inputs_output(a: Optional[pulumi.Input[Optional[str]]] = None,
-                                         b: Optional[pulumi.Input[Optional[str]]] = None,
+def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[str]] = None,
+                                         b: pulumi.Input[Optional[str]] = None,
                                          opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_default_value.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_default_value.py
@@ -56,7 +56,7 @@ def func_with_default_value(a: Optional[str] = None,
 
 @_utilities.lift_output_func(func_with_default_value)
 def func_with_default_value_output(a: Optional[pulumi.Input[str]] = None,
-                                   b: Optional[pulumi.Input[Optional[str]]] = None,
+                                   b: pulumi.Input[Optional[str]] = None,
                                    opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithDefaultValueResult]:
     """
     Check codegen of functions with default values.

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_dict_param.py
@@ -55,8 +55,8 @@ def func_with_dict_param(a: Optional[Mapping[str, str]] = None,
 
 
 @_utilities.lift_output_func(func_with_dict_param)
-def func_with_dict_param_output(a: Optional[pulumi.Input[Optional[Mapping[str, str]]]] = None,
-                                b: Optional[pulumi.Input[Optional[str]]] = None,
+def func_with_dict_param_output(a: pulumi.Input[Optional[Mapping[str, str]]] = None,
+                                b: pulumi.Input[Optional[str]] = None,
                                 opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithDictParamResult]:
     """
     Check codegen of functions with a Dict<str,str> parameter.

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_list_param.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/func_with_list_param.py
@@ -55,8 +55,8 @@ def func_with_list_param(a: Optional[Sequence[str]] = None,
 
 
 @_utilities.lift_output_func(func_with_list_param)
-def func_with_list_param_output(a: Optional[pulumi.Input[Optional[Sequence[str]]]] = None,
-                                b: Optional[pulumi.Input[Optional[str]]] = None,
+def func_with_list_param_output(a: pulumi.Input[Optional[Sequence[str]]] = None,
+                                b: pulumi.Input[Optional[str]] = None,
                                 opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithListParamResult]:
     """
     Check codegen of functions with a List parameter.

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
@@ -72,7 +72,7 @@ def get_bastion_shareable_link(bastion_host_name: Optional[str] = None,
 @_utilities.lift_output_func(get_bastion_shareable_link)
 def get_bastion_shareable_link_output(bastion_host_name: Optional[pulumi.Input[str]] = None,
                                       resource_group_name: Optional[pulumi.Input[str]] = None,
-                                      vms: Optional[pulumi.Input[Optional[Sequence[pulumi.InputType['BastionShareableLink']]]]] = None,
+                                      vms: pulumi.Input[Optional[Sequence[pulumi.InputType['BastionShareableLink']]]] = None,
                                       opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetBastionShareableLinkResult]:
     """
     Response for all the Bastion Shareable Link endpoints.

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
@@ -88,7 +88,7 @@ def get_integration_runtime_object_metadatum(factory_name: Optional[str] = None,
 @_utilities.lift_output_func(get_integration_runtime_object_metadatum)
 def get_integration_runtime_object_metadatum_output(factory_name: Optional[pulumi.Input[str]] = None,
                                                     integration_runtime_name: Optional[pulumi.Input[str]] = None,
-                                                    metadata_path: Optional[pulumi.Input[Optional[str]]] = None,
+                                                    metadata_path: pulumi.Input[Optional[str]] = None,
                                                     resource_group_name: Optional[pulumi.Input[str]] = None,
                                                     opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetIntegrationRuntimeObjectMetadatumResult]:
     """

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
@@ -71,7 +71,7 @@ def list_storage_account_keys(account_name: Optional[str] = None,
 
 @_utilities.lift_output_func(list_storage_account_keys)
 def list_storage_account_keys_output(account_name: Optional[pulumi.Input[str]] = None,
-                                     expand: Optional[pulumi.Input[Optional[str]]] = None,
+                                     expand: pulumi.Input[Optional[str]] = None,
                                      resource_group_name: Optional[pulumi.Input[str]] = None,
                                      opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ListStorageAccountKeysResult]:
     """

--- a/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/docs/moduleresource/_index.md
@@ -32,10 +32,10 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                    <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                   <span class="nx">optional_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
-                   <span class="nx">optional_enum</span><span class="p">:</span> <span class="nx">Optional[EnumThing]</span> = None<span class="p">,</span>
-                   <span class="nx">optional_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
-                   <span class="nx">optional_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_bool</span><span class="p">:</span> <span class="nx">Optional[Optional[bool]]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_enum</span><span class="p">:</span> <span class="nx">Optional[Optional[EnumThing]]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_number</span><span class="p">:</span> <span class="nx">Optional[Optional[float]]</span> = None<span class="p">,</span>
+                   <span class="nx">optional_string</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">,</span>
                    <span class="nx">plain_optional_bool</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
                    <span class="nx">plain_optional_number</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
                    <span class="nx">plain_optional_string</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
@@ -294,7 +294,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">bool</span>
+        <span class="property-type">bool?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -302,7 +302,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumthing">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Enum<wbr>Thing</a></span>
+        <span class="property-type">Pulumi.<wbr>Foo<wbr>Bar.<wbr>Enum<wbr>Thing?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -310,7 +310,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">double</span>
+        <span class="property-type">double?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -318,7 +318,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_csharp" style="color: inherit; text-decoration: inherit;">Optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -420,7 +420,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_go" style="color: inherit; text-decoration: inherit;">Optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
+        <span class="property-type">Enum<wbr>Thing</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -530,7 +530,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Boolean</span>
+        <span class="property-type">Optional&lt;Boolean&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -538,7 +538,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
+        <span class="property-type">Optional&lt;Enum<wbr>Thing&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -546,7 +546,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Double</span>
+        <span class="property-type">Optional&lt;Double&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -554,7 +554,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_java" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -648,7 +648,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">boolean</span>
+        <span class="property-type">boolean | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -656,7 +656,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
+        <span class="property-type">Enum<wbr>Thing | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -664,7 +664,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">number</span>
+        <span class="property-type">number | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -672,7 +672,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_nodejs" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -766,7 +766,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_bool_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>bool</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">bool</span>
+        <span class="property-type">Optional[bool]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -774,7 +774,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumthing">Enum<wbr>Thing</a></span>
+        <span class="property-type">Enum<wbr>Thing</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -782,7 +782,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_number_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>number</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">float</span>
+        <span class="property-type">Optional[float]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -790,7 +790,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_string_python" style="color: inherit; text-decoration: inherit;">optional_<wbr>string</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -892,7 +892,7 @@ The ModuleResource resource accepts the following [input](/docs/intro/concepts/i
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#optional_enum_yaml" style="color: inherit; text-decoration: inherit;">optional_<wbr>enum</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumthing">4 | 6 | 8</a></span>
+        <span class="property-type">4 | 6 | 8</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/ModuleResource.cs
@@ -70,19 +70,19 @@ namespace Pulumi.FooBar
     public sealed class ModuleResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("optional_bool")]
-        public Input<bool>? Optional_bool { get; set; }
+        public Input<bool?>? Optional_bool { get; set; }
 
         [Input("optional_const")]
-        public Input<string>? Optional_const { get; set; }
+        public Input<string?>? Optional_const { get; set; }
 
         [Input("optional_enum")]
-        public Input<Pulumi.FooBar.EnumThing>? Optional_enum { get; set; }
+        public Input<Pulumi.FooBar.EnumThing?>? Optional_enum { get; set; }
 
         [Input("optional_number")]
-        public Input<double>? Optional_number { get; set; }
+        public Input<double?>? Optional_number { get; set; }
 
         [Input("optional_string")]
-        public Input<string>? Optional_string { get; set; }
+        public Input<string?>? Optional_string { get; set; }
 
         [Input("plain_optional_bool")]
         public bool? Plain_optional_bool { get; set; }
@@ -124,7 +124,7 @@ namespace Pulumi.FooBar
         {
             Optional_bool = true;
             Optional_const = "another";
-            Optional_enum = Pulumi.FooBar.EnumThing.Eight;
+            Optional_enum = 8;
             Optional_number = 42;
             Optional_string = "buzzer";
             Plain_optional_bool = true;

--- a/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/go/foo/moduleResource.go
@@ -25,17 +25,17 @@ func NewModuleResource(ctx *pulumi.Context,
 	}
 
 	if args.Optional_bool == nil {
-		args.Optional_bool = pulumi.BoolPtr(true)
+		args.Optional_bool = *bool(true)
 	}
-	args.Optional_const = pulumi.StringPtr("val")
+	args.Optional_const = *string("val")
 	if args.Optional_enum == nil {
-		args.Optional_enum = EnumThing(8)
+		args.Optional_enum = *EnumThing(8)
 	}
 	if args.Optional_number == nil {
-		args.Optional_number = pulumi.Float64Ptr(42.0)
+		args.Optional_number = *float64(42.0)
 	}
 	if args.Optional_string == nil {
-		args.Optional_string = pulumi.StringPtr("buzzer")
+		args.Optional_string = *string("buzzer")
 	}
 	if args.Plain_optional_bool == nil {
 		plain_optional_bool_ := true
@@ -62,16 +62,20 @@ func NewModuleResource(ctx *pulumi.Context,
 		args.Plain_required_string = "buzzer"
 	}
 	if args.Required_bool == nil {
-		args.Required_bool = pulumi.Bool(true)
+		required_bool_ := true
+		args.Required_bool = &required_bool_
 	}
 	if args.Required_enum == nil {
-		args.Required_enum = EnumThing(4)
+		required_enum_ := EnumThing(4)
+		args.Required_enum = &required_enum_
 	}
 	if args.Required_number == nil {
-		args.Required_number = pulumi.Float64(42.0)
+		required_number_ := 42.0
+		args.Required_number = &required_number_
 	}
 	if args.Required_string == nil {
-		args.Required_string = pulumi.String("buzzer")
+		required_string_ := "buzzer"
+		args.Required_string = &required_string_
 	}
 	var resource ModuleResource
 	err := ctx.RegisterResource("foobar::ModuleResource", name, args, &resource, opts...)
@@ -126,11 +130,11 @@ type moduleResourceArgs struct {
 
 // The set of arguments for constructing a ModuleResource resource.
 type ModuleResourceArgs struct {
-	Optional_bool         pulumi.BoolPtrInput
-	Optional_const        pulumi.StringPtrInput
-	Optional_enum         EnumThingPtrInput
-	Optional_number       pulumi.Float64PtrInput
-	Optional_string       pulumi.StringPtrInput
+	Optional_bool         *bool
+	Optional_const        *string
+	Optional_enum         *EnumThing
+	Optional_number       *float64
+	Optional_string       *string
 	Plain_optional_bool   *bool
 	Plain_optional_const  *string
 	Plain_optional_number *float64

--- a/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/moduleResource.ts
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/nodejs/moduleResource.ts
@@ -100,11 +100,11 @@ export class ModuleResource extends pulumi.CustomResource {
  * The set of arguments for constructing a ModuleResource resource.
  */
 export interface ModuleResourceArgs {
-    optional_bool?: pulumi.Input<boolean>;
-    optional_const?: pulumi.Input<"val">;
-    optional_enum?: pulumi.Input<enums.EnumThing>;
-    optional_number?: pulumi.Input<number>;
-    optional_string?: pulumi.Input<string>;
+    optional_bool?: pulumi.Input<boolean | undefined>;
+    optional_const?: pulumi.Input<"val" | undefined>;
+    optional_enum?: pulumi.Input<enums.EnumThing | undefined>;
+    optional_number?: pulumi.Input<number | undefined>;
+    optional_string?: pulumi.Input<string | undefined>;
     plain_optional_bool?: boolean;
     plain_optional_const?: "val";
     plain_optional_number?: number;

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/pulumi_foobar/module_resource.py
@@ -23,11 +23,11 @@ class ModuleResourceArgs:
                  required_enum: pulumi.Input['EnumThing'],
                  required_number: pulumi.Input[float],
                  required_string: pulumi.Input[str],
-                 optional_bool: Optional[pulumi.Input[bool]] = None,
-                 optional_const: Optional[pulumi.Input[str]] = None,
-                 optional_enum: Optional[pulumi.Input['EnumThing']] = None,
-                 optional_number: Optional[pulumi.Input[float]] = None,
-                 optional_string: Optional[pulumi.Input[str]] = None,
+                 optional_bool: pulumi.Input[Optional[bool]] = None,
+                 optional_const: pulumi.Input[Optional[str]] = None,
+                 optional_enum: pulumi.Input[Optional['EnumThing']] = None,
+                 optional_number: pulumi.Input[Optional[float]] = None,
+                 optional_string: pulumi.Input[Optional[str]] = None,
                  plain_optional_bool: Optional[bool] = None,
                  plain_optional_const: Optional[str] = None,
                  plain_optional_number: Optional[float] = None,
@@ -170,47 +170,47 @@ class ModuleResourceArgs:
 
     @property
     @pulumi.getter
-    def optional_bool(self) -> Optional[pulumi.Input[bool]]:
+    def optional_bool(self) -> pulumi.Input[Optional[bool]]:
         return pulumi.get(self, "optional_bool")
 
     @optional_bool.setter
-    def optional_bool(self, value: Optional[pulumi.Input[bool]]):
+    def optional_bool(self, value: pulumi.Input[Optional[bool]]):
         pulumi.set(self, "optional_bool", value)
 
     @property
     @pulumi.getter
-    def optional_const(self) -> Optional[pulumi.Input[str]]:
+    def optional_const(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "optional_const")
 
     @optional_const.setter
-    def optional_const(self, value: Optional[pulumi.Input[str]]):
+    def optional_const(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "optional_const", value)
 
     @property
     @pulumi.getter
-    def optional_enum(self) -> Optional[pulumi.Input['EnumThing']]:
+    def optional_enum(self) -> pulumi.Input[Optional['EnumThing']]:
         return pulumi.get(self, "optional_enum")
 
     @optional_enum.setter
-    def optional_enum(self, value: Optional[pulumi.Input['EnumThing']]):
+    def optional_enum(self, value: pulumi.Input[Optional['EnumThing']]):
         pulumi.set(self, "optional_enum", value)
 
     @property
     @pulumi.getter
-    def optional_number(self) -> Optional[pulumi.Input[float]]:
+    def optional_number(self) -> pulumi.Input[Optional[float]]:
         return pulumi.get(self, "optional_number")
 
     @optional_number.setter
-    def optional_number(self, value: Optional[pulumi.Input[float]]):
+    def optional_number(self, value: pulumi.Input[Optional[float]]):
         pulumi.set(self, "optional_number", value)
 
     @property
     @pulumi.getter
-    def optional_string(self) -> Optional[pulumi.Input[str]]:
+    def optional_string(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "optional_string")
 
     @optional_string.setter
-    def optional_string(self, value: Optional[pulumi.Input[str]]):
+    def optional_string(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "optional_string", value)
 
     @property
@@ -255,11 +255,11 @@ class ModuleResource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 optional_bool: Optional[pulumi.Input[bool]] = None,
-                 optional_const: Optional[pulumi.Input[str]] = None,
-                 optional_enum: Optional[pulumi.Input['EnumThing']] = None,
-                 optional_number: Optional[pulumi.Input[float]] = None,
-                 optional_string: Optional[pulumi.Input[str]] = None,
+                 optional_bool: pulumi.Input[Optional[bool]] = None,
+                 optional_const: pulumi.Input[Optional[str]] = None,
+                 optional_enum: pulumi.Input[Optional['EnumThing']] = None,
+                 optional_number: pulumi.Input[Optional[float]] = None,
+                 optional_string: pulumi.Input[Optional[str]] = None,
                  plain_optional_bool: Optional[bool] = None,
                  plain_optional_const: Optional[str] = None,
                  plain_optional_number: Optional[float] = None,
@@ -301,11 +301,11 @@ class ModuleResource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 optional_bool: Optional[pulumi.Input[bool]] = None,
-                 optional_const: Optional[pulumi.Input[str]] = None,
-                 optional_enum: Optional[pulumi.Input['EnumThing']] = None,
-                 optional_number: Optional[pulumi.Input[float]] = None,
-                 optional_string: Optional[pulumi.Input[str]] = None,
+                 optional_bool: pulumi.Input[Optional[bool]] = None,
+                 optional_const: pulumi.Input[Optional[str]] = None,
+                 optional_enum: pulumi.Input[Optional['EnumThing']] = None,
+                 optional_number: pulumi.Input[Optional[float]] = None,
+                 optional_string: pulumi.Input[Optional[str]] = None,
                  plain_optional_bool: Optional[bool] = None,
                  plain_optional_const: Optional[str] = None,
                  plain_optional_number: Optional[float] = None,

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/foo/_index.md
@@ -36,8 +36,8 @@ test new feature with resoruces
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
         <span class="nx">argument</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
         <span class="nx">backup_kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
-        <span class="nx">kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
-        <span class="nx">settings</span><span class="p">:</span> <span class="nx">Optional[LayeredTypeArgs]</span> = None<span class="p">)</span>
+        <span class="nx">kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[Optional[KubeClientSettingsArgs]]</span> = None<span class="p">,</span>
+        <span class="nx">settings</span><span class="p">:</span> <span class="nx">Optional[Optional[LayeredTypeArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Foo</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">FooArgs</a></span><span class="p">,</span>
@@ -247,7 +247,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args?</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -256,7 +256,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_csharp" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args?</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -288,7 +288,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -297,7 +297,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_go" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -329,7 +329,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_java" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Kube<wbr>Client<wbr>Settings<wbr>Args&gt;</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -338,7 +338,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_java" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Layered<wbr>Type<wbr>Args&gt;</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -370,7 +370,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args | undefined</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -379,7 +379,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_nodejs" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args | undefined</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -411,7 +411,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kube_client_settings_python" style="color: inherit; text-decoration: inherit;">kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -420,7 +420,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_python" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -452,7 +452,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_yaml" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -461,7 +461,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_yaml" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -48,8 +48,8 @@ function </span>funcWithAllOptionalInputsOutput<span class="p">(</span><span cla
                                   <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithAllOptionalInputsResult</span
 ><span class="k">
-def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[HelmReleaseSettingsArgs]]</span> = None<span class="p">,</span>
-                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[HelmReleaseSettingsArgs]]</span> = None<span class="p">,</span>
+                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithAllOptionalInputsResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/moduletest/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleTest</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">mod1</span><span class="p">:</span> <span class="nx">Optional[_mod1.TypArgs]</span> = None<span class="p">,</span>
-               <span class="nx">val</span><span class="p">:</span> <span class="nx">Optional[TypArgs]</span> = None<span class="p">)</span>
+               <span class="nx">mod1</span><span class="p">:</span> <span class="nx">Optional[Optional[_mod1.TypArgs]]</span> = None<span class="p">,</span>
+               <span class="nx">val</span><span class="p">:</span> <span class="nx">Optional[Optional[TypArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleTest</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ModuleTestArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -248,7 +248,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -256,7 +256,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_java" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Typ<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_java" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Typ<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">mod1Typ<wbr>Args</a></span>
+        <span class="property-type">mod1Typ<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -336,7 +336,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_yaml" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -344,7 +344,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_yaml" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/docs/provider/_index.md
@@ -34,7 +34,7 @@ The provider type for the kubernetes package.
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Provider</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">helm_release_settings</span><span class="p">:</span> <span class="nx">Optional[HelmReleaseSettingsArgs]</span> = None<span class="p">)</span>
+             <span class="nx">helm_release_settings</span><span class="p">:</span> <span class="nx">Optional[Optional[HelmReleaseSettingsArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Provider</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ProviderArgs]</a></span> = None<span class="p">,</span>
@@ -227,7 +227,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_csharp" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args?</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -242,7 +242,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_go" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -257,7 +257,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_java" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Helm<wbr>Release<wbr>Settings<wbr>Args&gt;</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -272,7 +272,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_nodejs" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args | undefined</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -287,7 +287,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helm_release_settings_python" style="color: inherit; text-decoration: inherit;">helm_<wbr>release_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -302,7 +302,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_yaml" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Foo.cs
@@ -79,13 +79,13 @@ namespace Pulumi.Example
         /// Options for tuning the Kubernetes client used by a Provider.
         /// </summary>
         [Input("kubeClientSettings")]
-        public Input<Inputs.KubeClientSettingsArgs>? KubeClientSettings { get; set; }
+        public Input<Inputs.KubeClientSettingsArgs?>? KubeClientSettings { get; set; }
 
         /// <summary>
         /// describing things
         /// </summary>
         [Input("settings")]
-        public Input<Inputs.LayeredTypeArgs>? Settings { get; set; }
+        public Input<Inputs.LayeredTypeArgs?>? Settings { get; set; }
 
         public FooArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -52,13 +52,13 @@ namespace Pulumi.Example
         /// Property A
         /// </summary>
         [Input("a")]
-        public Input<Inputs.HelmReleaseSettingsArgs>? A { get; set; }
+        public Input<Inputs.HelmReleaseSettingsArgs?>? A { get; set; }
 
         /// <summary>
         /// Property B
         /// </summary>
         [Input("b")]
-        public Input<string>? B { get; set; }
+        public Input<string?>? B { get; set; }
 
         public FuncWithAllOptionalInputsInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
@@ -19,13 +19,13 @@ namespace Pulumi.Example.Inputs
         /// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
         /// </summary>
         [Input("driver")]
-        public Input<string>? Driver { get; set; }
+        public Input<string?>? Driver { get; set; }
 
         /// <summary>
         /// The path to the helm plugins directory.
         /// </summary>
         [Input("pluginsPath")]
-        public Input<string>? PluginsPath { get; set; }
+        public Input<string?>? PluginsPath { get; set; }
 
         /// <summary>
         /// to test required args

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
@@ -19,21 +19,21 @@ namespace Pulumi.Example.Inputs
         /// Maximum burst for throttle. Default value is 10.
         /// </summary>
         [Input("burst")]
-        public Input<int>? Burst { get; set; }
+        public Input<int?>? Burst { get; set; }
 
         /// <summary>
         /// Maximum queries per second (QPS) to the API server from this client. Default value is 5.
         /// </summary>
         [Input("qps")]
-        public Input<double>? Qps { get; set; }
+        public Input<double?>? Qps { get; set; }
 
         [Input("recTest")]
-        public Input<Inputs.KubeClientSettingsArgs>? RecTest { get; set; }
+        public Input<Inputs.KubeClientSettingsArgs?>? RecTest { get; set; }
 
         public KubeClientSettingsArgs()
         {
-            Burst = Utilities.GetEnvInt32("PULUMI_K8S_CLIENT_BURST");
-            Qps = Utilities.GetEnvDouble("PULUMI_K8S_CLIENT_QPS");
+            Burst = Utilities.GetEnv("PULUMI_K8S_CLIENT_BURST");
+            Qps = Utilities.GetEnv("PULUMI_K8S_CLIENT_QPS");
         }
         public static new KubeClientSettingsArgs Empty => new KubeClientSettingsArgs();
     }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/LayeredTypeArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/LayeredTypeArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Example.Inputs
         /// The answer to the question
         /// </summary>
         [Input("answer")]
-        public Input<double>? Answer { get; set; }
+        public Input<double?>? Answer { get; set; }
 
         [Input("other", required: true)]
         public Input<Inputs.HelmReleaseSettingsArgs> Other { get; set; } = null!;
@@ -34,10 +34,10 @@ namespace Pulumi.Example.Inputs
         /// The question already answered
         /// </summary>
         [Input("question")]
-        public Input<string>? Question { get; set; }
+        public Input<string?>? Question { get; set; }
 
         [Input("recursive")]
-        public Input<Inputs.LayeredTypeArgs>? Recursive { get; set; }
+        public Input<Inputs.LayeredTypeArgs?>? Recursive { get; set; }
 
         /// <summary>
         /// To ask and answer

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Inputs/TypArgs.cs
@@ -16,13 +16,13 @@ namespace Pulumi.Example.Inputs
     public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
-        public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }
+        public Input<Pulumi.Example.Mod1.Inputs.TypArgs?>? Mod1 { get; set; }
 
         [Input("mod2")]
-        public Input<Pulumi.Example.Mod2.Inputs.TypArgs>? Mod2 { get; set; }
+        public Input<Pulumi.Example.Mod2.Inputs.TypArgs?>? Mod2 { get; set; }
 
         [Input("val")]
-        public Input<string>? Val { get; set; }
+        public Input<string?>? Val { get; set; }
 
         public TypArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod1/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod1/Inputs/TypArgs.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Example.Mod1.Inputs
     public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("val")]
-        public Input<string>? Val { get; set; }
+        public Input<string?>? Val { get; set; }
 
         public TypArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod2/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Mod2/Inputs/TypArgs.cs
@@ -16,10 +16,10 @@ namespace Pulumi.Example.Mod2.Inputs
     public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
-        public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }
+        public Input<Pulumi.Example.Mod1.Inputs.TypArgs?>? Mod1 { get; set; }
 
         [Input("val")]
-        public Input<string>? Val { get; set; }
+        public Input<string?>? Val { get; set; }
 
         public TypArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/ModuleTest.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/ModuleTest.cs
@@ -57,10 +57,10 @@ namespace Pulumi.Example
     public sealed class ModuleTestArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
-        public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }
+        public Input<Pulumi.Example.Mod1.Inputs.TypArgs?>? Mod1 { get; set; }
 
         [Input("val")]
-        public Input<Inputs.TypArgs>? Val { get; set; }
+        public Input<Inputs.TypArgs?>? Val { get; set; }
 
         public ModuleTestArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Provider.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Example
         /// BETA FEATURE - Options to configure the Helm Release resource.
         /// </summary>
         [Input("helmReleaseSettings", json: true)]
-        public Input<Inputs.HelmReleaseSettingsArgs>? HelmReleaseSettings { get; set; }
+        public Input<Inputs.HelmReleaseSettingsArgs?>? HelmReleaseSettings { get; set; }
 
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/foo.go
@@ -30,12 +30,6 @@ func NewFoo(ctx *pulumi.Context,
 		return nil, errors.New("invalid value for required argument 'BackupKubeClientSettings'")
 	}
 	args.BackupKubeClientSettings = args.BackupKubeClientSettings.ToKubeClientSettingsOutput().ApplyT(func(v KubeClientSettings) KubeClientSettings { return *v.Defaults() }).(KubeClientSettingsOutput)
-	if args.KubeClientSettings != nil {
-		args.KubeClientSettings = args.KubeClientSettings.ToKubeClientSettingsPtrOutput().ApplyT(func(v *KubeClientSettings) *KubeClientSettings { return v.Defaults() }).(KubeClientSettingsPtrOutput)
-	}
-	if args.Settings != nil {
-		args.Settings = args.Settings.ToLayeredTypePtrOutput().ApplyT(func(v *LayeredType) *LayeredType { return v.Defaults() }).(LayeredTypePtrOutput)
-	}
 	var resource Foo
 	err := ctx.RegisterResource("example:index:Foo", name, args, &resource, opts...)
 	if err != nil {
@@ -83,9 +77,9 @@ type FooArgs struct {
 	// Options for tuning the Kubernetes client used by a Provider.
 	BackupKubeClientSettings KubeClientSettingsInput
 	// Options for tuning the Kubernetes client used by a Provider.
-	KubeClientSettings KubeClientSettingsPtrInput
+	KubeClientSettings *KubeClientSettingsArgs
 	// describing things
-	Settings LayeredTypePtrInput
+	Settings *LayeredTypeArgs
 }
 
 func (FooArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/funcWithAllOptionalInputs.go
@@ -61,9 +61,9 @@ func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOption
 
 type FuncWithAllOptionalInputsOutputArgs struct {
 	// Property A
-	A HelmReleaseSettingsPtrInput `pulumi:"a"`
+	A *HelmReleaseSettingsArgs `pulumi:"a"`
 	// Property B
-	B pulumi.StringPtrInput `pulumi:"b"`
+	B *string `pulumi:"b"`
 }
 
 func (FuncWithAllOptionalInputsOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod1/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod1/pulumiTypes.go
@@ -41,7 +41,7 @@ type TypInput interface {
 
 // A test for namespaces (mod 1)
 type TypArgs struct {
-	Val pulumi.StringPtrInput `pulumi:"val"`
+	Val *string `pulumi:"val"`
 }
 
 // Defaults sets the appropriate defaults for TypArgs
@@ -51,7 +51,7 @@ func (val *TypArgs) Defaults() *TypArgs {
 	}
 	tmp := *val
 	if tmp.Val == nil {
-		tmp.Val = pulumi.StringPtr(getEnvOrDefault("mod1", nil, "PULUMI_EXAMPLE_MOD1_DEFAULT").(string))
+		tmp.Val = *string(getEnvOrDefault("mod1", nil, "PULUMI_EXAMPLE_MOD1_DEFAULT").(string))
 	}
 	return &tmp
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod2/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/mod2/pulumiTypes.go
@@ -45,8 +45,8 @@ type TypInput interface {
 
 // A test for namespaces (mod 2)
 type TypArgs struct {
-	Mod1 mod1.TypPtrInput      `pulumi:"mod1"`
-	Val  pulumi.StringPtrInput `pulumi:"val"`
+	Mod1 *mod1.TypArgs `pulumi:"mod1"`
+	Val  *string       `pulumi:"val"`
 }
 
 // Defaults sets the appropriate defaults for TypArgs
@@ -55,9 +55,8 @@ func (val *TypArgs) Defaults() *TypArgs {
 		return nil
 	}
 	tmp := *val
-
 	if tmp.Val == nil {
-		tmp.Val = pulumi.StringPtr("mod2")
+		tmp.Val = *string("mod2")
 	}
 	return &tmp
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/moduleTest.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/moduleTest.go
@@ -22,12 +22,6 @@ func NewModuleTest(ctx *pulumi.Context,
 		args = &ModuleTestArgs{}
 	}
 
-	if args.Mod1 != nil {
-		args.Mod1 = args.Mod1.ToTypPtrOutput().ApplyT(func(v *mod1.Typ) *mod1.Typ { return v.Defaults() }).(mod1.TypPtrOutput)
-	}
-	if args.Val != nil {
-		args.Val = args.Val.ToTypPtrOutput().ApplyT(func(v *Typ) *Typ { return v.Defaults() }).(TypPtrOutput)
-	}
 	var resource ModuleTest
 	err := ctx.RegisterResource("example:index:moduleTest", name, args, &resource, opts...)
 	if err != nil {
@@ -66,8 +60,8 @@ type moduleTestArgs struct {
 
 // The set of arguments for constructing a ModuleTest resource.
 type ModuleTestArgs struct {
-	Mod1 mod1.TypPtrInput
-	Val  TypPtrInput
+	Mod1 *mod1.TypArgs
+	Val  *TypArgs
 }
 
 func (ModuleTestArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/provider.go
@@ -22,9 +22,6 @@ func NewProvider(ctx *pulumi.Context,
 		args = &ProviderArgs{}
 	}
 
-	if args.HelmReleaseSettings != nil {
-		args.HelmReleaseSettings = args.HelmReleaseSettings.ToHelmReleaseSettingsPtrOutput().ApplyT(func(v *HelmReleaseSettings) *HelmReleaseSettings { return v.Defaults() }).(HelmReleaseSettingsPtrOutput)
-	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:example", name, args, &resource, opts...)
 	if err != nil {
@@ -41,7 +38,7 @@ type providerArgs struct {
 // The set of arguments for constructing a Provider resource.
 type ProviderArgs struct {
 	// BETA FEATURE - Options to configure the Helm Release resource.
-	HelmReleaseSettings HelmReleaseSettingsPtrInput
+	HelmReleaseSettings *HelmReleaseSettingsArgs
 }
 
 func (ProviderArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/go/example/pulumiTypes.go
@@ -53,9 +53,9 @@ type HelmReleaseSettingsInput interface {
 // BETA FEATURE - Options to configure the Helm Release resource.
 type HelmReleaseSettingsArgs struct {
 	// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver *string `pulumi:"driver"`
 	// The path to the helm plugins directory.
-	PluginsPath pulumi.StringPtrInput `pulumi:"pluginsPath"`
+	PluginsPath *string `pulumi:"pluginsPath"`
 	// to test required args
 	RequiredArg pulumi.StringInput `pulumi:"requiredArg"`
 }
@@ -67,10 +67,10 @@ func (val *HelmReleaseSettingsArgs) Defaults() *HelmReleaseSettingsArgs {
 	}
 	tmp := *val
 	if tmp.Driver == nil {
-		tmp.Driver = pulumi.StringPtr(getEnvOrDefault("secret", nil, "PULUMI_K8S_HELM_DRIVER").(string))
+		tmp.Driver = *string(getEnvOrDefault("secret", nil, "PULUMI_K8S_HELM_DRIVER").(string))
 	}
 	if tmp.PluginsPath == nil {
-		tmp.PluginsPath = pulumi.StringPtr(getEnvOrDefault("", nil, "PULUMI_K8S_HELM_PLUGINS_PATH").(string))
+		tmp.PluginsPath = *string(getEnvOrDefault("", nil, "PULUMI_K8S_HELM_PLUGINS_PATH").(string))
 	}
 	return &tmp
 }
@@ -263,10 +263,10 @@ type KubeClientSettingsInput interface {
 // Options for tuning the Kubernetes client used by a Provider.
 type KubeClientSettingsArgs struct {
 	// Maximum burst for throttle. Default value is 10.
-	Burst pulumi.IntPtrInput `pulumi:"burst"`
+	Burst *int `pulumi:"burst"`
 	// Maximum queries per second (QPS) to the API server from this client. Default value is 5.
-	Qps     pulumi.Float64PtrInput     `pulumi:"qps"`
-	RecTest KubeClientSettingsPtrInput `pulumi:"recTest"`
+	Qps     *float64                `pulumi:"qps"`
+	RecTest *KubeClientSettingsArgs `pulumi:"recTest"`
 }
 
 // Defaults sets the appropriate defaults for KubeClientSettingsArgs
@@ -276,12 +276,11 @@ func (val *KubeClientSettingsArgs) Defaults() *KubeClientSettingsArgs {
 	}
 	tmp := *val
 	if tmp.Burst == nil {
-		tmp.Burst = pulumi.IntPtr(getEnvOrDefault(0, parseEnvInt, "PULUMI_K8S_CLIENT_BURST").(int))
+		tmp.Burst = *int(getEnvOrDefault("", nil, "PULUMI_K8S_CLIENT_BURST").(string))
 	}
 	if tmp.Qps == nil {
-		tmp.Qps = pulumi.Float64Ptr(getEnvOrDefault(0.0, parseEnvFloat, "PULUMI_K8S_CLIENT_QPS").(float64))
+		tmp.Qps = *float64(getEnvOrDefault("", nil, "PULUMI_K8S_CLIENT_QPS").(string))
 	}
-
 	return &tmp
 }
 func (KubeClientSettingsArgs) ElementType() reflect.Type {
@@ -483,13 +482,13 @@ type LayeredTypeInput interface {
 // Make sure that defaults propagate through types
 type LayeredTypeArgs struct {
 	// The answer to the question
-	Answer pulumi.Float64PtrInput   `pulumi:"answer"`
+	Answer *float64                 `pulumi:"answer"`
 	Other  HelmReleaseSettingsInput `pulumi:"other"`
 	// Test how plain types interact
 	PlainOther *HelmReleaseSettingsArgs `pulumi:"plainOther"`
 	// The question already answered
-	Question  pulumi.StringPtrInput `pulumi:"question"`
-	Recursive LayeredTypePtrInput   `pulumi:"recursive"`
+	Question  *string          `pulumi:"question"`
+	Recursive *LayeredTypeArgs `pulumi:"recursive"`
 	// To ask and answer
 	Thinker pulumi.StringInput `pulumi:"thinker"`
 }
@@ -501,17 +500,17 @@ func (val *LayeredTypeArgs) Defaults() *LayeredTypeArgs {
 	}
 	tmp := *val
 	if tmp.Answer == nil {
-		tmp.Answer = pulumi.Float64Ptr(42.0)
+		tmp.Answer = *float64(42.0)
 	}
+	tmp.Other = *tmp.Other.Defaults()
 
 	tmp.PlainOther = tmp.PlainOther.Defaults()
 
 	if tmp.Question == nil {
-		tmp.Question = pulumi.StringPtr(getEnvOrDefault("<unknown>", nil, "PULUMI_THE_QUESTION").(string))
+		tmp.Question = *string(getEnvOrDefault("<unknown>", nil, "PULUMI_THE_QUESTION").(string))
 	}
-
 	if tmp.Thinker == nil {
-		tmp.Thinker = pulumi.String("not a good interaction")
+		tmp.Thinker = "not a good interaction"
 	}
 	return &tmp
 }
@@ -740,9 +739,9 @@ type TypInput interface {
 
 // A test for namespaces (mod main)
 type TypArgs struct {
-	Mod1 mod1.TypPtrInput      `pulumi:"mod1"`
-	Mod2 mod2.TypPtrInput      `pulumi:"mod2"`
-	Val  pulumi.StringPtrInput `pulumi:"val"`
+	Mod1 *mod1.TypArgs `pulumi:"mod1"`
+	Mod2 *mod2.TypArgs `pulumi:"mod2"`
+	Val  *string       `pulumi:"val"`
 }
 
 // Defaults sets the appropriate defaults for TypArgs
@@ -751,9 +750,8 @@ func (val *TypArgs) Defaults() *TypArgs {
 		return nil
 	}
 	tmp := *val
-
 	if tmp.Val == nil {
-		tmp.Val = pulumi.StringPtr("mod main")
+		tmp.Val = *string("mod main")
 	}
 	return &tmp
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/foo.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/foo.ts
@@ -80,9 +80,9 @@ export interface FooArgs {
     /**
      * Options for tuning the Kubernetes client used by a Provider.
      */
-    kubeClientSettings?: pulumi.Input<inputs.KubeClientSettingsArgs>;
+    kubeClientSettings?: pulumi.Input<inputs.KubeClientSettingsArgs | undefined>;
     /**
      * describing things
      */
-    settings?: pulumi.Input<inputs.LayeredTypeArgs>;
+    settings?: pulumi.Input<inputs.LayeredTypeArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -44,9 +44,9 @@ export interface FuncWithAllOptionalInputsOutputArgs {
     /**
      * Property A
      */
-    a?: pulumi.Input<inputs.HelmReleaseSettingsArgs>;
+    a?: pulumi.Input<inputs.HelmReleaseSettingsArgs | undefined>;
     /**
      * Property B
      */
-    b?: pulumi.Input<string>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/moduleTest.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/moduleTest.ts
@@ -58,6 +58,6 @@ export class ModuleTest extends pulumi.CustomResource {
  * The set of arguments for constructing a ModuleTest resource.
  */
 export interface ModuleTestArgs {
-    mod1?: pulumi.Input<inputs.mod1.TypArgs>;
-    val?: pulumi.Input<inputs.TypArgs>;
+    mod1?: pulumi.Input<inputs.mod1.TypArgs | undefined>;
+    val?: pulumi.Input<inputs.TypArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/provider.ts
@@ -50,5 +50,5 @@ export interface ProviderArgs {
     /**
      * BETA FEATURE - Options to configure the Helm Release resource.
      */
-    helmReleaseSettings?: pulumi.Input<inputs.HelmReleaseSettingsArgs>;
+    helmReleaseSettings?: pulumi.Input<inputs.HelmReleaseSettingsArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/nodejs/types/input.ts
@@ -42,11 +42,11 @@ export interface HelmReleaseSettingsArgs {
     /**
      * The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
      */
-    driver?: pulumi.Input<string>;
+    driver?: pulumi.Input<string | undefined>;
     /**
      * The path to the helm plugins directory.
      */
-    pluginsPath?: pulumi.Input<string>;
+    pluginsPath?: pulumi.Input<string | undefined>;
     /**
      * to test required args
      */
@@ -70,12 +70,12 @@ export interface KubeClientSettingsArgs {
     /**
      * Maximum burst for throttle. Default value is 10.
      */
-    burst?: pulumi.Input<number>;
+    burst?: pulumi.Input<number | undefined>;
     /**
      * Maximum queries per second (QPS) to the API server from this client. Default value is 5.
      */
-    qps?: pulumi.Input<number>;
-    recTest?: pulumi.Input<inputs.KubeClientSettingsArgs>;
+    qps?: pulumi.Input<number | undefined>;
+    recTest?: pulumi.Input<inputs.KubeClientSettingsArgs | undefined>;
 }
 /**
  * kubeClientSettingsArgsProvideDefaults sets the appropriate defaults for KubeClientSettingsArgs
@@ -96,7 +96,7 @@ export interface LayeredTypeArgs {
     /**
      * The answer to the question
      */
-    answer?: pulumi.Input<number>;
+    answer?: pulumi.Input<number | undefined>;
     other: pulumi.Input<inputs.HelmReleaseSettingsArgs>;
     /**
      * Test how plain types interact
@@ -105,8 +105,8 @@ export interface LayeredTypeArgs {
     /**
      * The question already answered
      */
-    question?: pulumi.Input<string>;
-    recursive?: pulumi.Input<inputs.LayeredTypeArgs>;
+    question?: pulumi.Input<string | undefined>;
+    recursive?: pulumi.Input<inputs.LayeredTypeArgs | undefined>;
     /**
      * To ask and answer
      */
@@ -131,9 +131,9 @@ export function layeredTypeArgsProvideDefaults(val: LayeredTypeArgs): LayeredTyp
  * A test for namespaces (mod main)
  */
 export interface TypArgs {
-    mod1?: pulumi.Input<inputs.mod1.TypArgs>;
-    mod2?: pulumi.Input<inputs.mod2.TypArgs>;
-    val?: pulumi.Input<string>;
+    mod1?: pulumi.Input<inputs.mod1.TypArgs | undefined>;
+    mod2?: pulumi.Input<inputs.mod2.TypArgs | undefined>;
+    val?: pulumi.Input<string | undefined>;
 }
 /**
  * typArgsProvideDefaults sets the appropriate defaults for TypArgs
@@ -151,7 +151,7 @@ export namespace mod1 {
      * A test for namespaces (mod 1)
      */
     export interface TypArgs {
-        val?: pulumi.Input<string>;
+        val?: pulumi.Input<string | undefined>;
     }
     /**
      * typArgsProvideDefaults sets the appropriate defaults for TypArgs
@@ -169,8 +169,8 @@ export namespace mod2 {
      * A test for namespaces (mod 2)
      */
     export interface TypArgs {
-        mod1?: pulumi.Input<inputs.mod1.TypArgs>;
-        val?: pulumi.Input<string>;
+        mod1?: pulumi.Input<inputs.mod1.TypArgs | undefined>;
+        val?: pulumi.Input<string | undefined>;
     }
     /**
      * typArgsProvideDefaults sets the appropriate defaults for TypArgs

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/_inputs.py
@@ -82,13 +82,13 @@ class HelmReleaseSettings:
 class HelmReleaseSettingsArgs:
     def __init__(__self__, *,
                  required_arg: pulumi.Input[str],
-                 driver: Optional[pulumi.Input[str]] = None,
-                 plugins_path: Optional[pulumi.Input[str]] = None):
+                 driver: pulumi.Input[Optional[str]] = None,
+                 plugins_path: pulumi.Input[Optional[str]] = None):
         """
         BETA FEATURE - Options to configure the Helm Release resource.
         :param pulumi.Input[str] required_arg: to test required args
-        :param pulumi.Input[str] driver: The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
-        :param pulumi.Input[str] plugins_path: The path to the helm plugins directory.
+        :param pulumi.Input[Optional[str]] driver: The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
+        :param pulumi.Input[Optional[str]] plugins_path: The path to the helm plugins directory.
         """
         pulumi.set(__self__, "required_arg", required_arg)
         if driver is None:
@@ -114,46 +114,46 @@ class HelmReleaseSettingsArgs:
 
     @property
     @pulumi.getter
-    def driver(self) -> Optional[pulumi.Input[str]]:
+    def driver(self) -> pulumi.Input[Optional[str]]:
         """
         The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
         """
         return pulumi.get(self, "driver")
 
     @driver.setter
-    def driver(self, value: Optional[pulumi.Input[str]]):
+    def driver(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "driver", value)
 
     @property
     @pulumi.getter(name="pluginsPath")
-    def plugins_path(self) -> Optional[pulumi.Input[str]]:
+    def plugins_path(self) -> pulumi.Input[Optional[str]]:
         """
         The path to the helm plugins directory.
         """
         return pulumi.get(self, "plugins_path")
 
     @plugins_path.setter
-    def plugins_path(self, value: Optional[pulumi.Input[str]]):
+    def plugins_path(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "plugins_path", value)
 
 
 @pulumi.input_type
 class KubeClientSettingsArgs:
     def __init__(__self__, *,
-                 burst: Optional[pulumi.Input[int]] = None,
-                 qps: Optional[pulumi.Input[float]] = None,
-                 rec_test: Optional[pulumi.Input['KubeClientSettingsArgs']] = None):
+                 burst: pulumi.Input[Optional[int]] = None,
+                 qps: pulumi.Input[Optional[float]] = None,
+                 rec_test: pulumi.Input[Optional['KubeClientSettingsArgs']] = None):
         """
         Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input[int] burst: Maximum burst for throttle. Default value is 10.
-        :param pulumi.Input[float] qps: Maximum queries per second (QPS) to the API server from this client. Default value is 5.
+        :param pulumi.Input[Optional[int]] burst: Maximum burst for throttle. Default value is 10.
+        :param pulumi.Input[Optional[float]] qps: Maximum queries per second (QPS) to the API server from this client. Default value is 5.
         """
         if burst is None:
-            burst = _utilities.get_env_int('PULUMI_K8S_CLIENT_BURST')
+            burst = _utilities.get_env('PULUMI_K8S_CLIENT_BURST')
         if burst is not None:
             pulumi.set(__self__, "burst", burst)
         if qps is None:
-            qps = _utilities.get_env_float('PULUMI_K8S_CLIENT_QPS')
+            qps = _utilities.get_env('PULUMI_K8S_CLIENT_QPS')
         if qps is not None:
             pulumi.set(__self__, "qps", qps)
         if rec_test is not None:
@@ -161,35 +161,35 @@ class KubeClientSettingsArgs:
 
     @property
     @pulumi.getter
-    def burst(self) -> Optional[pulumi.Input[int]]:
+    def burst(self) -> pulumi.Input[Optional[int]]:
         """
         Maximum burst for throttle. Default value is 10.
         """
         return pulumi.get(self, "burst")
 
     @burst.setter
-    def burst(self, value: Optional[pulumi.Input[int]]):
+    def burst(self, value: pulumi.Input[Optional[int]]):
         pulumi.set(self, "burst", value)
 
     @property
     @pulumi.getter
-    def qps(self) -> Optional[pulumi.Input[float]]:
+    def qps(self) -> pulumi.Input[Optional[float]]:
         """
         Maximum queries per second (QPS) to the API server from this client. Default value is 5.
         """
         return pulumi.get(self, "qps")
 
     @qps.setter
-    def qps(self, value: Optional[pulumi.Input[float]]):
+    def qps(self, value: pulumi.Input[Optional[float]]):
         pulumi.set(self, "qps", value)
 
     @property
     @pulumi.getter(name="recTest")
-    def rec_test(self) -> Optional[pulumi.Input['KubeClientSettingsArgs']]:
+    def rec_test(self) -> pulumi.Input[Optional['KubeClientSettingsArgs']]:
         return pulumi.get(self, "rec_test")
 
     @rec_test.setter
-    def rec_test(self, value: Optional[pulumi.Input['KubeClientSettingsArgs']]):
+    def rec_test(self, value: pulumi.Input[Optional['KubeClientSettingsArgs']]):
         pulumi.set(self, "rec_test", value)
 
 
@@ -198,16 +198,16 @@ class LayeredTypeArgs:
     def __init__(__self__, *,
                  other: pulumi.Input['HelmReleaseSettingsArgs'],
                  thinker: pulumi.Input[str],
-                 answer: Optional[pulumi.Input[float]] = None,
+                 answer: pulumi.Input[Optional[float]] = None,
                  plain_other: Optional['HelmReleaseSettingsArgs'] = None,
-                 question: Optional[pulumi.Input[str]] = None,
-                 recursive: Optional[pulumi.Input['LayeredTypeArgs']] = None):
+                 question: pulumi.Input[Optional[str]] = None,
+                 recursive: pulumi.Input[Optional['LayeredTypeArgs']] = None):
         """
         Make sure that defaults propagate through types
         :param pulumi.Input[str] thinker: To ask and answer
-        :param pulumi.Input[float] answer: The answer to the question
+        :param pulumi.Input[Optional[float]] answer: The answer to the question
         :param 'HelmReleaseSettingsArgs' plain_other: Test how plain types interact
-        :param pulumi.Input[str] question: The question already answered
+        :param pulumi.Input[Optional[str]] question: The question already answered
         """
         pulumi.set(__self__, "other", other)
         if thinker is None:
@@ -249,14 +249,14 @@ class LayeredTypeArgs:
 
     @property
     @pulumi.getter
-    def answer(self) -> Optional[pulumi.Input[float]]:
+    def answer(self) -> pulumi.Input[Optional[float]]:
         """
         The answer to the question
         """
         return pulumi.get(self, "answer")
 
     @answer.setter
-    def answer(self, value: Optional[pulumi.Input[float]]):
+    def answer(self, value: pulumi.Input[Optional[float]]):
         pulumi.set(self, "answer", value)
 
     @property
@@ -273,32 +273,32 @@ class LayeredTypeArgs:
 
     @property
     @pulumi.getter
-    def question(self) -> Optional[pulumi.Input[str]]:
+    def question(self) -> pulumi.Input[Optional[str]]:
         """
         The question already answered
         """
         return pulumi.get(self, "question")
 
     @question.setter
-    def question(self, value: Optional[pulumi.Input[str]]):
+    def question(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "question", value)
 
     @property
     @pulumi.getter
-    def recursive(self) -> Optional[pulumi.Input['LayeredTypeArgs']]:
+    def recursive(self) -> pulumi.Input[Optional['LayeredTypeArgs']]:
         return pulumi.get(self, "recursive")
 
     @recursive.setter
-    def recursive(self, value: Optional[pulumi.Input['LayeredTypeArgs']]):
+    def recursive(self, value: pulumi.Input[Optional['LayeredTypeArgs']]):
         pulumi.set(self, "recursive", value)
 
 
 @pulumi.input_type
 class TypArgs:
     def __init__(__self__, *,
-                 mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
-                 mod2: Optional[pulumi.Input['_mod2.TypArgs']] = None,
-                 val: Optional[pulumi.Input[str]] = None):
+                 mod1: pulumi.Input[Optional['_mod1.TypArgs']] = None,
+                 mod2: pulumi.Input[Optional['_mod2.TypArgs']] = None,
+                 val: pulumi.Input[Optional[str]] = None):
         """
         A test for namespaces (mod main)
         """
@@ -313,29 +313,29 @@ class TypArgs:
 
     @property
     @pulumi.getter
-    def mod1(self) -> Optional[pulumi.Input['_mod1.TypArgs']]:
+    def mod1(self) -> pulumi.Input[Optional['_mod1.TypArgs']]:
         return pulumi.get(self, "mod1")
 
     @mod1.setter
-    def mod1(self, value: Optional[pulumi.Input['_mod1.TypArgs']]):
+    def mod1(self, value: pulumi.Input[Optional['_mod1.TypArgs']]):
         pulumi.set(self, "mod1", value)
 
     @property
     @pulumi.getter
-    def mod2(self) -> Optional[pulumi.Input['_mod2.TypArgs']]:
+    def mod2(self) -> pulumi.Input[Optional['_mod2.TypArgs']]:
         return pulumi.get(self, "mod2")
 
     @mod2.setter
-    def mod2(self, value: Optional[pulumi.Input['_mod2.TypArgs']]):
+    def mod2(self, value: pulumi.Input[Optional['_mod2.TypArgs']]):
         pulumi.set(self, "mod2", value)
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input[str]]:
+    def val(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input[str]]):
+    def val(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "val", value)
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/foo.py
@@ -18,13 +18,13 @@ class FooArgs:
     def __init__(__self__, *,
                  backup_kube_client_settings: pulumi.Input['KubeClientSettingsArgs'],
                  argument: Optional[str] = None,
-                 kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
-                 settings: Optional[pulumi.Input['LayeredTypeArgs']] = None):
+                 kube_client_settings: pulumi.Input[Optional['KubeClientSettingsArgs']] = None,
+                 settings: pulumi.Input[Optional['LayeredTypeArgs']] = None):
         """
         The set of arguments for constructing a Foo resource.
         :param pulumi.Input['KubeClientSettingsArgs'] backup_kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input['KubeClientSettingsArgs'] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input['LayeredTypeArgs'] settings: describing things
+        :param pulumi.Input[Optional['KubeClientSettingsArgs']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
+        :param pulumi.Input[Optional['LayeredTypeArgs']] settings: describing things
         """
         pulumi.set(__self__, "backup_kube_client_settings", backup_kube_client_settings)
         if argument is not None:
@@ -57,26 +57,26 @@ class FooArgs:
 
     @property
     @pulumi.getter(name="kubeClientSettings")
-    def kube_client_settings(self) -> Optional[pulumi.Input['KubeClientSettingsArgs']]:
+    def kube_client_settings(self) -> pulumi.Input[Optional['KubeClientSettingsArgs']]:
         """
         Options for tuning the Kubernetes client used by a Provider.
         """
         return pulumi.get(self, "kube_client_settings")
 
     @kube_client_settings.setter
-    def kube_client_settings(self, value: Optional[pulumi.Input['KubeClientSettingsArgs']]):
+    def kube_client_settings(self, value: pulumi.Input[Optional['KubeClientSettingsArgs']]):
         pulumi.set(self, "kube_client_settings", value)
 
     @property
     @pulumi.getter
-    def settings(self) -> Optional[pulumi.Input['LayeredTypeArgs']]:
+    def settings(self) -> pulumi.Input[Optional['LayeredTypeArgs']]:
         """
         describing things
         """
         return pulumi.get(self, "settings")
 
     @settings.setter
-    def settings(self, value: Optional[pulumi.Input['LayeredTypeArgs']]):
+    def settings(self, value: pulumi.Input[Optional['LayeredTypeArgs']]):
         pulumi.set(self, "settings", value)
 
 
@@ -87,8 +87,8 @@ class Foo(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  argument: Optional[str] = None,
                  backup_kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 settings: Optional[pulumi.Input[pulumi.InputType['LayeredTypeArgs']]] = None,
+                 kube_client_settings: pulumi.Input[Optional[pulumi.InputType['KubeClientSettingsArgs']]] = None,
+                 settings: pulumi.Input[Optional[pulumi.InputType['LayeredTypeArgs']]] = None,
                  __props__=None):
         """
         test new feature with resoruces
@@ -96,8 +96,8 @@ class Foo(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']] backup_kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input[pulumi.InputType['LayeredTypeArgs']] settings: describing things
+        :param pulumi.Input[Optional[pulumi.InputType['KubeClientSettingsArgs']]] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
+        :param pulumi.Input[Optional[pulumi.InputType['LayeredTypeArgs']]] settings: describing things
         """
         ...
     @overload
@@ -125,8 +125,8 @@ class Foo(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  argument: Optional[str] = None,
                  backup_kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 settings: Optional[pulumi.Input[pulumi.InputType['LayeredTypeArgs']]] = None,
+                 kube_client_settings: pulumi.Input[Optional[pulumi.InputType['KubeClientSettingsArgs']]] = None,
+                 settings: pulumi.Input[Optional[pulumi.InputType['LayeredTypeArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -60,8 +60,8 @@ def func_with_all_optional_inputs(a: Optional[pulumi.InputType['HelmReleaseSetti
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)
-def func_with_all_optional_inputs_output(a: Optional[pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettings']]]] = None,
-                                         b: Optional[pulumi.Input[Optional[str]]] = None,
+def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettings']]] = None,
+                                         b: pulumi.Input[Optional[str]] = None,
                                          opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod1/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod1/_inputs.py
@@ -16,7 +16,7 @@ __all__ = [
 @pulumi.input_type
 class TypArgs:
     def __init__(__self__, *,
-                 val: Optional[pulumi.Input[str]] = None):
+                 val: pulumi.Input[Optional[str]] = None):
         """
         A test for namespaces (mod 1)
         """
@@ -27,11 +27,11 @@ class TypArgs:
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input[str]]:
+    def val(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input[str]]):
+    def val(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "val", value)
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
@@ -17,8 +17,8 @@ __all__ = [
 @pulumi.input_type
 class TypArgs:
     def __init__(__self__, *,
-                 mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
-                 val: Optional[pulumi.Input[str]] = None):
+                 mod1: pulumi.Input[Optional['_mod1.TypArgs']] = None,
+                 val: pulumi.Input[Optional[str]] = None):
         """
         A test for namespaces (mod 2)
         """
@@ -31,20 +31,20 @@ class TypArgs:
 
     @property
     @pulumi.getter
-    def mod1(self) -> Optional[pulumi.Input['_mod1.TypArgs']]:
+    def mod1(self) -> pulumi.Input[Optional['_mod1.TypArgs']]:
         return pulumi.get(self, "mod1")
 
     @mod1.setter
-    def mod1(self, value: Optional[pulumi.Input['_mod1.TypArgs']]):
+    def mod1(self, value: pulumi.Input[Optional['_mod1.TypArgs']]):
         pulumi.set(self, "mod1", value)
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input[str]]:
+    def val(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input[str]]):
+    def val(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "val", value)
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/module_test.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/module_test.py
@@ -17,8 +17,8 @@ __all__ = ['ModuleTestArgs', 'ModuleTest']
 @pulumi.input_type
 class ModuleTestArgs:
     def __init__(__self__, *,
-                 mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
-                 val: Optional[pulumi.Input['TypArgs']] = None):
+                 mod1: pulumi.Input[Optional['_mod1.TypArgs']] = None,
+                 val: pulumi.Input[Optional['TypArgs']] = None):
         """
         The set of arguments for constructing a ModuleTest resource.
         """
@@ -29,20 +29,20 @@ class ModuleTestArgs:
 
     @property
     @pulumi.getter
-    def mod1(self) -> Optional[pulumi.Input['_mod1.TypArgs']]:
+    def mod1(self) -> pulumi.Input[Optional['_mod1.TypArgs']]:
         return pulumi.get(self, "mod1")
 
     @mod1.setter
-    def mod1(self, value: Optional[pulumi.Input['_mod1.TypArgs']]):
+    def mod1(self, value: pulumi.Input[Optional['_mod1.TypArgs']]):
         pulumi.set(self, "mod1", value)
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input['TypArgs']]:
+    def val(self) -> pulumi.Input[Optional['TypArgs']]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input['TypArgs']]):
+    def val(self, value: pulumi.Input[Optional['TypArgs']]):
         pulumi.set(self, "val", value)
 
 
@@ -51,8 +51,8 @@ class ModuleTest(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 mod1: Optional[pulumi.Input[pulumi.InputType['_mod1.TypArgs']]] = None,
-                 val: Optional[pulumi.Input[pulumi.InputType['TypArgs']]] = None,
+                 mod1: pulumi.Input[Optional[pulumi.InputType['_mod1.TypArgs']]] = None,
+                 val: pulumi.Input[Optional[pulumi.InputType['TypArgs']]] = None,
                  __props__=None):
         """
         Create a ModuleTest resource with the given unique name, props, and options.
@@ -82,8 +82,8 @@ class ModuleTest(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 mod1: Optional[pulumi.Input[pulumi.InputType['_mod1.TypArgs']]] = None,
-                 val: Optional[pulumi.Input[pulumi.InputType['TypArgs']]] = None,
+                 mod1: pulumi.Input[Optional[pulumi.InputType['_mod1.TypArgs']]] = None,
+                 val: pulumi.Input[Optional[pulumi.InputType['TypArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/pulumi_example/provider.py
@@ -15,24 +15,24 @@ __all__ = ['ProviderArgs', 'Provider']
 @pulumi.input_type
 class ProviderArgs:
     def __init__(__self__, *,
-                 helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None):
+                 helm_release_settings: pulumi.Input[Optional['HelmReleaseSettingsArgs']] = None):
         """
         The set of arguments for constructing a Provider resource.
-        :param pulumi.Input['HelmReleaseSettingsArgs'] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
+        :param pulumi.Input[Optional['HelmReleaseSettingsArgs']] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
         """
         if helm_release_settings is not None:
             pulumi.set(__self__, "helm_release_settings", helm_release_settings)
 
     @property
     @pulumi.getter(name="helmReleaseSettings")
-    def helm_release_settings(self) -> Optional[pulumi.Input['HelmReleaseSettingsArgs']]:
+    def helm_release_settings(self) -> pulumi.Input[Optional['HelmReleaseSettingsArgs']]:
         """
         BETA FEATURE - Options to configure the Helm Release resource.
         """
         return pulumi.get(self, "helm_release_settings")
 
     @helm_release_settings.setter
-    def helm_release_settings(self, value: Optional[pulumi.Input['HelmReleaseSettingsArgs']]):
+    def helm_release_settings(self, value: pulumi.Input[Optional['HelmReleaseSettingsArgs']]):
         pulumi.set(self, "helm_release_settings", value)
 
 
@@ -41,14 +41,14 @@ class Provider(pulumi.ProviderResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
+                 helm_release_settings: pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  __props__=None):
         """
         The provider type for the kubernetes package.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
+        :param pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettingsArgs']]] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
         """
         ...
     @overload
@@ -74,7 +74,7 @@ class Provider(pulumi.ProviderResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
+                 helm_release_settings: pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/foo/_index.md
@@ -36,8 +36,8 @@ test new feature with resoruces
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
         <span class="nx">argument</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
         <span class="nx">backup_kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
-        <span class="nx">kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[KubeClientSettingsArgs]</span> = None<span class="p">,</span>
-        <span class="nx">settings</span><span class="p">:</span> <span class="nx">Optional[LayeredTypeArgs]</span> = None<span class="p">)</span>
+        <span class="nx">kube_client_settings</span><span class="p">:</span> <span class="nx">Optional[Optional[KubeClientSettingsArgs]]</span> = None<span class="p">,</span>
+        <span class="nx">settings</span><span class="p">:</span> <span class="nx">Optional[Optional[LayeredTypeArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Foo</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">FooArgs</a></span><span class="p">,</span>
@@ -247,7 +247,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_csharp" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args?</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -256,7 +256,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_csharp" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args?</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -288,7 +288,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_go" style="color: inherit; text-decoration: inherit;">Kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -297,7 +297,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_go" style="color: inherit; text-decoration: inherit;">Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -329,7 +329,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_java" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Kube<wbr>Client<wbr>Settings<wbr>Args&gt;</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -338,7 +338,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_java" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Layered<wbr>Type<wbr>Args&gt;</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -370,7 +370,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_nodejs" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args | undefined</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -379,7 +379,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_nodejs" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args | undefined</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -411,7 +411,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kube_client_settings_python" style="color: inherit; text-decoration: inherit;">kube_<wbr>client_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Kube<wbr>Client<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Kube<wbr>Client<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -420,7 +420,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_python" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Layered<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">Layered<wbr>Type<wbr>Args</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>
@@ -452,7 +452,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#kubeclientsettings_yaml" style="color: inherit; text-decoration: inherit;">kube<wbr>Client<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#kubeclientsettings">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd><p>Options for tuning the Kubernetes client used by a Provider.</p>
 </dd><dt class="property-optional"
@@ -461,7 +461,7 @@ The Foo resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#settings_yaml" style="color: inherit; text-decoration: inherit;">settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#layeredtype">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd><p>describing things</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/funcwithalloptionalinputs/_index.md
@@ -48,8 +48,8 @@ function </span>funcWithAllOptionalInputsOutput<span class="p">(</span><span cla
                                   <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithAllOptionalInputsResult</span
 ><span class="k">
-def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[HelmReleaseSettingsArgs]]</span> = None<span class="p">,</span>
-                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[HelmReleaseSettingsArgs]]</span> = None<span class="p">,</span>
+                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithAllOptionalInputsResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/moduletest/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleTest</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">mod1</span><span class="p">:</span> <span class="nx">Optional[_mod1.TypArgs]</span> = None<span class="p">,</span>
-               <span class="nx">val</span><span class="p">:</span> <span class="nx">Optional[TypArgs]</span> = None<span class="p">)</span>
+               <span class="nx">mod1</span><span class="p">:</span> <span class="nx">Optional[Optional[_mod1.TypArgs]]</span> = None<span class="p">,</span>
+               <span class="nx">val</span><span class="p">:</span> <span class="nx">Optional[Optional[TypArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">ModuleTest</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ModuleTestArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_csharp" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Mod1.<wbr>Inputs.<wbr>Typ<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_csharp" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -248,7 +248,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_go" style="color: inherit; text-decoration: inherit;">Mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -256,7 +256,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_go" style="color: inherit; text-decoration: inherit;">Val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_java" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Typ<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_java" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Typ<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_nodejs" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">mod1Typ<wbr>Args</a></span>
+        <span class="property-type">mod1Typ<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_nodejs" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_python" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_python" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Typ<wbr>Args</a></span>
+        <span class="property-type">Typ<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -336,7 +336,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#mod1_yaml" style="color: inherit; text-decoration: inherit;">mod1</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -344,7 +344,7 @@ The ModuleTest resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#val_yaml" style="color: inherit; text-decoration: inherit;">val</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#typ">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/docs/provider/_index.md
@@ -34,7 +34,7 @@ The provider type for the kubernetes package.
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Provider</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">helm_release_settings</span><span class="p">:</span> <span class="nx">Optional[HelmReleaseSettingsArgs]</span> = None<span class="p">)</span>
+             <span class="nx">helm_release_settings</span><span class="p">:</span> <span class="nx">Optional[Optional[HelmReleaseSettingsArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Provider</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ProviderArgs]</a></span> = None<span class="p">,</span>
@@ -227,7 +227,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_csharp" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args?</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -242,7 +242,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_go" style="color: inherit; text-decoration: inherit;">Helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -257,7 +257,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_java" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Helm<wbr>Release<wbr>Settings<wbr>Args&gt;</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -272,7 +272,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_nodejs" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args | undefined</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -287,7 +287,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helm_release_settings_python" style="color: inherit; text-decoration: inherit;">helm_<wbr>release_<wbr>settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Helm<wbr>Release<wbr>Settings<wbr>Args</a></span>
+        <span class="property-type">Helm<wbr>Release<wbr>Settings<wbr>Args</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>
@@ -302,7 +302,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#helmreleasesettings_yaml" style="color: inherit; text-decoration: inherit;">helm<wbr>Release<wbr>Settings</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#helmreleasesettings">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd><p>BETA FEATURE - Options to configure the Helm Release resource.</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Foo.cs
@@ -79,13 +79,13 @@ namespace Pulumi.Example
         /// Options for tuning the Kubernetes client used by a Provider.
         /// </summary>
         [Input("kubeClientSettings")]
-        public Input<Inputs.KubeClientSettingsArgs>? KubeClientSettings { get; set; }
+        public Input<Inputs.KubeClientSettingsArgs?>? KubeClientSettings { get; set; }
 
         /// <summary>
         /// describing things
         /// </summary>
         [Input("settings")]
-        public Input<Inputs.LayeredTypeArgs>? Settings { get; set; }
+        public Input<Inputs.LayeredTypeArgs?>? Settings { get; set; }
 
         public FooArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/FuncWithAllOptionalInputs.cs
@@ -53,13 +53,13 @@ namespace Pulumi.Mypkg
         /// Property A
         /// </summary>
         [Input("a")]
-        public Input<Pulumi.Example.Inputs.HelmReleaseSettingsArgs>? A { get; set; }
+        public Input<Pulumi.Example.Inputs.HelmReleaseSettingsArgs?>? A { get; set; }
 
         /// <summary>
         /// Property B
         /// </summary>
         [Input("b")]
-        public Input<string>? B { get; set; }
+        public Input<string?>? B { get; set; }
 
         public FuncWithAllOptionalInputsInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/HelmReleaseSettingsArgs.cs
@@ -19,13 +19,13 @@ namespace Pulumi.Example.Inputs
         /// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
         /// </summary>
         [Input("driver")]
-        public Input<string>? Driver { get; set; }
+        public Input<string?>? Driver { get; set; }
 
         /// <summary>
         /// The path to the helm plugins directory.
         /// </summary>
         [Input("pluginsPath")]
-        public Input<string>? PluginsPath { get; set; }
+        public Input<string?>? PluginsPath { get; set; }
 
         /// <summary>
         /// to test required args

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/KubeClientSettingsArgs.cs
@@ -19,21 +19,21 @@ namespace Pulumi.Example.Inputs
         /// Maximum burst for throttle. Default value is 10.
         /// </summary>
         [Input("burst")]
-        public Input<int>? Burst { get; set; }
+        public Input<int?>? Burst { get; set; }
 
         /// <summary>
         /// Maximum queries per second (QPS) to the API server from this client. Default value is 5.
         /// </summary>
         [Input("qps")]
-        public Input<double>? Qps { get; set; }
+        public Input<double?>? Qps { get; set; }
 
         [Input("recTest")]
-        public Input<Inputs.KubeClientSettingsArgs>? RecTest { get; set; }
+        public Input<Inputs.KubeClientSettingsArgs?>? RecTest { get; set; }
 
         public KubeClientSettingsArgs()
         {
-            Burst = Utilities.GetEnvInt32("PULUMI_K8S_CLIENT_BURST");
-            Qps = Utilities.GetEnvDouble("PULUMI_K8S_CLIENT_QPS");
+            Burst = Utilities.GetEnv("PULUMI_K8S_CLIENT_BURST");
+            Qps = Utilities.GetEnv("PULUMI_K8S_CLIENT_QPS");
         }
         public static new KubeClientSettingsArgs Empty => new KubeClientSettingsArgs();
     }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/LayeredTypeArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/LayeredTypeArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Example.Inputs
         /// The answer to the question
         /// </summary>
         [Input("answer")]
-        public Input<double>? Answer { get; set; }
+        public Input<double?>? Answer { get; set; }
 
         [Input("other", required: true)]
         public Input<Inputs.HelmReleaseSettingsArgs> Other { get; set; } = null!;
@@ -34,10 +34,10 @@ namespace Pulumi.Example.Inputs
         /// The question already answered
         /// </summary>
         [Input("question")]
-        public Input<string>? Question { get; set; }
+        public Input<string?>? Question { get; set; }
 
         [Input("recursive")]
-        public Input<Inputs.LayeredTypeArgs>? Recursive { get; set; }
+        public Input<Inputs.LayeredTypeArgs?>? Recursive { get; set; }
 
         /// <summary>
         /// To ask and answer

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Inputs/TypArgs.cs
@@ -16,13 +16,13 @@ namespace Pulumi.Example.Inputs
     public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
-        public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }
+        public Input<Pulumi.Example.Mod1.Inputs.TypArgs?>? Mod1 { get; set; }
 
         [Input("mod2")]
-        public Input<Pulumi.Example.Mod2.Inputs.TypArgs>? Mod2 { get; set; }
+        public Input<Pulumi.Example.Mod2.Inputs.TypArgs?>? Mod2 { get; set; }
 
         [Input("val")]
-        public Input<string>? Val { get; set; }
+        public Input<string?>? Val { get; set; }
 
         public TypArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod1/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod1/Inputs/TypArgs.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Example.Mod1.Inputs
     public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("val")]
-        public Input<string>? Val { get; set; }
+        public Input<string?>? Val { get; set; }
 
         public TypArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod2/Inputs/TypArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Mod2/Inputs/TypArgs.cs
@@ -16,10 +16,10 @@ namespace Pulumi.Example.Mod2.Inputs
     public sealed class TypArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
-        public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }
+        public Input<Pulumi.Example.Mod1.Inputs.TypArgs?>? Mod1 { get; set; }
 
         [Input("val")]
-        public Input<string>? Val { get; set; }
+        public Input<string?>? Val { get; set; }
 
         public TypArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/ModuleTest.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/ModuleTest.cs
@@ -57,10 +57,10 @@ namespace Pulumi.Example
     public sealed class ModuleTestArgs : global::Pulumi.ResourceArgs
     {
         [Input("mod1")]
-        public Input<Pulumi.Example.Mod1.Inputs.TypArgs>? Mod1 { get; set; }
+        public Input<Pulumi.Example.Mod1.Inputs.TypArgs?>? Mod1 { get; set; }
 
         [Input("val")]
-        public Input<Inputs.TypArgs>? Val { get; set; }
+        public Input<Inputs.TypArgs?>? Val { get; set; }
 
         public ModuleTestArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Provider.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Example
         /// BETA FEATURE - Options to configure the Helm Release resource.
         /// </summary>
         [Input("helmReleaseSettings", json: true)]
-        public Input<Inputs.HelmReleaseSettingsArgs>? HelmReleaseSettings { get; set; }
+        public Input<Inputs.HelmReleaseSettingsArgs?>? HelmReleaseSettings { get; set; }
 
         public ProviderArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/foo.go
@@ -76,9 +76,9 @@ type FooArgs struct {
 	// Options for tuning the Kubernetes client used by a Provider.
 	BackupKubeClientSettings KubeClientSettingsInput
 	// Options for tuning the Kubernetes client used by a Provider.
-	KubeClientSettings KubeClientSettingsPtrInput
+	KubeClientSettings *KubeClientSettingsArgs
 	// describing things
-	Settings LayeredTypePtrInput
+	Settings *LayeredTypeArgs
 }
 
 func (FooArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/funcWithAllOptionalInputs.go
@@ -46,9 +46,9 @@ func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOption
 
 type FuncWithAllOptionalInputsOutputArgs struct {
 	// Property A
-	A HelmReleaseSettingsPtrInput `pulumi:"a"`
+	A *HelmReleaseSettingsArgs `pulumi:"a"`
 	// Property B
-	B pulumi.StringPtrInput `pulumi:"b"`
+	B *string `pulumi:"b"`
 }
 
 func (FuncWithAllOptionalInputsOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod1/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod1/pulumiTypes.go
@@ -28,7 +28,7 @@ type TypInput interface {
 
 // A test for namespaces (mod 1)
 type TypArgs struct {
-	Val pulumi.StringPtrInput `pulumi:"val"`
+	Val *string `pulumi:"val"`
 }
 
 func (TypArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod2/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/mod2/pulumiTypes.go
@@ -30,8 +30,8 @@ type TypInput interface {
 
 // A test for namespaces (mod 2)
 type TypArgs struct {
-	Mod1 mod1.TypPtrInput      `pulumi:"mod1"`
-	Val  pulumi.StringPtrInput `pulumi:"val"`
+	Mod1 *mod1.TypArgs `pulumi:"mod1"`
+	Val  *string       `pulumi:"val"`
 }
 
 func (TypArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/moduleTest.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/moduleTest.go
@@ -60,8 +60,8 @@ type moduleTestArgs struct {
 
 // The set of arguments for constructing a ModuleTest resource.
 type ModuleTestArgs struct {
-	Mod1 mod1.TypPtrInput
-	Val  TypPtrInput
+	Mod1 *mod1.TypArgs
+	Val  *TypArgs
 }
 
 func (ModuleTestArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/provider.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/provider.go
@@ -38,7 +38,7 @@ type providerArgs struct {
 // The set of arguments for constructing a Provider resource.
 type ProviderArgs struct {
 	// BETA FEATURE - Options to configure the Helm Release resource.
-	HelmReleaseSettings HelmReleaseSettingsPtrInput
+	HelmReleaseSettings *HelmReleaseSettingsArgs
 }
 
 func (ProviderArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/go/example/pulumiTypes.go
@@ -36,9 +36,9 @@ type HelmReleaseSettingsInput interface {
 // BETA FEATURE - Options to configure the Helm Release resource.
 type HelmReleaseSettingsArgs struct {
 	// The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
-	Driver pulumi.StringPtrInput `pulumi:"driver"`
+	Driver *string `pulumi:"driver"`
 	// The path to the helm plugins directory.
-	PluginsPath pulumi.StringPtrInput `pulumi:"pluginsPath"`
+	PluginsPath *string `pulumi:"pluginsPath"`
 	// to test required args
 	RequiredArg pulumi.StringInput `pulumi:"requiredArg"`
 }
@@ -213,10 +213,10 @@ type KubeClientSettingsInput interface {
 // Options for tuning the Kubernetes client used by a Provider.
 type KubeClientSettingsArgs struct {
 	// Maximum burst for throttle. Default value is 10.
-	Burst pulumi.IntPtrInput `pulumi:"burst"`
+	Burst *int `pulumi:"burst"`
 	// Maximum queries per second (QPS) to the API server from this client. Default value is 5.
-	Qps     pulumi.Float64PtrInput     `pulumi:"qps"`
-	RecTest KubeClientSettingsPtrInput `pulumi:"recTest"`
+	Qps     *float64                `pulumi:"qps"`
+	RecTest *KubeClientSettingsArgs `pulumi:"recTest"`
 }
 
 func (KubeClientSettingsArgs) ElementType() reflect.Type {
@@ -392,13 +392,13 @@ type LayeredTypeInput interface {
 // Make sure that defaults propagate through types
 type LayeredTypeArgs struct {
 	// The answer to the question
-	Answer pulumi.Float64PtrInput   `pulumi:"answer"`
+	Answer *float64                 `pulumi:"answer"`
 	Other  HelmReleaseSettingsInput `pulumi:"other"`
 	// Test how plain types interact
 	PlainOther *HelmReleaseSettingsArgs `pulumi:"plainOther"`
 	// The question already answered
-	Question  pulumi.StringPtrInput `pulumi:"question"`
-	Recursive LayeredTypePtrInput   `pulumi:"recursive"`
+	Question  *string          `pulumi:"question"`
+	Recursive *LayeredTypeArgs `pulumi:"recursive"`
 	// To ask and answer
 	Thinker pulumi.StringInput `pulumi:"thinker"`
 }
@@ -611,9 +611,9 @@ type TypInput interface {
 
 // A test for namespaces (mod main)
 type TypArgs struct {
-	Mod1 mod1.TypPtrInput      `pulumi:"mod1"`
-	Mod2 mod2.TypPtrInput      `pulumi:"mod2"`
-	Val  pulumi.StringPtrInput `pulumi:"val"`
+	Mod1 *mod1.TypArgs `pulumi:"mod1"`
+	Mod2 *mod2.TypArgs `pulumi:"mod2"`
+	Val  *string       `pulumi:"val"`
 }
 
 func (TypArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/foo.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/foo.ts
@@ -80,9 +80,9 @@ export interface FooArgs {
     /**
      * Options for tuning the Kubernetes client used by a Provider.
      */
-    kubeClientSettings?: pulumi.Input<inputs.KubeClientSettingsArgs>;
+    kubeClientSettings?: pulumi.Input<inputs.KubeClientSettingsArgs | undefined>;
     /**
      * describing things
      */
-    settings?: pulumi.Input<inputs.LayeredTypeArgs>;
+    settings?: pulumi.Input<inputs.LayeredTypeArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/funcWithAllOptionalInputs.ts
@@ -44,9 +44,9 @@ export interface FuncWithAllOptionalInputsOutputArgs {
     /**
      * Property A
      */
-    a?: pulumi.Input<inputs.HelmReleaseSettingsArgs>;
+    a?: pulumi.Input<inputs.HelmReleaseSettingsArgs | undefined>;
     /**
      * Property B
      */
-    b?: pulumi.Input<string>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/moduleTest.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/moduleTest.ts
@@ -58,6 +58,6 @@ export class ModuleTest extends pulumi.CustomResource {
  * The set of arguments for constructing a ModuleTest resource.
  */
 export interface ModuleTestArgs {
-    mod1?: pulumi.Input<inputs.mod1.TypArgs>;
-    val?: pulumi.Input<inputs.TypArgs>;
+    mod1?: pulumi.Input<inputs.mod1.TypArgs | undefined>;
+    val?: pulumi.Input<inputs.TypArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/provider.ts
@@ -50,5 +50,5 @@ export interface ProviderArgs {
     /**
      * BETA FEATURE - Options to configure the Helm Release resource.
      */
-    helmReleaseSettings?: pulumi.Input<inputs.HelmReleaseSettingsArgs>;
+    helmReleaseSettings?: pulumi.Input<inputs.HelmReleaseSettingsArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/nodejs/types/input.ts
@@ -42,11 +42,11 @@ export interface HelmReleaseSettingsArgs {
     /**
      * The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
      */
-    driver?: pulumi.Input<string>;
+    driver?: pulumi.Input<string | undefined>;
     /**
      * The path to the helm plugins directory.
      */
-    pluginsPath?: pulumi.Input<string>;
+    pluginsPath?: pulumi.Input<string | undefined>;
     /**
      * to test required args
      */
@@ -70,12 +70,12 @@ export interface KubeClientSettingsArgs {
     /**
      * Maximum burst for throttle. Default value is 10.
      */
-    burst?: pulumi.Input<number>;
+    burst?: pulumi.Input<number | undefined>;
     /**
      * Maximum queries per second (QPS) to the API server from this client. Default value is 5.
      */
-    qps?: pulumi.Input<number>;
-    recTest?: pulumi.Input<inputs.KubeClientSettingsArgs>;
+    qps?: pulumi.Input<number | undefined>;
+    recTest?: pulumi.Input<inputs.KubeClientSettingsArgs | undefined>;
 }
 /**
  * kubeClientSettingsArgsProvideDefaults sets the appropriate defaults for KubeClientSettingsArgs
@@ -96,7 +96,7 @@ export interface LayeredTypeArgs {
     /**
      * The answer to the question
      */
-    answer?: pulumi.Input<number>;
+    answer?: pulumi.Input<number | undefined>;
     other: pulumi.Input<inputs.HelmReleaseSettingsArgs>;
     /**
      * Test how plain types interact
@@ -105,8 +105,8 @@ export interface LayeredTypeArgs {
     /**
      * The question already answered
      */
-    question?: pulumi.Input<string>;
-    recursive?: pulumi.Input<inputs.LayeredTypeArgs>;
+    question?: pulumi.Input<string | undefined>;
+    recursive?: pulumi.Input<inputs.LayeredTypeArgs | undefined>;
     /**
      * To ask and answer
      */
@@ -131,9 +131,9 @@ export function layeredTypeArgsProvideDefaults(val: LayeredTypeArgs): LayeredTyp
  * A test for namespaces (mod main)
  */
 export interface TypArgs {
-    mod1?: pulumi.Input<inputs.mod1.TypArgs>;
-    mod2?: pulumi.Input<inputs.mod2.TypArgs>;
-    val?: pulumi.Input<string>;
+    mod1?: pulumi.Input<inputs.mod1.TypArgs | undefined>;
+    mod2?: pulumi.Input<inputs.mod2.TypArgs | undefined>;
+    val?: pulumi.Input<string | undefined>;
 }
 /**
  * typArgsProvideDefaults sets the appropriate defaults for TypArgs
@@ -151,7 +151,7 @@ export namespace mod1 {
      * A test for namespaces (mod 1)
      */
     export interface TypArgs {
-        val?: pulumi.Input<string>;
+        val?: pulumi.Input<string | undefined>;
     }
     /**
      * typArgsProvideDefaults sets the appropriate defaults for TypArgs
@@ -169,8 +169,8 @@ export namespace mod2 {
      * A test for namespaces (mod 2)
      */
     export interface TypArgs {
-        mod1?: pulumi.Input<inputs.mod1.TypArgs>;
-        val?: pulumi.Input<string>;
+        mod1?: pulumi.Input<inputs.mod1.TypArgs | undefined>;
+        val?: pulumi.Input<string | undefined>;
     }
     /**
      * typArgsProvideDefaults sets the appropriate defaults for TypArgs

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/_inputs.py
@@ -82,13 +82,13 @@ class HelmReleaseSettings:
 class HelmReleaseSettingsArgs:
     def __init__(__self__, *,
                  required_arg: pulumi.Input[str],
-                 driver: Optional[pulumi.Input[str]] = None,
-                 plugins_path: Optional[pulumi.Input[str]] = None):
+                 driver: pulumi.Input[Optional[str]] = None,
+                 plugins_path: pulumi.Input[Optional[str]] = None):
         """
         BETA FEATURE - Options to configure the Helm Release resource.
         :param pulumi.Input[str] required_arg: to test required args
-        :param pulumi.Input[str] driver: The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
-        :param pulumi.Input[str] plugins_path: The path to the helm plugins directory.
+        :param pulumi.Input[Optional[str]] driver: The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
+        :param pulumi.Input[Optional[str]] plugins_path: The path to the helm plugins directory.
         """
         pulumi.set(__self__, "required_arg", required_arg)
         if driver is None:
@@ -114,46 +114,46 @@ class HelmReleaseSettingsArgs:
 
     @property
     @pulumi.getter
-    def driver(self) -> Optional[pulumi.Input[str]]:
+    def driver(self) -> pulumi.Input[Optional[str]]:
         """
         The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
         """
         return pulumi.get(self, "driver")
 
     @driver.setter
-    def driver(self, value: Optional[pulumi.Input[str]]):
+    def driver(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "driver", value)
 
     @property
     @pulumi.getter(name="pluginsPath")
-    def plugins_path(self) -> Optional[pulumi.Input[str]]:
+    def plugins_path(self) -> pulumi.Input[Optional[str]]:
         """
         The path to the helm plugins directory.
         """
         return pulumi.get(self, "plugins_path")
 
     @plugins_path.setter
-    def plugins_path(self, value: Optional[pulumi.Input[str]]):
+    def plugins_path(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "plugins_path", value)
 
 
 @pulumi.input_type
 class KubeClientSettingsArgs:
     def __init__(__self__, *,
-                 burst: Optional[pulumi.Input[int]] = None,
-                 qps: Optional[pulumi.Input[float]] = None,
-                 rec_test: Optional[pulumi.Input['KubeClientSettingsArgs']] = None):
+                 burst: pulumi.Input[Optional[int]] = None,
+                 qps: pulumi.Input[Optional[float]] = None,
+                 rec_test: pulumi.Input[Optional['KubeClientSettingsArgs']] = None):
         """
         Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input[int] burst: Maximum burst for throttle. Default value is 10.
-        :param pulumi.Input[float] qps: Maximum queries per second (QPS) to the API server from this client. Default value is 5.
+        :param pulumi.Input[Optional[int]] burst: Maximum burst for throttle. Default value is 10.
+        :param pulumi.Input[Optional[float]] qps: Maximum queries per second (QPS) to the API server from this client. Default value is 5.
         """
         if burst is None:
-            burst = _utilities.get_env_int('PULUMI_K8S_CLIENT_BURST')
+            burst = _utilities.get_env('PULUMI_K8S_CLIENT_BURST')
         if burst is not None:
             pulumi.set(__self__, "burst", burst)
         if qps is None:
-            qps = _utilities.get_env_float('PULUMI_K8S_CLIENT_QPS')
+            qps = _utilities.get_env('PULUMI_K8S_CLIENT_QPS')
         if qps is not None:
             pulumi.set(__self__, "qps", qps)
         if rec_test is not None:
@@ -161,35 +161,35 @@ class KubeClientSettingsArgs:
 
     @property
     @pulumi.getter
-    def burst(self) -> Optional[pulumi.Input[int]]:
+    def burst(self) -> pulumi.Input[Optional[int]]:
         """
         Maximum burst for throttle. Default value is 10.
         """
         return pulumi.get(self, "burst")
 
     @burst.setter
-    def burst(self, value: Optional[pulumi.Input[int]]):
+    def burst(self, value: pulumi.Input[Optional[int]]):
         pulumi.set(self, "burst", value)
 
     @property
     @pulumi.getter
-    def qps(self) -> Optional[pulumi.Input[float]]:
+    def qps(self) -> pulumi.Input[Optional[float]]:
         """
         Maximum queries per second (QPS) to the API server from this client. Default value is 5.
         """
         return pulumi.get(self, "qps")
 
     @qps.setter
-    def qps(self, value: Optional[pulumi.Input[float]]):
+    def qps(self, value: pulumi.Input[Optional[float]]):
         pulumi.set(self, "qps", value)
 
     @property
     @pulumi.getter(name="recTest")
-    def rec_test(self) -> Optional[pulumi.Input['KubeClientSettingsArgs']]:
+    def rec_test(self) -> pulumi.Input[Optional['KubeClientSettingsArgs']]:
         return pulumi.get(self, "rec_test")
 
     @rec_test.setter
-    def rec_test(self, value: Optional[pulumi.Input['KubeClientSettingsArgs']]):
+    def rec_test(self, value: pulumi.Input[Optional['KubeClientSettingsArgs']]):
         pulumi.set(self, "rec_test", value)
 
 
@@ -198,16 +198,16 @@ class LayeredTypeArgs:
     def __init__(__self__, *,
                  other: pulumi.Input['HelmReleaseSettingsArgs'],
                  thinker: pulumi.Input[str],
-                 answer: Optional[pulumi.Input[float]] = None,
+                 answer: pulumi.Input[Optional[float]] = None,
                  plain_other: Optional['HelmReleaseSettingsArgs'] = None,
-                 question: Optional[pulumi.Input[str]] = None,
-                 recursive: Optional[pulumi.Input['LayeredTypeArgs']] = None):
+                 question: pulumi.Input[Optional[str]] = None,
+                 recursive: pulumi.Input[Optional['LayeredTypeArgs']] = None):
         """
         Make sure that defaults propagate through types
         :param pulumi.Input[str] thinker: To ask and answer
-        :param pulumi.Input[float] answer: The answer to the question
+        :param pulumi.Input[Optional[float]] answer: The answer to the question
         :param 'HelmReleaseSettingsArgs' plain_other: Test how plain types interact
-        :param pulumi.Input[str] question: The question already answered
+        :param pulumi.Input[Optional[str]] question: The question already answered
         """
         pulumi.set(__self__, "other", other)
         if thinker is None:
@@ -249,14 +249,14 @@ class LayeredTypeArgs:
 
     @property
     @pulumi.getter
-    def answer(self) -> Optional[pulumi.Input[float]]:
+    def answer(self) -> pulumi.Input[Optional[float]]:
         """
         The answer to the question
         """
         return pulumi.get(self, "answer")
 
     @answer.setter
-    def answer(self, value: Optional[pulumi.Input[float]]):
+    def answer(self, value: pulumi.Input[Optional[float]]):
         pulumi.set(self, "answer", value)
 
     @property
@@ -273,32 +273,32 @@ class LayeredTypeArgs:
 
     @property
     @pulumi.getter
-    def question(self) -> Optional[pulumi.Input[str]]:
+    def question(self) -> pulumi.Input[Optional[str]]:
         """
         The question already answered
         """
         return pulumi.get(self, "question")
 
     @question.setter
-    def question(self, value: Optional[pulumi.Input[str]]):
+    def question(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "question", value)
 
     @property
     @pulumi.getter
-    def recursive(self) -> Optional[pulumi.Input['LayeredTypeArgs']]:
+    def recursive(self) -> pulumi.Input[Optional['LayeredTypeArgs']]:
         return pulumi.get(self, "recursive")
 
     @recursive.setter
-    def recursive(self, value: Optional[pulumi.Input['LayeredTypeArgs']]):
+    def recursive(self, value: pulumi.Input[Optional['LayeredTypeArgs']]):
         pulumi.set(self, "recursive", value)
 
 
 @pulumi.input_type
 class TypArgs:
     def __init__(__self__, *,
-                 mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
-                 mod2: Optional[pulumi.Input['_mod2.TypArgs']] = None,
-                 val: Optional[pulumi.Input[str]] = None):
+                 mod1: pulumi.Input[Optional['_mod1.TypArgs']] = None,
+                 mod2: pulumi.Input[Optional['_mod2.TypArgs']] = None,
+                 val: pulumi.Input[Optional[str]] = None):
         """
         A test for namespaces (mod main)
         """
@@ -313,29 +313,29 @@ class TypArgs:
 
     @property
     @pulumi.getter
-    def mod1(self) -> Optional[pulumi.Input['_mod1.TypArgs']]:
+    def mod1(self) -> pulumi.Input[Optional['_mod1.TypArgs']]:
         return pulumi.get(self, "mod1")
 
     @mod1.setter
-    def mod1(self, value: Optional[pulumi.Input['_mod1.TypArgs']]):
+    def mod1(self, value: pulumi.Input[Optional['_mod1.TypArgs']]):
         pulumi.set(self, "mod1", value)
 
     @property
     @pulumi.getter
-    def mod2(self) -> Optional[pulumi.Input['_mod2.TypArgs']]:
+    def mod2(self) -> pulumi.Input[Optional['_mod2.TypArgs']]:
         return pulumi.get(self, "mod2")
 
     @mod2.setter
-    def mod2(self, value: Optional[pulumi.Input['_mod2.TypArgs']]):
+    def mod2(self, value: pulumi.Input[Optional['_mod2.TypArgs']]):
         pulumi.set(self, "mod2", value)
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input[str]]:
+    def val(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input[str]]):
+    def val(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "val", value)
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -18,13 +18,13 @@ class FooArgs:
     def __init__(__self__, *,
                  backup_kube_client_settings: pulumi.Input['KubeClientSettingsArgs'],
                  argument: Optional[str] = None,
-                 kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
-                 settings: Optional[pulumi.Input['LayeredTypeArgs']] = None):
+                 kube_client_settings: pulumi.Input[Optional['KubeClientSettingsArgs']] = None,
+                 settings: pulumi.Input[Optional['LayeredTypeArgs']] = None):
         """
         The set of arguments for constructing a Foo resource.
         :param pulumi.Input['KubeClientSettingsArgs'] backup_kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input['KubeClientSettingsArgs'] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input['LayeredTypeArgs'] settings: describing things
+        :param pulumi.Input[Optional['KubeClientSettingsArgs']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
+        :param pulumi.Input[Optional['LayeredTypeArgs']] settings: describing things
         """
         pulumi.set(__self__, "backup_kube_client_settings", backup_kube_client_settings)
         if argument is not None:
@@ -57,26 +57,26 @@ class FooArgs:
 
     @property
     @pulumi.getter(name="kubeClientSettings")
-    def kube_client_settings(self) -> Optional[pulumi.Input['KubeClientSettingsArgs']]:
+    def kube_client_settings(self) -> pulumi.Input[Optional['KubeClientSettingsArgs']]:
         """
         Options for tuning the Kubernetes client used by a Provider.
         """
         return pulumi.get(self, "kube_client_settings")
 
     @kube_client_settings.setter
-    def kube_client_settings(self, value: Optional[pulumi.Input['KubeClientSettingsArgs']]):
+    def kube_client_settings(self, value: pulumi.Input[Optional['KubeClientSettingsArgs']]):
         pulumi.set(self, "kube_client_settings", value)
 
     @property
     @pulumi.getter
-    def settings(self) -> Optional[pulumi.Input['LayeredTypeArgs']]:
+    def settings(self) -> pulumi.Input[Optional['LayeredTypeArgs']]:
         """
         describing things
         """
         return pulumi.get(self, "settings")
 
     @settings.setter
-    def settings(self, value: Optional[pulumi.Input['LayeredTypeArgs']]):
+    def settings(self, value: pulumi.Input[Optional['LayeredTypeArgs']]):
         pulumi.set(self, "settings", value)
 
 
@@ -87,8 +87,8 @@ class Foo(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  argument: Optional[str] = None,
                  backup_kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 settings: Optional[pulumi.Input[pulumi.InputType['LayeredTypeArgs']]] = None,
+                 kube_client_settings: pulumi.Input[Optional[pulumi.InputType['KubeClientSettingsArgs']]] = None,
+                 settings: pulumi.Input[Optional[pulumi.InputType['LayeredTypeArgs']]] = None,
                  __props__=None):
         """
         test new feature with resoruces
@@ -96,8 +96,8 @@ class Foo(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']] backup_kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
-        :param pulumi.Input[pulumi.InputType['LayeredTypeArgs']] settings: describing things
+        :param pulumi.Input[Optional[pulumi.InputType['KubeClientSettingsArgs']]] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
+        :param pulumi.Input[Optional[pulumi.InputType['LayeredTypeArgs']]] settings: describing things
         """
         ...
     @overload
@@ -125,8 +125,8 @@ class Foo(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  argument: Optional[str] = None,
                  backup_kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
-                 settings: Optional[pulumi.Input[pulumi.InputType['LayeredTypeArgs']]] = None,
+                 kube_client_settings: pulumi.Input[Optional[pulumi.InputType['KubeClientSettingsArgs']]] = None,
+                 settings: pulumi.Input[Optional[pulumi.InputType['LayeredTypeArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -60,8 +60,8 @@ def func_with_all_optional_inputs(a: Optional[pulumi.InputType['HelmReleaseSetti
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)
-def func_with_all_optional_inputs_output(a: Optional[pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettings']]]] = None,
-                                         b: Optional[pulumi.Input[Optional[str]]] = None,
+def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettings']]] = None,
+                                         b: pulumi.Input[Optional[str]] = None,
                                          opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod1/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod1/_inputs.py
@@ -16,7 +16,7 @@ __all__ = [
 @pulumi.input_type
 class TypArgs:
     def __init__(__self__, *,
-                 val: Optional[pulumi.Input[str]] = None):
+                 val: pulumi.Input[Optional[str]] = None):
         """
         A test for namespaces (mod 1)
         """
@@ -27,11 +27,11 @@ class TypArgs:
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input[str]]:
+    def val(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input[str]]):
+    def val(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "val", value)
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
@@ -17,8 +17,8 @@ __all__ = [
 @pulumi.input_type
 class TypArgs:
     def __init__(__self__, *,
-                 mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
-                 val: Optional[pulumi.Input[str]] = None):
+                 mod1: pulumi.Input[Optional['_mod1.TypArgs']] = None,
+                 val: pulumi.Input[Optional[str]] = None):
         """
         A test for namespaces (mod 2)
         """
@@ -31,20 +31,20 @@ class TypArgs:
 
     @property
     @pulumi.getter
-    def mod1(self) -> Optional[pulumi.Input['_mod1.TypArgs']]:
+    def mod1(self) -> pulumi.Input[Optional['_mod1.TypArgs']]:
         return pulumi.get(self, "mod1")
 
     @mod1.setter
-    def mod1(self, value: Optional[pulumi.Input['_mod1.TypArgs']]):
+    def mod1(self, value: pulumi.Input[Optional['_mod1.TypArgs']]):
         pulumi.set(self, "mod1", value)
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input[str]]:
+    def val(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input[str]]):
+    def val(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "val", value)
 
 

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/module_test.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/module_test.py
@@ -17,8 +17,8 @@ __all__ = ['ModuleTestArgs', 'ModuleTest']
 @pulumi.input_type
 class ModuleTestArgs:
     def __init__(__self__, *,
-                 mod1: Optional[pulumi.Input['_mod1.TypArgs']] = None,
-                 val: Optional[pulumi.Input['TypArgs']] = None):
+                 mod1: pulumi.Input[Optional['_mod1.TypArgs']] = None,
+                 val: pulumi.Input[Optional['TypArgs']] = None):
         """
         The set of arguments for constructing a ModuleTest resource.
         """
@@ -29,20 +29,20 @@ class ModuleTestArgs:
 
     @property
     @pulumi.getter
-    def mod1(self) -> Optional[pulumi.Input['_mod1.TypArgs']]:
+    def mod1(self) -> pulumi.Input[Optional['_mod1.TypArgs']]:
         return pulumi.get(self, "mod1")
 
     @mod1.setter
-    def mod1(self, value: Optional[pulumi.Input['_mod1.TypArgs']]):
+    def mod1(self, value: pulumi.Input[Optional['_mod1.TypArgs']]):
         pulumi.set(self, "mod1", value)
 
     @property
     @pulumi.getter
-    def val(self) -> Optional[pulumi.Input['TypArgs']]:
+    def val(self) -> pulumi.Input[Optional['TypArgs']]:
         return pulumi.get(self, "val")
 
     @val.setter
-    def val(self, value: Optional[pulumi.Input['TypArgs']]):
+    def val(self, value: pulumi.Input[Optional['TypArgs']]):
         pulumi.set(self, "val", value)
 
 
@@ -51,8 +51,8 @@ class ModuleTest(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 mod1: Optional[pulumi.Input[pulumi.InputType['_mod1.TypArgs']]] = None,
-                 val: Optional[pulumi.Input[pulumi.InputType['TypArgs']]] = None,
+                 mod1: pulumi.Input[Optional[pulumi.InputType['_mod1.TypArgs']]] = None,
+                 val: pulumi.Input[Optional[pulumi.InputType['TypArgs']]] = None,
                  __props__=None):
         """
         Create a ModuleTest resource with the given unique name, props, and options.
@@ -82,8 +82,8 @@ class ModuleTest(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 mod1: Optional[pulumi.Input[pulumi.InputType['_mod1.TypArgs']]] = None,
-                 val: Optional[pulumi.Input[pulumi.InputType['TypArgs']]] = None,
+                 mod1: pulumi.Input[Optional[pulumi.InputType['_mod1.TypArgs']]] = None,
+                 val: pulumi.Input[Optional[pulumi.InputType['TypArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -15,24 +15,24 @@ __all__ = ['ProviderArgs', 'Provider']
 @pulumi.input_type
 class ProviderArgs:
     def __init__(__self__, *,
-                 helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None):
+                 helm_release_settings: pulumi.Input[Optional['HelmReleaseSettingsArgs']] = None):
         """
         The set of arguments for constructing a Provider resource.
-        :param pulumi.Input['HelmReleaseSettingsArgs'] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
+        :param pulumi.Input[Optional['HelmReleaseSettingsArgs']] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
         """
         if helm_release_settings is not None:
             pulumi.set(__self__, "helm_release_settings", helm_release_settings)
 
     @property
     @pulumi.getter(name="helmReleaseSettings")
-    def helm_release_settings(self) -> Optional[pulumi.Input['HelmReleaseSettingsArgs']]:
+    def helm_release_settings(self) -> pulumi.Input[Optional['HelmReleaseSettingsArgs']]:
         """
         BETA FEATURE - Options to configure the Helm Release resource.
         """
         return pulumi.get(self, "helm_release_settings")
 
     @helm_release_settings.setter
-    def helm_release_settings(self, value: Optional[pulumi.Input['HelmReleaseSettingsArgs']]):
+    def helm_release_settings(self, value: pulumi.Input[Optional['HelmReleaseSettingsArgs']]):
         pulumi.set(self, "helm_release_settings", value)
 
 
@@ -41,14 +41,14 @@ class Provider(pulumi.ProviderResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
+                 helm_release_settings: pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  __props__=None):
         """
         The provider type for the kubernetes package.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
+        :param pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettingsArgs']]] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
         """
         ...
     @overload
@@ -74,7 +74,7 @@ class Provider(pulumi.ProviderResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
+                 helm_release_settings: pulumi.Input[Optional[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Inputs/FooArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Xyz.Inputs
     public sealed class FooArgs : global::Pulumi.ResourceArgs
     {
         [Input("a")]
-        public Input<bool>? A { get; set; }
+        public Input<bool?>? A { get; set; }
 
         public FooArgs()
         {

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/go/xyz/pulumiTypes.go
@@ -26,7 +26,7 @@ type FooInput interface {
 }
 
 type FooArgs struct {
-	A pulumi.BoolPtrInput `pulumi:"a"`
+	A *bool `pulumi:"a"`
 }
 
 func (FooArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/nodejs/types/input.ts
@@ -6,5 +6,5 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 
 export interface FooArgs {
-    a?: pulumi.Input<boolean>;
+    a?: pulumi.Input<boolean | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_inputs.py
@@ -16,17 +16,17 @@ __all__ = [
 @pulumi.input_type
 class FooArgs:
     def __init__(__self__, *,
-                 a: Optional[pulumi.Input[bool]] = None):
+                 a: pulumi.Input[Optional[bool]] = None):
         if a is not None:
             pulumi.set(__self__, "a", a)
 
     @property
     @pulumi.getter
-    def a(self) -> Optional[pulumi.Input[bool]]:
+    def a(self) -> pulumi.Input[Optional[bool]]:
         return pulumi.get(self, "a")
 
     @a.setter
-    def a(self, value: Optional[pulumi.Input[bool]]):
+    def a(self, value: pulumi.Input[Optional[bool]]):
         pulumi.set(self, "a", value)
 
 

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/funcwithalloptionalinputs/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/funcwithalloptionalinputs/_index.md
@@ -48,8 +48,8 @@ function </span>funcWithAllOptionalInputsOutput<span class="p">(</span><span cla
                                   <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>FuncWithAllOptionalInputsResult</span
 ><span class="k">
-def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+def </span>func_with_all_optional_inputs_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
+                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[FuncWithAllOptionalInputsResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/docs/provider/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Provider</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">favorite_color</span><span class="p">:</span> <span class="nx">Optional[Union[str, Color]]</span> = None<span class="p">,</span>
-             <span class="nx">secret_sandwiches</span><span class="p">:</span> <span class="nx">Optional[Sequence[_config.SandwichArgs]]</span> = None<span class="p">)</span>
+             <span class="nx">favorite_color</span><span class="p">:</span> <span class="nx">Optional[Optional[Union[str, Color]]]</span> = None<span class="p">,</span>
+             <span class="nx">secret_sandwiches</span><span class="p">:</span> <span class="nx">Optional[Optional[Sequence[_config.SandwichArgs]]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Provider</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ProviderArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_csharp" style="color: inherit; text-decoration: inherit;">Favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string | <a href="#color">Configstation.<wbr>Pulumi.<wbr>Configstation.<wbr>Color</a></span>
+        <span class="property-type">Union&lt;string, Configstation.<wbr>Pulumi.<wbr>Configstation.<wbr>Color&gt;?</span>
     </dt>
     <dd><p>this is a relaxed string enum which can also be set via env var It can also be sourced from the following environment variable: <code>FAVE_COLOR</code></p>
 </dd><dt class="property-optional"
@@ -235,7 +235,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#secretsandwiches_csharp" style="color: inherit; text-decoration: inherit;">Secret<wbr>Sandwiches</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#sandwich">List&lt;Configstation.<wbr>Pulumi.<wbr>Configstation.<wbr>Config.<wbr>Inputs.<wbr>Sandwich<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Configstation.<wbr>Pulumi.<wbr>Configstation.<wbr>Config.<wbr>Inputs.<wbr>Sandwich<wbr>Args&gt;?</span>
     </dt>
     <dd><p>Super duper secret sandwiches.</p>
 </dd></dl>
@@ -250,7 +250,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_go" style="color: inherit; text-decoration: inherit;">Favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string | <a href="#color">Color</a></span>
+        <span class="property-type">string</span>
     </dt>
     <dd><p>this is a relaxed string enum which can also be set via env var It can also be sourced from the following environment variable: <code>FAVE_COLOR</code></p>
 </dd><dt class="property-optional"
@@ -259,7 +259,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#secretsandwiches_go" style="color: inherit; text-decoration: inherit;">Secret<wbr>Sandwiches</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#sandwich">Sandwich<wbr>Args</a></span>
+        <span class="property-type">Sandwich<wbr>Args</span>
     </dt>
     <dd><p>Super duper secret sandwiches.</p>
 </dd></dl>
@@ -274,7 +274,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_java" style="color: inherit; text-decoration: inherit;">favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String | <a href="#color">Color</a></span>
+        <span class="property-type">Optional&lt;Either&lt;String,Color&gt;&gt;</span>
     </dt>
     <dd><p>this is a relaxed string enum which can also be set via env var It can also be sourced from the following environment variable: <code>FAVE_COLOR</code></p>
 </dd><dt class="property-optional"
@@ -283,7 +283,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#secretsandwiches_java" style="color: inherit; text-decoration: inherit;">secret<wbr>Sandwiches</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#sandwich">List&lt;Sandwich<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Sandwich<wbr>Args&gt;</span>
     </dt>
     <dd><p>Super duper secret sandwiches.</p>
 </dd></dl>
@@ -298,7 +298,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_nodejs" style="color: inherit; text-decoration: inherit;">favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string | <a href="#color">Color</a></span>
+        <span class="property-type">string | Color | undefined</span>
     </dt>
     <dd><p>this is a relaxed string enum which can also be set via env var It can also be sourced from the following environment variable: <code>FAVE_COLOR</code></p>
 </dd><dt class="property-optional"
@@ -307,7 +307,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#secretsandwiches_nodejs" style="color: inherit; text-decoration: inherit;">secret<wbr>Sandwiches</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#sandwich">config<wbr>Sandwich<wbr>Args[]</a></span>
+        <span class="property-type">config<wbr>Sandwich<wbr>Args[] | undefined</span>
     </dt>
     <dd><p>Super duper secret sandwiches.</p>
 </dd></dl>
@@ -322,7 +322,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favorite_color_python" style="color: inherit; text-decoration: inherit;">favorite_<wbr>color</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str | <a href="#color">Color</a></span>
+        <span class="property-type">Union[str, Color]</span>
     </dt>
     <dd><p>this is a relaxed string enum which can also be set via env var It can also be sourced from the following environment variable: <code>FAVE_COLOR</code></p>
 </dd><dt class="property-optional"
@@ -331,7 +331,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#secret_sandwiches_python" style="color: inherit; text-decoration: inherit;">secret_<wbr>sandwiches</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#sandwich">Sandwich<wbr>Args]</a></span>
+        <span class="property-type">Sandwich<wbr>Args]]</span>
     </dt>
     <dd><p>Super duper secret sandwiches.</p>
 </dd></dl>
@@ -346,7 +346,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#favoritecolor_yaml" style="color: inherit; text-decoration: inherit;">favorite<wbr>Color</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String | <a href="#color">&#34;blue&#34; | &#34;red&#34;</a></span>
+        <span class="property-type">String | &#34;blue&#34; | &#34;red&#34;</span>
     </dt>
     <dd><p>this is a relaxed string enum which can also be set via env var It can also be sourced from the following environment variable: <code>FAVE_COLOR</code></p>
 </dd><dt class="property-optional"
@@ -355,7 +355,7 @@ The Provider resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#secretsandwiches_yaml" style="color: inherit; text-decoration: inherit;">secret<wbr>Sandwiches</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#sandwich">List&lt;Property Map&gt;</a></span>
+        <span class="property-type">List&lt;Property Map&gt;</span>
     </dt>
     <dd><p>Super duper secret sandwiches.</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation/FuncWithAllOptionalInputs.cs
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation/FuncWithAllOptionalInputs.cs
@@ -52,13 +52,13 @@ namespace Configstation.Pulumi.Configstation
         /// Property A
         /// </summary>
         [Input("a")]
-        public Input<string>? A { get; set; }
+        public Input<string?>? A { get; set; }
 
         /// <summary>
         /// Property B
         /// </summary>
         [Input("b")]
-        public Input<string>? B { get; set; }
+        public Input<string?>? B { get; set; }
 
         public FuncWithAllOptionalInputsInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation/Provider.cs
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation/Provider.cs
@@ -44,21 +44,21 @@ namespace Configstation.Pulumi.Configstation
         /// this is a relaxed string enum which can also be set via env var
         /// </summary>
         [Input("favoriteColor", json: true)]
-        public InputUnion<string, Configstation.Pulumi.Configstation.Color>? FavoriteColor { get; set; }
+        public Input<Union<Input<string>, Input<Configstation.Pulumi.Configstation.Color>>?>? FavoriteColor { get; set; }
 
         [Input("secretSandwiches", json: true)]
-        private InputList<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs>? _secretSandwiches;
+        private Input<ImmutableArray<Input<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs>>>? _secretSandwiches;
 
         /// <summary>
         /// Super duper secret sandwiches.
         /// </summary>
-        public InputList<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs> SecretSandwiches
+        public Input<ImmutableArray<Input<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs>>>? SecretSandwiches
         {
-            get => _secretSandwiches ?? (_secretSandwiches = new InputList<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs>());
+            get => _secretSandwiches;
             set
             {
-                var emptySecret = Output.CreateSecret(ImmutableArray.Create<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs>());
-                _secretSandwiches = Output.All(value, emptySecret).Apply(v => v[0]);
+                var emptySecret = Output.CreateSecret(0);
+                _secretSandwiches = Output.Tuple<Input<ImmutableArray<Input<Configstation.Pulumi.Configstation.Config.Inputs.SandwichArgs>>>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/config/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/config/pulumiTypes.go
@@ -27,8 +27,8 @@ type SandwichInput interface {
 }
 
 type SandwichArgs struct {
-	Bread   pulumi.StringPtrInput   `pulumi:"bread"`
-	Veggies pulumi.StringArrayInput `pulumi:"veggies"`
+	Bread   *string              `pulumi:"bread"`
+	Veggies []pulumi.StringInput `pulumi:"veggies"`
 }
 
 func (SandwichArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/funcWithAllOptionalInputs.go
@@ -46,9 +46,9 @@ func FuncWithAllOptionalInputsOutput(ctx *pulumi.Context, args FuncWithAllOption
 
 type FuncWithAllOptionalInputsOutputArgs struct {
 	// Property A
-	A pulumi.StringPtrInput `pulumi:"a"`
+	A *string `pulumi:"a"`
 	// Property B
-	B pulumi.StringPtrInput `pulumi:"b"`
+	B *string `pulumi:"b"`
 }
 
 func (FuncWithAllOptionalInputsOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/provider.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/provider.go
@@ -23,10 +23,10 @@ func NewProvider(ctx *pulumi.Context,
 	}
 
 	if args.FavoriteColor == nil {
-		args.FavoriteColor = pulumi.StringPtr(getEnvOrDefault("", nil, "FAVE_COLOR").(string))
+		args.FavoriteColor = *string(getEnvOrDefault("", nil, "FAVE_COLOR").(string))
 	}
 	if args.SecretSandwiches != nil {
-		args.SecretSandwiches = pulumi.ToSecret(args.SecretSandwiches).(config.SandwichArrayInput)
+		args.SecretSandwiches = pulumi.ToSecret(args.SecretSandwiches).([]config.SandwichInput)
 	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:configstation", name, args, &resource, opts...)
@@ -46,9 +46,9 @@ type providerArgs struct {
 // The set of arguments for constructing a Provider resource.
 type ProviderArgs struct {
 	// this is a relaxed string enum which can also be set via env var
-	FavoriteColor pulumi.StringPtrInput
+	FavoriteColor *string
 	// Super duper secret sandwiches.
-	SecretSandwiches config.SandwichArrayInput
+	SecretSandwiches []config.SandwichInput
 }
 
 func (ProviderArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/go/configstation/pulumiTypes.go
@@ -27,8 +27,8 @@ type ChildInput interface {
 }
 
 type ChildArgs struct {
-	Age  pulumi.IntPtrInput    `pulumi:"age"`
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Age  *int    `pulumi:"age"`
+	Name *string `pulumi:"name"`
 }
 
 func (ChildArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/funcWithAllOptionalInputs.ts
@@ -42,9 +42,9 @@ export interface FuncWithAllOptionalInputsOutputArgs {
     /**
      * Property A
      */
-    a?: pulumi.Input<string>;
+    a?: pulumi.Input<string | undefined>;
     /**
      * Property B
      */
-    b?: pulumi.Input<string>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/provider.ts
@@ -49,9 +49,9 @@ export interface ProviderArgs {
     /**
      * this is a relaxed string enum which can also be set via env var
      */
-    favoriteColor?: pulumi.Input<string | enums.Color>;
+    favoriteColor?: pulumi.Input<pulumi.Input<string> | pulumi.Input<enums.Color> | undefined>;
     /**
      * Super duper secret sandwiches.
      */
-    secretSandwiches?: pulumi.Input<pulumi.Input<inputs.config.SandwichArgs>[]>;
+    secretSandwiches?: pulumi.Input<pulumi.Input<inputs.config.SandwichArgs>[] | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/nodejs/types/input.ts
@@ -8,7 +8,7 @@ import * as enums from "../types/enums";
 
 export namespace config {
     export interface SandwichArgs {
-        bread?: pulumi.Input<string>;
-        veggies?: pulumi.Input<pulumi.Input<string>[]>;
+        bread?: pulumi.Input<string | undefined>;
+        veggies?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     }
 }

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/config/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/config/_inputs.py
@@ -16,8 +16,8 @@ __all__ = [
 @pulumi.input_type
 class SandwichArgs:
     def __init__(__self__, *,
-                 bread: Optional[pulumi.Input[str]] = None,
-                 veggies: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
+                 bread: pulumi.Input[Optional[str]] = None,
+                 veggies: pulumi.Input[Optional[Sequence[pulumi.Input[str]]]] = None):
         if bread is not None:
             pulumi.set(__self__, "bread", bread)
         if veggies is not None:
@@ -25,20 +25,20 @@ class SandwichArgs:
 
     @property
     @pulumi.getter
-    def bread(self) -> Optional[pulumi.Input[str]]:
+    def bread(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "bread")
 
     @bread.setter
-    def bread(self, value: Optional[pulumi.Input[str]]):
+    def bread(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "bread", value)
 
     @property
     @pulumi.getter
-    def veggies(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+    def veggies(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[str]]]]:
         return pulumi.get(self, "veggies")
 
     @veggies.setter
-    def veggies(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+    def veggies(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "veggies", value)
 
 

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
@@ -59,8 +59,8 @@ def func_with_all_optional_inputs(a: Optional[str] = None,
 
 
 @_utilities.lift_output_func(func_with_all_optional_inputs)
-def func_with_all_optional_inputs_output(a: Optional[pulumi.Input[Optional[str]]] = None,
-                                         b: Optional[pulumi.Input[Optional[str]]] = None,
+def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[str]] = None,
+                                         b: pulumi.Input[Optional[str]] = None,
                                          opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/pulumi_configstation/provider.py
@@ -16,12 +16,12 @@ __all__ = ['ProviderArgs', 'Provider']
 @pulumi.input_type
 class ProviderArgs:
     def __init__(__self__, *,
-                 favorite_color: Optional[pulumi.Input[Union[str, 'Color']]] = None,
-                 secret_sandwiches: Optional[pulumi.Input[Sequence[pulumi.Input['_config.SandwichArgs']]]] = None):
+                 favorite_color: pulumi.Input[Optional[Union[str, 'Color']]] = None,
+                 secret_sandwiches: pulumi.Input[Optional[Sequence[pulumi.Input['_config.SandwichArgs']]]] = None):
         """
         The set of arguments for constructing a Provider resource.
-        :param pulumi.Input[Union[str, 'Color']] favorite_color: this is a relaxed string enum which can also be set via env var
-        :param pulumi.Input[Sequence[pulumi.Input['_config.SandwichArgs']]] secret_sandwiches: Super duper secret sandwiches.
+        :param pulumi.Input[Optional[Union[str, 'Color']]] favorite_color: this is a relaxed string enum which can also be set via env var
+        :param pulumi.Input[Optional[Sequence[pulumi.Input['_config.SandwichArgs']]]] secret_sandwiches: Super duper secret sandwiches.
         """
         if favorite_color is None:
             favorite_color = _utilities.get_env('FAVE_COLOR')
@@ -32,26 +32,26 @@ class ProviderArgs:
 
     @property
     @pulumi.getter(name="favoriteColor")
-    def favorite_color(self) -> Optional[pulumi.Input[Union[str, 'Color']]]:
+    def favorite_color(self) -> pulumi.Input[Optional[Union[str, 'Color']]]:
         """
         this is a relaxed string enum which can also be set via env var
         """
         return pulumi.get(self, "favorite_color")
 
     @favorite_color.setter
-    def favorite_color(self, value: Optional[pulumi.Input[Union[str, 'Color']]]):
+    def favorite_color(self, value: pulumi.Input[Optional[Union[str, 'Color']]]):
         pulumi.set(self, "favorite_color", value)
 
     @property
     @pulumi.getter(name="secretSandwiches")
-    def secret_sandwiches(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['_config.SandwichArgs']]]]:
+    def secret_sandwiches(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['_config.SandwichArgs']]]]:
         """
         Super duper secret sandwiches.
         """
         return pulumi.get(self, "secret_sandwiches")
 
     @secret_sandwiches.setter
-    def secret_sandwiches(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_config.SandwichArgs']]]]):
+    def secret_sandwiches(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['_config.SandwichArgs']]]]):
         pulumi.set(self, "secret_sandwiches", value)
 
 
@@ -60,15 +60,15 @@ class Provider(pulumi.ProviderResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 favorite_color: Optional[pulumi.Input[Union[str, 'Color']]] = None,
-                 secret_sandwiches: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_config.SandwichArgs']]]]] = None,
+                 favorite_color: pulumi.Input[Optional[Union[str, 'Color']]] = None,
+                 secret_sandwiches: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['_config.SandwichArgs']]]]] = None,
                  __props__=None):
         """
         Create a Configstation resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Union[str, 'Color']] favorite_color: this is a relaxed string enum which can also be set via env var
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_config.SandwichArgs']]]] secret_sandwiches: Super duper secret sandwiches.
+        :param pulumi.Input[Optional[Union[str, 'Color']]] favorite_color: this is a relaxed string enum which can also be set via env var
+        :param pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['_config.SandwichArgs']]]]] secret_sandwiches: Super duper secret sandwiches.
         """
         ...
     @overload
@@ -93,8 +93,8 @@ class Provider(pulumi.ProviderResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 favorite_color: Optional[pulumi.Input[Union[str, 'Color']]] = None,
-                 secret_sandwiches: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_config.SandwichArgs']]]]] = None,
+                 favorite_color: pulumi.Input[Optional[Union[str, 'Color']]] = None,
+                 secret_sandwiches: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['_config.SandwichArgs']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/pulumi-stack-reference-pp/go/pulumi-stack-reference.go
+++ b/pkg/codegen/testing/test/testdata/pulumi-stack-reference-pp/go/pulumi-stack-reference.go
@@ -7,7 +7,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := pulumi.NewStackReference(ctx, "stackRef", &pulumi.StackReferenceArgs{
-			Name: pulumi.String("foo/bar/dev"),
+			Name: "foo/bar/dev",
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/python-resource-names-pp/python/python-resource-names.py
+++ b/pkg/codegen/testing/test/testdata/python-resource-names-pp/python/python-resource-names.py
@@ -22,30 +22,30 @@ cluster = azure_native.containerservice.ManagedCluster("cluster",
     enable_rbac=True,
     kubernetes_version="1.21.9",
     location="eastus",
-    network_profile=azure_native.containerservice.ContainerServiceNetworkProfileArgs(
-        dns_service_ip="10.10.0.10",
-        docker_bridge_cidr="172.17.0.1/16",
-        load_balancer_profile=azure_native.containerservice.ManagedClusterLoadBalancerProfileArgs(
-            effective_outbound_ips=[azure_native.containerservice.ResourceReferenceArgs(
+    network_profile={
+        "dnsServiceIP": "10.10.0.10",
+        "dockerBridgeCidr": "172.17.0.1/16",
+        "loadBalancerProfile": {
+            "effectiveOutboundIPs": [azure_native.containerservice.ResourceReferenceArgs(
                 id="/subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/MC_test-rga2bd359a_test-aks5fb1e730_eastus/providers/Microsoft.Network/publicIPAddresses/2a2610b5-67f3-4aec-a277-a032b2364d70",
             )],
-            managed_outbound_ips=azure_native.containerservice.ManagedClusterLoadBalancerProfileManagedOutboundIPsArgs(
-                count=1,
-            ),
-        ),
-        load_balancer_sku="Standard",
-        network_plugin="azure",
-        outbound_type="loadBalancer",
-        service_cidr="10.10.0.0/16",
-    ),
+            "managedOutboundIPs": {
+                "count": 1,
+            },
+        },
+        "loadBalancerSku": "Standard",
+        "networkPlugin": "azure",
+        "outboundType": "loadBalancer",
+        "serviceCidr": "10.10.0.0/16",
+    },
     node_resource_group="MC_test-rga2bd359a_test-aks5fb1e730_eastus",
     resource_group_name="test-rga2bd359a",
     resource_name_="test-aks5fb1e730",
-    service_principal_profile=azure_native.containerservice.ManagedClusterServicePrincipalProfileArgs(
-        client_id="64e3783f-3214-4ba7-bb52-12ad85412527",
-    ),
-    sku=azure_native.containerservice.ManagedClusterSKUArgs(
-        name="Basic",
-        tier="Free",
-    ),
+    service_principal_profile={
+        "clientId": "64e3783f-3214-4ba7-bb52-12ad85412527",
+    },
+    sku={
+        "name": "Basic",
+        "tier": "Free",
+    },
     opts=pulumi.ResourceOptions(protect=True))

--- a/pkg/codegen/testing/test/testdata/random-pet-pp/go/random-pet.go
+++ b/pkg/codegen/testing/test/testdata/random-pet-pp/go/random-pet.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := random.NewRandomPet(ctx, "random-pet", &random.RandomPetArgs{
-			Prefix: pulumi.String("doggo"),
+			Prefix: "doggo",
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/pulumiTypes.go
@@ -26,7 +26,7 @@ type WorldInput interface {
 }
 
 type WorldArgs struct {
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 }
 
 func (WorldArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/universe.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/go/world/universe.go
@@ -58,7 +58,7 @@ type universeArgs struct {
 
 // The set of arguments for constructing a Universe resource.
 type UniverseArgs struct {
-	Worlds WorldMapInput
+	Worlds map[string]WorldInput
 }
 
 func (UniverseArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/conditionalAccessPolicy.go
+++ b/pkg/codegen/testing/test/testdata/regress-go-8664/go/my8664/conditionalAccessPolicy.go
@@ -53,7 +53,7 @@ type conditionalAccessPolicyState struct {
 }
 
 type ConditionalAccessPolicyState struct {
-	Conditions ConditionalAccessPolicyConditionsPtrInput
+	Conditions *ConditionalAccessPolicyConditionsArgs
 }
 
 func (ConditionalAccessPolicyState) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/go/my8110/pulumiTypes.go
@@ -26,7 +26,7 @@ type MyObjInput interface {
 }
 
 type MyObjArgs struct {
-	A pulumi.StringPtrInput `pulumi:"a"`
+	A *string `pulumi:"a"`
 }
 
 func (MyObjArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/iam/get_policy_document.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/pulumi_aws/x/iam/get_policy_document.py
@@ -74,7 +74,7 @@ def get_policy_document(statements: Optional[Sequence[pulumi.InputType['_x.GetPo
 
 
 @_utilities.lift_output_func(get_policy_document)
-def get_policy_document_output(statements: Optional[pulumi.Input[Optional[Sequence[pulumi.InputType['_x.GetPolicyDocumentStatementArgs']]]]] = None,
+def get_policy_document_output(statements: pulumi.Input[Optional[Sequence[pulumi.InputType['_x.GetPolicyDocumentStatementArgs']]]] = None,
                                opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetPolicyDocumentResult]:
     """
     Use this data source to access information about an existing resource.

--- a/pkg/codegen/testing/test/testdata/replace-on-change/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/go/example/pulumiTypes.go
@@ -28,7 +28,7 @@ type ChewInput interface {
 
 // A toy for a dog
 type ChewArgs struct {
-	Owner DogInput `pulumi:"owner"`
+	Owner *Dog `pulumi:"owner"`
 }
 
 func (ChewArgs) ElementType() reflect.Type {
@@ -166,9 +166,9 @@ type LaserInput interface {
 
 // A Toy for a cat
 type LaserArgs struct {
-	Animal    CatInput               `pulumi:"animal"`
-	Batteries pulumi.BoolPtrInput    `pulumi:"batteries"`
-	Light     pulumi.Float64PtrInput `pulumi:"light"`
+	Animal    *Cat     `pulumi:"animal"`
+	Batteries *bool    `pulumi:"batteries"`
+	Light     *float64 `pulumi:"light"`
 }
 
 func (LaserArgs) ElementType() reflect.Type {
@@ -328,7 +328,7 @@ type RecInput interface {
 }
 
 type RecArgs struct {
-	Rec1 RecPtrInput `pulumi:"rec1"`
+	Rec1 *RecArgs `pulumi:"rec1"`
 }
 
 func (RecArgs) ElementType() reflect.Type {
@@ -465,9 +465,9 @@ type ToyInput interface {
 
 // This is a toy
 type ToyArgs struct {
-	Associated ToyPtrInput            `pulumi:"associated"`
-	Color      pulumi.StringPtrInput  `pulumi:"color"`
-	Wear       pulumi.Float64PtrInput `pulumi:"wear"`
+	Associated *ToyArgs `pulumi:"associated"`
+	Color      *string  `pulumi:"color"`
+	Wear       *float64 `pulumi:"wear"`
 }
 
 func (ToyArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/person/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Person</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
            <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-           <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
-           <span class="nx">pets</span><span class="p">:</span> <span class="nx">Optional[Sequence[PetArgs]]</span> = None<span class="p">)</span>
+           <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">,</span>
+           <span class="nx">pets</span><span class="p">:</span> <span class="nx">Optional[Optional[Sequence[PetArgs]]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Person</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
            <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[PersonArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_csharp" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">List&lt;Pet<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Pet<wbr>Args&gt;?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -256,7 +256,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_go" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">[]Pet<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">[]Pet<wbr>Type<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_java" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_java" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">List&lt;Pet<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Pet<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_nodejs" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Pet<wbr>Args[]</a></span>
+        <span class="property-type">Pet<wbr>Args[] | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_python" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Sequence[Pet<wbr>Args]</a></span>
+        <span class="property-type">Sequence[Pet<wbr>Args]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -344,7 +344,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_yaml" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">List&lt;Property Map&gt;</a></span>
+        <span class="property-type">List&lt;Property Map&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/docs/pet/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Pet</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+        <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Pet</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[PetInitArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_java" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Inputs/PetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
-        public Input<string>? Name { get; set; }
+        public Input<string?>? Name { get; set; }
 
         public PetArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Person.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Person.cs
@@ -64,15 +64,10 @@ namespace Pulumi.Example
     public sealed class PersonArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
-        public Input<string>? Name { get; set; }
+        public Input<string?>? Name { get; set; }
 
         [Input("pets")]
-        private InputList<Inputs.PetArgs>? _pets;
-        public InputList<Inputs.PetArgs> Pets
-        {
-            get => _pets ?? (_pets = new InputList<Inputs.PetArgs>());
-            set => _pets = value;
-        }
+        public Input<ImmutableArray<Input<Inputs.PetArgs>>>? Pets { get; set; }
 
         public PersonArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pet.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pet.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Example
     public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
-        public Input<string>? Name { get; set; }
+        public Input<string?>? Name { get; set; }
 
         public PetArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/person.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/person.go
@@ -62,8 +62,8 @@ type personArgs struct {
 
 // The set of arguments for constructing a Person resource.
 type PersonArgs struct {
-	Name pulumi.StringPtrInput
-	Pets PetTypeArrayInput
+	Name *string
+	Pets []PetTypeInput
 }
 
 func (PersonArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
@@ -60,7 +60,7 @@ type petArgs struct {
 
 // The set of arguments for constructing a Pet resource.
 type PetArgs struct {
-	Name pulumi.StringPtrInput
+	Name *string
 }
 
 func (PetArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/go/example/pulumiTypes.go
@@ -26,7 +26,7 @@ type PetTypeInput interface {
 }
 
 type PetTypeArgs struct {
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 }
 
 func (PetTypeArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/person.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/person.ts
@@ -62,6 +62,6 @@ export class Person extends pulumi.CustomResource {
  * The set of arguments for constructing a Person resource.
  */
 export interface PersonArgs {
-    name?: pulumi.Input<string>;
-    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[]>;
+    name?: pulumi.Input<string | undefined>;
+    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[] | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/pet.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/pet.ts
@@ -57,5 +57,5 @@ export class Pet extends pulumi.CustomResource {
  * The set of arguments for constructing a Pet resource.
  */
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/nodejs/types/input.ts
@@ -6,5 +6,5 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_inputs.py
@@ -16,17 +16,17 @@ __all__ = [
 @pulumi.input_type
 class PetArgs:
     def __init__(__self__, *,
-                 name: Optional[pulumi.Input[str]] = None):
+                 name: pulumi.Input[Optional[str]] = None):
         if name is not None:
             pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[str]]:
+    def name(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[str]]):
+    def name(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "name", value)
 
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/person.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/person.py
@@ -16,8 +16,8 @@ __all__ = ['PersonArgs', 'Person']
 @pulumi.input_type
 class PersonArgs:
     def __init__(__self__, *,
-                 name: Optional[pulumi.Input[str]] = None,
-                 pets: Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]] = None):
+                 name: pulumi.Input[Optional[str]] = None,
+                 pets: pulumi.Input[Optional[Sequence[pulumi.Input['PetArgs']]]] = None):
         """
         The set of arguments for constructing a Person resource.
         """
@@ -28,20 +28,20 @@ class PersonArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[str]]:
+    def name(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[str]]):
+    def name(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
-    def pets(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]]:
+    def pets(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['PetArgs']]]]:
         return pulumi.get(self, "pets")
 
     @pets.setter
-    def pets(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]]):
+    def pets(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['PetArgs']]]]):
         pulumi.set(self, "pets", value)
 
 
@@ -50,8 +50,8 @@ class Person(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
-                 pets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
+                 pets: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
                  __props__=None):
         """
         Create a Person resource with the given unique name, props, and options.
@@ -81,8 +81,8 @@ class Person(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
-                 pets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
+                 pets: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/pet.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/pet.py
@@ -14,7 +14,7 @@ __all__ = ['PetInitArgs', 'Pet']
 @pulumi.input_type
 class PetInitArgs:
     def __init__(__self__, *,
-                 name: Optional[pulumi.Input[str]] = None):
+                 name: pulumi.Input[Optional[str]] = None):
         """
         The set of arguments for constructing a Pet resource.
         """
@@ -23,11 +23,11 @@ class PetInitArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[str]]:
+    def name(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[str]]):
+    def name(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "name", value)
 
 
@@ -36,7 +36,7 @@ class Pet(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         """
         Create a Pet resource with the given unique name, props, and options.
@@ -66,7 +66,7 @@ class Pet(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/person/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Person</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
            <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-           <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
-           <span class="nx">pets</span><span class="p">:</span> <span class="nx">Optional[Sequence[PetArgs]]</span> = None<span class="p">)</span>
+           <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">,</span>
+           <span class="nx">pets</span><span class="p">:</span> <span class="nx">Optional[Optional[Sequence[PetArgs]]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Person</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
            <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[PersonArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_csharp" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">List&lt;Pet<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Pet<wbr>Args&gt;?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -256,7 +256,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_go" style="color: inherit; text-decoration: inherit;">Pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">[]Pet<wbr>Type<wbr>Args</a></span>
+        <span class="property-type">[]Pet<wbr>Type<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_java" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_java" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">List&lt;Pet<wbr>Args&gt;</a></span>
+        <span class="property-type">List&lt;Pet<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_nodejs" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Pet<wbr>Args[]</a></span>
+        <span class="property-type">Pet<wbr>Args[] | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_python" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">Sequence[Pet<wbr>Args]</a></span>
+        <span class="property-type">Sequence[Pet<wbr>Args]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -344,7 +344,7 @@ The Person resource accepts the following [input](/docs/intro/concepts/inputs-ou
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#pets_yaml" style="color: inherit; text-decoration: inherit;">pets</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pet">List&lt;Property Map&gt;</a></span>
+        <span class="property-type">List&lt;Property Map&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/docs/pet/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Pet</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+        <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Pet</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[PetInitArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_csharp" style="color: inherit; text-decoration: inherit;">Name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_java" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Pet resource accepts the following [input](/docs/intro/concepts/inputs-outpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#name_python" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Inputs/PetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
-        public Input<string>? Name { get; set; }
+        public Input<string?>? Name { get; set; }
 
         public PetArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Person.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Person.cs
@@ -64,15 +64,10 @@ namespace Pulumi.Example
     public sealed class PersonArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
-        public Input<string>? Name { get; set; }
+        public Input<string?>? Name { get; set; }
 
         [Input("pets")]
-        private InputList<Inputs.PetArgs>? _pets;
-        public InputList<Inputs.PetArgs> Pets
-        {
-            get => _pets ?? (_pets = new InputList<Inputs.PetArgs>());
-            set => _pets = value;
-        }
+        public Input<ImmutableArray<Input<Inputs.PetArgs>>>? Pets { get; set; }
 
         public PersonArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pet.cs
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pet.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Example
     public sealed class PetArgs : global::Pulumi.ResourceArgs
     {
         [Input("name")]
-        public Input<string>? Name { get; set; }
+        public Input<string?>? Name { get; set; }
 
         public PetArgs()
         {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/person.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/person.go
@@ -62,8 +62,8 @@ type personArgs struct {
 
 // The set of arguments for constructing a Person resource.
 type PersonArgs struct {
-	Name pulumi.StringPtrInput
-	Pets PetTypeArrayInput
+	Name *string
+	Pets []PetTypeInput
 }
 
 func (PersonArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pet.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pet.go
@@ -60,7 +60,7 @@ type petArgs struct {
 
 // The set of arguments for constructing a Pet resource.
 type PetArgs struct {
-	Name pulumi.StringPtrInput
+	Name *string
 }
 
 func (PetArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/go/example/pulumiTypes.go
@@ -26,7 +26,7 @@ type PetTypeInput interface {
 }
 
 type PetTypeArgs struct {
-	Name pulumi.StringPtrInput `pulumi:"name"`
+	Name *string `pulumi:"name"`
 }
 
 func (PetTypeArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/person.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/person.ts
@@ -62,6 +62,6 @@ export class Person extends pulumi.CustomResource {
  * The set of arguments for constructing a Person resource.
  */
 export interface PersonArgs {
-    name?: pulumi.Input<string>;
-    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[]>;
+    name?: pulumi.Input<string | undefined>;
+    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[] | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/pet.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/pet.ts
@@ -57,5 +57,5 @@ export class Pet extends pulumi.CustomResource {
  * The set of arguments for constructing a Pet resource.
  */
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/nodejs/types/input.ts
@@ -6,5 +6,5 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/_inputs.py
@@ -16,17 +16,17 @@ __all__ = [
 @pulumi.input_type
 class PetArgs:
     def __init__(__self__, *,
-                 name: Optional[pulumi.Input[str]] = None):
+                 name: pulumi.Input[Optional[str]] = None):
         if name is not None:
             pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[str]]:
+    def name(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[str]]):
+    def name(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "name", value)
 
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/person.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/person.py
@@ -16,8 +16,8 @@ __all__ = ['PersonArgs', 'Person']
 @pulumi.input_type
 class PersonArgs:
     def __init__(__self__, *,
-                 name: Optional[pulumi.Input[str]] = None,
-                 pets: Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]] = None):
+                 name: pulumi.Input[Optional[str]] = None,
+                 pets: pulumi.Input[Optional[Sequence[pulumi.Input['PetArgs']]]] = None):
         """
         The set of arguments for constructing a Person resource.
         """
@@ -28,20 +28,20 @@ class PersonArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[str]]:
+    def name(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[str]]):
+    def name(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
-    def pets(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]]:
+    def pets(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['PetArgs']]]]:
         return pulumi.get(self, "pets")
 
     @pets.setter
-    def pets(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PetArgs']]]]):
+    def pets(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['PetArgs']]]]):
         pulumi.set(self, "pets", value)
 
 
@@ -50,8 +50,8 @@ class Person(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
-                 pets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
+                 pets: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
                  __props__=None):
         """
         Create a Person resource with the given unique name, props, and options.
@@ -81,8 +81,8 @@ class Person(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
-                 pets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
+                 pets: pulumi.Input[Optional[Sequence[pulumi.Input[pulumi.InputType['PetArgs']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/pet.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/pulumi_example/pet.py
@@ -14,7 +14,7 @@ __all__ = ['PetInitArgs', 'Pet']
 @pulumi.input_type
 class PetInitArgs:
     def __init__(__self__, *,
-                 name: Optional[pulumi.Input[str]] = None):
+                 name: pulumi.Input[Optional[str]] = None):
         """
         The set of arguments for constructing a Pet resource.
         """
@@ -23,11 +23,11 @@ class PetInitArgs:
 
     @property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[str]]:
+    def name(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[str]]):
+    def name(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "name", value)
 
 
@@ -36,7 +36,7 @@ class Pet(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         """
         Create a Pet resource with the given unique name, props, and options.
@@ -66,7 +66,7 @@ class Pet(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 name: Optional[pulumi.Input[str]] = None,
+                 name: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/secrets/dotnet/Inputs/ConfigArgs.cs
+++ b/pkg/codegen/testing/test/testdata/secrets/dotnet/Inputs/ConfigArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Mypkg.Inputs
     public sealed class ConfigArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<string>? Foo { get; set; }
+        public Input<string?>? Foo { get; set; }
 
         public ConfigArgs()
         {

--- a/pkg/codegen/testing/test/testdata/secrets/go/mypkg/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/secrets/go/mypkg/pulumiTypes.go
@@ -26,7 +26,7 @@ type ConfigInput interface {
 }
 
 type ConfigArgs struct {
-	Foo pulumi.StringPtrInput `pulumi:"foo"`
+	Foo *string `pulumi:"foo"`
 }
 
 func (ConfigArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/secrets/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/secrets/nodejs/types/input.ts
@@ -6,5 +6,5 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 
 export interface ConfigArgs {
-    foo?: pulumi.Input<string>;
+    foo?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/pulumi_mypkg/_inputs.py
@@ -16,17 +16,17 @@ __all__ = [
 @pulumi.input_type
 class ConfigArgs:
     def __init__(__self__, *,
-                 foo: Optional[pulumi.Input[str]] = None):
+                 foo: pulumi.Input[Optional[str]] = None):
         if foo is not None:
             pulumi.set(__self__, "foo", foo)
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input[str]]:
+    def foo(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input[str]]):
+    def foo(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "foo", value)
 
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/nursery/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, TreeSize]]</span> = None<span class="p">,</span>
+            <span class="nx">sizes</span><span class="p">:</span> <span class="nx">Optional[Optional[Mapping[str, TreeSize]]]</span> = None<span class="p">,</span>
             <span class="nx">varieties</span><span class="p">:</span> <span class="nx">Optional[Sequence[RubberTreeVariety]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Nursery</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
@@ -235,7 +235,7 @@ The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-o
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_csharp" style="color: inherit; text-decoration: inherit;">Sizes</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;</span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size&gt;?</span>
     </dt>
     <dd><p>The sizes of trees available</p>
 </dd></dl>
@@ -307,7 +307,7 @@ The Nursery resource accepts the following [input](/docs/intro/concepts/inputs-o
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#sizes_nodejs" style="color: inherit; text-decoration: inherit;">sizes</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: Tree<wbr>Size}</span>
+        <span class="property-type">{[key: string]: Tree<wbr>Size} | undefined</span>
     </dt>
     <dd><p>The sizes of trees available</p>
 </dd></dl>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/docs/tree/v1/rubbertree/_index.md
@@ -32,10 +32,10 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[_root_inputs.ContainerArgs]</span> = None<span class="p">,</span>
+               <span class="nx">container</span><span class="p">:</span> <span class="nx">Optional[Optional[_root_inputs.ContainerArgs]]</span> = None<span class="p">,</span>
                <span class="nx">diameter</span><span class="p">:</span> <span class="nx">Optional[Diameter]</span> = None<span class="p">,</span>
-               <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">,</span>
-               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[TreeSize]</span> = None<span class="p">,</span>
+               <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Optional[Union[Farm, str]]]</span> = None<span class="p">,</span>
+               <span class="nx">size</span><span class="p">:</span> <span class="nx">Optional[Optional[TreeSize]]</span> = None<span class="p">,</span>
                <span class="nx">type</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">RubberTree</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
@@ -245,7 +245,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_csharp" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args</a></span>
+        <span class="property-type">Pulumi.<wbr>Plant.<wbr>Inputs.<wbr>Container<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -253,7 +253,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
+        <span class="property-type">Union&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm, string&gt;?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -261,7 +261,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_csharp" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size</a></span>
+        <span class="property-type">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Tree<wbr>Size?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -291,7 +291,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_go" style="color: inherit; text-decoration: inherit;">Container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -299,7 +299,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">string</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -307,7 +307,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_go" style="color: inherit; text-decoration: inherit;">Size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -337,7 +337,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_java" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Container<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -345,7 +345,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_java" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | String</span>
+        <span class="property-type">Optional&lt;Either&lt;Farm,String&gt;&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -353,7 +353,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_java" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Optional&lt;Tree<wbr>Size&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -383,7 +383,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_nodejs" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -391,7 +391,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">Farm | string | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -399,7 +399,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_nodejs" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -429,7 +429,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_python" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Container<wbr>Args</a></span>
+        <span class="property-type">Container<wbr>Args]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -437,7 +437,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | str</span>
+        <span class="property-type">Union[Farm, str]</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -445,7 +445,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_python" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">Tree<wbr>Size</a></span>
+        <span class="property-type">Tree<wbr>Size</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -475,7 +475,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#container_yaml" style="color: inherit; text-decoration: inherit;">container</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#container">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -483,7 +483,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#farm_yaml" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34;</a> | String</span>
+        <span class="property-type">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34; | String</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -491,7 +491,7 @@ The RubberTree resource accepts the following [input](/docs/intro/concepts/input
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#size_yaml" style="color: inherit; text-decoration: inherit;">size</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#treesize">&#34;small&#34; | &#34;medium&#34; | &#34;large&#34;</a></span>
+        <span class="property-type">&#34;small&#34; | &#34;medium&#34; | &#34;large&#34;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -615,7 +615,7 @@ Get an existing RubberTree resource's state with the given name, ID, and optiona
 <span class="k">def </span><span class="nf">get</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">id</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
         <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-        <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Union[Farm, str]]</span> = None<span class="p">) -&gt;</span> RubberTree</code></pre></div>
+        <span class="nx">farm</span><span class="p">:</span> <span class="nx">Optional[Optional[Union[Farm, str]]]</span> = None<span class="p">) -&gt;</span> RubberTree</code></pre></div>
 </pulumi-choosable>
 </div>
 
@@ -789,7 +789,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_csharp" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm</a> | string</span>
+        <span class="property-type">Union&lt;Pulumi.<wbr>Plant.<wbr>Tree.<wbr>V1.<wbr>Farm, string&gt;?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -803,7 +803,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_go" style="color: inherit; text-decoration: inherit;">Farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">string</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -817,7 +817,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_java" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | String</span>
+        <span class="property-type">Optional&lt;Either&lt;Farm,String&gt;&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -831,7 +831,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_nodejs" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | string</span>
+        <span class="property-type">Farm | string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -845,7 +845,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_python" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">Farm</a> | str</span>
+        <span class="property-type">Union[Farm, str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -859,7 +859,7 @@ The following state arguments are supported:
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#state_farm_yaml" style="color: inherit; text-decoration: inherit;">farm</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#farm">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34;</a> | String</span>
+        <span class="property-type">&#34;Pulumi Planters Inc.&#34; | &#34;Plants&#39;R&#39;Us&#34; | String</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
@@ -13,20 +13,20 @@ namespace Pulumi.Plant.Inputs
     public sealed class ContainerArgs : global::Pulumi.ResourceArgs
     {
         [Input("brightness")]
-        public Input<Pulumi.Plant.ContainerBrightness>? Brightness { get; set; }
+        public Input<Pulumi.Plant.ContainerBrightness?>? Brightness { get; set; }
 
         [Input("color")]
-        public InputUnion<Pulumi.Plant.ContainerColor, string>? Color { get; set; }
+        public Input<Union<Input<Pulumi.Plant.ContainerColor>, Input<string>>?>? Color { get; set; }
 
         [Input("material")]
-        public Input<string>? Material { get; set; }
+        public Input<string?>? Material { get; set; }
 
         [Input("size", required: true)]
         public Input<Pulumi.Plant.ContainerSize> Size { get; set; } = null!;
 
         public ContainerArgs()
         {
-            Brightness = Pulumi.Plant.ContainerBrightness.One;
+            Brightness = 1;
         }
         public static new ContainerArgs Empty => new ContainerArgs();
     }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/Nursery.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/Nursery.cs
@@ -56,17 +56,11 @@ namespace Pulumi.Plant.Tree.V1
 
     public sealed class NurseryArgs : global::Pulumi.ResourceArgs
     {
-        [Input("sizes")]
-        private InputMap<Pulumi.Plant.Tree.V1.TreeSize>? _sizes;
-
         /// <summary>
         /// The sizes of trees available
         /// </summary>
-        public InputMap<Pulumi.Plant.Tree.V1.TreeSize> Sizes
-        {
-            get => _sizes ?? (_sizes = new InputMap<Pulumi.Plant.Tree.V1.TreeSize>());
-            set => _sizes = value;
-        }
+        [Input("sizes")]
+        public Input<ImmutableDictionary<string, Input<Pulumi.Plant.Tree.V1.TreeSize>>?>? Sizes { get; set; }
 
         [Input("varieties", required: true)]
         private InputList<Pulumi.Plant.Tree.V1.RubberTreeVariety>? _varieties;

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
@@ -74,16 +74,16 @@ namespace Pulumi.Plant.Tree.V1
     public sealed class RubberTreeArgs : global::Pulumi.ResourceArgs
     {
         [Input("container")]
-        public Input<Pulumi.Plant.Inputs.ContainerArgs>? Container { get; set; }
+        public Input<Pulumi.Plant.Inputs.ContainerArgs?>? Container { get; set; }
 
         [Input("diameter", required: true)]
         public Input<Pulumi.Plant.Tree.V1.Diameter> Diameter { get; set; } = null!;
 
         [Input("farm")]
-        public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+        public Input<Union<Input<Pulumi.Plant.Tree.V1.Farm>, Input<string>>?>? Farm { get; set; }
 
         [Input("size")]
-        public Input<Pulumi.Plant.Tree.V1.TreeSize>? Size { get; set; }
+        public Input<Pulumi.Plant.Tree.V1.TreeSize?>? Size { get; set; }
 
         [Input("type", required: true)]
         public Input<Pulumi.Plant.Tree.V1.RubberTreeVariety> Type { get; set; } = null!;
@@ -92,7 +92,7 @@ namespace Pulumi.Plant.Tree.V1
         {
             Diameter = Pulumi.Plant.Tree.V1.Diameter.Sixinch;
             Farm = "(unknown)";
-            Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
+            Size = "medium";
             Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
         }
         public static new RubberTreeArgs Empty => new RubberTreeArgs();
@@ -101,7 +101,7 @@ namespace Pulumi.Plant.Tree.V1
     public sealed class RubberTreeState : global::Pulumi.ResourceArgs
     {
         [Input("farm")]
-        public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+        public Input<Union<Input<Pulumi.Plant.Tree.V1.Farm>, Input<string>>?>? Farm { get; set; }
 
         public RubberTreeState()
         {

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
@@ -42,10 +42,10 @@ type ContainerInput interface {
 }
 
 type ContainerArgs struct {
-	Brightness ContainerBrightnessPtrInput `pulumi:"brightness"`
-	Color      pulumi.StringPtrInput       `pulumi:"color"`
-	Material   pulumi.StringPtrInput       `pulumi:"material"`
-	Size       ContainerSizeInput          `pulumi:"size"`
+	Brightness *ContainerBrightness `pulumi:"brightness"`
+	Color      *string              `pulumi:"color"`
+	Material   *string              `pulumi:"material"`
+	Size       ContainerSizeInput   `pulumi:"size"`
 }
 
 // Defaults sets the appropriate defaults for ContainerArgs
@@ -55,7 +55,7 @@ func (val *ContainerArgs) Defaults() *ContainerArgs {
 	}
 	tmp := *val
 	if tmp.Brightness == nil {
-		tmp.Brightness = ContainerBrightness(1.0)
+		tmp.Brightness = *ContainerBrightness(1.0)
 	}
 	return &tmp
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
@@ -66,7 +66,7 @@ type nurseryArgs struct {
 // The set of arguments for constructing a Nursery resource.
 type NurseryArgs struct {
 	// The sizes of trees available
-	Sizes TreeSizeMapInput
+	Sizes map[string]TreeSizeInput
 	// The varieties available
 	Varieties RubberTreeVarietyArrayInput
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -29,20 +29,19 @@ func NewRubberTree(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Container != nil {
-		args.Container = args.Container.ToContainerPtrOutput().ApplyT(func(v *plant.Container) *plant.Container { return v.Defaults() }).(plant.ContainerPtrOutput)
-	}
 	if args.Diameter == nil {
-		args.Diameter = Diameter(6.0)
+		diameter_ := Diameter(6.0)
+		args.Diameter = &diameter_
 	}
 	if args.Farm == nil {
-		args.Farm = pulumi.StringPtr("(unknown)")
+		args.Farm = *string("(unknown)")
 	}
 	if args.Size == nil {
-		args.Size = TreeSize("medium")
+		args.Size = *TreeSize("medium")
 	}
 	if args.Type == nil {
-		args.Type = RubberTreeVariety("Burgundy")
+		type_ := RubberTreeVariety("Burgundy")
+		args.Type = &type_
 	}
 	var resource RubberTree
 	err := ctx.RegisterResource("plant:tree/v1:RubberTree", name, args, &resource, opts...)
@@ -70,7 +69,7 @@ type rubberTreeState struct {
 }
 
 type RubberTreeState struct {
-	Farm pulumi.StringPtrInput
+	Farm *string
 }
 
 func (RubberTreeState) ElementType() reflect.Type {
@@ -87,10 +86,10 @@ type rubberTreeArgs struct {
 
 // The set of arguments for constructing a RubberTree resource.
 type RubberTreeArgs struct {
-	Container plant.ContainerPtrInput
+	Container *plant.ContainerArgs
 	Diameter  DiameterInput
-	Farm      pulumi.StringPtrInput
-	Size      TreeSizePtrInput
+	Farm      *string
+	Size      *TreeSize
 	Type      RubberTreeVarietyInput
 }
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/tree/v1/nursery.ts
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/tree/v1/nursery.ts
@@ -65,7 +65,7 @@ export interface NurseryArgs {
     /**
      * The sizes of trees available
      */
-    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>}>;
+    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>} | undefined>;
     /**
      * The varieties available
      */

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -63,7 +63,7 @@ export class RubberTree extends pulumi.CustomResource {
             if ((!args || args.type === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'type'");
             }
-            resourceInputs["container"] = args ? (args.container ? pulumi.output(args.container).apply(inputs.containerArgsProvideDefaults) : undefined) : undefined;
+            resourceInputs["container"] = args ? (args.container ? args.container === undefined ? undefined : pulumi.output(args.container).apply(x => x === undefined ? undefined : inputs.containerArgsProvideDefaults(x)) : undefined) : undefined;
             resourceInputs["diameter"] = (args ? args.diameter : undefined) ?? 6;
             resourceInputs["farm"] = (args ? args.farm : undefined) ?? "(unknown)";
             resourceInputs["size"] = (args ? args.size : undefined) ?? "medium";
@@ -75,16 +75,16 @@ export class RubberTree extends pulumi.CustomResource {
 }
 
 export interface RubberTreeState {
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string | undefined>;
 }
 
 /**
  * The set of arguments for constructing a RubberTree resource.
  */
 export interface RubberTreeArgs {
-    container?: pulumi.Input<inputs.ContainerArgs>;
+    container?: pulumi.Input<inputs.ContainerArgs | undefined>;
     diameter: pulumi.Input<enums.tree.v1.Diameter>;
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
-    size?: pulumi.Input<enums.tree.v1.TreeSize>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string | undefined>;
+    size?: pulumi.Input<enums.tree.v1.TreeSize | undefined>;
     type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/nodejs/types/input.ts
@@ -9,9 +9,9 @@ import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
 export interface ContainerArgs {
-    brightness?: pulumi.Input<enums.ContainerBrightness>;
-    color?: pulumi.Input<enums.ContainerColor | string>;
-    material?: pulumi.Input<string>;
+    brightness?: pulumi.Input<enums.ContainerBrightness | undefined>;
+    color?: pulumi.Input<enums.ContainerColor | string | undefined>;
+    material?: pulumi.Input<string | undefined>;
     size: pulumi.Input<enums.ContainerSize>;
 }
 /**
@@ -20,6 +20,6 @@ export interface ContainerArgs {
 export function containerArgsProvideDefaults(val: ContainerArgs): ContainerArgs {
     return {
         ...val,
-        brightness: (val.brightness) ?? 1,
+        brightness: val.brightness === undefined ? 1 : pulumi.output(val.brightness).apply(x => x ?? 1),
     };
 }

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
@@ -18,9 +18,9 @@ __all__ = [
 class ContainerArgs:
     def __init__(__self__, *,
                  size: pulumi.Input['ContainerSize'],
-                 brightness: Optional[pulumi.Input['ContainerBrightness']] = None,
-                 color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
-                 material: Optional[pulumi.Input[str]] = None):
+                 brightness: pulumi.Input[Optional['ContainerBrightness']] = None,
+                 color: pulumi.Input[Optional[Union['ContainerColor', str]]] = None,
+                 material: pulumi.Input[Optional[str]] = None):
         pulumi.set(__self__, "size", size)
         if brightness is None:
             brightness = 1
@@ -42,29 +42,29 @@ class ContainerArgs:
 
     @property
     @pulumi.getter
-    def brightness(self) -> Optional[pulumi.Input['ContainerBrightness']]:
+    def brightness(self) -> pulumi.Input[Optional['ContainerBrightness']]:
         return pulumi.get(self, "brightness")
 
     @brightness.setter
-    def brightness(self, value: Optional[pulumi.Input['ContainerBrightness']]):
+    def brightness(self, value: pulumi.Input[Optional['ContainerBrightness']]):
         pulumi.set(self, "brightness", value)
 
     @property
     @pulumi.getter
-    def color(self) -> Optional[pulumi.Input[Union['ContainerColor', str]]]:
+    def color(self) -> pulumi.Input[Optional[Union['ContainerColor', str]]]:
         return pulumi.get(self, "color")
 
     @color.setter
-    def color(self, value: Optional[pulumi.Input[Union['ContainerColor', str]]]):
+    def color(self, value: pulumi.Input[Optional[Union['ContainerColor', str]]]):
         pulumi.set(self, "color", value)
 
     @property
     @pulumi.getter
-    def material(self) -> Optional[pulumi.Input[str]]:
+    def material(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "material")
 
     @material.setter
-    def material(self, value: Optional[pulumi.Input[str]]):
+    def material(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "material", value)
 
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -16,11 +16,11 @@ __all__ = ['NurseryArgs', 'Nursery']
 class NurseryArgs:
     def __init__(__self__, *,
                  varieties: pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]],
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None):
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None):
         """
         The set of arguments for constructing a Nursery resource.
         :param pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]] varieties: The varieties available
-        :param pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]] sizes: The sizes of trees available
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] sizes: The sizes of trees available
         """
         pulumi.set(__self__, "varieties", varieties)
         if sizes is not None:
@@ -40,14 +40,14 @@ class NurseryArgs:
 
     @property
     @pulumi.getter
-    def sizes(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]]:
+    def sizes(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]]:
         """
         The sizes of trees available
         """
         return pulumi.get(self, "sizes")
 
     @sizes.setter
-    def sizes(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]]):
+    def sizes(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]]):
         pulumi.set(self, "sizes", value)
 
 
@@ -56,14 +56,14 @@ class Nursery(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
         """
         Create a Nursery resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]] sizes: The sizes of trees available
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] sizes: The sizes of trees available
         :param pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]] varieties: The varieties available
         """
         ...
@@ -89,7 +89,7 @@ class Nursery(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
+                 sizes: pulumi.Input[Optional[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -20,9 +20,9 @@ class RubberTreeArgs:
     def __init__(__self__, *,
                  diameter: pulumi.Input['Diameter'],
                  type: pulumi.Input['RubberTreeVariety'],
-                 container: Optional[pulumi.Input['_root_inputs.ContainerArgs']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None):
+                 container: pulumi.Input[Optional['_root_inputs.ContainerArgs']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None):
         """
         The set of arguments for constructing a RubberTree resource.
         """
@@ -63,36 +63,36 @@ class RubberTreeArgs:
 
     @property
     @pulumi.getter
-    def container(self) -> Optional[pulumi.Input['_root_inputs.ContainerArgs']]:
+    def container(self) -> pulumi.Input[Optional['_root_inputs.ContainerArgs']]:
         return pulumi.get(self, "container")
 
     @container.setter
-    def container(self, value: Optional[pulumi.Input['_root_inputs.ContainerArgs']]):
+    def container(self, value: pulumi.Input[Optional['_root_inputs.ContainerArgs']]):
         pulumi.set(self, "container", value)
 
     @property
     @pulumi.getter
-    def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+    def farm(self) -> pulumi.Input[Optional[Union['Farm', str]]]:
         return pulumi.get(self, "farm")
 
     @farm.setter
-    def farm(self, value: Optional[pulumi.Input[Union['Farm', str]]]):
+    def farm(self, value: pulumi.Input[Optional[Union['Farm', str]]]):
         pulumi.set(self, "farm", value)
 
     @property
     @pulumi.getter
-    def size(self) -> Optional[pulumi.Input['TreeSize']]:
+    def size(self) -> pulumi.Input[Optional['TreeSize']]:
         return pulumi.get(self, "size")
 
     @size.setter
-    def size(self, value: Optional[pulumi.Input['TreeSize']]):
+    def size(self, value: pulumi.Input[Optional['TreeSize']]):
         pulumi.set(self, "size", value)
 
 
 @pulumi.input_type
 class _RubberTreeState:
     def __init__(__self__, *,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None):
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None):
         """
         Input properties used for looking up and filtering RubberTree resources.
         """
@@ -103,11 +103,11 @@ class _RubberTreeState:
 
     @property
     @pulumi.getter
-    def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+    def farm(self) -> pulumi.Input[Optional[Union['Farm', str]]]:
         return pulumi.get(self, "farm")
 
     @farm.setter
-    def farm(self, value: Optional[pulumi.Input[Union['Farm', str]]]):
+    def farm(self, value: pulumi.Input[Optional[Union['Farm', str]]]):
         pulumi.set(self, "farm", value)
 
 
@@ -116,10 +116,10 @@ class RubberTree(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 container: Optional[pulumi.Input[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
+                 container: pulumi.Input[Optional[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
                  diameter: Optional[pulumi.Input['Diameter']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
         """
@@ -150,10 +150,10 @@ class RubberTree(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 container: Optional[pulumi.Input[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
+                 container: pulumi.Input[Optional[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
                  diameter: Optional[pulumi.Input['Diameter']] = None,
-                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
-                 size: Optional[pulumi.Input['TreeSize']] = None,
+                 farm: pulumi.Input[Optional[Union['Farm', str]]] = None,
+                 size: pulumi.Input[Optional['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -191,7 +191,7 @@ class RubberTree(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            farm: Optional[pulumi.Input[Union['Farm', str]]] = None) -> 'RubberTree':
+            farm: pulumi.Input[Optional[Union['Farm', str]]] = None) -> 'RubberTree':
         """
         Get an existing RubberTree resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/docs/foo/_index.md
@@ -320,8 +320,8 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <div>
 <pulumi-choosable type="language" values="python">
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span>get_kubeconfig(</span><span class="nx">self</span><span class="p">,</span>
-                   <span class="nx">profile_name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
-                   <span class="nx">role_arn</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">) -&gt;</span> Output[<span class="nx"><a href="#method_GetKubeconfig_result">str</a></span>]</code></pre></div>
+                   <span class="nx">profile_name</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
+                   <span class="nx">role_arn</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">) -&gt;</span> Output[<span class="nx"><a href="#method_GetKubeconfig_result">str</a></span>]</code></pre></div>
 </pulumi-choosable>
 </div>
 

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Foo.cs
@@ -54,10 +54,10 @@ namespace Pulumi.Example
     public sealed class FooGetKubeconfigArgs : global::Pulumi.CallArgs
     {
         [Input("profileName")]
-        public Input<string>? ProfileName { get; set; }
+        public Input<string?>? ProfileName { get; set; }
 
         [Input("roleArn")]
-        public Input<string>? RoleArn { get; set; }
+        public Input<string?>? RoleArn { get; set; }
 
         public FooGetKubeconfigArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/go/example/foo.go
@@ -55,8 +55,8 @@ type fooGetKubeconfigArgs struct {
 
 // The set of arguments for the GetKubeconfig method of the Foo resource.
 type FooGetKubeconfigArgs struct {
-	ProfileName pulumi.StringPtrInput
-	RoleArn     pulumi.StringPtrInput
+	ProfileName *string
+	RoleArn     *string
 }
 
 func (FooGetKubeconfigArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/foo.ts
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/nodejs/foo.ts
@@ -59,8 +59,8 @@ export namespace Foo {
      * The set of arguments for the Foo.getKubeconfig method.
      */
     export interface GetKubeconfigArgs {
-        profileName?: pulumi.Input<string>;
-        roleArn?: pulumi.Input<string>;
+        profileName?: pulumi.Input<string | undefined>;
+        roleArn?: pulumi.Input<string | undefined>;
     }
 
     /**

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/foo.py
@@ -85,8 +85,8 @@ class Foo(pulumi.ComponentResource):
             return pulumi.get(self, "kubeconfig")
 
     def get_kubeconfig(__self__, *,
-                       profile_name: Optional[pulumi.Input[str]] = None,
-                       role_arn: Optional[pulumi.Input[str]] = None) -> pulumi.Output['str']:
+                       profile_name: pulumi.Input[Optional[str]] = None,
+                       role_arn: pulumi.Input[Optional[str]] = None) -> pulumi.Output['str']:
         __args__ = dict()
         __args__['__self__'] = __self__
         __args__['profileName'] = profile_name

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/docs/foo/_index.md
@@ -326,13 +326,13 @@ A description of bar.
         <span class="nx">bool_value_required</span><span class="p">:</span> <span class="nx">pulumi.Input[bool]</span><span class="p">,</span>
         <span class="nx">name_required</span><span class="p">:</span> <span class="nx">pulumi.Input[pulumi_random.RandomPet]</span><span class="p">,</span>
         <span class="nx">string_value_required</span><span class="p">:</span> <span class="nx">pulumi.Input[str]</span><span class="p">,</span>
-        <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[_nested.BazArgs]]</span> = None<span class="p">,</span>
+        <span class="nx">baz</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[_nested.BazArgs]]</span> = None<span class="p">,</span>
         <span class="nx">baz_plain</span><span class="p">:</span> <span class="nx">Optional[_nested.BazArgs]</span> = None<span class="p">,</span>
-        <span class="nx">bool_value</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[bool]]</span> = None<span class="p">,</span>
+        <span class="nx">bool_value</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[bool]]</span> = None<span class="p">,</span>
         <span class="nx">bool_value_plain</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
-        <span class="nx">name</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[pulumi_random.RandomPet]]</span> = None<span class="p">,</span>
+        <span class="nx">name</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[pulumi_random.RandomPet]]</span> = None<span class="p">,</span>
         <span class="nx">name_plain</span><span class="p">:</span> <span class="nx">Optional[pulumi_random.RandomPet]</span> = None<span class="p">,</span>
-        <span class="nx">string_value</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[str]]</span> = None<span class="p">,</span>
+        <span class="nx">string_value</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[str]]</span> = None<span class="p">,</span>
         <span class="nx">string_value_plain</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">) -&gt;</span> Output[<span class="nx"><a href="#method_Bar_result">Foo.BarResult</a></span>]</code></pre></div>
 </pulumi-choosable>
 </div>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Foo.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Foo.cs
@@ -66,7 +66,7 @@ namespace Pulumi.Example
     public sealed class FooBarArgs : global::Pulumi.CallArgs
     {
         [Input("baz")]
-        public Input<Pulumi.Example.Nested.Inputs.BazArgs>? Baz { get; set; }
+        public Input<Pulumi.Example.Nested.Inputs.BazArgs?>? Baz { get; set; }
 
         [Input("bazPlain")]
         public Pulumi.Example.Nested.Inputs.BazArgs? BazPlain { get; set; }
@@ -75,7 +75,7 @@ namespace Pulumi.Example
         public Input<Pulumi.Example.Nested.Inputs.BazArgs> BazRequired { get; set; } = null!;
 
         [Input("boolValue")]
-        public Input<bool>? BoolValue { get; set; }
+        public Input<bool?>? BoolValue { get; set; }
 
         [Input("boolValuePlain")]
         public bool? BoolValuePlain { get; set; }
@@ -84,7 +84,7 @@ namespace Pulumi.Example
         public Input<bool> BoolValueRequired { get; set; } = null!;
 
         [Input("name")]
-        public Input<Pulumi.Random.RandomPet>? Name { get; set; }
+        public Input<Pulumi.Random.RandomPet?>? Name { get; set; }
 
         [Input("namePlain")]
         public Pulumi.Random.RandomPet? NamePlain { get; set; }
@@ -93,7 +93,7 @@ namespace Pulumi.Example
         public Input<Pulumi.Random.RandomPet> NameRequired { get; set; } = null!;
 
         [Input("stringValue")]
-        public Input<string>? StringValue { get; set; }
+        public Input<string?>? StringValue { get; set; }
 
         [Input("stringValuePlain")]
         public string? StringValuePlain { get; set; }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/BazArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Nested/Inputs/BazArgs.cs
@@ -13,10 +13,10 @@ namespace Pulumi.Example.Nested.Inputs
     public sealed class BazArgs : global::Pulumi.ResourceArgs
     {
         [Input("hello")]
-        public Input<string>? Hello { get; set; }
+        public Input<string?>? Hello { get; set; }
 
         [Input("world")]
-        public Input<string>? World { get; set; }
+        public Input<string?>? World { get; set; }
 
         public BazArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/foo.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/foo.go
@@ -68,16 +68,16 @@ type fooBarArgs struct {
 
 // The set of arguments for the Bar method of the Foo resource.
 type FooBarArgs struct {
-	Baz                 nested.BazPtrInput
+	Baz                 *nested.BazArgs
 	BazPlain            *nested.BazArgs
 	BazRequired         nested.BazInput
-	BoolValue           pulumi.BoolPtrInput
+	BoolValue           *bool
 	BoolValuePlain      *bool
 	BoolValueRequired   pulumi.BoolInput
-	Name                random.RandomPetInput
+	Name                *random.RandomPet
 	NamePlain           *random.RandomPet
 	NameRequired        random.RandomPetInput
-	StringValue         pulumi.StringPtrInput
+	StringValue         *string
 	StringValuePlain    *string
 	StringValueRequired pulumi.StringInput
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/nested/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/go/example/nested/pulumiTypes.go
@@ -27,8 +27,8 @@ type BazInput interface {
 }
 
 type BazArgs struct {
-	Hello pulumi.StringPtrInput `pulumi:"hello"`
-	World pulumi.StringPtrInput `pulumi:"world"`
+	Hello *string `pulumi:"hello"`
+	World *string `pulumi:"world"`
 }
 
 func (BazArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/foo.ts
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/foo.ts
@@ -90,16 +90,16 @@ export namespace Foo {
      * The set of arguments for the Foo.bar method.
      */
     export interface BarArgs {
-        baz?: pulumi.Input<inputs.nested.BazArgs>;
+        baz?: pulumi.Input<inputs.nested.BazArgs | undefined>;
         bazPlain?: inputs.nested.BazArgs;
         bazRequired: pulumi.Input<inputs.nested.BazArgs>;
-        boolValue?: pulumi.Input<boolean>;
+        boolValue?: pulumi.Input<boolean | undefined>;
         boolValuePlain?: boolean;
         boolValueRequired: pulumi.Input<boolean>;
-        name?: pulumi.Input<pulumiRandom.RandomPet>;
+        name?: pulumi.Input<pulumiRandom.RandomPet | undefined>;
         namePlain?: pulumiRandom.RandomPet;
         nameRequired: pulumi.Input<pulumiRandom.RandomPet>;
-        stringValue?: pulumi.Input<string>;
+        stringValue?: pulumi.Input<string | undefined>;
         stringValuePlain?: string;
         stringValueRequired: pulumi.Input<string>;
     }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/nodejs/types/input.ts
@@ -12,7 +12,7 @@ export namespace nested {
     }
 
     export interface BazArgs {
-        hello?: pulumi.Input<string>;
-        world?: pulumi.Input<string>;
+        hello?: pulumi.Input<string | undefined>;
+        world?: pulumi.Input<string | undefined>;
     }
 }

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
@@ -91,13 +91,13 @@ class Foo(pulumi.ComponentResource):
             bool_value_required: pulumi.Input[bool],
             name_required: pulumi.Input['pulumi_random.RandomPet'],
             string_value_required: pulumi.Input[str],
-            baz: Optional[pulumi.Input['_nested.BazArgs']] = None,
+            baz: pulumi.Input[Optional['_nested.BazArgs']] = None,
             baz_plain: Optional['_nested.BazArgs'] = None,
-            bool_value: Optional[pulumi.Input[bool]] = None,
+            bool_value: pulumi.Input[Optional[bool]] = None,
             bool_value_plain: Optional[bool] = None,
-            name: Optional[pulumi.Input['pulumi_random.RandomPet']] = None,
+            name: pulumi.Input[Optional['pulumi_random.RandomPet']] = None,
             name_plain: Optional['pulumi_random.RandomPet'] = None,
-            string_value: Optional[pulumi.Input[str]] = None,
+            string_value: pulumi.Input[Optional[str]] = None,
             string_value_plain: Optional[str] = None) -> pulumi.Output['Foo.BarResult']:
         """
         A description of bar.

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/docs/component/_index.md
@@ -40,7 +40,7 @@ no_edit_this_page: true
               <span class="nx">d</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">f</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
-              <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">)</span>
+              <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[FooArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span>
@@ -297,7 +297,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -375,7 +375,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -453,7 +453,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Foo<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -531,7 +531,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -609,7 +609,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -687,7 +687,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_yaml" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Component.cs
@@ -97,7 +97,7 @@ namespace Pulumi.Example
         public string? F { get; set; }
 
         [Input("foo")]
-        public Input<Inputs.FooArgs>? Foo { get; set; }
+        public Input<Inputs.FooArgs?>? Foo { get; set; }
 
         public ComponentArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/go/component.go
@@ -62,7 +62,7 @@ type ComponentArgs struct {
 	D   *int
 	E   string
 	F   *string
-	Foo FooPtrInput
+	Foo *FooArgs
 }
 
 func (ComponentArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/nodejs/component.ts
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/nodejs/component.ts
@@ -88,5 +88,5 @@ export interface ComponentArgs {
     d?: number;
     e: string;
     f?: string;
-    foo?: pulumi.Input<inputs.FooArgs>;
+    foo?: pulumi.Input<inputs.FooArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/component.py
@@ -24,7 +24,7 @@ class ComponentArgs:
                  baz: Optional[Sequence[pulumi.Input['FooArgs']]] = None,
                  d: Optional[int] = None,
                  f: Optional[str] = None,
-                 foo: Optional[pulumi.Input['FooArgs']] = None):
+                 foo: pulumi.Input[Optional['FooArgs']] = None):
         """
         The set of arguments for constructing a Component resource.
         """
@@ -118,11 +118,11 @@ class ComponentArgs:
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['FooArgs']]:
+    def foo(self) -> pulumi.Input[Optional['FooArgs']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['FooArgs']]):
+    def foo(self, value: pulumi.Input[Optional['FooArgs']]):
         pulumi.set(self, "foo", value)
 
 
@@ -139,7 +139,7 @@ class Component(pulumi.ComponentResource):
                  d: Optional[int] = None,
                  e: Optional[str] = None,
                  f: Optional[str] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['FooArgs']]] = None,
                  __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -177,7 +177,7 @@ class Component(pulumi.ComponentResource):
                  d: Optional[int] = None,
                  e: Optional[str] = None,
                  f: Optional[str] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['FooArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/docs/component/_index.md
@@ -41,7 +41,7 @@ no_edit_this_page: true
               <span class="nx">d</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
               <span class="nx">f</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
-              <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">)</span>
+              <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[FooArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span>
@@ -306,7 +306,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -392,7 +392,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -478,7 +478,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Foo<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -564,7 +564,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -650,7 +650,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+        <span class="property-type">Foo<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -736,7 +736,7 @@ The Component resource accepts the following [input](/docs/intro/concepts/inputs
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_yaml" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#foo">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Component.cs
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Component.cs
@@ -105,7 +105,7 @@ namespace Pulumi.Example
         public string? F { get; set; }
 
         [Input("foo")]
-        public Input<Inputs.FooArgs>? Foo { get; set; }
+        public Input<Inputs.FooArgs?>? Foo { get; set; }
 
         public ComponentArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/go/example/component.go
@@ -64,7 +64,7 @@ type ComponentArgs struct {
 	D      *int
 	E      string
 	F      *string
-	Foo    FooPtrInput
+	Foo    *FooArgs
 }
 
 func (ComponentArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/nodejs/component.ts
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/nodejs/component.ts
@@ -90,5 +90,5 @@ export interface ComponentArgs {
     d?: number;
     e: string;
     f?: string;
-    foo?: pulumi.Input<inputs.FooArgs>;
+    foo?: pulumi.Input<inputs.FooArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -25,7 +25,7 @@ class ComponentArgs:
                  baz_map: Optional[Mapping[str, pulumi.Input['FooArgs']]] = None,
                  d: Optional[int] = None,
                  f: Optional[str] = None,
-                 foo: Optional[pulumi.Input['FooArgs']] = None):
+                 foo: pulumi.Input[Optional['FooArgs']] = None):
         """
         The set of arguments for constructing a Component resource.
         """
@@ -130,11 +130,11 @@ class ComponentArgs:
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['FooArgs']]:
+    def foo(self) -> pulumi.Input[Optional['FooArgs']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['FooArgs']]):
+    def foo(self, value: pulumi.Input[Optional['FooArgs']]):
         pulumi.set(self, "foo", value)
 
 
@@ -152,7 +152,7 @@ class Component(pulumi.ComponentResource):
                  d: Optional[int] = None,
                  e: Optional[str] = None,
                  f: Optional[str] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['FooArgs']]] = None,
                  __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -191,7 +191,7 @@ class Component(pulumi.ComponentResource):
                  d: Optional[int] = None,
                  e: Optional[str] = None,
                  f: Optional[str] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['FooArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-range-pp/go/simple-range.go
+++ b/pkg/codegen/testing/test/testdata/simple-range-pp/go/simple-range.go
@@ -16,7 +16,7 @@ func main() {
 			__res, err := random.NewRandomInteger(ctx, fmt.Sprintf("numbers-%v", key0), &random.RandomIntegerArgs{
 				Min:  pulumi.Int(1),
 				Max:  pulumi.Int(val0),
-				Seed: pulumi.String(fmt.Sprintf("seed%v", val0)),
+				Seed: fmt.Sprintf("seed%v", val0),
 			})
 			if err != nil {
 				return err

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/argfunction/_index.md
@@ -45,7 +45,7 @@ function </span>argFunctionOutput<span class="p">(</span><span class="nx">args</
 ><span class="k">def </span>arg_function<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ArgFunctionResult</span
 ><span class="k">
-def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Resource]]</span> = None<span class="p">,</span>
+def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Resource]]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ArgFunctionResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/otherresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[OtherResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/docs/resource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/ArgFunction.cs
@@ -33,7 +33,7 @@ namespace Pulumi.Example
     public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
-        public Input<Pulumi.Example.Resource>? Arg1 { get; set; }
+        public Input<Pulumi.Example.Resource?>? Arg1 { get; set; }
 
         public ArgFunctionInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/OtherResource.cs
@@ -44,7 +44,7 @@ namespace Pulumi.Example
     public sealed class OtherResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<Pulumi.Example.Resource>? Foo { get; set; }
+        public Input<Pulumi.Example.Resource?>? Foo { get; set; }
 
         public OtherResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Resource.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Example
     public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<string>? Bar { get; set; }
+        public Input<string?>? Bar { get; set; }
 
         public ResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/argFunction.go
@@ -41,7 +41,7 @@ func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...
 }
 
 type ArgFunctionOutputArgs struct {
-	Arg1 ResourceInput `pulumi:"arg1"`
+	Arg1 *Resource `pulumi:"arg1"`
 }
 
 func (ArgFunctionOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
@@ -37,7 +37,7 @@ type otherResourceArgs struct {
 
 // The set of arguments for constructing a OtherResource resource.
 type OtherResourceArgs struct {
-	Foo ResourceInput
+	Foo *Resource
 }
 
 func (OtherResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
@@ -26,7 +26,7 @@ type ConfigMapInput interface {
 }
 
 type ConfigMapArgs struct {
-	Config pulumi.StringPtrInput `pulumi:"config"`
+	Config *string `pulumi:"config"`
 }
 
 func (ConfigMapArgs) ElementType() reflect.Type {
@@ -126,13 +126,13 @@ type ObjectInput interface {
 }
 
 type ObjectArgs struct {
-	Bar     pulumi.StringPtrInput `pulumi:"bar"`
-	Configs ConfigMapArrayInput   `pulumi:"configs"`
-	Foo     ResourceInput         `pulumi:"foo"`
+	Bar     *string          `pulumi:"bar"`
+	Configs []ConfigMapInput `pulumi:"configs"`
+	Foo     *Resource        `pulumi:"foo"`
 	// List of lists of other objects
-	Others SomeOtherObjectArrayArrayInput `pulumi:"others"`
+	Others []SomeOtherObjectArrayInput `pulumi:"others"`
 	// Mapping from string to list of some other object
-	StillOthers SomeOtherObjectArrayMapInput `pulumi:"stillOthers"`
+	StillOthers map[string]SomeOtherObjectArrayInput `pulumi:"stillOthers"`
 }
 
 func (ObjectArgs) ElementType() reflect.Type {
@@ -199,7 +199,7 @@ type OtherResourceOutputTypeInput interface {
 }
 
 type OtherResourceOutputTypeArgs struct {
-	Foo pulumi.StringPtrInput `pulumi:"foo"`
+	Foo *string `pulumi:"foo"`
 }
 
 func (OtherResourceOutputTypeArgs) ElementType() reflect.Type {
@@ -248,7 +248,7 @@ type SomeOtherObjectInput interface {
 }
 
 type SomeOtherObjectArgs struct {
-	Baz pulumi.StringPtrInput `pulumi:"baz"`
+	Baz *string `pulumi:"baz"`
 }
 
 func (SomeOtherObjectArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
@@ -60,7 +60,7 @@ type resourceArgs struct {
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Bar pulumi.StringPtrInput
+	Bar *string
 }
 
 func (ResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
@@ -27,5 +27,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    arg1?: pulumi.Input<Resource>;
+    arg1?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/otherResource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/otherResource.ts
@@ -47,5 +47,5 @@ export class OtherResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a OtherResource resource.
  */
 export interface OtherResourceArgs {
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/resource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/resource.ts
@@ -57,5 +57,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/arg_function.py
@@ -54,7 +54,7 @@ def arg_function(arg1: Optional['Resource'] = None,
 
 
 @_utilities.lift_output_func(arg_function)
-def arg_function_output(arg1: Optional[pulumi.Input[Optional['Resource']]] = None,
+def arg_function_output(arg1: pulumi.Input[Optional['Resource']] = None,
                         opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ArgFunctionResult]:
     """
     Use this data source to access information about an existing resource.

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/other_resource.py
@@ -15,7 +15,7 @@ __all__ = ['OtherResourceArgs', 'OtherResource']
 @pulumi.input_type
 class OtherResourceArgs:
     def __init__(__self__, *,
-                 foo: Optional[pulumi.Input['Resource']] = None):
+                 foo: pulumi.Input[Optional['Resource']] = None):
         """
         The set of arguments for constructing a OtherResource resource.
         """
@@ -24,11 +24,11 @@ class OtherResourceArgs:
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['Resource']]:
+    def foo(self) -> pulumi.Input[Optional['Resource']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['Resource']]):
+    def foo(self, value: pulumi.Input[Optional['Resource']]):
         pulumi.set(self, "foo", value)
 
 
@@ -37,7 +37,7 @@ class OtherResource(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         """
         Create a OtherResource resource with the given unique name, props, and options.
@@ -67,7 +67,7 @@ class OtherResource(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/resource.py
@@ -14,7 +14,7 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input[str]] = None):
+                 bar: pulumi.Input[Optional[str]] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
@@ -23,11 +23,11 @@ class ResourceArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[str]]:
+    def bar(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[str]]):
+    def bar(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "bar", value)
 
 
@@ -36,7 +36,7 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -66,7 +66,7 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/argfunction/_index.md
@@ -45,7 +45,7 @@ function </span>argFunctionOutput<span class="p">(</span><span class="nx">args</
 ><span class="k">def </span>arg_function<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ArgFunctionResult</span
 ><span class="k">
-def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Resource]]</span> = None<span class="p">,</span>
+def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Resource]]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ArgFunctionResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/barresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">BarResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">BarResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[BarResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The BarResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The BarResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The BarResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/fooresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">FooResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">FooResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                 <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[FooResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The FooResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The FooResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The FooResource resource accepts the following [input](/docs/intro/concepts/inpu
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/otherresource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[OtherResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayfunction/_index.md
@@ -45,7 +45,7 @@ function </span>overlayFunctionOutput<span class="p">(</span><span class="nx">ar
 ><span class="k">def </span>overlay_function<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">,</span>
                      <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>OverlayFunctionResult</span
 ><span class="k">
-def </span>overlay_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Resource]]</span> = None<span class="p">,</span>
+def </span>overlay_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Resource]]</span> = None<span class="p">,</span>
                      <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[OverlayFunctionResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/overlayresource/_index.md
@@ -32,8 +32,8 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OverlayResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                     <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-                    <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[EnumOverlay]</span> = None<span class="p">,</span>
-                    <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[ConfigMapOverlayArgs]</span> = None<span class="p">)</span>
+                    <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[EnumOverlay]]</span> = None<span class="p">,</span>
+                    <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[ConfigMapOverlayArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OverlayResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                     <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[OverlayResourceArgs]</a></span> = None<span class="p">,</span>
@@ -226,7 +226,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Pulumi.<wbr>Example.<wbr>Enum<wbr>Overlay</a></span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Enum<wbr>Overlay?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -234,7 +234,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Config<wbr>Map<wbr>Overlay<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -248,7 +248,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Enum<wbr>Overlay</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -256,7 +256,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Config<wbr>Map<wbr>Overlay<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -270,7 +270,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Optional&lt;Enum<wbr>Overlay&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -278,7 +278,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Config<wbr>Map<wbr>Overlay<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -292,7 +292,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Enum<wbr>Overlay | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Config<wbr>Map<wbr>Overlay<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -314,7 +314,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">Enum<wbr>Overlay</a></span>
+        <span class="property-type">Enum<wbr>Overlay</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -322,7 +322,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Config<wbr>Map<wbr>Overlay<wbr>Args</a></span>
+        <span class="property-type">Config<wbr>Map<wbr>Overlay<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -336,7 +336,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_yaml" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#enumoverlay">&#34;SOME_ENUM_VALUE&#34;</a></span>
+        <span class="property-type">&#34;SOME_ENUM_VALUE&#34;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -344,7 +344,7 @@ The OverlayResource resource accepts the following [input](/docs/intro/concepts/
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_yaml" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#configmapoverlay">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/resource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/docs/typeuses/_index.md
@@ -32,9 +32,9 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">TypeUses</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[SomeOtherObjectArgs]</span> = None<span class="p">,</span>
-             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[ObjectWithNodeOptionalInputsArgs]</span> = None<span class="p">,</span>
-             <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[ObjectArgs]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[SomeOtherObjectArgs]]</span> = None<span class="p">,</span>
+             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Optional[ObjectWithNodeOptionalInputsArgs]]</span> = None<span class="p">,</span>
+             <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[ObjectArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">TypeUses</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[TypeUsesArgs]</a></span> = None<span class="p">,</span>
@@ -227,7 +227,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -235,7 +235,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -243,7 +243,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -257,7 +257,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -265,7 +265,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -273,7 +273,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -287,7 +287,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Some<wbr>Other<wbr>Object<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -295,7 +295,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_java" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -303,7 +303,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Object<wbr>Args&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -317,7 +317,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -325,7 +325,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -333,7 +333,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -347,7 +347,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -355,7 +355,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -363,7 +363,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -377,7 +377,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_yaml" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -385,7 +385,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_yaml" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -393,7 +393,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_yaml" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/ArgFunction.cs
@@ -33,7 +33,7 @@ namespace Pulumi.Example
     public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
-        public Input<Pulumi.Example.Resource>? Arg1 { get; set; }
+        public Input<Pulumi.Example.Resource?>? Arg1 { get; set; }
 
         public ArgFunctionInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/BarResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/BarResource.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Example
     public sealed class BarResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<Pulumi.Example.Resource>? Foo { get; set; }
+        public Input<Pulumi.Example.Resource?>? Foo { get; set; }
 
         public BarResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/FooResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/FooResource.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Example
     public sealed class FooResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<Pulumi.Example.Resource>? Foo { get; set; }
+        public Input<Pulumi.Example.Resource?>? Foo { get; set; }
 
         public FooResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ConfigMapArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class ConfigMapArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
-        public Input<string>? Config { get; set; }
+        public Input<string?>? Config { get; set; }
 
         public ConfigMapArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectArgs.cs
@@ -13,42 +13,25 @@ namespace Pulumi.Example.Inputs
     public sealed class ObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<string>? Bar { get; set; }
+        public Input<string?>? Bar { get; set; }
 
         [Input("configs")]
-        private InputList<Inputs.ConfigMapArgs>? _configs;
-        public InputList<Inputs.ConfigMapArgs> Configs
-        {
-            get => _configs ?? (_configs = new InputList<Inputs.ConfigMapArgs>());
-            set => _configs = value;
-        }
+        public Input<ImmutableArray<Input<Inputs.ConfigMapArgs>>>? Configs { get; set; }
 
         [Input("foo")]
-        public Input<Pulumi.Example.Resource>? Foo { get; set; }
-
-        [Input("others")]
-        private InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>>? _others;
+        public Input<Pulumi.Example.Resource?>? Foo { get; set; }
 
         /// <summary>
         /// List of lists of other objects
         /// </summary>
-        public InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>> Others
-        {
-            get => _others ?? (_others = new InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>>());
-            set => _others = value;
-        }
-
-        [Input("stillOthers")]
-        private InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>>? _stillOthers;
+        [Input("others")]
+        public Input<ImmutableArray<InputList<Inputs.SomeOtherObjectArgs>>>? Others { get; set; }
 
         /// <summary>
         /// Mapping from string to list of some other object
         /// </summary>
-        public InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>> StillOthers
-        {
-            get => _stillOthers ?? (_stillOthers = new InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>>());
-            set => _stillOthers = value;
-        }
+        [Input("stillOthers")]
+        public Input<ImmutableDictionary<string, InputList<Inputs.SomeOtherObjectArgs>>?>? StillOthers { get; set; }
 
         public ObjectArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class ObjectWithNodeOptionalInputsArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<int>? Bar { get; set; }
+        public Input<int?>? Bar { get; set; }
 
         [Input("foo", required: true)]
         public Input<string> Foo { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class SomeOtherObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
-        public Input<string>? Baz { get; set; }
+        public Input<string?>? Baz { get; set; }
 
         public SomeOtherObjectArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/OtherResource.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Example
     public sealed class OtherResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("foo")]
-        public Input<Pulumi.Example.Resource>? Foo { get; set; }
+        public Input<Pulumi.Example.Resource?>? Foo { get; set; }
 
         public OtherResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Resource.cs
@@ -70,14 +70,14 @@ namespace Pulumi.Example
     public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        private Input<string>? _bar;
-        public Input<string>? Bar
+        private Input<string?>? _bar;
+        public Input<string?>? Bar
         {
             get => _bar;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _bar = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _bar = Output.Tuple<Input<string?>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/TypeUses.cs
@@ -68,13 +68,13 @@ namespace Pulumi.Example
     public sealed class TypeUsesArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<Inputs.SomeOtherObjectArgs>? Bar { get; set; }
+        public Input<Inputs.SomeOtherObjectArgs?>? Bar { get; set; }
 
         [Input("baz")]
-        public Input<Inputs.ObjectWithNodeOptionalInputsArgs>? Baz { get; set; }
+        public Input<Inputs.ObjectWithNodeOptionalInputsArgs?>? Baz { get; set; }
 
         [Input("foo")]
-        public Input<Inputs.ObjectArgs>? Foo { get; set; }
+        public Input<Inputs.ObjectArgs?>? Foo { get; set; }
 
         public TypeUsesArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/argFunction.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/argFunction.go
@@ -42,7 +42,7 @@ func ArgFunctionOutput(ctx *pulumi.Context, args ArgFunctionOutputArgs, opts ...
 }
 
 type ArgFunctionOutputArgs struct {
-	Arg1 ResourceInput `pulumi:"arg1"`
+	Arg1 *Resource `pulumi:"arg1"`
 }
 
 func (ArgFunctionOutputArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/barResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/barResource.go
@@ -38,7 +38,7 @@ type barResourceArgs struct {
 
 // The set of arguments for constructing a BarResource resource.
 type BarResourceArgs struct {
-	Foo ResourceInput
+	Foo *Resource
 }
 
 func (BarResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/fooResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/fooResource.go
@@ -38,7 +38,7 @@ type fooResourceArgs struct {
 
 // The set of arguments for constructing a FooResource resource.
 type FooResourceArgs struct {
-	Foo ResourceInput
+	Foo *Resource
 }
 
 func (FooResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/otherResource.go
@@ -38,7 +38,7 @@ type otherResourceArgs struct {
 
 // The set of arguments for constructing a OtherResource resource.
 type OtherResourceArgs struct {
-	Foo ResourceInput
+	Foo *Resource
 }
 
 func (OtherResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
@@ -26,7 +26,7 @@ type ConfigMapInput interface {
 }
 
 type ConfigMapArgs struct {
-	Config pulumi.StringPtrInput `pulumi:"config"`
+	Config *string `pulumi:"config"`
 }
 
 func (ConfigMapArgs) ElementType() reflect.Type {
@@ -126,13 +126,13 @@ type ObjectInput interface {
 }
 
 type ObjectArgs struct {
-	Bar     pulumi.StringPtrInput `pulumi:"bar"`
-	Configs ConfigMapArrayInput   `pulumi:"configs"`
-	Foo     ResourceInput         `pulumi:"foo"`
+	Bar     *string          `pulumi:"bar"`
+	Configs []ConfigMapInput `pulumi:"configs"`
+	Foo     *Resource        `pulumi:"foo"`
 	// List of lists of other objects
-	Others SomeOtherObjectArrayArrayInput `pulumi:"others"`
+	Others []SomeOtherObjectArrayInput `pulumi:"others"`
 	// Mapping from string to list of some other object
-	StillOthers SomeOtherObjectArrayMapInput `pulumi:"stillOthers"`
+	StillOthers map[string]SomeOtherObjectArrayInput `pulumi:"stillOthers"`
 }
 
 func (ObjectArgs) ElementType() reflect.Type {
@@ -322,7 +322,7 @@ type ObjectWithNodeOptionalInputsInput interface {
 }
 
 type ObjectWithNodeOptionalInputsArgs struct {
-	Bar pulumi.IntPtrInput `pulumi:"bar"`
+	Bar *int               `pulumi:"bar"`
 	Foo pulumi.StringInput `pulumi:"foo"`
 }
 
@@ -469,7 +469,7 @@ type OtherResourceOutputTypeInput interface {
 }
 
 type OtherResourceOutputTypeArgs struct {
-	Foo pulumi.StringPtrInput `pulumi:"foo"`
+	Foo *string `pulumi:"foo"`
 }
 
 func (OtherResourceOutputTypeArgs) ElementType() reflect.Type {
@@ -518,7 +518,7 @@ type SomeOtherObjectInput interface {
 }
 
 type SomeOtherObjectArgs struct {
-	Baz pulumi.StringPtrInput `pulumi:"baz"`
+	Baz *string `pulumi:"baz"`
 }
 
 func (SomeOtherObjectArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/resource.go
@@ -25,7 +25,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Bar != nil {
-		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrInput)
+		args.Bar = pulumi.ToSecret(args.Bar).(*string)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"bar",
@@ -70,7 +70,7 @@ type resourceArgs struct {
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Bar pulumi.StringPtrInput
+	Bar *string
 }
 
 func (ResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/typeUses.go
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/go/example/typeUses.go
@@ -65,9 +65,9 @@ type typeUsesArgs struct {
 
 // The set of arguments for constructing a TypeUses resource.
 type TypeUsesArgs struct {
-	Bar SomeOtherObjectPtrInput
-	Baz ObjectWithNodeOptionalInputsPtrInput
-	Foo ObjectPtrInput
+	Bar *SomeOtherObjectArgs
+	Baz *ObjectWithNodeOptionalInputsArgs
+	Foo *ObjectArgs
 }
 
 func (TypeUsesArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/argFunction.ts
@@ -27,5 +27,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    arg1?: pulumi.Input<Resource>;
+    arg1?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/barResource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/barResource.ts
@@ -47,5 +47,5 @@ export class BarResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a BarResource resource.
  */
 export interface BarResourceArgs {
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/fooResource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/fooResource.ts
@@ -47,5 +47,5 @@ export class FooResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a FooResource resource.
  */
 export interface FooResourceArgs {
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/otherResource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/otherResource.ts
@@ -47,5 +47,5 @@ export class OtherResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a OtherResource resource.
  */
 export interface OtherResourceArgs {
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/resource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/resource.ts
@@ -62,5 +62,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/typeUses.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/typeUses.ts
@@ -67,7 +67,7 @@ export class TypeUses extends pulumi.CustomResource {
  * The set of arguments for constructing a TypeUses resource.
  */
 export interface TypeUsesArgs {
-    bar?: pulumi.Input<inputs.SomeOtherObjectArgs>;
-    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs>;
-    foo?: pulumi.Input<inputs.ObjectArgs>;
+    bar?: pulumi.Input<inputs.SomeOtherObjectArgs | undefined>;
+    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs | undefined>;
+    foo?: pulumi.Input<inputs.ObjectArgs | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/nodejs/types/input.ts
@@ -8,28 +8,28 @@ import * as outputs from "../types/output";
 import {Resource} from "..";
 
 export interface ConfigMapArgs {
-    config?: pulumi.Input<string>;
+    config?: pulumi.Input<string | undefined>;
 }
 
 export interface ObjectArgs {
-    bar?: pulumi.Input<string>;
-    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[]>;
-    foo?: pulumi.Input<Resource>;
+    bar?: pulumi.Input<string | undefined>;
+    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[] | undefined>;
+    foo?: pulumi.Input<Resource | undefined>;
     /**
      * List of lists of other objects
      */
-    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[]>;
+    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[] | undefined>;
     /**
      * Mapping from string to list of some other object
      */
-    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>}>;
+    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>} | undefined>;
 }
 
 export interface ObjectWithNodeOptionalInputsArgs {
-    bar?: pulumi.Input<number>;
+    bar?: pulumi.Input<number | undefined>;
     foo?: pulumi.Input<string>;
 }
 
 export interface SomeOtherObjectArgs {
-    baz?: pulumi.Input<string>;
+    baz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/_inputs.py
@@ -20,17 +20,17 @@ __all__ = [
 @pulumi.input_type
 class ConfigMapArgs:
     def __init__(__self__, *,
-                 config: Optional[pulumi.Input[str]] = None):
+                 config: pulumi.Input[Optional[str]] = None):
         if config is not None:
             pulumi.set(__self__, "config", config)
 
     @property
     @pulumi.getter
-    def config(self) -> Optional[pulumi.Input[str]]:
+    def config(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "config")
 
     @config.setter
-    def config(self, value: Optional[pulumi.Input[str]]):
+    def config(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "config", value)
 
 
@@ -38,7 +38,7 @@ class ConfigMapArgs:
 class ObjectWithNodeOptionalInputsArgs:
     def __init__(__self__, *,
                  foo: pulumi.Input[str],
-                 bar: Optional[pulumi.Input[int]] = None):
+                 bar: pulumi.Input[Optional[int]] = None):
         pulumi.set(__self__, "foo", foo)
         if bar is not None:
             pulumi.set(__self__, "bar", bar)
@@ -54,25 +54,25 @@ class ObjectWithNodeOptionalInputsArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[int]]:
+    def bar(self) -> pulumi.Input[Optional[int]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[int]]):
+    def bar(self, value: pulumi.Input[Optional[int]]):
         pulumi.set(self, "bar", value)
 
 
 @pulumi.input_type
 class ObjectArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input[str]] = None,
-                 configs: Optional[pulumi.Input[Sequence[pulumi.Input['ConfigMapArgs']]]] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
-                 others: Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
-                 still_others: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None):
+                 bar: pulumi.Input[Optional[str]] = None,
+                 configs: pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
+                 others: pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
+                 still_others: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None):
         """
-        :param pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]] others: List of lists of other objects
-        :param pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]] still_others: Mapping from string to list of some other object
+        :param pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] others: List of lists of other objects
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] still_others: Mapping from string to list of some other object
         """
         if bar is not None:
             pulumi.set(__self__, "bar", bar)
@@ -87,70 +87,70 @@ class ObjectArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[str]]:
+    def bar(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[str]]):
+    def bar(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "bar", value)
 
     @property
     @pulumi.getter
-    def configs(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ConfigMapArgs']]]]:
+    def configs(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]]:
         return pulumi.get(self, "configs")
 
     @configs.setter
-    def configs(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ConfigMapArgs']]]]):
+    def configs(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]]):
         pulumi.set(self, "configs", value)
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['Resource']]:
+    def foo(self) -> pulumi.Input[Optional['Resource']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['Resource']]):
+    def foo(self, value: pulumi.Input[Optional['Resource']]):
         pulumi.set(self, "foo", value)
 
     @property
     @pulumi.getter
-    def others(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
+    def others(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
         """
         List of lists of other objects
         """
         return pulumi.get(self, "others")
 
     @others.setter
-    def others(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
+    def others(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
         pulumi.set(self, "others", value)
 
     @property
     @pulumi.getter(name="stillOthers")
-    def still_others(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
+    def still_others(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
         """
         Mapping from string to list of some other object
         """
         return pulumi.get(self, "still_others")
 
     @still_others.setter
-    def still_others(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
+    def still_others(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
         pulumi.set(self, "still_others", value)
 
 
 @pulumi.input_type
 class SomeOtherObjectArgs:
     def __init__(__self__, *,
-                 baz: Optional[pulumi.Input[str]] = None):
+                 baz: pulumi.Input[Optional[str]] = None):
         if baz is not None:
             pulumi.set(__self__, "baz", baz)
 
     @property
     @pulumi.getter
-    def baz(self) -> Optional[pulumi.Input[str]]:
+    def baz(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "baz")
 
     @baz.setter
-    def baz(self, value: Optional[pulumi.Input[str]]):
+    def baz(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "baz", value)
 
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
@@ -54,7 +54,7 @@ def arg_function(arg1: Optional['Resource'] = None,
 
 
 @_utilities.lift_output_func(arg_function)
-def arg_function_output(arg1: Optional[pulumi.Input[Optional['Resource']]] = None,
+def arg_function_output(arg1: pulumi.Input[Optional['Resource']] = None,
                         opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ArgFunctionResult]:
     """
     Use this data source to access information about an existing resource.

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/bar_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/bar_resource.py
@@ -15,7 +15,7 @@ __all__ = ['BarResourceArgs', 'BarResource']
 @pulumi.input_type
 class BarResourceArgs:
     def __init__(__self__, *,
-                 foo: Optional[pulumi.Input['Resource']] = None):
+                 foo: pulumi.Input[Optional['Resource']] = None):
         """
         The set of arguments for constructing a BarResource resource.
         """
@@ -24,11 +24,11 @@ class BarResourceArgs:
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['Resource']]:
+    def foo(self) -> pulumi.Input[Optional['Resource']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['Resource']]):
+    def foo(self, value: pulumi.Input[Optional['Resource']]):
         pulumi.set(self, "foo", value)
 
 
@@ -37,7 +37,7 @@ class BarResource(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         """
         Create a BarResource resource with the given unique name, props, and options.
@@ -67,7 +67,7 @@ class BarResource(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/foo_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/foo_resource.py
@@ -15,7 +15,7 @@ __all__ = ['FooResourceArgs', 'FooResource']
 @pulumi.input_type
 class FooResourceArgs:
     def __init__(__self__, *,
-                 foo: Optional[pulumi.Input['Resource']] = None):
+                 foo: pulumi.Input[Optional['Resource']] = None):
         """
         The set of arguments for constructing a FooResource resource.
         """
@@ -24,11 +24,11 @@ class FooResourceArgs:
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['Resource']]:
+    def foo(self) -> pulumi.Input[Optional['Resource']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['Resource']]):
+    def foo(self, value: pulumi.Input[Optional['Resource']]):
         pulumi.set(self, "foo", value)
 
 
@@ -37,7 +37,7 @@ class FooResource(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         """
         Create a FooResource resource with the given unique name, props, and options.
@@ -67,7 +67,7 @@ class FooResource(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -15,7 +15,7 @@ __all__ = ['OtherResourceArgs', 'OtherResource']
 @pulumi.input_type
 class OtherResourceArgs:
     def __init__(__self__, *,
-                 foo: Optional[pulumi.Input['Resource']] = None):
+                 foo: pulumi.Input[Optional['Resource']] = None):
         """
         The set of arguments for constructing a OtherResource resource.
         """
@@ -24,11 +24,11 @@ class OtherResourceArgs:
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['Resource']]:
+    def foo(self) -> pulumi.Input[Optional['Resource']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['Resource']]):
+    def foo(self, value: pulumi.Input[Optional['Resource']]):
         pulumi.set(self, "foo", value)
 
 
@@ -37,7 +37,7 @@ class OtherResource(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         """
         Create a OtherResource resource with the given unique name, props, and options.
@@ -67,7 +67,7 @@ class OtherResource(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -14,7 +14,7 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input[str]] = None):
+                 bar: pulumi.Input[Optional[str]] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
@@ -23,11 +23,11 @@ class ResourceArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[str]]:
+    def bar(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[str]]):
+    def bar(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "bar", value)
 
 
@@ -36,7 +36,7 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -66,7 +66,7 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/type_uses.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/pulumi_example/type_uses.py
@@ -17,9 +17,9 @@ __all__ = ['TypeUsesArgs', 'TypeUses']
 @pulumi.input_type
 class TypeUsesArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input['SomeOtherObjectArgs']] = None,
-                 baz: Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']] = None,
-                 foo: Optional[pulumi.Input['ObjectArgs']] = None):
+                 bar: pulumi.Input[Optional['SomeOtherObjectArgs']] = None,
+                 baz: pulumi.Input[Optional['ObjectWithNodeOptionalInputsArgs']] = None,
+                 foo: pulumi.Input[Optional['ObjectArgs']] = None):
         """
         The set of arguments for constructing a TypeUses resource.
         """
@@ -32,29 +32,29 @@ class TypeUsesArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input['SomeOtherObjectArgs']]:
+    def bar(self) -> pulumi.Input[Optional['SomeOtherObjectArgs']]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input['SomeOtherObjectArgs']]):
+    def bar(self, value: pulumi.Input[Optional['SomeOtherObjectArgs']]):
         pulumi.set(self, "bar", value)
 
     @property
     @pulumi.getter
-    def baz(self) -> Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']]:
+    def baz(self) -> pulumi.Input[Optional['ObjectWithNodeOptionalInputsArgs']]:
         return pulumi.get(self, "baz")
 
     @baz.setter
-    def baz(self, value: Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']]):
+    def baz(self, value: pulumi.Input[Optional['ObjectWithNodeOptionalInputsArgs']]):
         pulumi.set(self, "baz", value)
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['ObjectArgs']]:
+    def foo(self) -> pulumi.Input[Optional['ObjectArgs']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['ObjectArgs']]):
+    def foo(self, value: pulumi.Input[Optional['ObjectArgs']]):
         pulumi.set(self, "foo", value)
 
 
@@ -63,9 +63,9 @@ class TypeUses(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[pulumi.InputType['SomeOtherObjectArgs']]] = None,
-                 baz: Optional[pulumi.Input[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['ObjectArgs']]] = None,
+                 bar: pulumi.Input[Optional[pulumi.InputType['SomeOtherObjectArgs']]] = None,
+                 baz: pulumi.Input[Optional[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['ObjectArgs']]] = None,
                  __props__=None):
         """
         Create a TypeUses resource with the given unique name, props, and options.
@@ -95,9 +95,9 @@ class TypeUses(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[pulumi.InputType['SomeOtherObjectArgs']]] = None,
-                 baz: Optional[pulumi.Input[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['ObjectArgs']]] = None,
+                 bar: pulumi.Input[Optional[pulumi.InputType['SomeOtherObjectArgs']]] = None,
+                 baz: pulumi.Input[Optional[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['ObjectArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/argfunction/_index.md
@@ -45,7 +45,7 @@ function </span>argFunctionOutput<span class="p">(</span><span class="nx">args</
 ><span class="k">def </span>arg_function<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>ArgFunctionResult</span
 ><span class="k">
-def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[Resource]]</span> = None<span class="p">,</span>
+def </span>arg_function_output<span class="p">(</span><span class="nx">arg1</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[Resource]]</span> = None<span class="p">,</span>
                  <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[ArgFunctionResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/otherresource/_index.md
@@ -33,7 +33,7 @@ no_edit_this_page: true
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
                   <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Sequence[str]]</span> = None<span class="p">,</span>
-                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Resource]</span> = None<span class="p">)</span>
+                  <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[Resource]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">OtherResource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
                   <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[OtherResourceArgs]</a></span> = None<span class="p">,</span>
@@ -234,7 +234,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Resource?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -278,7 +278,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Optional&lt;Resource&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -300,7 +300,7 @@ The OtherResource resource accepts the following [input](/docs/intro/concepts/in
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Resource</span>
+        <span class="property-type">Resource | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/resource/_index.md
@@ -32,7 +32,7 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[str]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Resource</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ResourceArgs]</a></span> = None<span class="p">,</span>
@@ -225,7 +225,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -253,7 +253,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">String</span>
+        <span class="property-type">Optional&lt;String&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -267,7 +267,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">string</span>
+        <span class="property-type">string | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -281,7 +281,7 @@ The Resource resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">str</span>
+        <span class="property-type">Optional[str]</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/docs/typeuses/_index.md
@@ -32,10 +32,10 @@ no_edit_this_page: true
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">TypeUses</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[SomeOtherObjectArgs]</span> = None<span class="p">,</span>
-             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[ObjectWithNodeOptionalInputsArgs]</span> = None<span class="p">,</span>
-             <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[ObjectArgs]</span> = None<span class="p">,</span>
-             <span class="nx">qux</span><span class="p">:</span> <span class="nx">Optional[RubberTreeVariety]</span> = None<span class="p">)</span>
+             <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[Optional[SomeOtherObjectArgs]]</span> = None<span class="p">,</span>
+             <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Optional[ObjectWithNodeOptionalInputsArgs]]</span> = None<span class="p">,</span>
+             <span class="nx">foo</span><span class="p">:</span> <span class="nx">Optional[Optional[ObjectArgs]]</span> = None<span class="p">,</span>
+             <span class="nx">qux</span><span class="p">:</span> <span class="nx">Optional[Optional[RubberTreeVariety]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">TypeUses</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[TypeUsesArgs]</a></span> = None<span class="p">,</span>
@@ -228,7 +228,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -236,7 +236,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -244,7 +244,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_csharp" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args?</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -252,7 +252,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_csharp" style="color: inherit; text-decoration: inherit;">Qux</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#rubbertreevariety">Pulumi.<wbr>Example.<wbr>Rubber<wbr>Tree<wbr>Variety</a></span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Rubber<wbr>Tree<wbr>Variety?</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -266,7 +266,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -274,7 +274,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -282,7 +282,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_go" style="color: inherit; text-decoration: inherit;">Foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -290,7 +290,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_go" style="color: inherit; text-decoration: inherit;">Qux</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
+        <span class="property-type">Rubber<wbr>Tree<wbr>Variety</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -304,7 +304,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_java" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Some<wbr>Other<wbr>Object<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -312,7 +312,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_java" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -320,7 +320,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_java" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Optional&lt;Object<wbr>Args&gt;</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -328,7 +328,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_java" style="color: inherit; text-decoration: inherit;">qux</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
+        <span class="property-type">Optional&lt;Rubber<wbr>Tree<wbr>Variety&gt;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -342,7 +342,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -350,7 +350,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -358,7 +358,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_nodejs" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args | undefined</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -366,7 +366,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_nodejs" style="color: inherit; text-decoration: inherit;">qux</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
+        <span class="property-type">Rubber<wbr>Tree<wbr>Variety | undefined</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -380,7 +380,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Some<wbr>Other<wbr>Object<wbr>Args</a></span>
+        <span class="property-type">Some<wbr>Other<wbr>Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -388,7 +388,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>With<wbr>Node<wbr>Optional<wbr>Inputs<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -396,7 +396,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_python" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Object<wbr>Args</a></span>
+        <span class="property-type">Object<wbr>Args</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -404,7 +404,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_python" style="color: inherit; text-decoration: inherit;">qux</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#rubbertreevariety">Rubber<wbr>Tree<wbr>Variety</a></span>
+        <span class="property-type">Rubber<wbr>Tree<wbr>Variety</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>
@@ -418,7 +418,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#bar_yaml" style="color: inherit; text-decoration: inherit;">bar</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#someotherobject">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -426,7 +426,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#baz_yaml" style="color: inherit; text-decoration: inherit;">baz</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectwithnodeoptionalinputs">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -434,7 +434,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#foo_yaml" style="color: inherit; text-decoration: inherit;">foo</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#object">Property Map</a></span>
+        <span class="property-type">Property Map</span>
     </dt>
     <dd></dd><dt class="property-optional"
             title="Optional">
@@ -442,7 +442,7 @@ The TypeUses resource accepts the following [input](/docs/intro/concepts/inputs-
 <a data-swiftype-name="resource-property" data-swiftype-type="text" href="#qux_yaml" style="color: inherit; text-decoration: inherit;">qux</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#rubbertreevariety">&#34;Burgundy&#34; | &#34;Ruby&#34; | &#34;Tineke&#34;</a></span>
+        <span class="property-type">&#34;Burgundy&#34; | &#34;Ruby&#34; | &#34;Tineke&#34;</span>
     </dt>
     <dd></dd></dl>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/ArgFunction.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/ArgFunction.cs
@@ -33,7 +33,7 @@ namespace Pulumi.Example
     public sealed class ArgFunctionInvokeArgs : global::Pulumi.InvokeArgs
     {
         [Input("arg1")]
-        public Input<Pulumi.Example.Resource>? Arg1 { get; set; }
+        public Input<Pulumi.Example.Resource?>? Arg1 { get; set; }
 
         public ArgFunctionInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ConfigMapArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ConfigMapArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class ConfigMapArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
-        public Input<string>? Config { get; set; }
+        public Input<string?>? Config { get; set; }
 
         public ConfigMapArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectArgs.cs
@@ -13,42 +13,25 @@ namespace Pulumi.Example.Inputs
     public sealed class ObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<string>? Bar { get; set; }
+        public Input<string?>? Bar { get; set; }
 
         [Input("configs")]
-        private InputList<Inputs.ConfigMapArgs>? _configs;
-        public InputList<Inputs.ConfigMapArgs> Configs
-        {
-            get => _configs ?? (_configs = new InputList<Inputs.ConfigMapArgs>());
-            set => _configs = value;
-        }
+        public Input<ImmutableArray<Input<Inputs.ConfigMapArgs>>>? Configs { get; set; }
 
         [Input("foo")]
-        public Input<Pulumi.Example.Resource>? Foo { get; set; }
-
-        [Input("others")]
-        private InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>>? _others;
+        public Input<Pulumi.Example.Resource?>? Foo { get; set; }
 
         /// <summary>
         /// List of lists of other objects
         /// </summary>
-        public InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>> Others
-        {
-            get => _others ?? (_others = new InputList<ImmutableArray<Inputs.SomeOtherObjectArgs>>());
-            set => _others = value;
-        }
-
-        [Input("stillOthers")]
-        private InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>>? _stillOthers;
+        [Input("others")]
+        public Input<ImmutableArray<InputList<Inputs.SomeOtherObjectArgs>>>? Others { get; set; }
 
         /// <summary>
         /// Mapping from string to list of some other object
         /// </summary>
-        public InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>> StillOthers
-        {
-            get => _stillOthers ?? (_stillOthers = new InputMap<ImmutableArray<Inputs.SomeOtherObjectArgs>>());
-            set => _stillOthers = value;
-        }
+        [Input("stillOthers")]
+        public Input<ImmutableDictionary<string, InputList<Inputs.SomeOtherObjectArgs>>?>? StillOthers { get; set; }
 
         public ObjectArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/ObjectWithNodeOptionalInputsArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class ObjectWithNodeOptionalInputsArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<int>? Bar { get; set; }
+        public Input<int?>? Bar { get; set; }
 
         [Input("foo", required: true)]
         public Input<string> Foo { get; set; } = null!;

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Inputs/SomeOtherObjectArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example.Inputs
     public sealed class SomeOtherObjectArgs : global::Pulumi.ResourceArgs
     {
         [Input("baz")]
-        public Input<string>? Baz { get; set; }
+        public Input<string?>? Baz { get; set; }
 
         public SomeOtherObjectArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/OtherResource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/OtherResource.cs
@@ -52,7 +52,7 @@ namespace Pulumi.Example
         }
 
         [Input("foo")]
-        public Input<Pulumi.Example.Resource>? Foo { get; set; }
+        public Input<Pulumi.Example.Resource?>? Foo { get; set; }
 
         public OtherResourceArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Resource.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Resource.cs
@@ -65,14 +65,14 @@ namespace Pulumi.Example
     public sealed class ResourceArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        private Input<string>? _bar;
-        public Input<string>? Bar
+        private Input<string?>? _bar;
+        public Input<string?>? Bar
         {
             get => _bar;
             set
             {
                 var emptySecret = Output.CreateSecret(0);
-                _bar = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+                _bar = Output.Tuple<Input<string?>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
 

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/TypeUses.cs
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/TypeUses.cs
@@ -82,16 +82,16 @@ namespace Pulumi.Example
     public sealed class TypeUsesArgs : global::Pulumi.ResourceArgs
     {
         [Input("bar")]
-        public Input<Inputs.SomeOtherObjectArgs>? Bar { get; set; }
+        public Input<Inputs.SomeOtherObjectArgs?>? Bar { get; set; }
 
         [Input("baz")]
-        public Input<Inputs.ObjectWithNodeOptionalInputsArgs>? Baz { get; set; }
+        public Input<Inputs.ObjectWithNodeOptionalInputsArgs?>? Baz { get; set; }
 
         [Input("foo")]
-        public Input<Inputs.ObjectArgs>? Foo { get; set; }
+        public Input<Inputs.ObjectArgs?>? Foo { get; set; }
 
         [Input("qux")]
-        public Input<Pulumi.Example.RubberTreeVariety>? Qux { get; set; }
+        public Input<Pulumi.Example.RubberTreeVariety?>? Qux { get; set; }
 
         public TypeUsesArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/otherResource.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/otherResource.go
@@ -39,7 +39,7 @@ type otherResourceArgs struct {
 // The set of arguments for constructing a OtherResource resource.
 type OtherResourceArgs struct {
 	Bar []pulumi.StringInput
-	Foo ResourceInput
+	Foo *Resource
 }
 
 func (OtherResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
@@ -26,7 +26,7 @@ type ConfigMapInput interface {
 }
 
 type ConfigMapArgs struct {
-	Config pulumi.StringPtrInput `pulumi:"config"`
+	Config *string `pulumi:"config"`
 }
 
 func (ConfigMapArgs) ElementType() reflect.Type {
@@ -126,13 +126,13 @@ type ObjectInput interface {
 }
 
 type ObjectArgs struct {
-	Bar     pulumi.StringPtrInput `pulumi:"bar"`
-	Configs ConfigMapArrayInput   `pulumi:"configs"`
-	Foo     ResourceInput         `pulumi:"foo"`
+	Bar     *string          `pulumi:"bar"`
+	Configs []ConfigMapInput `pulumi:"configs"`
+	Foo     *Resource        `pulumi:"foo"`
 	// List of lists of other objects
-	Others SomeOtherObjectArrayArrayInput `pulumi:"others"`
+	Others []SomeOtherObjectArrayInput `pulumi:"others"`
 	// Mapping from string to list of some other object
-	StillOthers SomeOtherObjectArrayMapInput `pulumi:"stillOthers"`
+	StillOthers map[string]SomeOtherObjectArrayInput `pulumi:"stillOthers"`
 }
 
 func (ObjectArgs) ElementType() reflect.Type {
@@ -322,7 +322,7 @@ type ObjectWithNodeOptionalInputsInput interface {
 }
 
 type ObjectWithNodeOptionalInputsArgs struct {
-	Bar pulumi.IntPtrInput `pulumi:"bar"`
+	Bar *int               `pulumi:"bar"`
 	Foo pulumi.StringInput `pulumi:"foo"`
 }
 
@@ -548,7 +548,7 @@ type SomeOtherObjectInput interface {
 }
 
 type SomeOtherObjectArgs struct {
-	Baz pulumi.StringPtrInput `pulumi:"baz"`
+	Baz *string `pulumi:"baz"`
 }
 
 func (SomeOtherObjectArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/resource.go
@@ -24,7 +24,7 @@ func NewResource(ctx *pulumi.Context,
 	}
 
 	if args.Bar != nil {
-		args.Bar = pulumi.ToSecret(args.Bar).(pulumi.StringPtrInput)
+		args.Bar = pulumi.ToSecret(args.Bar).(*string)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"bar",
@@ -67,7 +67,7 @@ type resourceArgs struct {
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Bar pulumi.StringPtrInput
+	Bar *string
 }
 
 func (ResourceArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/typeUses.go
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/go/example/typeUses.go
@@ -70,10 +70,10 @@ type typeUsesArgs struct {
 
 // The set of arguments for constructing a TypeUses resource.
 type TypeUsesArgs struct {
-	Bar SomeOtherObjectPtrInput
-	Baz ObjectWithNodeOptionalInputsPtrInput
-	Foo ObjectPtrInput
-	Qux RubberTreeVarietyPtrInput
+	Bar *SomeOtherObjectArgs
+	Baz *ObjectWithNodeOptionalInputsArgs
+	Foo *ObjectArgs
+	Qux *RubberTreeVariety
 }
 
 func (TypeUsesArgs) ElementType() reflect.Type {

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/argFunction.ts
@@ -27,5 +27,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    arg1?: pulumi.Input<Resource>;
+    arg1?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/otherResource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/otherResource.ts
@@ -49,5 +49,5 @@ export class OtherResource extends pulumi.ComponentResource {
  */
 export interface OtherResourceArgs {
     bar?: pulumi.Input<string>[];
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/resource.ts
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/typeUses.ts
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/typeUses.ts
@@ -83,8 +83,8 @@ export class TypeUses extends pulumi.CustomResource {
  * The set of arguments for constructing a TypeUses resource.
  */
 export interface TypeUsesArgs {
-    bar?: pulumi.Input<inputs.SomeOtherObjectArgs>;
-    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs>;
-    foo?: pulumi.Input<inputs.ObjectArgs>;
-    qux?: pulumi.Input<enums.RubberTreeVariety>;
+    bar?: pulumi.Input<inputs.SomeOtherObjectArgs | undefined>;
+    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs | undefined>;
+    foo?: pulumi.Input<inputs.ObjectArgs | undefined>;
+    qux?: pulumi.Input<enums.RubberTreeVariety | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/types/input.ts
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/nodejs/types/input.ts
@@ -9,28 +9,28 @@ import * as enums from "../types/enums";
 import {Resource} from "..";
 
 export interface ConfigMapArgs {
-    config?: pulumi.Input<string>;
+    config?: pulumi.Input<string | undefined>;
 }
 
 export interface ObjectArgs {
-    bar?: pulumi.Input<string>;
-    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[]>;
-    foo?: pulumi.Input<Resource>;
+    bar?: pulumi.Input<string | undefined>;
+    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[] | undefined>;
+    foo?: pulumi.Input<Resource | undefined>;
     /**
      * List of lists of other objects
      */
-    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[]>;
+    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[] | undefined>;
     /**
      * Mapping from string to list of some other object
      */
-    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>}>;
+    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>} | undefined>;
 }
 
 export interface ObjectWithNodeOptionalInputsArgs {
-    bar?: pulumi.Input<number>;
+    bar?: pulumi.Input<number | undefined>;
     foo?: pulumi.Input<string>;
 }
 
 export interface SomeOtherObjectArgs {
-    baz?: pulumi.Input<string>;
+    baz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/_inputs.py
@@ -21,17 +21,17 @@ __all__ = [
 @pulumi.input_type
 class ConfigMapArgs:
     def __init__(__self__, *,
-                 config: Optional[pulumi.Input[str]] = None):
+                 config: pulumi.Input[Optional[str]] = None):
         if config is not None:
             pulumi.set(__self__, "config", config)
 
     @property
     @pulumi.getter
-    def config(self) -> Optional[pulumi.Input[str]]:
+    def config(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "config")
 
     @config.setter
-    def config(self, value: Optional[pulumi.Input[str]]):
+    def config(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "config", value)
 
 
@@ -39,7 +39,7 @@ class ConfigMapArgs:
 class ObjectWithNodeOptionalInputsArgs:
     def __init__(__self__, *,
                  foo: pulumi.Input[str],
-                 bar: Optional[pulumi.Input[int]] = None):
+                 bar: pulumi.Input[Optional[int]] = None):
         pulumi.set(__self__, "foo", foo)
         if bar is not None:
             pulumi.set(__self__, "bar", bar)
@@ -55,25 +55,25 @@ class ObjectWithNodeOptionalInputsArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[int]]:
+    def bar(self) -> pulumi.Input[Optional[int]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[int]]):
+    def bar(self, value: pulumi.Input[Optional[int]]):
         pulumi.set(self, "bar", value)
 
 
 @pulumi.input_type
 class ObjectArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input[str]] = None,
-                 configs: Optional[pulumi.Input[Sequence[pulumi.Input['ConfigMapArgs']]]] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
-                 others: Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
-                 still_others: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None):
+                 bar: pulumi.Input[Optional[str]] = None,
+                 configs: pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
+                 others: pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None,
+                 still_others: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] = None):
         """
-        :param pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]] others: List of lists of other objects
-        :param pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]] still_others: Mapping from string to list of some other object
+        :param pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] others: List of lists of other objects
+        :param pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]] still_others: Mapping from string to list of some other object
         """
         if bar is not None:
             pulumi.set(__self__, "bar", bar)
@@ -88,70 +88,70 @@ class ObjectArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[str]]:
+    def bar(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[str]]):
+    def bar(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "bar", value)
 
     @property
     @pulumi.getter
-    def configs(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ConfigMapArgs']]]]:
+    def configs(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]]:
         return pulumi.get(self, "configs")
 
     @configs.setter
-    def configs(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ConfigMapArgs']]]]):
+    def configs(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]]):
         pulumi.set(self, "configs", value)
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['Resource']]:
+    def foo(self) -> pulumi.Input[Optional['Resource']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['Resource']]):
+    def foo(self, value: pulumi.Input[Optional['Resource']]):
         pulumi.set(self, "foo", value)
 
     @property
     @pulumi.getter
-    def others(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
+    def others(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
         """
         List of lists of other objects
         """
         return pulumi.get(self, "others")
 
     @others.setter
-    def others(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
+    def others(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
         pulumi.set(self, "others", value)
 
     @property
     @pulumi.getter(name="stillOthers")
-    def still_others(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
+    def still_others(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]:
         """
         Mapping from string to list of some other object
         """
         return pulumi.get(self, "still_others")
 
     @still_others.setter
-    def still_others(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
+    def still_others(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
         pulumi.set(self, "still_others", value)
 
 
 @pulumi.input_type
 class SomeOtherObjectArgs:
     def __init__(__self__, *,
-                 baz: Optional[pulumi.Input[str]] = None):
+                 baz: pulumi.Input[Optional[str]] = None):
         if baz is not None:
             pulumi.set(__self__, "baz", baz)
 
     @property
     @pulumi.getter
-    def baz(self) -> Optional[pulumi.Input[str]]:
+    def baz(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "baz")
 
     @baz.setter
-    def baz(self, value: Optional[pulumi.Input[str]]):
+    def baz(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "baz", value)
 
 

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/arg_function.py
@@ -54,7 +54,7 @@ def arg_function(arg1: Optional['Resource'] = None,
 
 
 @_utilities.lift_output_func(arg_function)
-def arg_function_output(arg1: Optional[pulumi.Input[Optional['Resource']]] = None,
+def arg_function_output(arg1: pulumi.Input[Optional['Resource']] = None,
                         opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[ArgFunctionResult]:
     """
     Use this data source to access information about an existing resource.

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/other_resource.py
@@ -16,7 +16,7 @@ __all__ = ['OtherResourceArgs', 'OtherResource']
 class OtherResourceArgs:
     def __init__(__self__, *,
                  bar: Optional[Sequence[pulumi.Input[str]]] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None):
+                 foo: pulumi.Input[Optional['Resource']] = None):
         """
         The set of arguments for constructing a OtherResource resource.
         """
@@ -36,11 +36,11 @@ class OtherResourceArgs:
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['Resource']]:
+    def foo(self) -> pulumi.Input[Optional['Resource']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['Resource']]):
+    def foo(self, value: pulumi.Input[Optional['Resource']]):
         pulumi.set(self, "foo", value)
 
 
@@ -50,7 +50,7 @@ class OtherResource(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[Sequence[pulumi.Input[str]]] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         """
         Create a OtherResource resource with the given unique name, props, and options.
@@ -81,7 +81,7 @@ class OtherResource(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[Sequence[pulumi.Input[str]]] = None,
-                 foo: Optional[pulumi.Input['Resource']] = None,
+                 foo: pulumi.Input[Optional['Resource']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/resource.py
@@ -14,7 +14,7 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input[str]] = None):
+                 bar: pulumi.Input[Optional[str]] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
@@ -23,11 +23,11 @@ class ResourceArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input[str]]:
+    def bar(self) -> pulumi.Input[Optional[str]]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input[str]]):
+    def bar(self, value: pulumi.Input[Optional[str]]):
         pulumi.set(self, "bar", value)
 
 
@@ -36,7 +36,7 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -66,7 +66,7 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[str]] = None,
+                 bar: pulumi.Input[Optional[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/type_uses.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/pulumi_example/type_uses.py
@@ -18,10 +18,10 @@ __all__ = ['TypeUsesArgs', 'TypeUses']
 @pulumi.input_type
 class TypeUsesArgs:
     def __init__(__self__, *,
-                 bar: Optional[pulumi.Input['SomeOtherObjectArgs']] = None,
-                 baz: Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']] = None,
-                 foo: Optional[pulumi.Input['ObjectArgs']] = None,
-                 qux: Optional[pulumi.Input['RubberTreeVariety']] = None):
+                 bar: pulumi.Input[Optional['SomeOtherObjectArgs']] = None,
+                 baz: pulumi.Input[Optional['ObjectWithNodeOptionalInputsArgs']] = None,
+                 foo: pulumi.Input[Optional['ObjectArgs']] = None,
+                 qux: pulumi.Input[Optional['RubberTreeVariety']] = None):
         """
         The set of arguments for constructing a TypeUses resource.
         """
@@ -36,38 +36,38 @@ class TypeUsesArgs:
 
     @property
     @pulumi.getter
-    def bar(self) -> Optional[pulumi.Input['SomeOtherObjectArgs']]:
+    def bar(self) -> pulumi.Input[Optional['SomeOtherObjectArgs']]:
         return pulumi.get(self, "bar")
 
     @bar.setter
-    def bar(self, value: Optional[pulumi.Input['SomeOtherObjectArgs']]):
+    def bar(self, value: pulumi.Input[Optional['SomeOtherObjectArgs']]):
         pulumi.set(self, "bar", value)
 
     @property
     @pulumi.getter
-    def baz(self) -> Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']]:
+    def baz(self) -> pulumi.Input[Optional['ObjectWithNodeOptionalInputsArgs']]:
         return pulumi.get(self, "baz")
 
     @baz.setter
-    def baz(self, value: Optional[pulumi.Input['ObjectWithNodeOptionalInputsArgs']]):
+    def baz(self, value: pulumi.Input[Optional['ObjectWithNodeOptionalInputsArgs']]):
         pulumi.set(self, "baz", value)
 
     @property
     @pulumi.getter
-    def foo(self) -> Optional[pulumi.Input['ObjectArgs']]:
+    def foo(self) -> pulumi.Input[Optional['ObjectArgs']]:
         return pulumi.get(self, "foo")
 
     @foo.setter
-    def foo(self, value: Optional[pulumi.Input['ObjectArgs']]):
+    def foo(self, value: pulumi.Input[Optional['ObjectArgs']]):
         pulumi.set(self, "foo", value)
 
     @property
     @pulumi.getter
-    def qux(self) -> Optional[pulumi.Input['RubberTreeVariety']]:
+    def qux(self) -> pulumi.Input[Optional['RubberTreeVariety']]:
         return pulumi.get(self, "qux")
 
     @qux.setter
-    def qux(self, value: Optional[pulumi.Input['RubberTreeVariety']]):
+    def qux(self, value: pulumi.Input[Optional['RubberTreeVariety']]):
         pulumi.set(self, "qux", value)
 
 
@@ -76,10 +76,10 @@ class TypeUses(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[pulumi.InputType['SomeOtherObjectArgs']]] = None,
-                 baz: Optional[pulumi.Input[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['ObjectArgs']]] = None,
-                 qux: Optional[pulumi.Input['RubberTreeVariety']] = None,
+                 bar: pulumi.Input[Optional[pulumi.InputType['SomeOtherObjectArgs']]] = None,
+                 baz: pulumi.Input[Optional[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['ObjectArgs']]] = None,
+                 qux: pulumi.Input[Optional['RubberTreeVariety']] = None,
                  __props__=None):
         """
         Create a TypeUses resource with the given unique name, props, and options.
@@ -109,10 +109,10 @@ class TypeUses(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 bar: Optional[pulumi.Input[pulumi.InputType['SomeOtherObjectArgs']]] = None,
-                 baz: Optional[pulumi.Input[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
-                 foo: Optional[pulumi.Input[pulumi.InputType['ObjectArgs']]] = None,
-                 qux: Optional[pulumi.Input['RubberTreeVariety']] = None,
+                 bar: pulumi.Input[Optional[pulumi.InputType['SomeOtherObjectArgs']]] = None,
+                 baz: pulumi.Input[Optional[pulumi.InputType['ObjectWithNodeOptionalInputsArgs']]] = None,
+                 foo: pulumi.Input[Optional[pulumi.InputType['ObjectArgs']]] = None,
+                 qux: pulumi.Input[Optional['RubberTreeVariety']] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargs/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargs/_index.md
@@ -50,7 +50,7 @@ function </span>absMultiArgsOutput<span class="p">(</span><span class="nx">args<
                    <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>AbsMultiArgsResult</span
 ><span class="k">
 def </span>abs_multi_args_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
-                   <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+                   <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
                    <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[AbsMultiArgsResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutput/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absmultiargsreducedoutput/_index.md
@@ -50,7 +50,7 @@ function </span>absMultiArgsReducedOutputOutput<span class="p">(</span><span cla
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>AbsMultiArgsReducedOutputResult</span
 ><span class="k">
 def </span>abs_multi_args_reduced_output_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
-                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+                                  <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
                                   <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[AbsMultiArgsReducedOutputResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absreducedoutput/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/absreducedoutput/_index.md
@@ -50,7 +50,7 @@ function </span>absReducedOutputOutput<span class="p">(</span><span class="nx">a
                        <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>AbsReducedOutputResult</span
 ><span class="k">
 def </span>abs_reduced_output_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
-                       <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+                       <span class="nx">b</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
                        <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[AbsReducedOutputResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarchive/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarchive/_index.md
@@ -45,7 +45,7 @@ function </span>getArchiveOutput<span class="p">(</span><span class="nx">args</s
 ><span class="k">def </span>get_archive<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetArchiveResult</span
 ><span class="k">
-def </span>get_archive_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+def </span>get_archive_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
                 <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetArchiveResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarraycustomresult/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getarraycustomresult/_index.md
@@ -45,7 +45,7 @@ function </span>getArrayCustomResultOutput<span class="p">(</span><span class="n
 ><span class="k">def </span>get_array_custom_result<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
                             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetArrayCustomResultResult</span
 ><span class="k">
-def </span>get_array_custom_result_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+def </span>get_array_custom_result_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
                             <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetArrayCustomResultResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getasset/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getasset/_index.md
@@ -45,7 +45,7 @@ function </span>getAssetOutput<span class="p">(</span><span class="nx">args</spa
 ><span class="k">def </span>get_asset<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetAssetResult</span
 ><span class="k">
-def </span>get_asset_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+def </span>get_asset_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetAssetResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getcustomresult/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getcustomresult/_index.md
@@ -45,7 +45,7 @@ function </span>getCustomResultOutput<span class="p">(</span><span class="nx">ar
 ><span class="k">def </span>get_custom_result<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
                       <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetCustomResultResult</span
 ><span class="k">
-def </span>get_custom_result_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+def </span>get_custom_result_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
                       <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetCustomResultResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getdictionary/_index.md
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/docs/getdictionary/_index.md
@@ -45,7 +45,7 @@ function </span>getDictionaryOutput<span class="p">(</span><span class="nx">args
 ><span class="k">def </span>get_dictionary<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[float]</span> = None<span class="p">,</span>
                    <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>GetDictionaryResult</span
 ><span class="k">
-def </span>get_dictionary_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[pulumi.Input[float]]</span> = None<span class="p">,</span>
+def </span>get_dictionary_output<span class="p">(</span><span class="nx">a</span><span class="p">:</span> <span class="nx">pulumi.Input[Optional[float]]</span> = None<span class="p">,</span>
                    <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.InvokeOptions">Optional[InvokeOptions]</a></span> = None<span class="p">) -&gt;</span> <span>Output[GetDictionaryResult]</span
 ></code></pre></div>
 </pulumi-choosable>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/dotnet/AbsReducedOutput.cs
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/dotnet/AbsReducedOutput.cs
@@ -47,7 +47,7 @@ namespace Pulumi.Std
         public Input<double> A { get; set; } = null!;
 
         [Input("b")]
-        public Input<double>? B { get; set; }
+        public Input<double?>? B { get; set; }
 
         public AbsReducedOutputInvokeArgs()
         {

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/nodejs/absReducedOutput.ts
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/nodejs/absReducedOutput.ts
@@ -31,5 +31,5 @@ export function absReducedOutputOutput(args: AbsReducedOutputOutputArgs, opts?: 
 
 export interface AbsReducedOutputOutputArgs {
     a: pulumi.Input<number>;
-    b?: pulumi.Input<number>;
+    b?: pulumi.Input<number | undefined>;
 }

--- a/pkg/codegen/testing/test/testdata/third-party-package-pp/go/third-party-package.go
+++ b/pkg/codegen/testing/test/testdata/third-party-package-pp/go/third-party-package.go
@@ -9,25 +9,25 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := pkg.NewThing(ctx, "Other", &pkg.ThingArgs{
-			Idea: pulumi.String("Support Third Party"),
+			Idea: "Support Third Party",
 		})
 		if err != nil {
 			return err
 		}
 		_, err = module.NewObject(ctx, "Question", &module.ObjectArgs{
-			Answer: pulumi.Float64(42),
+			Answer: 42,
 		})
 		if err != nil {
 			return err
 		}
 		_, err = module.NewObject(ctx, "Question2", &module.ObjectArgs{
-			Answer: pulumi.Float64(24),
+			Answer: 24,
 		})
 		if err != nil {
 			return err
 		}
 		_, err = pkg.NewProvider(ctx, "Provider", &pkg.ProviderArgs{
-			ObjectProp: pulumi.StringMap{
+			ObjectProp: map[string]pulumi.String{
 				"prop1": pulumi.String("foo"),
 				"prop2": pulumi.String("bar"),
 				"prop3": pulumi.String("fizz"),

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/aws-static-website-pp/python/aws-static-website.py
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/aws-static-website-pp/python/aws-static-website.py
@@ -2,9 +2,9 @@ import pulumi
 import pulumi_aws as aws
 import pulumi_aws_native as aws_native
 
-site_bucket = aws_native.s3.Bucket("site-bucket", website_configuration=aws_native.s3.BucketWebsiteConfigurationArgs(
-    index_document="index.html",
-))
+site_bucket = aws_native.s3.Bucket("site-bucket", website_configuration={
+    "indexDocument": "index.html",
+})
 index_html = aws.s3.BucketObject("index.html",
     bucket=site_bucket,
     source=pulumi.FileAsset("./www/index.html"),

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/azure-app-service-pp/python/azure-app-service.py
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/azure-app-service-pp/python/azure-app-service.py
@@ -32,10 +32,10 @@ blob_access_token = pulumi.Output.secret(pulumi.Output.all(sa.name, appservicegr
 appserviceplan = azure_native.web.AppServicePlan("appserviceplan",
     resource_group_name=appservicegroup.name,
     kind="App",
-    sku=azure_native.web.SkuDescriptionArgs(
-        name="B1",
-        tier="Basic",
-    ))
+    sku={
+        "name": "B1",
+        "tier": "Basic",
+    })
 blob = azure_native.storage.Blob("blob",
     resource_group_name=appservicegroup.name,
     account_name=sa.name,
@@ -57,14 +57,14 @@ sql_server = azure_native.sql.Server("sqlServer",
 db = azure_native.sql.Database("db",
     resource_group_name=appservicegroup.name,
     server_name=sql_server.name,
-    sku=azure_native.sql.SkuArgs(
-        name="S0",
-    ))
+    sku={
+        "name": "S0",
+    })
 app = azure_native.web.WebApp("app",
     resource_group_name=appservicegroup.name,
     server_farm_id=appserviceplan.id,
-    site_config=azure_native.web.SiteConfigArgs(
-        app_settings=[
+    site_config={
+        "appSettings": [
             azure_native.web.NameValuePairArgs(
                 name="WEBSITE_RUN_FROM_PACKAGE",
                 value=pulumi.Output.all(sa.name, container.name, blob.name, blob_access_token).apply(lambda saName, containerName, blobName, blob_access_token: f"https://{sa_name}.blob.core.windows.net/{container_name}/{blob_name}?{blob_access_token}"),
@@ -82,10 +82,10 @@ app = azure_native.web.WebApp("app",
                 value="~2",
             ),
         ],
-        connection_strings=[azure_native.web.ConnStringInfoArgs(
+        "connectionStrings": [azure_native.web.ConnStringInfoArgs(
             name="db",
             type=azure_native.web.ConnectionStringType.SQL_AZURE,
             connection_string=pulumi.Output.all(sql_server.name, db.name, sql_password.result).apply(lambda sqlServerName, dbName, result: f"Server= tcp:{sql_server_name}.database.windows.net;initial catalog={db_name};userID={sql_admin};password={result};Min Pool Size=0;Max Pool Size=30;Persist Security Info=true;"),
         )],
-    ))
+    })
 pulumi.export("endpoint", app.default_host_name)

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/go/cue-random.go
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/go/cue-random.go
@@ -11,8 +11,8 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		randomPassword, err := random.NewRandomPassword(ctx, "randomPassword", &random.RandomPasswordArgs{
 			Length:          pulumi.Int(16),
-			Special:         pulumi.Bool(true),
-			OverrideSpecial: pulumi.String(fmt.Sprintf("_%v@", "%")),
+			Special:         true,
+			OverrideSpecial: fmt.Sprintf("_%v@", "%"),
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/getting-started-pp/python/getting-started.py
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/getting-started-pp/python/getting-started.py
@@ -1,9 +1,9 @@
 import pulumi
 import pulumi_aws as aws
 
-mybucket = aws.s3.Bucket("mybucket", website=aws.s3.BucketWebsiteArgs(
-    index_document="index.html",
-))
+mybucket = aws.s3.Bucket("mybucket", website={
+    "indexDocument": "index.html",
+})
 indexhtml = aws.s3.BucketObject("indexhtml",
     bucket=mybucket.id,
     source=pulumi.StringAsset("<h1>Hello, world!</h1>"),

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/kubernetes-pp/python/kubernetes.py
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/kubernetes-pp/python/kubernetes.py
@@ -7,68 +7,68 @@ if hostname is None:
     hostname = "example.com"
 nginx_demo = kubernetes.core.v1.Namespace("nginx-demo")
 app = kubernetes.apps.v1.Deployment("app",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        namespace=nginx_demo.metadata.name,
-    ),
-    spec=kubernetes.apps.v1.DeploymentSpecArgs(
-        selector=kubernetes.meta.v1.LabelSelectorArgs(
+    metadata={
+        "namespace": nginx_demo.metadata.name,
+    },
+    spec={
+        "selector": kubernetes.meta.v1.LabelSelectorArgs(
             match_labels={
                 "app.kubernetes.io/name": "nginx-demo",
             },
         ),
-        replicas=1,
-        template=kubernetes.core.v1.PodTemplateSpecArgs(
-            metadata=kubernetes.meta.v1.ObjectMetaArgs(
-                labels={
+        "replicas": 1,
+        "template": kubernetes.core.v1.PodTemplateSpecArgs(
+            metadata={
+                "labels": {
                     "app.kubernetes.io/name": "nginx-demo",
                 },
-            ),
-            spec=kubernetes.core.v1.PodSpecArgs(
-                containers=[kubernetes.core.v1.ContainerArgs(
+            },
+            spec={
+                "containers": [kubernetes.core.v1.ContainerArgs(
                     name="app",
                     image="nginx:1.15-alpine",
                 )],
-            ),
+            },
         ),
-    ))
+    })
 service = kubernetes.core.v1.Service("service",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        namespace=nginx_demo.metadata.name,
-        labels={
+    metadata={
+        "namespace": nginx_demo.metadata.name,
+        "labels": {
             "app.kubernetes.io/name": "nginx-demo",
         },
-    ),
-    spec=kubernetes.core.v1.ServiceSpecArgs(
-        type="ClusterIP",
-        ports=[kubernetes.core.v1.ServicePortArgs(
+    },
+    spec={
+        "type": "ClusterIP",
+        "ports": [kubernetes.core.v1.ServicePortArgs(
             port=80,
             target_port=80,
             protocol="TCP",
         )],
-        selector={
+        "selector": {
             "app.kubernetes.io/name": "nginx-demo",
         },
-    ))
+    })
 ingress = kubernetes.networking.v1.Ingress("ingress",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        namespace=nginx_demo.metadata.name,
-    ),
-    spec=kubernetes.networking.v1.IngressSpecArgs(
-        rules=[kubernetes.networking.v1.IngressRuleArgs(
+    metadata={
+        "namespace": nginx_demo.metadata.name,
+    },
+    spec={
+        "rules": [kubernetes.networking.v1.IngressRuleArgs(
             host=hostname,
-            http=kubernetes.networking.v1.HTTPIngressRuleValueArgs(
-                paths=[kubernetes.networking.v1.HTTPIngressPathArgs(
+            http={
+                "paths": [kubernetes.networking.v1.HTTPIngressPathArgs(
                     path="/",
                     path_type="Prefix",
                     backend=kubernetes.networking.v1.IngressBackendArgs(
-                        service=kubernetes.networking.v1.IngressServiceBackendArgs(
-                            name=service.metadata.name,
-                            port=kubernetes.networking.v1.ServiceBackendPortArgs(
-                                number=80,
-                            ),
-                        ),
+                        service={
+                            "name": service.metadata.name,
+                            "port": {
+                                "number": 80,
+                            },
+                        },
                     ),
                 )],
-            ),
+            },
         )],
-    ))
+    })

--- a/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/go/traverse-union-repro.go
+++ b/pkg/codegen/testing/test/testdata/traverse-union-repro-pp/go/traverse-union-repro.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := fsx.NewOpenZfsFileSystem(ctx, "test", &fsx.OpenZfsFileSystemArgs{
-			StorageCapacity: pulumi.Int(64),
+			StorageCapacity: 64,
 			SubnetIds: pulumi.String{
 				aws_subnet.Test1.Id,
 			},

--- a/pkg/codegen/testing/test/testdata/typed-enum-pp/dotnet/typed-enum.cs
+++ b/pkg/codegen/testing/test/testdata/typed-enum-pp/dotnet/typed-enum.cs
@@ -29,7 +29,7 @@ return await Deployment.RunAsync(() =>
         ResourceGroupName = someString,
         AccountName = someString,
         ContainerName = someString,
-        Type = staticwebsite.IndexDocument.Apply(System.Enum.Parse<AzureNative.Storage.BlobType>),
+        Type = staticwebsite.IndexDocument,
     });
 
     // Unsafe enum

--- a/pkg/codegen/testing/test/testdata/typed-enum-pp/nodejs/typed-enum.ts
+++ b/pkg/codegen/testing/test/testdata/typed-enum-pp/nodejs/typed-enum.ts
@@ -19,7 +19,7 @@ const _404html = new azure_native.storage.Blob("_404html", {
     resourceGroupName: someString,
     accountName: someString,
     containerName: someString,
-    type: staticwebsite.indexDocument.apply((x) => azure_native.storage.BlobType[x]),
+    type: staticwebsite.indexDocument,
 });
 // Unsafe enum
 const another = new azure_native.storage.Blob("another", {

--- a/pkg/codegen/testing/test/testdata/typed-enum-pp/python/typed-enum.py
+++ b/pkg/codegen/testing/test/testdata/typed-enum-pp/python/typed-enum.py
@@ -17,7 +17,7 @@ _404html = azure_native.storage.Blob("_404html",
     resource_group_name=some_string,
     account_name=some_string,
     container_name=some_string,
-    type=staticwebsite.index_document.apply(lambda x: azure_native.storage.BlobType(x)))
+    type=staticwebsite.index_document)
 # Unsafe enum
 another = azure_native.storage.Blob("another",
     resource_group_name=some_string,

--- a/pkg/codegen/testing/test/testdata/types.json
+++ b/pkg/codegen/testing/test/testdata/types.json
@@ -54,19 +54,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "InputMap<string>",
+                  "input": "Input<ImmutableDictionary<string, Input<string>>?>?",
                   "plain": "ImmutableDictionary<string, string>?"
                 },
                 "go": {
-                  "input": "pulumi.StringMapInput",
+                  "input": "map[string]pulumi.StringInput",
                   "plain": "map[string]string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>}> | undefined",
+                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined> | undefined",
                   "plain": "{[key: string]: string} | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]",
+                  "input": "pulumi.Input[Optional[Mapping[str, pulumi.Input[str]]]]",
                   "plain": "Optional[Mapping[str, str]]"
                 }
               }
@@ -85,19 +85,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input<object>?",
+                  "input": "Input<object?>?",
                   "plain": "object?"
                 },
                 "go": {
-                  "input": "pulumi.Input",
+                  "input": "interface{}",
                   "plain": "interface{}"
                 },
                 "nodejs": {
-                  "input": "any | undefined",
+                  "input": "pulumi.Input<any | undefined> | undefined",
                   "plain": "any | undefined"
                 },
                 "python": {
-                  "input": "Optional[Any]",
+                  "input": "pulumi.Input[Optional[Any]]",
                   "plain": "Optional[Any]"
                 }
               }
@@ -110,19 +110,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input<Archive>?",
+                  "input": "Input<Archive?>?",
                   "plain": "Archive?"
                 },
                 "go": {
-                  "input": "pulumi.ArchiveInput",
+                  "input": "pulumi.Archive",
                   "plain": "pulumi.Archive"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<pulumi.asset.Archive> | undefined",
+                  "input": "pulumi.Input<pulumi.asset.Archive | undefined> | undefined",
                   "plain": "pulumi.asset.Archive | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[pulumi.Archive]]",
+                  "input": "pulumi.Input[Optional[pulumi.Archive]]",
                   "plain": "Optional[pulumi.Archive]"
                 }
               }
@@ -135,19 +135,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input<AssetOrArchive>?",
+                  "input": "Input<AssetOrArchive?>?",
                   "plain": "AssetOrArchive?"
                 },
                 "go": {
-                  "input": "pulumi.AssetOrArchiveInput",
+                  "input": "pulumi.AssetOrArchive",
                   "plain": "pulumi.AssetOrArchive"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive> | undefined",
+                  "input": "pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive | undefined> | undefined",
                   "plain": "pulumi.asset.Asset | pulumi.asset.Archive | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]",
+                  "input": "pulumi.Input[Optional[Union[pulumi.Asset, pulumi.Archive]]]",
                   "plain": "Optional[Union[pulumi.Asset, pulumi.Archive]]"
                 }
               }
@@ -160,19 +160,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input<bool>?",
+                  "input": "Input<bool?>?",
                   "plain": "bool?"
                 },
                 "go": {
-                  "input": "pulumi.BoolPtrInput",
+                  "input": "*bool",
                   "plain": "*bool"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<boolean> | undefined",
+                  "input": "pulumi.Input<boolean | undefined> | undefined",
                   "plain": "boolean | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[bool]]",
+                  "input": "pulumi.Input[Optional[bool]]",
                   "plain": "Optional[bool]"
                 }
               }
@@ -185,19 +185,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input<int>?",
+                  "input": "Input<int?>?",
                   "plain": "int?"
                 },
                 "go": {
-                  "input": "pulumi.IntPtrInput",
+                  "input": "*int",
                   "plain": "*int"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<number> | undefined",
+                  "input": "pulumi.Input<number | undefined> | undefined",
                   "plain": "number | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[int]]",
+                  "input": "pulumi.Input[Optional[int]]",
                   "plain": "Optional[int]"
                 }
               }
@@ -210,19 +210,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "InputJson?",
+                  "input": "Input<System.Text.Json.JsonElement?>?",
                   "plain": "System.Text.Json.JsonElement?"
                 },
                 "go": {
-                  "input": "pulumi.Input",
+                  "input": "interface{}",
                   "plain": "interface{}"
                 },
                 "nodejs": {
-                  "input": "any | undefined",
+                  "input": "pulumi.Input<any | undefined> | undefined",
                   "plain": "any | undefined"
                 },
                 "python": {
-                  "input": "Optional[Any]",
+                  "input": "pulumi.Input[Optional[Any]]",
                   "plain": "Optional[Any]"
                 }
               }
@@ -235,19 +235,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input<double>?",
+                  "input": "Input<double?>?",
                   "plain": "double?"
                 },
                 "go": {
-                  "input": "pulumi.Float64PtrInput",
+                  "input": "*float64",
                   "plain": "*float64"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<number> | undefined",
+                  "input": "pulumi.Input<number | undefined> | undefined",
                   "plain": "number | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[float]]",
+                  "input": "pulumi.Input[Optional[float]]",
                   "plain": "Optional[float]"
                 }
               }
@@ -460,19 +460,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input<string>?",
+                  "input": "Input<string?>?",
                   "plain": "string?"
                 },
                 "go": {
-                  "input": "pulumi.StringPtrInput",
+                  "input": "*string",
                   "plain": "*string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<string> | undefined",
+                  "input": "pulumi.Input<string | undefined> | undefined",
                   "plain": "string | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[str]]",
+                  "input": "pulumi.Input[Optional[str]]",
                   "plain": "Optional[str]"
                 }
               }
@@ -504,19 +504,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "InputMap<string>",
+                  "input": "Input<ImmutableDictionary<string, Input<string>>?>?",
                   "plain": "ImmutableDictionary<string, string>?"
                 },
                 "go": {
-                  "input": "pulumi.StringMapInput",
+                  "input": "map[string]pulumi.StringInput",
                   "plain": "map[string]string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>}> | undefined",
+                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined> | undefined",
                   "plain": "{[key: string]: string} | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]",
+                  "input": "pulumi.Input[Optional[Mapping[str, pulumi.Input[str]]]]",
                   "plain": "Optional[Mapping[str, str]]"
                 }
               }
@@ -545,19 +545,19 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "InputUnion<ObjectArgs, ImmutableArray<System.Text.Json.JsonElement>>?",
+                  "input": "Input<Union<Input<ObjectArgs>, InputList<System.Text.Json.JsonElement>>?>?",
                   "plain": "Union<Object, ImmutableArray<System.Text.Json.JsonElement>>?"
                 },
                 "go": {
-                  "input": "pulumi.Input",
+                  "input": "interface{}",
                   "plain": "interface{}"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<outputs.ObjectArgs | any[]> | undefined",
+                  "input": "pulumi.Input<pulumi.Input<outputs.ObjectArgs> | pulumi.Input<any[]> | undefined> | undefined",
                   "plain": "outputs.Object | any[] | undefined"
                 },
                 "python": {
-                  "input": "Optional[Any]",
+                  "input": "pulumi.Input[Optional[Any]]",
                   "plain": "Optional[Any]"
                 }
               }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Changes the binding of resources properties from `Optional[T]` to `Optional[Input[Optional[U]` iff `T` is `Input[U]`.

Fixes https://github.com/pulumi/pulumi/issues/12105
Fixes https://github.com/pulumi/pulumi/issues/6175

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
