### PR TITLE
sdk/go: Support looking inside []ResourceOption

### DIFF
--- a/changelog/pending/20230209--sdk-go--adds-newresourceoptions-to-preview-the-effect-of-a-list-of-resourceoption-values.yaml
+++ b/changelog/pending/20230209--sdk-go--adds-newresourceoptions-to-preview-the-effect-of-a-list-of-resourceoption-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Adds `NewResourceOptions` to preview the effect of a list of `ResourceOption` values.

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -290,55 +290,89 @@ type CustomTimeouts struct {
 //
 // It provides a preview of the collective effect of options
 // passed to a resource.
+//
+// See https://www.pulumi.com/docs/intro/concepts/resources/options/
+// for more details on individual options.
 type ResourceOptions struct {
-	// AdditionalSecretOutputs is an optional list of output properties to mark as secret.
+	// AdditionalSecretOutputs lists output properties
+	// that must be encrypted as secrets.
 	AdditionalSecretOutputs []string
-	// Aliases is an optional list of identifiers used to find and use existing resources.
+
+	// Aliases lists aliases for this resource
+	// that are used to find and use existing resources.
 	Aliases []Alias
-	// CustomTimeouts is an optional configuration block used for CRUD operations
+
+	// CustomTimeouts, if set, overrides the default timeouts
+	// for resource CRUD operations.
 	CustomTimeouts *CustomTimeouts
-	// DeleteBeforeReplace, when set to true, ensures that this resource is deleted prior to replacement.
+
+	// DeleteBeforeReplace specifies that resources being replaced
+	// should be deleted before creating the replacement
+	// instead of Pulumi's default behavior of creating the replacement
+	// before performing deletion.
 	DeleteBeforeReplace bool
-	// DependsOn is an optional array of explicit dependencies on other resources.
-	DependsOn       []Resource
+
+	// DependsOn lists additional explicit dependencies for the resource
+	// in addition to those tracked automatically by Pulumi.
+	DependsOn []Resource
+
+	// DependsOnInputs holds explicit dependencies for the resource
+	// that may not be fully known yet.
 	DependsOnInputs []ResourceArrayInput
-	// IgnoreChanges ignores changes to any of the specified properties.
+
+	// IgnoreChanges lists properties changes to which should be ignored.
 	IgnoreChanges []string
-	// Import, when provided with a resource ID, indicates that this resource's provider should import its state from
-	// the cloud resource with the given ID. The inputs to the resource's constructor must align with the resource's
-	// current state. Once a resource has been imported, the import property must be removed from the resource's
-	// options.
+
+	// Import specifies that the provider for this resource
+	// should import its state from a cloud resource with the given ID.
 	Import IDInput
-	// Parent is an optional parent resource to which this resource belongs.
+
+	// Parent is the parent resource for the resource being created,
+	// or nil if this resource does not have a parent.
 	Parent Resource
-	// Protect, when set to true, ensures that this resource cannot be deleted (without first setting it to false).
+
+	// Protect prevents this resource from being deleted.
 	Protect bool
-	// Provider is an optional provider resource to use for this resource's CRUD operations.
+
+	// Provider is the provider resource to use for this resource's CRUD operations.
+	// It's nil if the default provider should be used.
 	Provider ProviderResource
-	// Providers is an optional map of package to provider resource for a component resource.
+
+	// Providers is a bag of providers available
+	// to instantiate resources of various types.
+	// These are used for a type when a provider for that type
+	// was not explicitly supplied.
 	Providers []ProviderResource
-	// ReplaceOnChanges will force a replacement when any of these property paths are set.  If this list includes `"*"`,
-	// changes to any properties will force a replacement.  Initialization errors from previous deployments will
-	// require replacement instead of update only if `"*"` is passed.
+
+	// ReplaceOnChanges lists properties that, when modified,
+	// force a replacement of the resource.
+	// The list may include '*' to indicate that all properties trigger
+	// replacements.
 	ReplaceOnChanges []string
-	// Transformations is an optional list of transformations to apply to this resource during construction.
-	// The transformations are applied in order, and are applied prior to transformation and to parents
-	// walking from the resource up to the stack.
+
+	// Transformations is a list of functions that transform
+	// the resource's properties during construction.
 	Transformations []ResourceTransformation
-	// URN is an optional URN of a previously-registered resource of this type to read from the engine.
+
+	// URN is the URN of a previously-registered resource of this type.
 	URN string
-	// Version is an optional version, corresponding to the version of the provider plugin that should be used when
-	// operating on this resource. This version overrides the version information inferred from the current package and
-	// should rarely be used.
+
+	// Version changes the version of the provider plugin that should be used
+	// when operating on this resource.
+	// This will be blank if the version was automatically inferred.
 	Version string
-	// PluginDownloadURL is an optional url, corresponding to the download url of the provider
-	// plugin that should be used when operating on this resource. This url overrides the url
-	// information inferred from the current package and should rarely be used.
+
+	// PluginDownloadURL specifies the URL from which the provider plugin
+	// should be downloaded.
+	// This will be blank if the URL was inferred automatically.
 	PluginDownloadURL string
-	// If set to True, the providers Delete method will not be called for this resource.
+
+	// RetainOnDelete specifies that the resource should not be deleted
+	// in the cloud provider, even if it's deleted from Pulumi.
 	RetainOnDelete bool
-	// If set, the providers Delete method will not be called for this resource
-	// if specified resource is being deleted as well.
+
+	// DeletedWith holds a container resource that, if deleted,
+	// also deletes this resource.
 	DeletedWith Resource
 }
 


### PR DESCRIPTION
Adds a new ResourceOptions type
and a constructor for it

    func NewResourceOptions(...ResourceOption) ResourceOptions

Together, these provide a means for users
to look inside a `...ResourceOption` argument
from mocks and component resource implementations.

ResourceOptions is intended to *mostly* mirror
the internal resourceOptions struct
that the ResourceOption interface operates on.
However, it diverges from the internal representation
in a few places for a better user-facing API.
For example,

- instead of `map[string]Provider`, expose `[]Provider`
  sorted by the `string`
- instead of dependency URN information,
  expose fields analogous to the original options

More importantly, note that ResourceOptions currently
**does not** have a Provider field.
This is because of a bug that caused #12192.
When #12192 is resolved, the Provider field
can be added to ResourceOptions.

In a separately reviewable commit,
this redocuments the fields of ResourceOptions
from the point of view of a consumer of the struct.
The prior documentation for those fields
was lifted directly from their option constructors
which is aimsed at producers of those options.

Refs #11698
