### PR TITLE
Indicate resources being orphaned when `RetainOnDelete` is true

### DIFF
--- a/changelog/pending/20230405--cli-display--adds-an-indicator-for-resources-that-are-being-deleted-replaced-with-retainondelete-set-as-well-as-an-itemized-warning.yaml
+++ b/changelog/pending/20230405--cli-display--adds-an-indicator-for-resources-that-are-being-deleted-replaced-with-retainondelete-set-as-well-as-an-itemized-warning.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/display
+  description: Adds an indicator for resources that are being deleted/replaced with `retainOnDelete` set as well as an itemized warning.

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -148,13 +148,11 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 			break
 		}
 		fmt.Printf(
-			infoPrefix+"This update will leave %d resource(s) untracked in your environment:\n",
-			len(stats.retainedResources))
+			"%sThis update will leave %d resource(s) untracked in your environment:\n",
+			infoPrefix, len(stats.retainedResources))
 		for _, res := range stats.retainedResources {
 			urn := res.URN
-			name := string(urn.Name())
-			typ := display.SimplifyTypeName(urn.Type())
-			fmt.Printf("    - %s %s\n", typ, name)
+			fmt.Printf("    - %s %s\n", urn.Type().DisplayName(), urn.Name())
 		}
 		fmt.Print("\n")
 	}
@@ -301,7 +299,7 @@ func computeUpdateStats(events []engine.Event) updateStats {
 		// Track deleted resources that are retained.
 		switch p.Metadata.Op {
 		case deploy.OpDelete, deploy.OpReplace:
-			if p.Metadata.Old != nil && p.Metadata.Old.State != nil && p.Metadata.Old.State.RetainOnDelete {
+			if old := p.Metadata.Old; old != nil && old.State != nil && old.State.RetainOnDelete {
 				stats.retainedResources = append(stats.retainedResources, p.Metadata)
 			}
 		}

--- a/pkg/backend/apply_test.go
+++ b/pkg/backend/apply_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestComputeUpdateStats tests that the number of non-stack resources and the number of retained resources is correct.
+func TestComputeUpdateStats(t *testing.T) {
+	t.Parallel()
+
+	events := []engine.Event{
+		makeResourcePreEvent("res1", "pulumi:pulumi:Stack", deploy.OpCreate, false),
+		makeResourcePreEvent("res2", "custom:resource:Type", deploy.OpCreate, false),
+		makeResourcePreEvent("res3", "custom:resource:Type", deploy.OpDelete, true),
+		makeResourcePreEvent("res4", "custom:resource:Type", deploy.OpReplace, true),
+		makeResourcePreEvent("res5", "custom:resource:Type", deploy.OpSame, false),
+	}
+
+	stats := computeUpdateStats(events)
+
+	assert.Equal(t, 4, stats.numNonStackResources)
+	assert.Equal(t, 2, len(stats.retainedResources))
+}
+
+func makeResourcePreEvent(urn, resType string, op display.StepOp, retainOnDelete bool) engine.Event {
+	event := engine.NewEvent(engine.ResourcePreEvent, engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op:   op,
+			URN:  resource.URN(urn),
+			Type: tokens.Type(resType),
+			Old: &engine.StepEventStateMetadata{
+				State: &resource.State{
+					URN:            resource.URN(urn),
+					Type:           tokens.Type(resType),
+					RetainOnDelete: retainOnDelete,
+				},
+			},
+		},
+	})
+
+	return event
+}

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -165,6 +165,10 @@ func camelCase(s string) string {
 	return string(runes)
 }
 
