### PR TITLE
Make SortedKeys type safe with generics

### DIFF
--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -17,7 +17,6 @@ package codegen
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -113,16 +112,11 @@ func (s Set) Has(v interface{}) bool {
 	return ok
 }
 
-// SortedKeys returns a sorted list of keys for the given map. The map's key type must be of kind string.
-func SortedKeys(m interface{}) []string {
-	mv := reflect.ValueOf(m)
-
-	contract.Require(mv.Type().Kind() == reflect.Map, "m")
-	contract.Require(mv.Type().Key().Kind() == reflect.String, "m")
-
-	keys := make([]string, mv.Len())
-	for i, k := range mv.MapKeys() {
-		keys[i] = k.String()
+// SortedKeys returns a sorted list of keys for the given map.
+func SortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Small change to remove a reflect check and just use Go generics instead.
I think this is our first use of generics in /pkg, which may affect providers but they should be on 1.18 by now.

I had a look at cleaning up the StringSet/Set stuff in this file as well but looks like that's best left till we require 1.20 so we can use the `comparable` constraint with interfaces https://stackoverflow.com/questions/71505556/go-generics-type-constraint-for-map-keys

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
