### PR TITLE
sdk/go: Drop unused resourceOptions field

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -638,13 +638,13 @@ func (ctx *Context) ReadResource(
 	}
 
 	// Merge providers.
-	providers, err := ctx.mergeProviders(t, options.Parent, options.Provider, options.Providers)
+	providers, err := ctx.mergeProviders(t, options.Parent, nil /* provider */, options.Providers)
 	if err != nil {
 		return err
 	}
 
 	// Get the provider for the resource.
-	provider := getProvider(t, options.Provider, providers)
+	provider := getProvider(t, nil /* provider */, providers)
 
 	// Create resolvers for the resource's outputs.
 	res := ctx.makeResourceState(t, name, resource, providers, provider,
@@ -835,13 +835,13 @@ func (ctx *Context) registerResource(
 	}
 
 	// Merge providers.
-	providers, err := ctx.mergeProviders(t, options.Parent, options.Provider, options.Providers)
+	providers, err := ctx.mergeProviders(t, options.Parent, nil /* provider */, options.Providers)
 	if err != nil {
 		return err
 	}
 
 	// Get the provider for the resource.
-	provider := getProvider(t, options.Provider, providers)
+	provider := getProvider(t, nil /* provider */, providers)
 
 	// Create resolvers for the resource's outputs.
 	resState := ctx.makeResourceState(t, name, resource, providers, provider,

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -287,8 +287,6 @@ type resourceOptions struct {
 	Parent Resource
 	// Protect, when set to true, ensures that this resource cannot be deleted (without first setting it to false).
 	Protect bool
-	// Provider is an optional provider resource to use for this resource's CRUD operations.
-	Provider ProviderResource
 	// Providers is an optional map of package to provider resource for a component resource.
 	Providers map[string]ProviderResource
 	// ReplaceOnChanges will force a replacement when any of these property paths are set.  If this list includes `"*"`,


### PR DESCRIPTION
The `Provider` field is never set by any option.
The corresponding option `func Provider(..)`,
when used as a `ResourceOption` delegates to the `Providers` function
which sets the `Providers` map instead.

```go
func Provider(r ProviderResource) ResourceOrInvokeOption {
	... {
	    Providers(r).applyResourceOption(ro)
	}
}
```

This drops the unused field in preparation for exposing
a mirror of the resourceOptions struct for #11698.

Refs #11698