+func SimplifyTypeName(typ tokens.Type) string {
+	return simplifyTypeName(typ)
+}
+
 func simplifyTypeName(typ tokens.Type) string {
 	typeString := string(typ)
 
@@ -974,6 +978,18 @@ func (display *ProgressDisplay) renderProgressDiagEvent(payload engine.DiagEvent
 	}
 
 	return strings.TrimRightFunc(msg, unicode.IsSpace)
+}
+
+// getStepStatus handles getting the value to put in the status column.
+func (display *ProgressDisplay) getStepStatus(step engine.StepEventMetadata, done bool, failed bool) string {
+	var status string
+	if done {
+		status = display.getStepDoneDescription(step, failed)
+	} else {
+		status = display.getStepInProgressDescription(step)
+	}
+	status = addRetainStatusFlag(status, step)
+	return status
 }
 
 func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMetadata, failed bool) string {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -155,46 +155,6 @@ func newOpStopwatch() opStopwatch {
 // policyPayloads is a collection of policy violation events for a single resource.
 var policyPayloads []engine.PolicyViolationEventPayload
 
-func camelCase(s string) string {
-	if len(s) == 0 {
-		return s
-	}
-
-	runes := []rune(s)
-	runes[0] = unicode.ToLower(runes[0])
-	return string(runes)
-}
-
-func SimplifyTypeName(typ tokens.Type) string {
-	return simplifyTypeName(typ)
-}
-
-func simplifyTypeName(typ tokens.Type) string {
-	typeString := string(typ)
-
-	components := strings.Split(typeString, ":")
-	if len(components) != 3 {
-		return typeString
-	}
-	pkg, module, name := components[0], components[1], components[2]
-
-	if len(name) == 0 {
-		return typeString
-	}
-
-	lastSlashInModule := strings.LastIndexByte(module, '/')
-	if lastSlashInModule == -1 {
-		return typeString
-	}
-	file := module[lastSlashInModule+1:]
-
-	if file != camelCase(name) {
-		return typeString
-	}
-
-	return fmt.Sprintf("%v:%v:%v", pkg, module[:lastSlashInModule], name)
-}
-
 // getEventUrn returns the resource URN associated with an event, or the empty URN if this is not an
 // event that has a URN.  If this is also a 'step' event, then this will return the step metadata as
 // well.
@@ -832,7 +792,7 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 				Ephemeral: true,
 				Severity:  diag.Info,
 				Color:     cmdutil.GetGlobalColorization(),
-				Message:   fmt.Sprintf("read %v %v", simplifyTypeName(eventUrn.Type()), eventUrn.Name()),
+				Message:   fmt.Sprintf("read %v %v", eventUrn.Type().DisplayName(), eventUrn.Name()),
 			}))
 			return
 		}

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -129,7 +129,7 @@ func TestProgressEvents(t *testing.T) {
 func TestStatusDisplayFlags(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
+	tests := []struct {
 		name         string
 		stepOp       display.StepOp
 		shouldRetain bool
@@ -156,8 +156,8 @@ func TestStatusDisplayFlags(t *testing.T) {
 		// {"remove-pending-replace", deploy.OpRemovePendingReplace, false},
 	}
 
-	for _, test := range testCases {
-		tt := test
+	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -188,6 +189,51 @@ func TestStatusDisplayFlags(t *testing.T) {
 				assert.NotContains(t, doneStatus, "[retain]", "%s should NOT contain [retain] (done)", step.Op)
 				assert.NotContains(t, inProgressStatus, "[retain]", "%s should NOT contain [retain] (in-progress)", step.Op)
 			}
+		})
+	}
+}
+
+func TestSimplifyTypeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give tokens.Type
+		want string
+	}{
+		{
+			desc: "not enough parts",
+			give: "incomplete",
+			want: "incomplete",
+		},
+		{
+			desc: "no name",
+			give: "pkg:mod:",
+			want: "pkg:mod:",
+		},
+		{
+			desc: "no slash",
+			give: "pkg:mod:typ",
+			want: "pkg:mod:typ",
+		},
+		{
+			desc: "bad casing",
+			give: "pkg:Mod/foo:typ",
+			want: "pkg:Mod/foo:typ",
+		},
+		{
+			desc: "remove slash",
+			give: "pkg:mod/foo/bar:Bar",
+			want: "pkg:mod/foo:Bar",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, simplifyTypeName(tt.give))
 		})
 	}
 }

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -189,51 +188,6 @@ func TestStatusDisplayFlags(t *testing.T) {
 				assert.NotContains(t, doneStatus, "[retain]", "%s should NOT contain [retain] (done)", step.Op)
 				assert.NotContains(t, inProgressStatus, "[retain]", "%s should NOT contain [retain] (in-progress)", step.Op)
 			}
