### PR TITLE
Add gitlab source

### DIFF
--- a/changelog/pending/20230211--cli-plugin--plugin-download-urls-now-support-gitlab-as-a-first-class-url-schema-for-example-gitlab-gitlab-com-43429536.yaml
+++ b/changelog/pending/20230211--cli-plugin--plugin-download-urls-now-support-gitlab-as-a-first-class-url-schema-for-example-gitlab-gitlab-com-43429536.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/plugin
+  description: Plugin download urls now support GitLab as a first class url schema. For example "gitlab://gitlab.com/43429536".


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Plugin download urls now support GitLab as a first class url schema. For example "gitlab://gitlab.com/43429536".
The scheme is `gitlab://<host>/<project_id>`.

This assumes the apis are at `https://<host>//api/v4` e.g. fetching the latest version for the above url would fetch from `https://gitlab.com/api/v4/projects/43429536/releases/permalink/latest`.

It assumes that the GitLab release will have asset links in the same style as our GitHub releases. e.g.
`pulumi-resource-<package>-v<version>-<os>-<arch>.tar.gz` these names must be set for the `direct_asset_path` of the asset link in the GitLab release (see https://docs.gitlab.com/ee/api/releases/links.html#create-a-release-link).

It also assumes release names will be of the form `v<version>` like we do for GitHub, e.g. `v4.3.0`.

Whether the assets themselves are hosted on GitLab via its generic package support or elsewhere doesn't really matter, as long as the asset link exists we can download it through gitlab via the download link `https://<host>/api/v4/projects/<project>/releases/v<version>/downloads/pulumi-resource-<package>-v<version>-<os>-<arch>.tar.gz`.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
