### PR TITLE
sdk/go: Prefer contract.Assertf over Assert

### DIFF
--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -433,7 +433,7 @@ func TestUpsertStackLocalSource(t *testing.T) {
 func randomStackName() string {
 	b := make([]byte, 4)
 	_, err := cryptorand.Read(b)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to generate random stack name")
 	return "test" + hex.EncodeToString(b)
 }
 

--- a/sdk/go/common/diag/sink.go
+++ b/sdk/go/common/diag/sink.go
@@ -17,10 +17,11 @@ package diag
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-	"io"
 )
 
 // Sink facilitates pluggable diagnostics messages.
@@ -62,8 +63,8 @@ type FormatOptions struct {
 
 // DefaultSink returns a default sink that simply logs output to stderr/stdout.
 func DefaultSink(stdout io.Writer, stderr io.Writer, opts FormatOptions) Sink {
-	contract.Require(stdout != nil, "stdout")
-	contract.Require(stderr != nil, "stderr")
+	contract.Requiref(stdout != nil, "stdout", "must not be nil")
+	contract.Requiref(stderr != nil, "stderr", "must not be nil")
 	// Discard debug output by default unless requested.
 	debug := io.Discard
 	if opts.Debug {
@@ -79,11 +80,11 @@ func DefaultSink(stdout io.Writer, stderr io.Writer, opts FormatOptions) Sink {
 }
 
 func newDefaultSink(opts FormatOptions, writers map[Severity]io.Writer) *defaultSink {
-	contract.Assert(writers[Debug] != nil)
-	contract.Assert(writers[Info] != nil)
-	contract.Assert(writers[Infoerr] != nil)
-	contract.Assert(writers[Error] != nil)
-	contract.Assert(writers[Warning] != nil)
+	contract.Assertf(writers[Debug] != nil, "Writer for %v must be set", Debug)
+	contract.Assertf(writers[Info] != nil, "Writer for %v must be set", Info)
+	contract.Assertf(writers[Infoerr] != nil, "Writer for %v must be set", Infoerr)
+	contract.Assertf(writers[Error] != nil, "Writer for %v must be set", Error)
+	contract.Assertf(writers[Warning] != nil, "Writer for %v must be set", Warning)
 	contract.Assertf(opts.Color != "", "FormatOptions.Color must be set")
 	return &defaultSink{
 		opts:    opts,

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -363,9 +363,9 @@ func (a *Asset) readURI() (*Blob, error) {
 		}
 		return NewReadCloserBlob(resp.Body)
 	case "file":
-		contract.Assert(url.User == nil)
-		contract.Assert(url.RawQuery == "")
-		contract.Assert(url.Fragment == "")
+		contract.Assertf(url.User == nil, "file:// URIs cannot have a user: %v", url)
+		contract.Assertf(url.RawQuery == "", "file:// URIs cannot have a query string: %v", url)
+		contract.Assertf(url.Fragment == "", "file:// URIs cannot have a fragment: %v", url)
 		if url.Host != "" && url.Host != "localhost" {
 			return nil, fmt.Errorf("file:// host '%v' not supported (only localhost)", url.Host)
 		}
@@ -912,10 +912,10 @@ func (a *Archive) openURLStream(url *url.URL) (io.ReadCloser, error) {
 		}
 		return resp.Body, nil
 	case "file":
-		contract.Assert(url.Host == "")
-		contract.Assert(url.User == nil)
-		contract.Assert(url.RawQuery == "")
-		contract.Assert(url.Fragment == "")
+		contract.Assertf(url.Host == "", "file:// URIs cannot have a host: %v", url)
+		contract.Assertf(url.User == nil, "file:// URIs cannot have a user: %v", url)
+		contract.Assertf(url.RawQuery == "", "file:// URIs cannot have a query string: %v", url)
+		contract.Assertf(url.Fragment == "", "file:// URIs cannot have a fragment: %v", url)
 		return os.Open(url.Path)
 	default:
 		return nil, fmt.Errorf("Unrecognized or unsupported URI scheme: %v", s)

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -210,10 +210,10 @@ func encryptAES256GCGM(plaintext string, key []byte) ([]byte, []byte) {
 	contract.Assertf(err == nil, "could not read from system random source")
 
 	block, err := aes.NewCipher(key)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error creating AES cipher")
 
 	aesgcm, err := cipher.NewGCM(block)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error creating AES-GCM cipher")
 
 	msg := aesgcm.Seal(nil, nonce, []byte(plaintext), nil)
 
@@ -224,10 +224,10 @@ func decryptAES256GCM(ciphertext []byte, key []byte, nonce []byte) (string, erro
 	contract.Requiref(len(key) == SymmetricCrypterKeyBytes, "key", "AES-256-GCM needs a 32 byte key")
 
 	block, err := aes.NewCipher(key)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error creating AES cipher")
 
 	aesgcm, err := cipher.NewGCM(block)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error creating AES-GCM cipher")
 
 	msg, err := aesgcm.Open(nil, nonce, ciphertext, nil)
 

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -63,7 +63,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	if err != nil {
 		return nil, rpcerror.Convert(err)
 	}
-	contract.Assert(path != "")
+	contract.Assertf(path != "", "unexpected empty path for analyzer plugin %s", name)
 
 	dialOpts := rpcutil.OpenTracingInterceptorDialOptions()
 

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -279,7 +279,7 @@ func (host *defaultHost) Analyzer(name tokens.QName) (Analyzer, error) {
 	plugin, err := loadPlugin(host.loadRequests, func() (interface{}, error) {
 		// First see if we already loaded this plugin.
 		if plug, has := host.analyzerPlugins[name]; has {
-			contract.Assert(plug != nil)
+			contract.Assertf(plug != nil, "analyzer plugin %v was loaded but is nil", name)
 			return plug.Plugin, nil
 		}
 
@@ -307,7 +307,7 @@ func (host *defaultHost) PolicyAnalyzer(name tokens.QName, path string, opts *Po
 	plugin, err := loadPlugin(host.loadRequests, func() (interface{}, error) {
 		// First see if we already loaded this plugin.
 		if plug, has := host.analyzerPlugins[name]; has {
-			contract.Assert(plug != nil)
+			contract.Assertf(plug != nil, "analyzer plugin %v was loaded but is nil", name)
 			return plug.Plugin, nil
 		}
 
@@ -400,7 +400,7 @@ func (host *defaultHost) LanguageRuntime(root, pwd, runtime string,
 
 		// First see if we already loaded this plugin.
 		if plug, has := host.languagePlugins[key]; has {
-			contract.Assert(plug != nil)
+			contract.Assertf(plug != nil, "language plugin %v was loaded but is nil", key)
 			return plug.Plugin, nil
 		}
 

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -59,7 +59,7 @@ func NewLanguageRuntime(host Host, ctx *Context, root, pwd, runtime string,
 		return nil, err
 	}
 
-	contract.Assert(path != "")
+	contract.Assertf(path != "", "unexpected empty path for language plugin %s", runtime)
 
 	args, err := buildArgsForNewPlugin(host, root, options)
 	if err != nil {
@@ -406,12 +406,12 @@ func (h *langhost) RunPlugin(info RunPluginInfo) (io.Reader, io.Reader, context.
 
 			if value, ok := msg.Output.(*pulumirpc.RunPluginResponse_Stdout); ok {
 				n, err := outw.Write(value.Stdout)
-				contract.AssertNoError(err)
-				contract.Assert(n == len(value.Stdout))
+				contract.AssertNoErrorf(err, "failed to write to stdout pipe: %v", err)
+				contract.Assertf(n == len(value.Stdout), "wrote fewer bytes (%d) than expected (%d)", n, len(value.Stdout))
 			} else if value, ok := msg.Output.(*pulumirpc.RunPluginResponse_Stderr); ok {
 				n, err := errw.Write(value.Stderr)
-				contract.AssertNoError(err)
-				contract.Assert(n == len(value.Stderr))
+				contract.AssertNoErrorf(err, "failed to write to stderr pipe: %v", err)
+				contract.Assertf(n == len(value.Stderr), "wrote fewer bytes (%d) than expected (%d)", n, len(value.Stderr))
 			} else if _, ok := msg.Output.(*pulumirpc.RunPluginResponse_Exitcode); ok {
 				// If stdout and stderr are empty we've flushed and are returning the exit code
 				outw.Close()

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -187,7 +187,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, kind workspace.PluginKind,
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load plugin %s", bin)
 	}
-	contract.Assert(plug != nil)
+	contract.Assertf(plug != nil, "plugin %v canot be nil", bin)
 
 	// If we did not successfully launch the plugin, we still need to wait for stderr and stdout to drain.
 	defer func() {

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -288,7 +288,7 @@ func UnmarshalProperties(props *structpb.Struct, opts MarshalOptions) (resource.
 // UnmarshalPropertyValue unmarshals a single "JSON-like" value into a new property value.
 func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 	opts MarshalOptions) (*resource.PropertyValue, error) {
-	contract.Assert(v != nil)
+	contract.Assertf(v != nil, "a value is required")
 
 	switch v.Kind.(type) {
 	case *structpb.Value_NullValue:
@@ -357,7 +357,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 			}
 			// This can only be false with a non-nil error if there is a signature match. We've already verified the
 			// signature.
-			contract.Assert(isasset)
+			contract.Assertf(isasset, "value must be an asset")
 			if opts.ComputeAssetHashes {
 				if err = asset.EnsureHash(); err != nil {
 					return nil, errors.Wrapf(err, "failed to compute asset hash for %q", key)
@@ -375,7 +375,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 			}
 			// This can only be false with a non-nil error if there is a signature match. We've already verified the
 			// signature.
-			contract.Assert(isarchive)
+			contract.Assertf(isarchive, "value must be an archive")
 			if opts.ComputeAssetHashes {
 				if err = archive.EnsureHash(); err != nil {
 					return nil, errors.Wrapf(err, "failed to compute archive hash for %q", key)

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -28,7 +28,7 @@ import (
 
 func setProperty(key resource.PropertyKey, s *structpb.Value, k string, v interface{}) {
 	marshaled, err := MarshalPropertyValue(key, resource.NewPropertyValue(v), MarshalOptions{})
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "error marshaling property value")
 	s.GetStructValue().Fields[k] = marshaled
 }
 

--- a/sdk/go/common/resource/resource_id.go
+++ b/sdk/go/common/resource/resource_id.go
@@ -76,8 +76,8 @@ func NewUniqueHex(prefix string, randlen, maxlen int) (string, error) {
 
 	bs := make([]byte, (randlen+1)/2)
 	n, err := cryptorand.Read(bs)
-	contract.AssertNoError(err)
-	contract.Assert(n == len(bs))
+	contract.AssertNoErrorf(err, "error generating random bytes")
+	contract.Assertf(n == len(bs), "generated fewer bytes (%d) than requested (%d)", n, len(bs))
 
 	return prefix + hex.EncodeToString(bs)[:randlen], nil
 }
@@ -119,13 +119,13 @@ func NewUniqueHexV2(urn URN, sequenceNumber int, prefix string, randLen, maxLen 
 	hasher := crypto.SHA512.New()
 
 	_, err := hasher.Write([]byte(urn))
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error hashing urn")
 
 	err = binary.Write(hasher, binary.LittleEndian, uint32(sequenceNumber))
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error hashing sequence number")
 
 	bs := hasher.Sum(nil)
-	contract.Assert(len(bs) == 64)
+	contract.Assertf(len(bs) == 64, "expected 64 bytes from sha512, got %d", len(bs))
 
 	return prefix + hex.EncodeToString(bs)[:randLen], nil
 }

--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -95,7 +95,7 @@ func (nm QName) Name() Name {
 	} else {
 		nmn = string(nm[ix+1:])
 	}
-	contract.Assert(IsName(nmn))
+	contract.Assertf(IsName(nmn), "QName %q has invalid name %q", nm, nmn)
 	return Name(nmn)
 }
 
@@ -108,7 +108,7 @@ func (nm QName) Namespace() QName {
 	} else {
 		qn = string(nm[:ix])
 	}
-	contract.Assert(IsQName(qn))
+	contract.Assertf(IsQName(qn), "QName %q has invalid namespace %q", nm, qn)
 	return QName(qn)
 }
 

--- a/sdk/go/common/util/buildutil/semver.go
+++ b/sdk/go/common/util/buildutil/semver.go
@@ -114,5 +114,5 @@ func captureToMap(r *regexp.Regexp, s string) map[string]string {
 
 func mustFprintf(w io.Writer, format string, a ...interface{}) {
 	_, err := fmt.Fprintf(w, format, a...)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "failed to write")
 }

--- a/sdk/go/common/util/mapper/mapper_decode.go
+++ b/sdk/go/common/util/mapper/mapper_decode.go
@@ -107,7 +107,7 @@ func (md *mapper) DecodeValue(obj map[string]interface{}, ty reflect.Type, key s
 				vdstType = vdstType.Elem()
 				if !vdst.Elem().CanSet() {
 					// If the pointer is nil, initialize it so we can set it below.
-					contract.Assert(vdst.IsNil())
+					contract.Assertf(vdst.IsNil(), "destination pointer must be nil")
 					vdst.Set(reflect.New(vdstType))
 				}
 			}
@@ -162,7 +162,7 @@ func (md *mapper) adjustValueForAssignment(val reflect.Value,
 				adjusted.Elem().Set(val)          // *adjusted = val
 			}
 			// In either case, the loop condition should be sastisfied at this point.
-			contract.Assert(adjusted.Type().AssignableTo(to))
+			contract.Assertf(adjusted.Type().AssignableTo(to), "type %v is not assignable to %v", adjusted.Type(), to)
 			return adjusted, nil
 		} else if val.Kind() == reflect.Interface {
 			// It could be that the source is an interface{} with the right element type (or the right element type

--- a/sdk/go/common/util/mapper/mapper_encode.go
+++ b/sdk/go/common/util/mapper/mapper_encode.go
@@ -29,7 +29,7 @@ func (md *mapper) Encode(source interface{}) (map[string]interface{}, MappingErr
 }
 
 func (md *mapper) encode(vsrc reflect.Value) (map[string]interface{}, MappingError) {
-	contract.Assert(vsrc.IsValid())
+	contract.Requiref(vsrc.IsValid(), "vsrc", "value must be valid")
 
 	// Fetch the type; if it's a pointer, do a quick nil check, otherwise operate on its underlying type.
 	vsrcType := vsrc.Type()
@@ -82,7 +82,7 @@ func (md *mapper) EncodeValue(v interface{}) (interface{}, MappingError) {
 }
 
 func (md *mapper) encodeValue(vsrc reflect.Value) (interface{}, MappingError) {
-	contract.Assert(vsrc.IsValid())
+	contract.Requiref(vsrc.IsValid(), "vsrc", "value must be valid")
 
 	// Otherwise, try to map to the closest JSON-like destination type we can.
 	switch k := vsrc.Kind(); k {
@@ -129,7 +129,8 @@ func (md *mapper) encodeValue(vsrc reflect.Value) (interface{}, MappingError) {
 		if vsrc.IsNil() {
 			return nil, nil
 		}
-		contract.Assert(vsrc.Type().Key().Kind() == reflect.String)
+		ktype := vsrc.Type().Key()
+		contract.Assertf(ktype.Kind() == reflect.String, "expected map with string keys, got %v (%v)", ktype, ktype.Kind())
 
 		iter := vsrc.MapRange()
 		mmap := make(map[string]interface{}, vsrc.Len())

--- a/sdk/go/common/util/rpcutil/rpcerror/rpcerror.go
+++ b/sdk/go/common/util/rpcutil/rpcerror/rpcerror.go
@@ -129,7 +129,7 @@ func Wrap(code codes.Code, err error, message string) error {
 	status := status.New(code, message)
 	cause := serializeErrorCause(err)
 	status, newErr := status.WithDetails(cause)
-	contract.AssertNoError(newErr)
+	contract.AssertNoErrorf(newErr, "error adding details to status")
 	return status.Err()
 }
 
@@ -142,7 +142,7 @@ func Wrapf(code codes.Code, err error, messageFormat string, args ...interface{}
 	status := status.Newf(code, messageFormat, args...)
 	cause := serializeErrorCause(err)
 	status, newErr := status.WithDetails(cause)
-	contract.AssertNoError(newErr)
+	contract.AssertNoErrorf(newErr, "error adding details to status")
 	return status.Err()
 }
 
@@ -153,7 +153,7 @@ func WithDetails(err error, details ...proto.Message) error {
 	status, ok := status.FromError(err)
 	contract.Assertf(ok, "WithDetails called on error not created by rpcerror")
 	status, conversionError := status.WithDetails(details...)
-	contract.AssertNoError(conversionError)
+	contract.AssertNoErrorf(conversionError, "error adding details to status")
 	return status.Err()
 }
 

--- a/sdk/go/common/util/rpcutil/writer.go
+++ b/sdk/go/common/util/rpcutil/writer.go
@@ -35,8 +35,8 @@ type ptyCloser struct {
 func (w *ptyCloser) Close() error {
 	// Close can be called multiple times, but we will of nil'd out everything first time.
 	if w.done == nil {
-		contract.Assert(w.pty == nil)
-		contract.Assert(w.tty == nil)
+		contract.Assertf(w.pty == nil, "ptyCloser.Close called twice: pty is nil")
+		contract.Assertf(w.tty == nil, "ptyCloser.Close called twice: tty is nil")
 		return nil
 	}
 

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -335,28 +335,28 @@ func (singleton *policyPackProjectLoader) load(path string) (*PolicyPackProject,
 
 // LoadProject reads a project definition from a file.
 func LoadProject(path string) (*Project, error) {
-	contract.Require(path != "", "path")
+	contract.Requiref(path != "", "path", "must not be empty")
 
 	return projectSingleton.load(path)
 }
 
 // LoadProjectStack reads a stack definition from a file.
 func LoadProjectStack(project *Project, path string) (*ProjectStack, error) {
-	contract.Require(path != "", "path")
+	contract.Requiref(path != "", "path", "must not be empty")
 
 	return projectStackSingleton.load(project, path)
 }
 
 // LoadPluginProject reads a plugin project definition from a file.
 func LoadPluginProject(path string) (*PluginProject, error) {
-	contract.Require(path != "", "path")
+	contract.Requiref(path != "", "path", "must not be empty")
 
 	return pluginProjectSingleton.load(path)
 }
 
 // LoadPolicyPack reads a policy pack definition from a file.
 func LoadPolicyPack(path string) (*PolicyPackProject, error) {
-	contract.Require(path != "", "path")
+	contract.Requiref(path != "", "path", "must not be empty")
 
 	return policyPackProjectSingleton.load(path)
 }

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -212,7 +212,7 @@ type githubSource struct {
 
 // Creates a new github source adding authentication data in the environment, if it exists
 func newGithubSource(url *url.URL, name string, kind PluginKind) (*githubSource, error) {
-	contract.Assert(url.Scheme == "github")
+	contract.Requiref(url.Scheme == "github", "url", `scheme must be "github", was %q`, url.Scheme)
 
 	// 14-03-2022 we stopped looking at GITHUB_PERSONAL_ACCESS_TOKEN and sending basic auth for github and
 	// instead just look at GITHUB_TOKEN and send in a header. Given GITHUB_PERSONAL_ACCESS_TOKEN was an
@@ -405,7 +405,7 @@ func newFallbackSource(name string, kind PluginKind) *fallbackSource {
 
 func urlMustParse(rawURL string) *url.URL {
 	url, err := url.Parse(rawURL)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "url.Parse(%q)", rawURL)
 	return url
 }
 
@@ -490,8 +490,8 @@ func (reader *checksumReader) Read(p []byte) (int, error) {
 	}
 
 	m, err := reader.hasher.Write(p[0:n])
-	contract.AssertNoError(err)
-	contract.Assert(m == n)
+	contract.AssertNoErrorf(err, "error hashing input")
+	contract.Assertf(m == n, "wrote %d bytes, expected %d", m, n)
 
 	return n, nil
 }
@@ -1416,7 +1416,8 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version,
 		return "", err
 	}
 
-	contract.Assert(info.Path == filepath.Dir(path))
+	contract.Assertf(info.Path == filepath.Dir(path),
+		"plugin executable (%v) is not inside plugin directory (%v)", path, info.Path)
 	return path, err
 }
 
@@ -1427,7 +1428,8 @@ func GetPluginInfo(kind PluginKind, name string, version *semver.Version,
 		return nil, err
 	}
 
-	contract.Assert(info.Path == filepath.Dir(path))
+	contract.Assertf(info.Path == filepath.Dir(path),
+		"plugin executable (%v) is not inside plugin directory (%v)", path, info.Path)
 	return info, nil
 }
 

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -360,7 +360,7 @@ func ValidateProject(raw interface{}) error {
 	appendError = func(err *jsonschema.ValidationError) {
 		if err.InstanceLocation != "" && err.Message != "" {
 			errorf := func(path, message string, args ...interface{}) error {
-				contract.Require(path != "", "path")
+				contract.Requiref(path != "", "path", "path must not be empty")
 				return fmt.Errorf("%s: %s", path, fmt.Sprintf(message, args...))
 			}
 
@@ -514,8 +514,8 @@ func (proj *Project) TrustResourceDependencies() bool {
 
 // Save writes a project definition to a file.
 func (proj *Project) Save(path string) error {
-	contract.Require(path != "", "path")
-	contract.Require(proj != nil, "proj")
+	contract.Requiref(path != "", "path", "must not be empty")
+	contract.Requiref(proj != nil, "proj", "must not be nil")
 	contract.Requiref(proj.Validate() == nil, "proj", "Validate()")
 	return save(path, proj, false /*mkDirAll*/)
 }
@@ -557,8 +557,8 @@ func (proj *PolicyPackProject) Validate() error {
 
 // Save writes a project definition to a file.
 func (proj *PolicyPackProject) Save(path string) error {
-	contract.Require(path != "", "path")
-	contract.Require(proj != nil, "proj")
+	contract.Requiref(path != "", "path", "must not be empty")
+	contract.Requiref(proj != nil, "proj", "must not be nil")
 	contract.Requiref(proj.Validate() == nil, "proj", "Validate()")
 	return save(path, proj, false /*mkDirAll*/)
 }
@@ -599,8 +599,8 @@ func (ps ProjectStack) RawValue() []byte {
 
 // Save writes a project definition to a file.
 func (ps *ProjectStack) Save(path string) error {
-	contract.Require(path != "", "path")
-	contract.Require(ps != nil, "ps")
+	contract.Requiref(path != "", "path", "must not be empty")
+	contract.Requiref(ps != nil, "ps", "must not be nil")
 	return save(path, ps, true /*mkDirAll*/)
 }
 
@@ -702,8 +702,8 @@ func marshallerForPath(path string) (encoding.Marshaler, error) {
 }
 
 func save(path string, value interface{}, mkDirAll bool) error {
-	contract.Require(path != "", "path")
-	contract.Require(value != nil, "value")
+	contract.Requiref(path != "", "path", "must not be empty")
+	contract.Requiref(value != nil, "value", "must not be nil")
 
 	m, err := marshallerForPath(path)
 	if err != nil {

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -697,9 +697,9 @@ func getValidProjectName(name string) string {
 func walkFiles(sourceDir string, destDir string, projectName string,
 	actionFn func(entry os.DirEntry, source string, dest string) error) error {
 
-	contract.Require(sourceDir != "", "sourceDir")
-	contract.Require(destDir != "", "destDir")
-	contract.Require(actionFn != nil, "actionFn")
+	contract.Requiref(sourceDir != "", "sourceDir", "must not be empty")
+	contract.Requiref(destDir != "", "destDir", "must not be empty")
+	contract.Requiref(actionFn != nil, "actionFn", "must not be nil")
 
 	entries, err := os.ReadDir(sourceDir)
 	if err != nil {
@@ -744,7 +744,7 @@ func walkFiles(sourceDir string, destDir string, projectName string,
 // newExistingFilesError returns a new error from a list of existing file names
 // that would be overwritten.
 func newExistingFilesError(existing []string) error {
-	contract.Assert(len(existing) > 0)
+	contract.Assertf(len(existing) > 0, "called with no existing files")
 	message := "creating this template will make changes to existing files:\n"
 	for _, file := range existing {
 		message = message + fmt.Sprintf("  overwrite   %s\n", file)

--- a/sdk/go/common/workspace/workspace.go
+++ b/sdk/go/common/workspace/workspace.go
@@ -53,7 +53,7 @@ func loadFromCache(key string) (W, bool) {
 }
 
 func upsertIntoCache(key string, w W) {
-	contract.Require(w != nil, "w")
+	contract.Requiref(w != nil, "w", "cannot be nil")
 
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
@@ -198,7 +198,7 @@ func sha1HexString(value string) string {
 	//nolint:gosec
 	h := sha1.New()
 	_, err := h.Write([]byte(value))
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error hashing string")
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1182,10 +1182,10 @@ func (ctx *Context) makeResourceState(t, name string, resourceV Resource, provid
 
 	// Populate ResourceState resolvers. (Pulled into function to keep the nil-ness linter check happy).
 	populateResourceStateResolvers := func() {
-		contract.Assert(rs != nil)
+		contract.Assertf(rs != nil, "ResourceState must not be nil")
 		if rs.urn.OutputState != nil {
 			err := ctx.Log.Error(fmt.Sprintf("The resource named %v (type: %v) was initialized multiple times.", name, t), nil)
-			contract.AssertNoError(err)
+			contract.IgnoreError(err)
 		}
 		state.providers = providers
 		rs.providers = providers

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -261,7 +261,7 @@ func gatherDeps(v resource.PropertyValue, deps urnSet) {
 }
 
 func copyInputTo(ctx *Context, v resource.PropertyValue, dest reflect.Value) error {
-	contract.Assert(dest.CanSet())
+	contract.Requiref(dest.CanSet(), "dest", "value must be settable")
 
 	// Check for nils. The destination will be left with the zero value.
 	if v.IsNull() {

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -43,7 +43,7 @@ func Run(body RunFunc, opts ...RunOption) {
 	logError := func(ctx *Context, programErr error) {
 		logErr := ctx.Log.Error(fmt.Sprintf("an unhandled error occurred: program failed: \n%v",
 			programErr), nil)
-		contract.AssertNoError(logErr)
+		contract.IgnoreError(logErr)
 	}
 
 	err := runErrInner(body, logError, opts...)

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -197,7 +197,7 @@ func ActivateVirtualEnv(environ []string, virtualEnvDir string) []string {
 	var result []string
 	for _, env := range environ {
 		split := strings.SplitN(env, "=", 2)
-		contract.Assert(len(split) == 2)
+		contract.Assertf(len(split) == 2, "unexpected environment variable: %q", env)
 		key, value := split[0], split[1]
 
 		// Case-insensitive compare, as Windows will normally be "Path", not "PATH".


### PR DESCRIPTION
Migrates all uses of contract.{Assert, AssertNoError, Require} in sdk/
to the `*f` variants that are required to provide more error context.

Step towards deprecating non-f variants entirely.

For context, `contract.Require` is similar to `contract.Assert`,
except it has a required parameter name as an argument:

    func Require(cond bool, param string)
    func Requiref(cond bool, param string, msg string, args ...any)

It includes the parameter name in the error message by default,
so the `msg` and `args` should only describe the constraint
without naming the parameter.

Refs #12132
