### PR TITLE
sdk/go: Support looking inside []InvokeOption

### DIFF
--- a/changelog/pending/20230209--sdk-go--adds-newinvokeoptions-to-preview-the-effect-of-a-list-of-invokeoption-values.yaml
+++ b/changelog/pending/20230209--sdk-go--adds-newinvokeoptions-to-preview-the-effect-of-a-list-of-invokeoption-values.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Adds `NewInvokeOptions` to preview the effect of a list of `InvokeOption` values.

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -267,11 +267,9 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 		return errors.New("result must be a pointer to a struct or map value")
 	}
 
-	options := &invokeOptions{}
-	for _, o := range opts {
-		if o != nil {
-			o.applyInvokeOption(options)
-		}
+	options, err := NewInvokeOptions(opts...)
+	if err != nil {
+		return err
 	}
 
 	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.
@@ -378,11 +376,9 @@ func (ctx *Context) Call(tok string, args Input, output Output, self Resource, o
 
 	output = ctx.newOutput(reflect.TypeOf(output))
 
-	options := &invokeOptions{}
-	for _, o := range opts {
-		if o != nil {
-			o.applyInvokeOption(options)
-		}
+	options, err := NewInvokeOptions(opts...)
+	if err != nil {
+		return nil, err
 	}
 
 	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -312,19 +312,19 @@ func TestInvokeOptionComposite(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []InvokeOption
-		want  *invokeOptions
+		want  *InvokeOptions
 	}{
 		{
 			name:  "no options",
 			input: []InvokeOption{},
-			want:  &invokeOptions{},
+			want:  &InvokeOptions{},
 		},
 		{
 			name: "single option",
 			input: []InvokeOption{
 				Version("test"),
 			},
-			want: &invokeOptions{
+			want: &InvokeOptions{
 				Version: "test",
 			},
 		},
@@ -334,7 +334,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 				Version("test1"),
 				Version("test2"),
 			},
-			want: &invokeOptions{
+			want: &InvokeOptions{
 				Version: "test2",
 			},
 		},
@@ -345,7 +345,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 				Version("test2"),
 				Version("test1"),
 			},
-			want: &invokeOptions{
+			want: &InvokeOptions{
 				Version: "test1",
 			},
 		},
@@ -355,7 +355,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 				Version("test"),
 				PluginDownloadURL("url"),
 			},
-			want: &invokeOptions{
+			want: &InvokeOptions{
 				Version:           "test",
 				PluginDownloadURL: "url",
 			},
@@ -367,7 +367,7 @@ func TestInvokeOptionComposite(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := &invokeOptions{}
+			opts := &InvokeOptions{}
 			CompositeInvoke(tt.input...).applyInvokeOption(opts)
 			assert.Equal(t, tt.want, opts)
 		})
@@ -1097,6 +1097,52 @@ func TestNewResourceOptions(t *testing.T) {
 		ropts.Transformations[0](&ResourceTransformationArgs{})
 		assert.True(t, called, "Transformation function was not called")
 	})
+}
+
+func TestNewInvokeOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give InvokeOption
+		want InvokeOptions
+	}{
+		{
+			desc: "Parent",
+			give: Parent(&testRes{foo: "foo"}),
+			want: InvokeOptions{
+				Parent: &testRes{foo: "foo"},
+			},
+		},
+		{
+			desc: "Provider",
+			give: Provider(&testProv{foo: "bar"}),
+			want: InvokeOptions{
+				Provider: &testProv{foo: "bar"},
+			},
+		},
+		{
+			desc: "Version",
+			give: Version("1.2.3"),
+			want: InvokeOptions{Version: "1.2.3"},
+		},
+		{
+			desc: "PluginDownloadURL",
+			give: PluginDownloadURL("https://example.com/whatever"),
+			want: InvokeOptions{PluginDownloadURL: "https://example.com/whatever"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewInvokeOptions(tt.give)
+			require.NoError(t, err)
+			assert.Equal(t, &tt.want, got)
+		})
+	}
 }
 
 func assertHasDeps(


### PR DESCRIPTION
This is the InvokeOption analog for NewResourceOptions added in #12124.

However, in contrast to ResourceOptions, this just exports the existing
invokeOptions struct.
The reason for this is that right now, the public API for InvokeOptions
is the same as the internal representation,
so we don't need the separation-- for now.
To keep future edits aware of this distinction,
I've included a loud comment about what to do
when they do inevitably diverge.

Refs #11698
