### PR TITLE
Set O_APPEND on the engine event log file

### DIFF
--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -99,7 +99,10 @@ func logJSONEvent(encoder *json.Encoder, event engine.Event, opts Options, seq i
 
 func startEventLogger(events <-chan engine.Event, done chan<- bool, opts Options) (<-chan engine.Event, chan<- bool) {
 	// Before moving further, attempt to open the log file.
-	logFile, err := os.Create(opts.EventLogPath)
+	//
+	// Try setting O_APPEND to see if that helps with the malformed reads we've been seeing in automation api:
+	// https://github.com/pulumi/pulumi/issues/6768
+	logFile, err := os.OpenFile(opts.EventLogPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_APPEND, 0666)
 	if err != nil {
 		logging.V(7).Infof("could not create event log: %v", err)
 		return events, done


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This _might_ help with the issues we've been seeing with [automation api reading malformed JSON lines](https://github.com/pulumi/pulumi/issues/6768).


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - Should be covered by existing tests to make sure this doesn't break automation api.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change - Probably not user visible, we just need this in and then track if we still get bug reports about automation api.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
