### PR TITLE
Warn if `refresh` or `destroy` use older plugins

### DIFF
--- a/changelog/pending/20241210--engine--warn-if-refresh-or-destroy-use-older-plugins.yaml
+++ b/changelog/pending/20241210--engine--warn-if-refresh-or-destroy-use-older-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Warn if `refresh` or `destroy` use older plugins

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -16,9 +16,11 @@ package engine
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -73,16 +75,48 @@ func newRefreshSource(
 	ctx context.Context, client deploy.BackendClient, opts *deploymentOptions, proj *workspace.Project, pwd, main,
 	projectRoot string, target *deploy.Target, plugctx *plugin.Context,
 ) (deploy.Source, error) {
-	// Like Update, we need to gather the set of plugins necessary to refresh everything in the snapshot.
-	// Unlike Update, we don't actually run the user's program so we only need the set of plugins described
-	// in the snapshot.
-	plugins, err := gatherPluginsFromSnapshot(plugctx, target)
+	// Like update, we need to gather the set of plugins necessary to refresh everything in the snapshot. While we don't
+	// run the program like update does, we still grab the plugins from the program in order to inform the user if their
+	// program has updates to plugins that will not be used as part of the refresh operation. In the event that there is
+	// no root directory/Pulumi.yaml (perhaps as the result of a command to which an explicit stack name has been passed),
+	// we'll populate an empty set of program plugins.
+
+	var programPlugins PluginSet
+	if plugctx.Root != "" {
+		runtime := proj.Runtime.Name()
+		programInfo := plugin.NewProgramInfo(
+			/* rootDirectory */ plugctx.Root,
+			/* programDirectory */ pwd,
+			/* entryPoint */ main,
+			/* options */ proj.Runtime.Options(),
+		)
+
+		var err error
+		programPlugins, err = gatherPluginsFromProgram(plugctx, runtime, programInfo)
+		if err != nil {
+			programPlugins = NewPluginSet()
+		}
+	} else {
+		programPlugins = NewPluginSet()
+	}
+
+	snapshotPlugins, err := gatherPluginsFromSnapshot(plugctx, target)
 	if err != nil {
 		return nil, err
 	}
 
+	pluginUpdates := programPlugins.UpdatesTo(snapshotPlugins)
+	if len(pluginUpdates) > 0 {
+		for _, update := range pluginUpdates {
+			plugctx.Diag.Warningf(diag.Message("", fmt.Sprintf(
+				"refresh operation is using an older version of plugin '%s' than the specified program version: %s < %s",
+				update.New.Name, update.Old.Version, update.New.Version,
+			)))
+		}
+	}
+
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
-	if err := EnsurePluginsAreInstalled(ctx, opts, plugctx.Diag, plugins.Deduplicate(),
+	if err := EnsurePluginsAreInstalled(ctx, opts, plugctx.Diag, snapshotPlugins.Deduplicate(),
 		plugctx.Host.GetProjectPlugins(), false /*reinstall*/, false /*explicitInstall*/); err != nil {
 		logging.V(7).Infof("newRefreshSource(): failed to install missing plugins: %v", err)
 	}


### PR DESCRIPTION
`refresh` and `destroy` operations do not run the user program, and instead rely on the plugin versions specified in the state. This can lead to confusing behavior where a user has updated a provider dependency in their program, but these operations ignore that setting. This change prints a warning if either of these operations will use an older plugin version than the one specified in the program dependencies.

> [!NOTE]  
> This may be redundant once a fix for #12177 lands.