### PR TITLE
Fixes multiline secrets not being masked when escaped.

### DIFF
--- a/changelog/pending/20230210--engine--fixed-issue-where-pulumi-displays-multiline-secrets-when-the-newlines-n-are-escaped.yaml
+++ b/changelog/pending/20230210--engine--fixed-issue-where-pulumi-displays-multiline-secrets-when-the-newlines-n-are-escaped.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: "Fixed issue where pulumi displays multiline secrets when the newlines('\\n') are escaped."

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -23,6 +23,7 @@ package logging
 // should be updated to properly filter as well before forwarding things along.
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"strconv"
@@ -160,6 +161,15 @@ func CreateFilter(secrets []string, replacement string) Filter {
 			continue
 		}
 		items = append(items, secret, replacement)
+
+		// Catch secrets that are serialized to JSON.
+		bs, err := json.Marshal(secret)
+		if err != nil {
+			continue
+		}
+		if escaped := string(bs[1 : len(bs)-1]); escaped != secret {
+			items = append(items, escaped, replacement)
+		}
 	}
 	if len(items) > 0 {
 		return &replacerFilter{replacer: strings.NewReplacer(items...)}

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -55,4 +55,20 @@ func TestFilter(t *testing.T) {
 	filter4 := CreateFilter([]string{"a", "my", "123"}, "[creds]")
 	msg4 := filter4.Filter("These are my secrets: a, my, 123")
 	assert.Equal(t, msg4, "These are my secrets: a, my, [creds]")
+
+	// Ensure that multi-line secrets are masked in output.
+	filter5 := CreateFilter([]string{"multi\nline\nsecret"}, "[secret]")
+	msg5 := filter5.Filter(
+		`These are my secrets: multi\nline\nsecret`)
+	assert.Equal(t,
+		"These are my secrets: [secret]",
+		msg5)
+
+	// Ensure that secrets with tabs are masked in output.
+	filter6 := CreateFilter([]string{"secretwith\t"}, "[secret]")
+	msg6 := filter6.Filter(
+		`These are my secrets: secretwith\t`)
+	assert.Equal(t,
+		"These are my secrets: [secret]",
+		msg6)
 }

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -38,23 +38,35 @@ func TestFilter(t *testing.T) {
 	t.Parallel()
 
 	filter1 := CreateFilter([]string{"secret1", "secret2"}, "[secret]")
-	msg1 := filter1.Filter("These are my secrets: secret1, secret2, secret3, secret10")
-	assert.Equal(t, msg1, "These are my secrets: [secret], [secret], secret3, [secret]0")
+	msg1 := filter1.Filter(
+		"These are my secrets: secret1, secret2, secret3, secret10")
+	assert.Equal(t,
+		"These are my secrets: [secret], [secret], secret3, [secret]0",
+		msg1)
 
 	// Ensure that special characters don't screw up the search
 	filter2 := CreateFilter([]string{"secret.*", "secre[t]3"}, "[creds]")
-	msg2 := filter2.Filter("These are my secrets: secret1, secret2, secret3, secret.*, secre[t]3")
-	assert.Equal(t, msg2, "These are my secrets: secret1, secret2, secret3, [creds], [creds]")
+	msg2 := filter2.Filter(
+		"These are my secrets: secret1, secret2, secret3, secret.*, secre[t]3")
+	assert.Equal(t,
+		"These are my secrets: secret1, secret2, secret3, [creds], [creds]",
+		msg2)
 
 	// Ensure that non-UTF8 characters don't screw up the search
 	filter3 := CreateFilter([]string{"nonutf8\xa7", "secret1"}, "[creds]")
-	msg3 := filter3.Filter("These are my secrets: secret1, nonutf8\xa7")
-	assert.Equal(t, msg3, "These are my secrets: [creds], [creds]")
+	msg3 := filter3.Filter(
+		"These are my secrets: secret1, nonutf8\xa7")
+	assert.Equal(t,
+		"These are my secrets: [creds], [creds]",
+		msg3)
 
 	// Short secrets of 1-2 characters are not masked
 	filter4 := CreateFilter([]string{"a", "my", "123"}, "[creds]")
-	msg4 := filter4.Filter("These are my secrets: a, my, 123")
-	assert.Equal(t, msg4, "These are my secrets: a, my, [creds]")
+	msg4 := filter4.Filter(
+		"These are my secrets: a, my, 123")
+	assert.Equal(t,
+		"These are my secrets: a, my, [creds]",
+		msg4)
 
 	// Ensure that multi-line secrets are masked in output.
 	filter5 := CreateFilter([]string{"multi\nline\nsecret"}, "[secret]")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
This PR fixes an issue where pulumi fails to mask multiline secrets that are JSONified. String matching did not work when newlines were replaced with `\n`.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12016 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
