### PR TITLE
pkg/engine: Prefer contract.Assertf over Assert

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -45,7 +45,7 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 	diag, statusDiag diag.Sink, disableProviderPreview bool,
 	tracingSpan opentracing.Span) (string, string, *plugin.Context, error) {
 
-	contract.Require(projinfo != nil, "projinfo")
+	contract.Requiref(projinfo != nil, "projinfo", "must not be nil")
 
 	// If the package contains an override for the main entrypoint, use it.
 	pwd, main, err := projinfo.GetPwdMain()
@@ -98,7 +98,7 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host,
 // newDeploymentContext creates a context for a subsequent deployment. Callers must call Close on the context after the
 // associated deployment completes.
 func newDeploymentContext(u UpdateInfo, opName string, parentSpan opentracing.SpanContext) (*deploymentContext, error) {
-	contract.Require(u != nil, "u")
+	contract.Requiref(u != nil, "u", "must not be nil")
 
 	// Create a root span for the operation
 	opts := []opentracing.StartSpanOption{}
@@ -157,15 +157,15 @@ type deploymentSourceFunc func(
 // newDeployment creates a new deployment with the given context and options.
 func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions,
 	dryRun bool) (*deployment, error) {
-	contract.Assert(info != nil)
-	contract.Assert(info.Update != nil)
-	contract.Assert(opts.SourceFunc != nil)
+	contract.Assertf(info != nil, "a deployment context must be provided")
+	contract.Assertf(info.Update != nil, "update info cannot be nil")
+	contract.Assertf(opts.SourceFunc != nil, "a source factory must be provided")
 
 	// First, load the package metadata and the deployment target in preparation for executing the package's program
 	// and creating resources.  This includes fetching its pwd and main overrides.
 	proj, target := info.Update.GetProject(), info.Update.GetTarget()
-	contract.Assert(proj != nil)
-	contract.Assert(target != nil)
+	contract.Assertf(proj != nil, "update project cannot be nil")
+	contract.Assertf(target != nil, "update target cannot be nil")
 	projinfo := &Projinfo{Proj: proj, Root: info.Update.GetRoot()}
 	pwd, main, plugctx, err := ProjectInfoContext(projinfo, opts.Host,
 		opts.Diag, opts.StatusDiag, opts.DisableProviderPreview, info.TracingSpan)

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -30,8 +30,8 @@ func Destroy(
 	opts UpdateOptions,
 	dryRun bool) (*deploy.Plan, display.ResourceChanges, result.Result) {
 
-	contract.Require(u != nil, "u")
-	contract.Require(ctx != nil, "ctx")
+	contract.Requiref(u != nil, "u", "cannot be nil")
+	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- cancelEvent() }()
 

--- a/pkg/engine/detailedDiff.go
+++ b/pkg/engine/detailedDiff.go
@@ -40,7 +40,7 @@ func getProperty(key interface{}, v resource.PropertyValue) resource.PropertyVal
 func addDiff(path resource.PropertyPath, kind plugin.DiffKind, parent *resource.ValueDiff,
 	oldParent, newParent resource.PropertyValue) {
 
-	contract.Require(len(path) > 0, "len(path) > 0")
+	contract.Requiref(len(path) > 0, "path", "must not be empty")
 
 	element := path[0]
 
@@ -132,7 +132,7 @@ func addDiff(path resource.PropertyPath, kind plugin.DiffKind, parent *resource.
 // TranslateDetailedDiff converts the detailed diff stored in the step event into an ObjectDiff that is appropriate
 // for display.
 func TranslateDetailedDiff(step *StepEventMetadata) *resource.ObjectDiff {
-	contract.Assert(step.DetailedDiff != nil)
+	contract.Assertf(step.DetailedDiff != nil, "%v step has no detailed diff", step.Op)
 
 	// The rich diff is presented as a list of simple JS property paths and corresponding diffs. We translate this to
 	// an ObjectDiff by iterating the list and inserting ValueDiffs that reflect the changes in the detailed diff. Old

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -259,11 +259,10 @@ func queueEvents(events chan<- Event, buffer chan Event, done chan bool) {
 	// buffered channel will be scheduled when new data is placed in the channel.
 
 	defer close(done)
+	contract.Assertf(buffer != nil, "buffer channel must not be nil")
 
 	var queue []Event
 	for {
-		contract.Assert(buffer != nil)
-
 		e, ok := <-buffer
 		if !ok {
 			return
@@ -291,7 +290,8 @@ func queueEvents(events chan<- Event, buffer chan Event, done chan bool) {
 }
 
 func makeStepEventMetadata(op display.StepOp, step deploy.Step, debug bool) StepEventMetadata {
-	contract.Assert(op == step.Op() || step.Op() == deploy.OpRefresh)
+	contract.Assertf(op == step.Op() || step.Op() == deploy.OpRefresh,
+		"step must be %v or %v, got %v", op, deploy.OpRefresh, step.Op())
 
 	var keys, diffs []resource.PropertyKey
 	if keyer, hasKeys := step.(interface{ Keys() []resource.PropertyKey }); hasKeys {
@@ -394,7 +394,7 @@ func (e *eventEmitter) preludeEvent(isPreview bool, cfg config.Map) {
 	for k, v := range cfg {
 		keyString := k.String()
 		valueString, err := v.Value(config.NewBlindingDecrypter())
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "error getting configuration value for entry %q", keyString)
 		configStringMap[keyString] = valueString
 	}
 

--- a/pkg/engine/import.go
+++ b/pkg/engine/import.go
@@ -24,8 +24,8 @@ import (
 func Import(u UpdateInfo, ctx *Context, opts UpdateOptions, imports []deploy.Import,
 	dryRun bool) (*deploy.Plan, display.ResourceChanges, result.Result) {
 
-	contract.Require(u != nil, "u")
-	contract.Require(ctx != nil, "ctx")
+	contract.Requiref(u != nil, "u", "cannot be nil")
+	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- cancelEvent() }()
 

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -38,8 +38,8 @@ type QueryOptions struct {
 }
 
 func Query(ctx *Context, q QueryInfo, opts UpdateOptions) result.Result {
-	contract.Require(q != nil, "update")
-	contract.Require(ctx != nil, "ctx")
+	contract.Requiref(q != nil, "update", "cannot be nil")
+	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- cancelEvent() }()
 
@@ -68,7 +68,7 @@ func Query(ctx *Context, q QueryInfo, opts UpdateOptions) result.Result {
 	statusDiag := newEventSink(emitter, true)
 
 	proj := q.GetProject()
-	contract.Assert(proj != nil)
+	contract.Assertf(proj != nil, "query project cannot be nil")
 
 	pwd, main, plugctx, err := ProjectInfoContext(&Projinfo{Proj: proj, Root: q.GetRoot()},
 		opts.Host, diag, statusDiag, false, tracingSpan)

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -30,8 +30,8 @@ func Refresh(
 	opts UpdateOptions,
 	dryRun bool) (*deploy.Plan, display.ResourceChanges, result.Result) {
 
-	contract.Require(u != nil, "u")
-	contract.Require(ctx != nil, "ctx")
+	contract.Requiref(u != nil, "u", "cannot be nil")
+	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- cancelEvent() }()
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -65,7 +65,8 @@ type LocalPolicyPack struct {
 func MakeLocalPolicyPacks(localPaths []string, configPaths []string) []LocalPolicyPack {
 	// If we have any configPaths, we should have already validated that the length of
 	// the localPaths and configPaths are the same.
-	contract.Assert(len(configPaths) == 0 || len(configPaths) == len(localPaths))
+	contract.Assertf(len(configPaths) == 0 || len(configPaths) == len(localPaths),
+		"configPaths must be empty or match localPaths count (%d), got %d", len(localPaths), len(configPaths))
 
 	r := make([]LocalPolicyPack, len(localPaths))
 	for i, p := range localPaths {
@@ -174,8 +175,8 @@ func HasChanges(changes display.ResourceChanges) bool {
 func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	*deploy.Plan, display.ResourceChanges, result.Result) {
 
-	contract.Require(u != nil, "update")
-	contract.Require(ctx != nil, "ctx")
+	contract.Requiref(u != nil, "update", "cannot be nil")
+	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 
 	defer func() { ctx.Events <- cancelEvent() }()
 
@@ -601,8 +602,8 @@ func (acts *updateActions) OnResourceStepPost(
 			step.URN())
 		new := step.New()
 		old := step.Old()
-		contract.Assert(new != nil)
-		contract.Assert(old != nil)
+		contract.Assertf(new != nil, "new state should not be nil for partially-failed update")
+		contract.Assertf(old != nil, "old state should not be nil for partially-failed update")
 		new.Inputs = make(resource.PropertyMap)
 		for key, value := range old.Inputs {
 			new.Inputs[key] = value


### PR DESCRIPTION
Incremental step towards #12132

Migrates uses of contract.{Assert, AssertNoError, Require} in pkg/engine
to `*f` variants so that we're required to provide more error context.

Refs #12132