-		})
-	}
-}
-
-func TestSimplifyTypeName(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		desc string
-		give tokens.Type
-		want string
-	}{
-		{
-			desc: "not enough parts",
-			give: "incomplete",
-			want: "incomplete",
-		},
-		{
-			desc: "no name",
-			give: "pkg:mod:",
-			want: "pkg:mod:",
-		},
-		{
-			desc: "no slash",
-			give: "pkg:mod:typ",
-			want: "pkg:mod:typ",
-		},
-		{
-			desc: "bad casing",
-			give: "pkg:Mod/foo:typ",
-			want: "pkg:Mod/foo:typ",
-		},
-		{
-			desc: "remove slash",
-			give: "pkg:mod/foo/bar:Bar",
-			want: "pkg:mod/foo:Bar",
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.want, simplifyTypeName(tt.give))
 		})
 	}
 }

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -117,6 +120,74 @@ func TestProgressEvents(t *testing.T) {
 			t.Parallel()
 
 			testProgressEvents(t, path, accept, false, 80, 24, false)
+		})
+	}
+}
+
+// The following test checks that the status display elements have retain on delete details added.
+func TestStatusDisplayFlags(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		stepOp       display.StepOp
+		shouldRetain bool
+	}{
+		// Should display `retain`.
+		{"delete", deploy.OpDelete, true},
+		{"replace", deploy.OpReplace, true},
+		{"create-replacement", deploy.OpCreateReplacement, true},
+		{"delete-replaced", deploy.OpDeleteReplaced, true},
+
+		// Should be unaffected.
+		{"same", deploy.OpSame, false},
+		{"create", deploy.OpCreate, false},
+		{"update", deploy.OpUpdate, false},
+		{"read", deploy.OpRead, false},
+		{"read-replacement", deploy.OpReadReplacement, false},
+		{"refresh", deploy.OpRefresh, false},
+		{"discard", deploy.OpReadDiscard, false},
+		{"discard-replaced", deploy.OpDiscardReplaced, false},
+		{"import", deploy.OpImport, false},
+		{"import-replacement", deploy.OpImportReplacement, false},
+
+		// "remove-pending-replace" is not a valid step operation.
+		// {"remove-pending-replace", deploy.OpRemovePendingReplace, false},
+	}
+
+	for _, test := range testCases {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := &ProgressDisplay{}
+			name := resource.NewURN("test", "test", "test", "test", "test")
+
+			step := engine.StepEventMetadata{
+				URN: name,
+				Op:  tt.stepOp,
+				Old: &engine.StepEventStateMetadata{
+					State: &resource.State{
+						RetainOnDelete: true,
+					},
+				},
+			}
+
+			doneStatus := d.getStepStatus(step,
+				true,  // done
+				false, // failed
+			)
+			inProgressStatus := d.getStepStatus(step,
+				false, // done
+				false, // failed
+			)
+			if tt.shouldRetain {
+				assert.Contains(t, doneStatus, "[retain]", "%s should contain [retain] (done)", step.Op)
+				assert.Contains(t, inProgressStatus, "[retain]", "%s should contain [retain] (in-progress)", step.Op)
+			} else {
+				assert.NotContains(t, doneStatus, "[retain]", "%s should NOT contain [retain] (done)", step.Op)
+				assert.NotContains(t, inProgressStatus, "[retain]", "%s should NOT contain [retain] (in-progress)", step.Op)
+			}
 		})
 	}
 }

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -294,7 +294,7 @@ func (data *resourceRowData) ColorizedColumns() []string {
 		urn = resource.DefaultRootStackURN(data.display.stack.Q(), data.display.proj)
 	}
 	name := string(urn.Name())
-	typ := simplifyTypeName(urn.Type())
+	typ := urn.Type().DisplayName()
 
 	done := data.IsDone()
 

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -315,17 +315,11 @@ func (data *resourceRowData) ColorizedColumns() []string {
 // addRetainStatusFlag adds a "[retain]" suffix to the input string if the resource is marked as
 // RetainOnDelete and the step will discard the resource.
 func addRetainStatusFlag(status string, step engine.StepEventMetadata) string {
-	// Guard against nil pointer dereference and return the status string as is.
-	if step.Old == nil {
+	// If there's no old status, we don't need to report retain.
+	if step.Old == nil || step.Old.State == nil {
 		return status
 	}
 
-	// Guard against nil pointer dereference and return the status string as is.
-	if step.Old.State == nil {
-		return status
-	}
-
-	// If a resource is not marked as RetainOnDelete, return the status string as is.
 	if !step.Old.State.RetainOnDelete {
 		return status
 	}
@@ -333,7 +327,7 @@ func addRetainStatusFlag(status string, step engine.StepEventMetadata) string {
 	// Deletes and Replacements should indicate retain on delete behavior as they can leave
 	// untracked resources in the environment.
 	case deploy.OpDelete, deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced:
-		return status + "[retain]"
+		status += "[retain]"
 	}
 
 	// The resource's update status behavior is not affected by the RetainOnDelete flag.

--- a/sdk/go/common/tokens/tokens_test.go
+++ b/sdk/go/common/tokens/tokens_test.go
@@ -56,3 +56,53 @@ func TestTokens(t *testing.T) {
 	assert.Equal(t, p, modm.Module().Package().Name().String())
 	assert.Equal(t, p+TokenDelimiter+m+TokenDelimiter+mm, modm.String())
 }
+
+func TestTypeDisplayName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give Type
+		want string
+	}{
+		{
+			desc: "not enough parts",
+			give: "incomplete",
+			want: "incomplete",
+		},
+		{
+			desc: "no name",
+			give: "pkg:mod:",
+			want: "pkg:mod:",
+		},
+		{
+			desc: "no slash",
+			give: "pkg:mod:typ",
+			want: "pkg:mod:typ",
+		},
+		{
+			desc: "bad casing",
+			give: "pkg:Mod/foo:typ",
+			want: "pkg:Mod/foo:typ",
+		},
+		{
+			desc: "remove slash",
+			give: "pkg:mod/foo/bar:Bar",
+			want: "pkg:mod/foo:Bar",
+		},
+		{
+			desc: "remove up to last slash",
+			give: "pkg:mod/foo/bar/baz:Baz",
+			want: "pkg:mod/foo/bar:Baz",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.give.DisplayName())
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
This PR adds a `[retain]` suffix to Replace and Delete operations to indicate that it is leaving a resource behind. It also adds a warning message before preview to indicate how many and which URNs are leaving resources behind.

Preview:
[![asciicast](https://asciinema.org/a/VCiMwPieV5kUA8RzRLBPyiDiL.svg)](https://asciinema.org/a/VCiMwPieV5kUA8RzRLBPyiDiL)

Fixes #12030 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
