### PR TITLE
remove "of the day" from login tip

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -456,7 +456,7 @@ func WelcomeUser(opts display.Options) {
 
 `,
 		opts.Color.Colorize(colors.SpecHeadline+"Welcome to Pulumi!"+colors.Reset),
-		opts.Color.Colorize(colors.SpecSubHeadline+"Tip of the day:"+colors.Reset))
+		opts.Color.Colorize(colors.SpecSubHeadline+"Tip:"+colors.Reset))
 }
 
 func (b *cloudBackend) StackConsoleURL(stackRef backend.StackReference) (string, error) {


### PR DESCRIPTION
we have said "tip of the day" since pulumi's birth
adjusting it to say "tip" since it never changes