### PR TITLE
Remove the "yes, using Update Plans" prompt

### DIFF
--- a/changelog/pending/20230210--cli--remove-the-experimental-yes-using-update-plans-prompt.yaml
+++ b/changelog/pending/20230210--cli--remove-the-experimental-yes-using-update-plans-prompt.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Remove the `[experimental] yes, using Update Plans` prompt.

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -75,7 +75,6 @@ type response string
 
 const (
 	yes     response = "yes"
-	yesPlan response = "[experimental] yes, using Update Plans (https://pulumi.com/updateplans)"
 	no      response = "no"
 	details response = "details"
 )
@@ -163,12 +162,6 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 			choices = append(choices, string(details))
 		}
 
-		// If we have a new plan but didn't start with a plan we can prompt to use the new plan.
-		// If we're in experimental mode we don't add this because "yes" will also use the plan
-		if plan != nil && opts.Engine.Plan == nil && !opts.Engine.Experimental {
-			choices = append(choices, string(yesPlan))
-		}
-
 		var previewWarning string
 		if opts.SkipPreview {
 			previewWarning = colors.SpecWarning + " without a preview" + colors.Bold
@@ -205,9 +198,6 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 				return nil, plan
 			}
 			return nil, nil
-		}
-		if response == string(yesPlan) {
-			return nil, plan
 		}
 
 		if response == string(details) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/11894

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
