### PR TITLE
Try to delete temporary files from plugin downloads

### DIFF
--- a/changelog/pending/20230211--cli-plugin--remove-temporary-files-from-plugin-downloads.yaml
+++ b/changelog/pending/20230211--cli-plugin--remove-temporary-files-from-plugin-downloads.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Remove temporary files from plugin downloads.

--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 
 	"github.com/blang/semver"
@@ -174,6 +175,7 @@ func newPluginInstallCmd() *cobra.Command {
 					if err != nil {
 						return fmt.Errorf("%s downloading from %s: %w", label, install.PluginDownloadURL, err)
 					}
+					defer func() { contract.IgnoreError(os.Remove(r.Name())) }()
 
 					payload = workspace.TarPlugin(r)
 				} else {

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -244,6 +244,7 @@ func installPlugin(ctx context.Context, plugin workspace.PluginSpec) error {
 	if err != nil {
 		return fmt.Errorf("failed to download plugin: %s: %w", plugin, err)
 	}
+	defer func() { contract.IgnoreError(os.Remove(tarball.Name())) }()
 
 	fmt.Fprintf(os.Stderr, "[%s plugin %s-%s] installing\n", plugin.Kind, plugin.Name, plugin.Version)
 

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -478,7 +478,7 @@ func (host *defaultHost) InstallPlugin(pkgPlugin workspace.PluginSpec) error {
 		if err != nil {
 			return fmt.Errorf("failed to download plugin: %s: %w", pkgPlugin, err)
 		}
-		defer os.Remove(tarball.Name())
+		defer func() { contract.IgnoreError(os.Remove(tarball.Name())) }()
 		if err := pkgPlugin.InstallWithContext(host.ctx.baseContext, workspace.TarPlugin(tarball), false); err != nil {
 			return fmt.Errorf("failed to install plugin %s: %w", pkgPlugin, err)
 		}


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12144

There's only three places in the codebase that we call `workspace.DownloadToFile`. Before this change only one of them tried to run `os.Remove` to cleanup afterwards.

This unifies all to use `os.Remove` and to also explictly ignore the error returned by that (if it does fail it will log to `V(3)`).

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
