### PR TITLE
WIP: Readd project support to filestate

### DIFF
--- a/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
+++ b/changelog/pending/20230128--backend-filestate--the-filestate-backend-now-supports-project-scoped-stacks.yaml
@@ -1,0 +1,10 @@
+changes:
+- type: feat
+  scope: backend/filestate
+  description: |
+    The filestate backend now supports project scoped stacks.
+    Newly initialized storage will automatically use this mode.
+    You can migrate your old state store to enable project support by running `pulumi state upgrade`.
+    Note that this will make the state incompatible with old CLI versions.
+    Old CLI versions will not understand new stacks, but may write stack files to the old locations;
+    new CLIs will warn if they see those files and suggest running `pulumi state migrate` again.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -74,7 +74,7 @@ type StackReference interface {
 	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.Name
 
-	// Fully qualified name of the stack.
+	// Fully qualified name of the stack, including any organization, project, or other information.
 	FullyQualifiedName() tokens.QName
 }
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -103,7 +103,8 @@ type localBackend struct {
 type localBackendReference struct {
 	name    tokens.Name
 	project tokens.Name
-	b       *localBackend
+
+	currentProject string // name of the current project, if any
 }
 
 func (r *localBackendReference) String() string {
@@ -115,7 +116,7 @@ func (r *localBackendReference) String() string {
 	// For project scoped references when stringifying backend references,
 	// we take the current project (if present) into account.
 	// If the project names match, we can elide them.
-	if r.b.currentProject != nil && string(r.project) == string(r.b.currentProject.Name) {
+	if string(r.project) == r.currentProject {
 		return string(r.name)
 	}
 
@@ -371,6 +372,13 @@ func (b *localBackend) StateDir() string {
 
 func (b *localBackend) SetCurrentProject(project *workspace.Project) {
 	b.currentProject = project
+}
+
+func (b *localBackend) currentProjectName() string {
+	if b.currentProject != nil {
+		return b.currentProject.Name.String()
+	}
+	return ""
 }
 
 func (b *localBackend) GetPolicyPack(ctx context.Context, policyPack string,

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -1053,10 +1053,7 @@ func (b *localBackend) getLocalStacks() ([]*localBackendReference, error) {
 }
 
 func (b *localBackend) getLocalProjects() ([]tokens.Name, error) {
-	// Read the stack directory.
-	path := b.stackPath(nil)
-
-	files, err := listBucket(b.bucket, path)
+	files, err := listBucket(b.bucket, StacksDir)
 	if err != nil {
 		return nil, fmt.Errorf("error listing projects: %w", err)
 	}

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -104,7 +104,8 @@ type localBackendReference struct {
 	name    tokens.Name
 	project tokens.Name
 
-	currentProject string // name of the current project, if any
+	// Backend that created this reference.
+	b *localBackend
 
 	// referenceStore that created this reference.
 	//
@@ -122,7 +123,7 @@ func (r *localBackendReference) String() string {
 	// For project scoped references when stringifying backend references,
 	// we take the current project (if present) into account.
 	// If the project names match, we can elide them.
-	if string(r.project) == r.currentProject {
+	if r.b.currentProject != nil && string(r.project) == string(r.b.currentProject.Name) {
 		return string(r.name)
 	}
 
@@ -388,13 +389,6 @@ func (b *localBackend) StateDir() string {
 
 func (b *localBackend) SetCurrentProject(project *workspace.Project) {
 	b.currentProject = project
-}
-
-func (b *localBackend) currentProjectName() string {
-	if b.currentProject != nil {
-		return b.currentProject.Name.String()
-	}
-	return ""
 }
 
 func (b *localBackend) GetPolicyPack(ctx context.Context, policyPack string,

--- a/pkg/backend/filestate/backend_legacy_test.go
+++ b/pkg/backend/filestate/backend_legacy_test.go
@@ -1,0 +1,361 @@
+package filestate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// This file contains copies of old backend tests
+// that were upgraded to run with project support.
+// This duplicates those tests to run with legacy, non-project state,
+// validating that the legacy behavior is preserved.
+
+//nolint:paralleltest // mutates environment variables
+func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
+	// Login to a temp dir filestate backend
+	tmpDir := t.TempDir()
+
+	markLegacyStore(t, tmpDir)
+
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Create stack "a" and import a checkpoint with a secret
+	aStackRef, err := b.ParseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+	defer func() {
+		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
+		_, err := b.RemoveStack(ctx, aStack, true)
+		assert.NoError(t, err)
+	}()
+	deployment, err := makeUntypedDeployment("a", "abc123",
+		"v1:4iF78gb0nF0=:v1:Co6IbTWYs/UdrjgY:FSrAWOFZnj9ealCUDdJL7LrUKXX9BA==")
+	assert.NoError(t, err)
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
+	err = b.ImportDeployment(ctx, aStack, deployment)
+	assert.NoError(t, err)
+
+	// Create stack "b" and import a checkpoint with a secret
+	bStackRef, err := b.ParseStackReference("b")
+	assert.NoError(t, err)
+	bStack, err := b.CreateStack(ctx, bStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, bStack)
+	defer func() {
+		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
+		_, err := b.RemoveStack(ctx, bStack, true)
+		assert.NoError(t, err)
+	}()
+	deployment, err = makeUntypedDeployment("b", "123abc",
+		"v1:C7H2a7/Ietk=:v1:yfAd1zOi6iY9DRIB:dumdsr+H89VpHIQWdB01XEFqYaYjAg==")
+	assert.NoError(t, err)
+	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
+	err = b.ImportDeployment(ctx, bStack, deployment)
+	assert.NoError(t, err)
+
+	// Remove the config passphrase so that we can no longer deserialize the checkpoints
+	err = os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
+	assert.NoError(t, err)
+
+	// Ensure that we can list the stacks we created even without a passphrase
+	stacks, outContToken, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
+	assert.NoError(t, err)
+	assert.Nil(t, outContToken)
+	assert.Len(t, stacks, 2)
+	for _, stack := range stacks {
+		assert.NotNil(t, stack.ResourceCount())
+		assert.Equal(t, 1, *stack.ResourceCount())
+	}
+}
+
+func TestDrillError_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := t.TempDir()
+	markLegacyStore(t, tmpDir)
+
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Get a non-existent stack and expect a nil error because it won't be found.
+	stackRef, err := b.ParseStackReference("dev")
+	if err != nil {
+		t.Fatalf("unexpected error %v when parsing stack reference", err)
+	}
+	_, err = b.GetStack(ctx, stackRef)
+	assert.Nil(t, err)
+}
+
+func TestCancel_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := t.TempDir()
+	markLegacyStore(t, tmpDir)
+
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Check that trying to cancel a stack that isn't created yet doesn't error
+	aStackRef, err := b.ParseStackReference("a")
+	assert.NoError(t, err)
+	err = b.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+
+	// Check that trying to cancel a stack that isn't locked doesn't error
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+	err = b.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+
+	// Locking and lock checks are only part of the internal interface
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Lock the stack and check CancelCurrentUpdate deletes the lock file
+	err = lb.Lock(ctx, aStackRef)
+	assert.NoError(t, err)
+	// check the lock file exists
+	lockExists, err := lb.bucket.Exists(ctx, lb.lockPath(aStackRef))
+	assert.NoError(t, err)
+	assert.True(t, lockExists)
+	// Call CancelCurrentUpdate
+	err = lb.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+	// Now check the lock file no longer exists
+	lockExists, err = lb.bucket.Exists(ctx, lb.lockPath(aStackRef))
+	assert.NoError(t, err)
+	assert.False(t, lockExists)
+
+	// Make another filestate backend which will have a different lockId
+	ob, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+	otherBackend, ok := ob.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Lock the stack with this new backend, then check that checkForLocks on the first backend now errors
+	err = otherBackend.Lock(ctx, aStackRef)
+	assert.NoError(t, err)
+	err = lb.checkForLock(ctx, aStackRef)
+	assert.Error(t, err)
+	// Now call CancelCurrentUpdate and check that checkForLocks no longer errors
+	err = lb.CancelCurrentUpdate(ctx, aStackRef)
+	assert.NoError(t, err)
+	err = lb.checkForLock(ctx, aStackRef)
+	assert.NoError(t, err)
+}
+
+func TestRemoveMakesBackups_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := t.TempDir()
+	markLegacyStore(t, tmpDir)
+
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Grab the bucket interface to test with
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Check that creating a new stack doesn't make a backup file
+	aStackRef, err := lb.parseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+
+	// Check the stack file now exists, but the backup file doesn't
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	assert.NoError(t, err)
+	assert.False(t, backupFileExists)
+
+	// Now remove the stack
+	removed, err := b.RemoveStack(ctx, aStack, false)
+	assert.NoError(t, err)
+	assert.False(t, removed)
+
+	// Check the stack file is now gone, but the backup file exists
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.False(t, stackFileExists)
+	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
+	assert.NoError(t, err)
+	assert.True(t, backupFileExists)
+}
+
+func TestRenameWorks_legacy(t *testing.T) {
+	t.Parallel()
+
+	// Login to a temp dir filestate backend
+	tmpDir := t.TempDir()
+	markLegacyStore(t, tmpDir)
+
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Grab the bucket interface to test with
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	// Create a new stack
+	aStackRef, err := lb.parseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+
+	// Check the stack file now exists
+	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+
+	// Fake up some history
+	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
+	assert.NoError(t, err)
+	// And pollute the history folder
+	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
+	assert.NoError(t, err)
+
+	// Rename the stack
+	bStackRefI, err := b.RenameStack(ctx, aStack, "b")
+	assert.NoError(t, err)
+	assert.Equal(t, "b", bStackRefI.String())
+	bStackRef := bStackRefI.(*localBackendReference)
+
+	// Check the new stack file now exists and the old one is gone
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
+	assert.NoError(t, err)
+	assert.False(t, stackFileExists)
+
+	// Rename again
+	bStack, err := b.GetStack(ctx, bStackRef)
+	assert.NoError(t, err)
+	cStackRefI, err := b.RenameStack(ctx, bStack, "c")
+	assert.NoError(t, err)
+	assert.Equal(t, "c", cStackRefI.String())
+	cStackRef := cStackRefI.(*localBackendReference)
+
+	// Check the new stack file now exists and the old one is gone
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(cStackRef))
+	assert.NoError(t, err)
+	assert.True(t, stackFileExists)
+	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
+	assert.NoError(t, err)
+	assert.False(t, stackFileExists)
+
+	// Check we can still get the history
+	history, err := b.GetHistory(ctx, cStackRef, 10, 0)
+	assert.NoError(t, err)
+	assert.Len(t, history, 1)
+	assert.Equal(t, apitype.DestroyUpdate, history[0].Kind)
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/10439
+func TestHtmlEscaping_legacy(t *testing.T) {
+	t.Parallel()
+
+	sm := b64.NewBase64SecretsManager()
+	resources := []*resource.State{
+		{
+			URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "name"),
+			Type: "a:b:c",
+			Inputs: resource.PropertyMap{
+				resource.PropertyKey("html"): resource.NewStringProperty("<html@tags>"),
+			},
+		},
+	}
+
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
+
+	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrsts */)
+	assert.NoError(t, err)
+
+	data, err := encoding.JSON.Marshal(sdep)
+	assert.NoError(t, err)
+
+	// Ensure data has the string contents "<html@tags>"", not "\u003chtml\u0026tags\u003e"
+	// ImportDeployment below should not modify the data
+	assert.Contains(t, string(data), "<html@tags>")
+
+	udep := &apitype.UntypedDeployment{
+		Version:    3,
+		Deployment: json.RawMessage(data),
+	}
+
+	// Login to a temp dir filestate backend
+	tmpDir := t.TempDir()
+	markLegacyStore(t, tmpDir)
+	ctx := context.Background()
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
+	assert.NoError(t, err)
+
+	// Create stack "a" and import a checkpoint with a secret
+	aStackRef, err := b.ParseStackReference("a")
+	assert.NoError(t, err)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, aStack)
+	err = b.ImportDeployment(ctx, aStack, udep)
+	assert.NoError(t, err)
+
+	// Ensure the file has the string contents "<html@tags>"", not "\u003chtml\u0026tags\u003e"
+
+	// Grab the bucket interface to read the file with
+	lb, ok := b.(*localBackend)
+	assert.True(t, ok)
+	assert.NotNil(t, lb)
+
+	chkpath := lb.stackPath(aStackRef.(*localBackendReference))
+	bytes, err := lb.bucket.ReadAll(context.Background(), chkpath)
+	assert.NoError(t, err)
+	state := string(bytes)
+	assert.Contains(t, state, "<html@tags>")
+}
+
+// markLegacyStore marks the given directory as a legacy store.
+// This is done by dropping a single file into the bookkeeping directory.
+// ensurePulumiMeta will treat this as a legacy store if the directory exists.
+func markLegacyStore(t *testing.T, dir string) {
+	marker := filepath.Join(dir, workspace.BookkeepingDir, ".legacy")
+	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
+	require.NoError(t, os.WriteFile(marker, []byte(nil), 0o600))
+}

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -859,6 +859,35 @@ func TestInvalidStateFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// Verifies that the StackReference.String method
+// takes the current project name into account,
+// even if the current project name changes
+// after the stack reference is created.
+func TestStackReferenceString_currentProjectChange(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(dir), nil)
+	require.NoError(t, err)
+
+	foo, err := b.ParseStackReference("organization/proj1/foo")
+	require.NoError(t, err)
+
+	bar, err := b.ParseStackReference("organization/proj2/bar")
+	require.NoError(t, err)
+
+	assert.Equal(t, "organization/proj1/foo", foo.String())
+	assert.Equal(t, "organization/proj2/bar", bar.String())
+
+	// Change the current project name
+	b.SetCurrentProject(&workspace.Project{Name: "proj1"})
+
+	assert.Equal(t, "foo", foo.String())
+	assert.Equal(t, "organization/proj2/bar", bar.String())
+}
+
 func TestUnsupportedStateFile(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -1066,8 +1066,8 @@ func TestNew_legacyFileWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	stderr := buff.String()
-	assert.Contains(t, stderr, "Found legacy stack file 'a', you should run 'pulumi state migrate'")
-	assert.Contains(t, stderr, "Found legacy stack file 'b', you should run 'pulumi state migrate'")
+	assert.Contains(t, stderr, "Found legacy stack file 'a', you should run 'pulumi state upgrade'")
+	assert.Contains(t, stderr, "Found legacy stack file 'b', you should run 'pulumi state upgrade'")
 }
 
 func TestNew_unsupportedStoreVersion(t *testing.T) {

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -150,69 +150,7 @@ func makeUntypedDeployment(name tokens.QName, phrase, state string) (*apitype.Un
 }
 
 //nolint:paralleltest // mutates environment variables
-func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-
-	markLegacyStore(t, tmpDir)
-
-	ctx := context.Background()
-	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-
-	// Create stack "a" and import a checkpoint with a secret
-	aStackRef, err := b.ParseStackReference("a")
-	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, aStack)
-	defer func() {
-		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
-		_, err := b.RemoveStack(ctx, aStack, true)
-		assert.NoError(t, err)
-	}()
-	deployment, err := makeUntypedDeployment("a", "abc123",
-		"v1:4iF78gb0nF0=:v1:Co6IbTWYs/UdrjgY:FSrAWOFZnj9ealCUDdJL7LrUKXX9BA==")
-	assert.NoError(t, err)
-	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
-	err = b.ImportDeployment(ctx, aStack, deployment)
-	assert.NoError(t, err)
-
-	// Create stack "b" and import a checkpoint with a secret
-	bStackRef, err := b.ParseStackReference("b")
-	assert.NoError(t, err)
-	bStack, err := b.CreateStack(ctx, bStackRef, "", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, bStack)
-	defer func() {
-		t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
-		_, err := b.RemoveStack(ctx, bStack, true)
-		assert.NoError(t, err)
-	}()
-	deployment, err = makeUntypedDeployment("b", "123abc",
-		"v1:C7H2a7/Ietk=:v1:yfAd1zOi6iY9DRIB:dumdsr+H89VpHIQWdB01XEFqYaYjAg==")
-	assert.NoError(t, err)
-	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
-	err = b.ImportDeployment(ctx, bStack, deployment)
-	assert.NoError(t, err)
-
-	// Remove the config passphrase so that we can no longer deserialize the checkpoints
-	err = os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
-	assert.NoError(t, err)
-
-	// Ensure that we can list the stacks we created even without a passphrase
-	stacks, outContToken, err := b.ListStacks(ctx, backend.ListStacksFilter{}, nil /* inContToken */)
-	assert.NoError(t, err)
-	assert.Nil(t, outContToken)
-	assert.Len(t, stacks, 2)
-	for _, stack := range stacks {
-		assert.NotNil(t, stack.ResourceCount())
-		assert.Equal(t, 1, *stack.ResourceCount())
-	}
-}
-
-//nolint:paralleltest // mutates environment variables
-func TestListStacksWithMultiplePassphrases_project(t *testing.T) {
+func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
 	ctx := context.Background()
@@ -270,27 +208,7 @@ func TestListStacksWithMultiplePassphrases_project(t *testing.T) {
 	}
 }
 
-func TestDrillError_legacy(t *testing.T) {
-	t.Parallel()
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	markLegacyStore(t, tmpDir)
-
-	ctx := context.Background()
-	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-
-	// Get a non-existent stack and expect a nil error because it won't be found.
-	stackRef, err := b.ParseStackReference("dev")
-	if err != nil {
-		t.Fatalf("unexpected error %v when parsing stack reference", err)
-	}
-	_, err = b.GetStack(ctx, stackRef)
-	assert.Nil(t, err)
-}
-
-func TestDrillError_project(t *testing.T) {
+func TestDrillError(t *testing.T) {
 	t.Parallel()
 
 	// Login to a temp dir filestate backend
@@ -308,70 +226,7 @@ func TestDrillError_project(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestCancel_legacy(t *testing.T) {
-	t.Parallel()
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	markLegacyStore(t, tmpDir)
-
-	ctx := context.Background()
-	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-
-	// Check that trying to cancel a stack that isn't created yet doesn't error
-	aStackRef, err := b.ParseStackReference("a")
-	assert.NoError(t, err)
-	err = b.CancelCurrentUpdate(ctx, aStackRef)
-	assert.NoError(t, err)
-
-	// Check that trying to cancel a stack that isn't locked doesn't error
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, aStack)
-	err = b.CancelCurrentUpdate(ctx, aStackRef)
-	assert.NoError(t, err)
-
-	// Locking and lock checks are only part of the internal interface
-	lb, ok := b.(*localBackend)
-	assert.True(t, ok)
-	assert.NotNil(t, lb)
-
-	// Lock the stack and check CancelCurrentUpdate deletes the lock file
-	err = lb.Lock(ctx, aStackRef)
-	assert.NoError(t, err)
-	// check the lock file exists
-	lockExists, err := lb.bucket.Exists(ctx, lb.lockPath(aStackRef))
-	assert.NoError(t, err)
-	assert.True(t, lockExists)
-	// Call CancelCurrentUpdate
-	err = lb.CancelCurrentUpdate(ctx, aStackRef)
-	assert.NoError(t, err)
-	// Now check the lock file no longer exists
-	lockExists, err = lb.bucket.Exists(ctx, lb.lockPath(aStackRef))
-	assert.NoError(t, err)
-	assert.False(t, lockExists)
-
-	// Make another filestate backend which will have a different lockId
-	ob, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-	otherBackend, ok := ob.(*localBackend)
-	assert.True(t, ok)
-	assert.NotNil(t, lb)
-
-	// Lock the stack with this new backend, then check that checkForLocks on the first backend now errors
-	err = otherBackend.Lock(ctx, aStackRef)
-	assert.NoError(t, err)
-	err = lb.checkForLock(ctx, aStackRef)
-	assert.Error(t, err)
-	// Now call CancelCurrentUpdate and check that checkForLocks no longer errors
-	err = lb.CancelCurrentUpdate(ctx, aStackRef)
-	assert.NoError(t, err)
-	err = lb.checkForLock(ctx, aStackRef)
-	assert.NoError(t, err)
-}
-
-func TestCancel_project(t *testing.T) {
+func TestCancel(t *testing.T) {
 	t.Parallel()
 
 	// Login to a temp dir filestate backend
@@ -432,52 +287,7 @@ func TestCancel_project(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRemoveMakesBackups_legacy(t *testing.T) {
-	t.Parallel()
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	markLegacyStore(t, tmpDir)
-
-	ctx := context.Background()
-	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-
-	// Grab the bucket interface to test with
-	lb, ok := b.(*localBackend)
-	assert.True(t, ok)
-	assert.NotNil(t, lb)
-
-	// Check that creating a new stack doesn't make a backup file
-	aStackRef, err := lb.parseStackReference("a")
-	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, aStack)
-
-	// Check the stack file now exists, but the backup file doesn't
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
-	assert.NoError(t, err)
-	assert.True(t, stackFileExists)
-	backupFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
-	assert.NoError(t, err)
-	assert.False(t, backupFileExists)
-
-	// Now remove the stack
-	removed, err := b.RemoveStack(ctx, aStack, false)
-	assert.NoError(t, err)
-	assert.False(t, removed)
-
-	// Check the stack file is now gone, but the backup file exists
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
-	assert.NoError(t, err)
-	assert.False(t, stackFileExists)
-	backupFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef)+".bak")
-	assert.NoError(t, err)
-	assert.True(t, backupFileExists)
-}
-
-func TestRemoveMakesBackups_project(t *testing.T) {
+func TestRemoveMakesBackups(t *testing.T) {
 	t.Parallel()
 
 	// Login to a temp dir filestate backend
@@ -520,79 +330,7 @@ func TestRemoveMakesBackups_project(t *testing.T) {
 	assert.True(t, backupFileExists)
 }
 
-func TestRenameWorks_legacy(t *testing.T) {
-	t.Parallel()
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	markLegacyStore(t, tmpDir)
-
-	ctx := context.Background()
-	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-
-	// Grab the bucket interface to test with
-	lb, ok := b.(*localBackend)
-	assert.True(t, ok)
-	assert.NotNil(t, lb)
-
-	// Create a new stack
-	aStackRef, err := lb.parseStackReference("a")
-	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, aStack)
-
-	// Check the stack file now exists
-	stackFileExists, err := lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
-	assert.NoError(t, err)
-	assert.True(t, stackFileExists)
-
-	// Fake up some history
-	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
-	assert.NoError(t, err)
-	// And pollute the history folder
-	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
-	assert.NoError(t, err)
-
-	// Rename the stack
-	bStackRefI, err := b.RenameStack(ctx, aStack, "b")
-	assert.NoError(t, err)
-	assert.Equal(t, "b", bStackRefI.String())
-	bStackRef := bStackRefI.(*localBackendReference)
-
-	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
-	assert.NoError(t, err)
-	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(aStackRef))
-	assert.NoError(t, err)
-	assert.False(t, stackFileExists)
-
-	// Rename again
-	bStack, err := b.GetStack(ctx, bStackRef)
-	assert.NoError(t, err)
-	cStackRefI, err := b.RenameStack(ctx, bStack, "c")
-	assert.NoError(t, err)
-	assert.Equal(t, "c", cStackRefI.String())
-	cStackRef := cStackRefI.(*localBackendReference)
-
-	// Check the new stack file now exists and the old one is gone
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(cStackRef))
-	assert.NoError(t, err)
-	assert.True(t, stackFileExists)
-	stackFileExists, err = lb.bucket.Exists(ctx, lb.stackPath(bStackRef))
-	assert.NoError(t, err)
-	assert.False(t, stackFileExists)
-
-	// Check we can still get the history
-	history, err := b.GetHistory(ctx, cStackRef, 10, 0)
-	assert.NoError(t, err)
-	assert.Len(t, history, 1)
-	assert.Equal(t, apitype.DestroyUpdate, history[0].Kind)
-}
-
-func TestRenameWorks_project(t *testing.T) {
+func TestRenameWorks(t *testing.T) {
 	t.Parallel()
 
 	// Login to a temp dir filestate backend
@@ -686,69 +424,7 @@ func TestParseEmptyStackFails(t *testing.T) {
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/10439
-func TestHtmlEscaping_legacy(t *testing.T) {
-	t.Parallel()
-
-	sm := b64.NewBase64SecretsManager()
-	resources := []*resource.State{
-		{
-			URN:  resource.NewURN("a", "proj", "d:e:f", "a:b:c", "name"),
-			Type: "a:b:c",
-			Inputs: resource.PropertyMap{
-				resource.PropertyKey("html"): resource.NewStringProperty("<html@tags>"),
-			},
-		},
-	}
-
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil)
-
-	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrsts */)
-	assert.NoError(t, err)
-
-	data, err := encoding.JSON.Marshal(sdep)
-	assert.NoError(t, err)
-
-	// Ensure data has the string contents "<html@tags>"", not "\u003chtml\u0026tags\u003e"
-	// ImportDeployment below should not modify the data
-	assert.Contains(t, string(data), "<html@tags>")
-
-	udep := &apitype.UntypedDeployment{
-		Version:    3,
-		Deployment: json.RawMessage(data),
-	}
-
-	// Login to a temp dir filestate backend
-	tmpDir := t.TempDir()
-	markLegacyStore(t, tmpDir)
-	ctx := context.Background()
-	b, err := New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil)
-	assert.NoError(t, err)
-
-	// Create stack "a" and import a checkpoint with a secret
-	aStackRef, err := b.ParseStackReference("a")
-	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, aStack)
-	err = b.ImportDeployment(ctx, aStack, udep)
-	assert.NoError(t, err)
-
-	// Ensure the file has the string contents "<html@tags>"", not "\u003chtml\u0026tags\u003e"
-
-	// Grab the bucket interface to read the file with
-	lb, ok := b.(*localBackend)
-	assert.True(t, ok)
-	assert.NotNil(t, lb)
-
-	chkpath := lb.stackPath(aStackRef.(*localBackendReference))
-	bytes, err := lb.bucket.ReadAll(context.Background(), chkpath)
-	assert.NoError(t, err)
-	state := string(bytes)
-	assert.Contains(t, state, "<html@tags>")
-}
-
-// Regression test for https://github.com/pulumi/pulumi/issues/10439
-func TestHtmlEscaping_project(t *testing.T) {
+func TestHtmlEscaping(t *testing.T) {
 	t.Parallel()
 
 	sm := b64.NewBase64SecretsManager()
@@ -1172,13 +848,4 @@ func TestNew_unsupportedStoreVersion(t *testing.T) {
 	_, err = New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(stateDir), nil)
 	assert.ErrorContains(t, err, "state store unsupported")
 	assert.ErrorContains(t, err, "'Pulumi.yaml' version (999999999) is not supported")
-}
-
-// markLegacyStore marks the given directory as a legacy store.
-// This is done by dropping a single file into the bookkeeping directory.
-// ensurePulumiMeta will treat this as a legacy store if the directory exists.
-func markLegacyStore(t *testing.T, dir string) {
-	marker := filepath.Join(dir, workspace.BookkeepingDir, ".legacy")
-	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
-	require.NoError(t, os.WriteFile(marker, []byte(nil), 0o600))
 }

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -550,7 +550,7 @@ func TestRenameWorks_legacy(t *testing.T) {
 	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
 	assert.NoError(t, err)
 	// And pollute the history folder
-	err = lb.bucket.WriteAll(ctx, path.Join(lb.historyDirectory(aStackRef), "randomfile.txt"), []byte{0, 13}, nil)
+	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
 	assert.NoError(t, err)
 
 	// Rename the stack
@@ -620,7 +620,7 @@ func TestRenameWorks_project(t *testing.T) {
 	err = lb.addToHistory(aStackRef, backend.UpdateInfo{Kind: apitype.DestroyUpdate})
 	assert.NoError(t, err)
 	// And pollute the history folder
-	err = lb.bucket.WriteAll(ctx, path.Join(lb.historyDirectory(aStackRef), "randomfile.txt"), []byte{0, 13}, nil)
+	err = lb.bucket.WriteAll(ctx, path.Join(aStackRef.HistoryDir(), "randomfile.txt"), []byte{0, 13}, nil)
 	assert.NoError(t, err)
 
 	// Rename the stack

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -87,7 +87,12 @@ func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
 
 // objectName returns the filename of a ListObject (an object from a bucket).
 func objectName(obj *blob.ListObject) string {
-	_, filename := path.Split(obj.Key)
+	// If obj.Key ends in "/" we want to trim that to get the name just before
+	key := obj.Key
+	if key[len(key)-1] == '/' {
+		key = key[0 : len(key)-1]
+	}
+	_, filename := path.Split(key)
 	return filename
 }
 

--- a/pkg/backend/filestate/meta.go
+++ b/pkg/backend/filestate/meta.go
@@ -1,0 +1,97 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
+	"gopkg.in/yaml.v3"
+)
+
+// pulumiMeta holds the contents of the .pulumi/Pulumi.yaml file
+// in a filestate backend.
+//
+// This file holds metadata for the backend,
+// including a version number that the backend can use
+// to maintain compatibility with older versions of the CLI.
+type pulumiMeta struct {
+	// Version is the current version of the state store
+	Version int `json:"version,omitempty" yaml:"version,omitempty"`
+}
+
+// ensurePulumiMeta loads the .pulumi/Pulumi.yaml file from the bucket,
+// creating it if the bucket is new.
+//
+// If the bucket is not new, and the file does not exist,
+// it returns a Version of 0 to indicate that the bucket is in legacy mode (no project).
+func ensurePulumiMeta(ctx context.Context, b Bucket) (*pulumiMeta, error) {
+	statePath := filepath.Join(workspace.BookkeepingDir, "Pulumi.yaml")
+	stateBody, err := b.ReadAll(ctx, statePath)
+	if err != nil {
+		if gcerrors.Code(err) != gcerrors.NotFound {
+			return nil, fmt.Errorf("could not read 'Pulumi.yaml': %w", err)
+		}
+	}
+
+	if err == nil {
+		// File exists. Load and validate it.
+		var state pulumiMeta
+		if err := yaml.Unmarshal(stateBody, &state); err != nil {
+			return nil, fmt.Errorf("state store corrupted, could not unmarshal 'Pulumi.yaml': %w", err)
+		}
+		if state.Version < 1 {
+			return nil, fmt.Errorf("state store corrupted, 'Pulumi.yaml' reports an invalid version of %d", state.Version)
+		}
+		if state.Version > 1 {
+			return nil, fmt.Errorf(
+				"state store unsupported, 'Pulumi.yaml' reports an version of %d unsupported by this version of pulumi",
+				state.Version)
+		}
+		return &state, nil
+	}
+
+	// We'll only get here if err is NotFound, at this point we want to see if this is a fresh new store,
+	// in which case we'll write the new Pulumi.yaml, or if there's existing data here we'll fallback to
+	// non-project mode.
+	bucketIter := b.List(&blob.ListOptions{
+		Delimiter: "/",
+		Prefix:    workspace.BookkeepingDir,
+	})
+	if _, err := bucketIter.Next(ctx); err == nil {
+		// Already exists. We're in legacy mode.
+		return &pulumiMeta{Version: 0}, nil
+	} else if !errors.Is(err, io.EOF) {
+		// io.EOF is expected, but any other error is not.
+		return nil, fmt.Errorf("could not examine bucket: %w", err)
+	}
+
+	// Empty bucket. Turn on project mode.
+	state := pulumiMeta{Version: 1}
+	stateBody, err = yaml.Marshal(state)
+	contract.AssertNoErrorf(err, "Could not marshal filestate.pulumiMeta to yaml")
+	if err := b.WriteAll(ctx, statePath, stateBody, nil); err != nil {
+		return nil, fmt.Errorf("could not write 'Pulumi.yaml': %w", err)
+	}
+
+	return &state, nil
+}

--- a/pkg/backend/filestate/meta.go
+++ b/pkg/backend/filestate/meta.go
@@ -62,11 +62,6 @@ func ensurePulumiMeta(ctx context.Context, b Bucket) (*pulumiMeta, error) {
 		if state.Version < 1 {
 			return nil, fmt.Errorf("state store corrupted, 'Pulumi.yaml' reports an invalid version of %d", state.Version)
 		}
-		if state.Version > 1 {
-			return nil, fmt.Errorf(
-				"state store unsupported, 'Pulumi.yaml' reports an version of %d unsupported by this version of pulumi",
-				state.Version)
-		}
 		return &state, nil
 	}
 

--- a/pkg/backend/filestate/meta_test.go
+++ b/pkg/backend/filestate/meta_test.go
@@ -91,11 +91,6 @@ func TestEnsurePulumiMeta_corruption(t *testing.T) {
 			give:    `version: foo`,
 			wantErr: "could not unmarshal 'Pulumi.yaml'",
 		},
-		{
-			desc:    "unsupported version",
-			give:    `version: 42`,
-			wantErr: "version of 42 unsupported by this version of pulumi",
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/backend/filestate/meta_test.go
+++ b/pkg/backend/filestate/meta_test.go
@@ -1,0 +1,114 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob/memblob"
+)
+
+func TestEnsurePulumiMeta(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give map[string]string // files in the bucket
+		want pulumiMeta
+	}{
+		{
+			// Empty bucket should be initialized to
+			// the current version.
+			desc: "empty",
+			want: pulumiMeta{Version: 1},
+		},
+		{
+			// Non-empty bucket without a version file
+			// should get version 0 for legacy mode.
+			desc: "legacy",
+			give: map[string]string{
+				".pulumi/stacks/a.json": `{}`,
+			},
+			want: pulumiMeta{Version: 0},
+		},
+		{
+			desc: "version 1",
+			give: map[string]string{
+				".pulumi/Pulumi.yaml": `version: 1`,
+			},
+			want: pulumiMeta{Version: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			b := memblob.OpenBucket(nil)
+			ctx := context.Background()
+			for name, body := range tt.give {
+				require.NoError(t, b.WriteAll(ctx, name, []byte(body), nil))
+			}
+
+			state, err := ensurePulumiMeta(ctx, b)
+			require.NoError(t, err)
+			assert.Equal(t, &tt.want, state)
+		})
+	}
+}
+
+func TestEnsurePulumiMeta_corruption(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		give    string // contents of Pulumi.yaml
+		wantErr string
+	}{
+		{
+			desc:    "empty",
+			give:    ``, // no YAML will get zero value
+			wantErr: "reports an invalid version of 0",
+		},
+		{
+			desc:    "corrupt version",
+			give:    `version: foo`,
+			wantErr: "could not unmarshal 'Pulumi.yaml'",
+		},
+		{
+			desc:    "unsupported version",
+			give:    `version: 42`,
+			wantErr: "version of 42 unsupported by this version of pulumi",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			b := memblob.OpenBucket(nil)
+			ctx := context.Background()
+			require.NoError(t, b.WriteAll(ctx, ".pulumi/Pulumi.yaml", []byte(tt.give), nil))
+
+			_, err := ensurePulumiMeta(context.Background(), b)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/backend/filestate/snapshot.go
+++ b/pkg/backend/filestate/snapshot.go
@@ -17,13 +17,12 @@ package filestate
 import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 // localSnapshotManager is a simple SnapshotManager implementation that persists snapshots
 // to disk on the local machine.
 type localSnapshotPersister struct {
-	name    tokens.Name
+	ref     *localBackendReference
 	backend *localBackend
 	sm      secrets.Manager
 }
@@ -33,10 +32,10 @@ func (sp *localSnapshotPersister) SecretsManager() secrets.Manager {
 }
 
 func (sp *localSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
-	_, err := sp.backend.saveStack(sp.name, snapshot, sp.sm)
+	_, err := sp.backend.saveStack(sp.ref, snapshot, sp.sm)
 	return err
 }
 
-func (b *localBackend) newSnapshotPersister(stackName tokens.Name, sm secrets.Manager) *localSnapshotPersister {
-	return &localSnapshotPersister{name: stackName, backend: b, sm: sm}
+func (b *localBackend) newSnapshotPersister(ref *localBackendReference, sm secrets.Manager) *localSnapshotPersister {
+	return &localSnapshotPersister{ref: ref, backend: b, sm: sm}
 }

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
@@ -39,13 +40,15 @@ type Stack interface {
 
 // localStack is a local stack descriptor.
 type localStack struct {
-	ref      backend.StackReference // the stack's reference (qualified name).
+	ref      *localBackendReference // the stack's reference (qualified name).
 	path     string                 // a path to the stack's checkpoint file on disk.
 	snapshot *deploy.Snapshot       // a snapshot representing the latest deployment state.
 	b        *localBackend          // a pointer to the backend this stack belongs to.
 }
 
-func newStack(ref backend.StackReference, path string, snapshot *deploy.Snapshot, b *localBackend) Stack {
+func newStack(ref *localBackendReference, path string, snapshot *deploy.Snapshot, b *localBackend) Stack {
+	contract.Requiref(ref != nil, "ref", "ref was nil")
+
 	return &localStack{
 		ref:      ref,
 		path:     path,

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -364,7 +364,7 @@ func (b *localBackend) backupStack(ref *localBackendReference) error {
 
 func (b *localBackend) stackPath(ref *localBackendReference) string {
 	if ref == nil {
-		return b.store.StackDir()
+		return StacksDir
 	}
 
 	// We can't use listBucket here for as we need to do a partial prefix match on filename, while the

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -79,10 +79,10 @@ var _ referenceStore = (*projectReferenceStore)(nil)
 // This DOES NOT modify the underlying storage.
 func (p *projectReferenceStore) newReference(project, name tokens.Name) *localBackendReference {
 	return &localBackendReference{
-		name:           name,
-		project:        project,
-		store:          p,
-		currentProject: p.b.currentProjectName(),
+		name:    name,
+		project: project,
+		store:   p,
+		b:       p.b,
 	}
 }
 
@@ -134,11 +134,12 @@ func (p *projectReferenceStore) ParseReference(stackRef string) (*localBackendRe
 	}
 
 	if project == "" {
-		project = p.b.currentProjectName()
-		if project == "" {
+		if p.b.currentProject == nil {
 			return nil, fmt.Errorf("if you're using the --stack flag, " +
 				"pass the fully qualified name (organization/project/stack)")
 		}
+
+		project = p.b.currentProject.Name.String()
 	}
 
 	if len(project) > 100 {
@@ -240,7 +241,7 @@ func (p *legacyReferenceStore) newReference(name tokens.Name) *localBackendRefer
 	return &localBackendReference{
 		name:  name,
 		store: p,
-		// currentProject is not relevant for legacy stacks
+		b:     p.b,
 	}
 }
 

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -146,12 +146,13 @@ func (p *projectReferenceStore) ParseReference(stackRef string) (*localBackendRe
 	}
 
 	if project == "" {
-		if p.b.currentProject == nil {
+		currentProject := p.b.currentProject.Load()
+		if currentProject == nil {
 			return nil, fmt.Errorf("if you're using the --stack flag, " +
 				"pass the fully qualified name (organization/project/stack)")
 		}
 
-		project = p.b.currentProject.Name.String()
+		project = currentProject.Name.String()
 	}
 
 	if len(project) > 100 {

--- a/pkg/backend/filestate/store.go
+++ b/pkg/backend/filestate/store.go
@@ -1,0 +1,244 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestate
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// referenceStore stores and provides access to stack information.
+//
+// Each implementation of referenceStore is a different version of the stack
+// storage format.
+type referenceStore interface {
+	ListReferences() ([]*localBackendReference, error)
+
+	// ParseReference parses a localBackendReference from a string.
+	ParseReference(ref string) (*localBackendReference, error)
+
+	// ConvertReference converts a StackReference to a localBackendReference,
+	// ensuring that it's a valid localBackendReference.
+	ConvertReference(ref backend.StackReference) (*localBackendReference, error)
+}
+
+// projectReferenceStore is a referenceStore that stores stack
+// information with the new project-based layout.
+//
+// This is version 1 of the stack storage format.
+type projectReferenceStore struct {
+	b *localBackend
+}
+
+var _ referenceStore = (*projectReferenceStore)(nil)
+
+func (p *projectReferenceStore) ParseReference(stackRef string) (*localBackendReference, error) {
+	var name, project, org string
+	split := strings.Split(stackRef, "/")
+	switch len(split) {
+	case 1:
+		name = split[0]
+	case 2:
+		org = split[0]
+		name = split[1]
+	case 3:
+		org = split[0]
+		project = split[1]
+		name = split[2]
+	default:
+		return nil, fmt.Errorf("could not parse stack reference '%s'", stackRef)
+	}
+
+	// If the provided stack name didn't include the org or project, infer them from the local
+	// environment.
+	if org == "" {
+		// Filestate organization MUST always be "organization"
+		org = "organization"
+	}
+
+	if org != "organization" {
+		return nil, errors.New("organization name must be 'organization'")
+	}
+
+	if project == "" {
+		if p.b.currentProject == nil {
+			return nil, fmt.Errorf("if you're using the --stack flag, " +
+				"pass the fully qualified name (organization/project/stack)")
+		}
+
+		project = p.b.currentProject.Name.String()
+	}
+
+	if len(project) > 100 {
+		return nil, errors.New("project names must be less than 100 characters")
+	}
+
+	if project != "" && !tokens.IsName(project) {
+		return nil, fmt.Errorf(
+			"project names may only contain alphanumerics, hyphens, underscores, and periods: %s",
+			project)
+	}
+
+	if !tokens.IsName(name) || len(name) > 100 {
+		return nil, fmt.Errorf(
+			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods: %s",
+			name)
+	}
+
+	return &localBackendReference{name: tokens.Name(name), project: tokens.Name(project), b: p.b}, nil
+}
+
+func (p *projectReferenceStore) ConvertReference(ref backend.StackReference) (*localBackendReference, error) {
+	localStackRef, ok := ref.(*localBackendReference)
+	if !ok {
+		return nil, fmt.Errorf("bad stack reference type")
+	}
+	if localStackRef.project == "" {
+		return nil, fmt.Errorf("bad stack reference, project was not set")
+	}
+	return localStackRef, nil
+}
+
+func (p *projectReferenceStore) ListReferences() ([]*localBackendReference, error) {
+	// The first level of the bucket is the project name.
+	// The second level of the bucket is the stack name.
+	path := p.b.stackPath(nil)
+
+	files, err := listBucket(p.b.bucket, path)
+	if err != nil {
+		return nil, fmt.Errorf("error listing stacks: %w", err)
+	}
+
+	var stacks []*localBackendReference
+	for _, file := range files {
+		if file.IsDir {
+			projName := objectName(file)
+			// If this isn't a valid Name it won't be a project directory, so skip it
+			if !tokens.IsName(projName) {
+				continue
+			}
+
+			// TODO: Could we improve the efficiency here by firstly making listBucket return an enumerator not
+			// eagerly collecting all keys into a slice, and secondly by getting listBucket to return all
+			// descendent items not just the immediate children. We could then do the necessary splitting by
+			// file paths here to work out project names.
+			projectFiles, err := listBucket(p.b.bucket, filepath.Join(path, projName))
+			if err != nil {
+				return nil, fmt.Errorf("error listing stacks: %w", err)
+			}
+
+			for _, projectFile := range projectFiles {
+				// Can ignore directories at this level
+				if projectFile.IsDir {
+					continue
+				}
+
+				objName := objectName(projectFile)
+				// Skip files without valid extensions (e.g., *.bak files).
+				ext := filepath.Ext(objName)
+				// But accept gzip compression
+				if ext == encoding.GZIPExt {
+					objName = strings.TrimSuffix(objName, encoding.GZIPExt)
+					ext = filepath.Ext(objName)
+				}
+
+				if _, has := encoding.Marshalers[ext]; !has {
+					continue
+				}
+
+				// Read in this stack's information.
+				name := objName[:len(objName)-len(ext)]
+				stacks = append(stacks, &localBackendReference{
+					project: tokens.Name(projName),
+					name:    tokens.Name(name),
+					b:       p.b,
+				})
+			}
+		}
+	}
+
+	return stacks, nil
+}
+
+// legacyReferenceStore is a referenceStore that stores stack
+// information with the legacy layout that did not support projects.
+//
+// This is the format we used before we introduced versioning.
+type legacyReferenceStore struct {
+	b *localBackend
+}
+
+var _ referenceStore = (*legacyReferenceStore)(nil)
+
+func (p *legacyReferenceStore) ParseReference(stackRef string) (*localBackendReference, error) {
+	if !tokens.IsName(stackRef) || len(stackRef) > 100 {
+		return nil, fmt.Errorf(
+			"stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods: %q",
+			stackRef)
+	}
+	return &localBackendReference{name: tokens.Name(stackRef), b: p.b}, nil
+}
+
+func (p *legacyReferenceStore) ConvertReference(ref backend.StackReference) (*localBackendReference, error) {
+	localStackRef, ok := ref.(*localBackendReference)
+	if !ok {
+		return nil, fmt.Errorf("bad stack reference type")
+	}
+	if localStackRef.project != "" {
+		return nil, fmt.Errorf("bad stack reference, project was set")
+	}
+	return localStackRef, nil
+}
+
+func (p *legacyReferenceStore) ListReferences() ([]*localBackendReference, error) {
+	// Read the stack directory.
+	path := p.b.stackPath(nil)
+
+	files, err := listBucket(p.b.bucket, path)
+	if err != nil {
+		return nil, fmt.Errorf("error listing stacks: %w", err)
+	}
+	stacks := make([]*localBackendReference, 0, len(files))
+
+	for _, file := range files {
+		objName := objectName(file)
+		// Skip files without valid extensions (e.g., *.bak files).
+		ext := filepath.Ext(objName)
+		// But accept gzip compression
+		if ext == encoding.GZIPExt {
+			objName = strings.TrimSuffix(objName, encoding.GZIPExt)
+			ext = filepath.Ext(objName)
+		}
+
+		if _, has := encoding.Marshalers[ext]; !has {
+			continue
+		}
+
+		// Read in this stack's information.
+		name := objName[:len(objName)-len(ext)]
+		stacks = append(stacks, &localBackendReference{
+			name: tokens.Name(name),
+			b:    p.b,
+		})
+	}
+
+	return stacks, nil
+}

--- a/pkg/cmd/pulumi/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/new_acceptance_test.go
@@ -149,7 +149,8 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, defaultProjectName, proj.Name.String())
 	// Expect the stack directory to have a checkpoint file for the stack.
-	_, err = os.Stat(filepath.Join(fileStateDir, workspace.BookkeepingDir, workspace.StackDir, stackName+".json"))
+	_, err = os.Stat(filepath.Join(
+		fileStateDir, workspace.BookkeepingDir, workspace.StackDir, defaultProjectName, stackName+".json"))
 	assert.NoError(t, err)
 
 	b, err = currentBackend(ctx, nil, display.Options{})

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ troubleshooting a stack or when performing specific edits that otherwise would r
 	cmd.AddCommand(newStateDeleteCommand())
 	cmd.AddCommand(newStateUnprotectCommand())
 	cmd.AddCommand(newStateRenameCommand())
+	cmd.AddCommand(newStateUpgradeCommand())
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -31,7 +31,7 @@ func newStateUpgradeCommand() *cobra.Command {
 
 This only has an effect on the filestate backend.
 `,
-		Args: cmdutil.ExactArgs(1),
+		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			ctx := commandContext()
 

--- a/pkg/cmd/pulumi/state_upgrade.go
+++ b/pkg/cmd/pulumi/state_upgrade.go
@@ -1,0 +1,54 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+
+	"github.com/spf13/cobra"
+)
+
+func newStateUpgradeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Migrates the current backend to the latest supported version",
+		Long: `Migrates the current backend to the latest supported version
+
+This only has an effect on the filestate backend.
+`,
+		Args: cmdutil.ExactArgs(1),
+		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
+			ctx := commandContext()
+
+			b, err := currentBackend(ctx, nil, display.Options{Color: cmdutil.GetGlobalColorization()})
+			if err != nil {
+				return result.FromError(err)
+			}
+
+			if lb, is := b.(filestate.Backend); is {
+				err = lb.Upgrade(ctx)
+				if err != nil {
+					return result.FromError(err)
+				}
+			}
+
+			return nil
+		}),
+	}
+	return cmd
+}

--- a/pkg/cmd/pulumi/state_upgrade_test.go
+++ b/pkg/cmd/pulumi/state_upgrade_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateUpgradeCommand_parseArgs(t *testing.T) {
+	t.Parallel()
+
+	// Parsing flags with a cobra.Command without running the command
+	// is a bit verbose.
+	// You have to run ParseFlags to parse the flags,
+	// then extract non-flag arguments with cmd.Flags().Args(),
+	// then run ValidateArgs to validate the positional arguments.
+
+	cmd := newStateUpgradeCommand()
+	args := []string{} // no arguments
+
+	require.NoError(t, cmd.ParseFlags(args))
+	args = cmd.Flags().Args() // non flag args
+	require.NoError(t, cmd.ValidateArgs(args))
+}
+
+func TestStateUpgradeCommand_parseArgsErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		give    []string
+		wantErr string
+	}{
+		{
+			desc:    "unknown flag",
+			give:    []string{"--unknown"},
+			wantErr: "unknown flag: --unknown",
+		},
+		// Unfortunately,
+		// our cmdutil.NoArgs validator exits the program,
+		// causing the test to fail.
+		// Until we resolve this, we'll skip this test
+		// and rely on the positive test case
+		// to validate the arguments intead.
+		// {
+		// 	desc: "unexpected argument",
+		// 	give: []string{"arg"},
+		// 	wantErr: `unknown command "arg" for "upgrade"`,
+		// },
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newStateUpgradeCommand()
+			args := tt.give
+
+			// Errors can occur during flag parsing
+			// or argument validation.
+			// If there's no error on ParseFlags,
+			// expect one on ValidateArgs.
+			if err := cmd.ParseFlags(args); err != nil {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			args = cmd.Flags().Args() // non flag args
+			assert.ErrorContains(t, cmd.ValidateArgs(args), tt.wantErr)
+		})
+	}
+}

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -80,13 +80,13 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(m encoding.Marshaler, bytes 
 }
 
 func MarshalUntypedDeploymentToVersionedCheckpoint(
-	stack tokens.Name, deployment *apitype.UntypedDeployment,
+	stack tokens.QName, deployment *apitype.UntypedDeployment,
 ) (*apitype.VersionedCheckpoint, error) {
 	chk := struct {
 		Stack  tokens.QName
 		Latest json.RawMessage
 	}{
-		Stack:  stack.Q(),
+		Stack:  stack,
 		Latest: deployment.Deployment,
 	}
 
@@ -102,7 +102,7 @@ func MarshalUntypedDeploymentToVersionedCheckpoint(
 }
 
 // SerializeCheckpoint turns a snapshot into a data structure suitable for serialization.
-func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
+func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
 	sm secrets.Manager, showSecrets bool,
 ) (*apitype.VersionedCheckpoint, error) {
 	// If snap is nil, that's okay, we will just create an empty deployment; otherwise, serialize the whole snapshot.
@@ -116,7 +116,7 @@ func SerializeCheckpoint(stack tokens.Name, snap *deploy.Snapshot,
 	}
 
 	b, err := encoding.JSON.Marshal(apitype.CheckpointV3{
-		Stack:  stack.Q(),
+		Stack:  stack,
 		Latest: latest,
 	})
 	if err != nil {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -71,10 +71,14 @@ func TestConfigCommands(t *testing.T) {
 
 		// check that the nested config does not exist because we didn't use path
 		_, stderr := e.RunCommandExpectError("pulumi", "config", "get", "outer")
-		assert.Equal(t, "error: configuration key 'outer' not found for stack 'test'", strings.Trim(stderr, "\r\n"))
+		assert.Equal(t,
+			"error: configuration key 'outer' not found for stack 'test'",
+			strings.Trim(stderr, "\r\n"))
 
 		_, stderr = e.RunCommandExpectError("pulumi", "config", "get", "myList")
-		assert.Equal(t, "error: configuration key 'myList' not found for stack 'test'", strings.Trim(stderr, "\r\n"))
+		assert.Equal(t,
+			"error: configuration key 'myList' not found for stack 'test'",
+			strings.Trim(stderr, "\r\n"))
 
 		// set the nested config using --path
 		e.RunCommand("pulumi", "config", "set-all", "--path",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -531,7 +531,7 @@ func TestDestroyStackRef(t *testing.T) {
 
 	e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
 	e.CWD = os.TempDir()
-	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes", "-s", "dev")
+	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes", "-s", "organization/large_resource_js/dev")
 }
 
 //nolint:paralleltest // uses parallel programtest

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -367,7 +367,7 @@ func TestStackBackups(t *testing.T) {
 		const stackName = "imulup"
 
 		// Get the path to the backup directory for this project.
-		backupDir, err := getStackProjectBackupDir(e, stackName)
+		backupDir, err := getStackProjectBackupDir(e, "stack_outputs", stackName)
 		assert.NoError(t, err, "getting stack project backup path")
 		defer func() {
 			if !t.Failed() {
@@ -560,8 +560,8 @@ func TestLocalStateLocking(t *testing.T) {
 
 // stackFileFormatAsserters returns a function to assert that the current file
 // format is for gzip and plain formats respectively.
-func stackFileFormatAsserters(t *testing.T, e *ptesting.Environment, stackName string) (func(), func()) {
-	stacksDir := filepath.Join(".pulumi", "stacks")
+func stackFileFormatAsserters(t *testing.T, e *ptesting.Environment, projectName, stackName string) (func(), func()) {
+	stacksDir := filepath.Join(".pulumi", "stacks", projectName)
 	pathStack := filepath.Join(stacksDir, stackName+".json")
 	pathStackGzip := pathStack + ".gz"
 	pathStackBak := pathStack + ".bak"
@@ -622,7 +622,7 @@ func TestLocalStateGzip(t *testing.T) { //nolint:paralleltest
 	e.RunCommand("yarn", "install")
 	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
 
-	assertGzipFileFormat, assertPlainFileFormat := stackFileFormatAsserters(t, e, stackName)
+	assertGzipFileFormat, assertPlainFileFormat := stackFileFormatAsserters(t, e, "stack_dependencies", stackName)
 	switchGzipOff := func() { e.Setenv(filestate.PulumiFilestateGzipEnvVar, "0") }
 	switchGzipOn := func() { e.Setenv(filestate.PulumiFilestateGzipEnvVar, "1") }
 	pulumiUp := func() { e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview") }
@@ -691,10 +691,11 @@ func assertBackupStackFile(t *testing.T, stackName string, file os.DirEntry, bef
 	assert.True(t, parsedTime < after, "False: %v < %v", parsedTime, after)
 }
 
-func getStackProjectBackupDir(e *ptesting.Environment, stackName string) (string, error) {
+func getStackProjectBackupDir(e *ptesting.Environment, projectName, stackName string) (string, error) {
 	return filepath.Join(e.RootPath,
 		workspace.BookkeepingDir,
 		workspace.BackupDir,
+		projectName,
 		stackName,
 	), nil
 }


### PR DESCRIPTION
Adds project support to the filestate backend.

For backwards compatibility, and to plan for the future,
this requires versioning the storage state.
We introduce a `.pulumi/Pulumi.yaml` file where we hold metadata
like the version of the filestate storage protocol.
Version 1 is the initial version that introduces project support.

    # .pulumi/Pulumi.yaml
    version: 1

If we ever need to make breaking changes to the storage protocol
we can bump the format version.

Newly initialized states will use the new project-mode format.
Existing states will continue to run in the old, non-project mode.
State can be migrated to the new format with `pulumi state upgrade`,
at which point they will become incompatible with older CLIs.

For more graceful degradation, if an old CLI writes to an upgraded state
the CLI will warn about these files, and recommend re-running `upgrade`.

---

- [ ] Upgrade should fail gracefully: if a stack fails to upgrade, log about it but upgrade the others.
- [ ] `state upgrade` should accept an optional `--project` option for when a project for a stack cannot be determined automatically.
- [ ] `state upgrade` should first warn the user that if they do this, older versions of the CLI will be unable to use the stack. Once they confirm with "y/n", only then should we upgrade the state.