### PR TITLE
pkg/backend: Prefer contract.Assertf over Assert

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -49,8 +49,8 @@ type Applier func(ctx context.Context, kind apitype.UpdateKind, stack Stack, op 
 
 func ActionLabel(kind apitype.UpdateKind, dryRun bool) string {
 	v := updateTextMap[kind]
-	contract.Assert(v.previewText != "")
-	contract.Assert(v.text != "")
+	contract.Assertf(v.previewText != "", "preview text for %q cannot be empty", kind)
+	contract.Assertf(v.text != "", "text for %q cannot be empty", kind)
 
 	if dryRun {
 		return "Previewing " + v.previewText

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -754,7 +754,7 @@ func (b *localBackend) GetLogs(ctx context.Context,
 
 // GetLogsForTarget fetches stack logs using the config, decrypter, and checkpoint in the given target.
 func GetLogsForTarget(target *deploy.Target, query operations.LogQuery) ([]operations.LogEntry, error) {
-	contract.Assert(target != nil)
+	contract.Requiref(target != nil, "target", "must not be nil")
 
 	if target.Snapshot == nil {
 		// If the stack has not been deployed yet, return no logs.

--- a/pkg/backend/filestate/lock.go
+++ b/pkg/backend/filestate/lock.go
@@ -143,11 +143,11 @@ func lockDir() string {
 }
 
 func stackLockDir(stack tokens.Name) string {
-	contract.Require(stack != "", "stack")
+	contract.Requiref(stack != "", "stack", "must not be empty")
 	return path.Join(lockDir(), fsutil.NamePath(stack))
 }
 
 func (b *localBackend) lockPath(stack tokens.Name) string {
-	contract.Require(stack != "", "stack")
+	contract.Requiref(stack != "", "stack", "must not be empty")
 	return path.Join(stackLockDir(stack), b.lockID+".json")
 }

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -98,7 +98,7 @@ func (b *localBackend) newUpdate(
 	ctx context.Context,
 	stackName tokens.Name,
 	op backend.UpdateOperation) (*update, error) {
-	contract.Require(stackName != "", "stackName")
+	contract.Requiref(stackName != "", "stackName", "must not be empty")
 
 	// Construct the deployment target.
 	target, err := b.getTarget(ctx, stackName,
@@ -295,7 +295,7 @@ func (b *localBackend) saveStack(name tokens.Name, snap *deploy.Snapshot, sm sec
 
 // removeStack removes information about a stack from the current workspace.
 func (b *localBackend) removeStack(name tokens.Name) error {
-	contract.Require(name != "", "name")
+	contract.Requiref(name != "", "name", "must not be empty")
 
 	// Just make a backup of the file and don't write out anything new.
 	file := b.stackPath(name)
@@ -307,7 +307,7 @@ func (b *localBackend) removeStack(name tokens.Name) error {
 
 // backupTarget makes a backup of an existing file, in preparation for writing a new one.
 func backupTarget(bucket Bucket, file string, keepOriginal bool) string {
-	contract.Require(file != "", "file")
+	contract.Requiref(file != "", "file", "must not be empty")
 	bck := file + ".bak"
 
 	err := bucket.Copy(context.TODO(), bck, file, nil)
@@ -328,7 +328,7 @@ func backupTarget(bucket Bucket, file string, keepOriginal bool) string {
 
 // backupStack copies the current Checkpoint file to ~/.pulumi/backups.
 func (b *localBackend) backupStack(name tokens.Name) error {
-	contract.Require(name != "", "name")
+	contract.Requiref(name != "", "name", "must not be empty")
 
 	// Exit early if backups are disabled.
 	if cmdutil.IsTruthy(os.Getenv(DisableCheckpointBackupsEnvVar)) {
@@ -406,19 +406,19 @@ func (b *localBackend) stackPath(stack tokens.Name) string {
 }
 
 func (b *localBackend) historyDirectory(stack tokens.Name) string {
-	contract.Require(stack != "", "stack")
+	contract.Requiref(stack != "", "stack", "must not be empty")
 	return filepath.Join(b.StateDir(), workspace.HistoryDir, fsutil.NamePath(stack))
 }
 
 func (b *localBackend) backupDirectory(stack tokens.Name) string {
-	contract.Require(stack != "", "stack")
+	contract.Requiref(stack != "", "stack", "must not be empty")
 	return filepath.Join(b.StateDir(), workspace.BackupDir, fsutil.NamePath(stack))
 }
 
 // getHistory returns locally stored update history. The first element of the result will be
 // the most recent update record.
 func (b *localBackend) getHistory(name tokens.Name, pageSize int, page int) ([]backend.UpdateInfo, error) {
-	contract.Require(name != "", "name")
+	contract.Requiref(name != "", "name", "must not be empty")
 
 	dir := b.historyDirectory(name)
 	// TODO: we could consider optimizing the list operation using `page` and `pageSize`.
@@ -490,8 +490,8 @@ func (b *localBackend) getHistory(name tokens.Name, pageSize int, page int) ([]b
 }
 
 func (b *localBackend) renameHistory(oldName tokens.Name, newName tokens.Name) error {
-	contract.Require(oldName != "", "oldName")
-	contract.Require(newName != "", "newName")
+	contract.Requiref(oldName != "", "oldName", "must not be empty")
+	contract.Requiref(newName != "", "newName", "must not be empty")
 
 	oldHistory := b.historyDirectory(oldName)
 	newHistory := b.historyDirectory(newName)
@@ -534,7 +534,7 @@ func (b *localBackend) renameHistory(oldName tokens.Name, newName tokens.Name) e
 
 // addToHistory saves the UpdateInfo and makes a copy of the current Checkpoint file.
 func (b *localBackend) addToHistory(name tokens.Name, update backend.UpdateInfo) error {
-	contract.Require(name != "", "name")
+	contract.Requiref(name != "", "name", "must not be empty")
 
 	dir := b.historyDirectory(name)
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -184,7 +184,7 @@ func loginWithBrowser(ctx context.Context, d diag.Sink, cloudURL string,
 	nonce := hex.EncodeToString(nonceBytes)
 
 	u, err := url.Parse(loginURL)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error parsing login url: %s", loginURL)
 
 	// Generate a description to associate with the access token we'll generate, for display on the Account Settings
 	// page.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -543,7 +543,7 @@ func (pc *Client) CreateUpdate(
 	wireConfig := make(map[string]apitype.ConfigValue)
 	for k, cv := range cfg {
 		v, err := cv.Value(config.NopDecrypter)
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "error fetching config value for key %v", k)
 
 		wireConfig[k.String()] = apitype.ConfigValue{
 			String: v,

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -122,7 +122,8 @@ func (s *cloudStack) Tags() map[apitype.StackTagName]string      { return s.tags
 
 func (s *cloudStack) StackIdentifier() client.StackIdentifier {
 	si, err := s.b.getCloudStackIdentifier(s.ref)
-	contract.AssertNoError(err) // the above only fails when ref is of the wrong type.
+	// the above only fails when ref is of the wrong type.
+	contract.AssertNoErrorf(err, "unexpected stack reference type: %T", s.ref)
 	return si
 }
 
@@ -204,7 +205,7 @@ type cloudStackSummary struct {
 }
 
 func (css cloudStackSummary) Name() backend.StackReference {
-	contract.Assert(css.summary.ProjectName != "")
+	contract.Assertf(css.summary.ProjectName != "", "project name must not be empty")
 
 	return cloudBackendReference{
 		owner:   css.summary.OrgName,

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -88,7 +88,7 @@ func (u *cloudUpdate) Complete(status apitype.UpdateStatus) error {
 // recordEngineEvents will record the events with the Pulumi Service, enabling things like viewing
 // the update logs or drilling into the timeline of an update.
 func (u *cloudUpdate) recordEngineEvents(startingSeqNumber int, events []engine.Event) error {
-	contract.Assert(u.tokenSource != nil)
+	contract.Assertf(u.tokenSource != nil, "cloud update requires a token source")
 	token, err := u.tokenSource.GetToken()
 	if err != nil {
 		return err

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -127,7 +127,7 @@ func (sm *SnapshotManager) RegisterResourceOutputs(step deploy.Step) error {
 // by performing the given Step. This function gives the SnapshotManager a chance to record the
 // intent to mutate before the mutation occurs.
 func (sm *SnapshotManager) BeginMutation(step deploy.Step) (engine.SnapshotMutation, error) {
-	contract.Require(step != nil, "step != nil")
+	contract.Requiref(step != nil, "step", "cannot be nil")
 	logging.V(9).Infof("SnapshotManager: Beginning mutation for step `%s` on resource `%s`", step.Op(), step.URN())
 
 	switch step.Op() {
@@ -175,9 +175,13 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 	old := step.Old()
 	new := step.New()
 
-	contract.Assert(old.Delete == new.Delete)
-	contract.Assert(old.External == new.External)
-	contract.Assert(!step.IsSkippedCreate())
+	contract.Assertf(old.Delete == new.Delete,
+		"either both or neither resource must be pending deletion, got %v (old) != %v (new)",
+		old.Delete, new.Delete)
+	contract.Assertf(old.External == new.External,
+		"either both or neither resource must be external, got %v (old) != %v (new)",
+		old.External, new.External)
+	contract.Assertf(!step.IsSkippedCreate(), "create cannot be skipped for step")
 
 	// If the URN of this resource has changed, we must write the checkpoint. This should only be possible when a
 	// resource is aliased.
@@ -211,7 +215,8 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 		return true
 	}
 
-	contract.Assert(old.ID == new.ID)
+	contract.Assertf(old.ID == new.ID,
+		"old and new resource IDs must be equal, got %v (old) != %v (new)", old.ID, new.ID)
 
 	// If this resource's provider has changed, we must write the checkpoint. This can happen in scenarios involving
 	// aliased providers or upgrades to default providers.
@@ -273,9 +278,9 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 }
 
 func (ssm *sameSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
-	contract.Require(step.Op() == deploy.OpSame, "step.Op() == deploy.OpSame")
-	contract.Assert(successful)
+	contract.Requiref(step != nil, "step", "must not be nil")
+	contract.Requiref(step.Op() == deploy.OpSame, "step.Op()", "must be %q, got %q", deploy.OpSame, step.Op())
+	contract.Assertf(successful, "expected mutation to be successful")
 	logging.V(9).Infof("SnapshotManager: sameSnapshotMutation.End(..., %v)", successful)
 	return ssm.manager.mutate(func() bool {
 		sameStep := step.(*deploy.SameStep)
@@ -325,7 +330,7 @@ type createSnapshotMutation struct {
 }
 
 func (csm *createSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
+	contract.Requiref(step != nil, "step", "must not be nil")
 	logging.V(9).Infof("SnapshotManager: createSnapshotMutation.End(..., %v)", successful)
 	return csm.manager.mutate(func() bool {
 		csm.manager.markOperationComplete(step.New())
@@ -369,7 +374,7 @@ type updateSnapshotMutation struct {
 }
 
 func (usm *updateSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
+	contract.Requiref(step != nil, "step", "must not be nil")
 	logging.V(9).Infof("SnapshotManager: updateSnapshotMutation.End(..., %v)", successful)
 	return usm.manager.mutate(func() bool {
 		usm.manager.markOperationComplete(step.New())
@@ -399,16 +404,17 @@ type deleteSnapshotMutation struct {
 }
 
 func (dsm *deleteSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
+	contract.Requiref(step != nil, "step", "must not be nil")
 	logging.V(9).Infof("SnapshotManager: deleteSnapshotMutation.End(..., %v)", successful)
 	return dsm.manager.mutate(func() bool {
 		dsm.manager.markOperationComplete(step.Old())
 		if successful {
-			// Either old should not be protected or this is a replace
-			contract.Assert(
+			contract.Assertf(
 				!step.Old().Protect ||
 					step.Op() == deploy.OpDiscardReplaced ||
-					step.Op() == deploy.OpDeleteReplaced)
+					step.Op() == deploy.OpDeleteReplaced,
+				"Old must be unprotected (got %v) or the operation must be a replace (got %q)",
+				step.Old().Protect, step.Op())
 
 			if !step.Old().PendingReplacement {
 				dsm.manager.markDone(step.Old())
@@ -445,7 +451,7 @@ type readSnapshotMutation struct {
 }
 
 func (rsm *readSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
+	contract.Requiref(step != nil, "step", "must not be nil")
 	logging.V(9).Infof("SnapshotManager: readSnapshotMutation.End(..., %v)", successful)
 	return rsm.manager.mutate(func() bool {
 		rsm.manager.markOperationComplete(step.New())
@@ -465,8 +471,8 @@ type refreshSnapshotMutation struct {
 }
 
 func (rsm *refreshSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
-	contract.Require(step.Op() == deploy.OpRefresh, "step.Op() == deploy.OpRefresh")
+	contract.Requiref(step != nil, "step", "must not be nil")
+	contract.Requiref(step.Op() == deploy.OpRefresh, "step.Op", "must be %q, got %q", deploy.OpRefresh, step.Op())
 	logging.V(9).Infof("SnapshotManager: refreshSnapshotMutation.End(..., %v)", successful)
 	return rsm.manager.mutate(func() bool {
 		// We always elide refreshes. The expectation is that all of these run before any actual mutations and that
@@ -482,11 +488,12 @@ type removePendingReplaceSnapshotMutation struct {
 }
 
 func (rsm *removePendingReplaceSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
-	contract.Require(step.Op() == deploy.OpRemovePendingReplace, "step.Op() == deploy.OpRemovePendingReplace")
+	contract.Requiref(step != nil, "step", "must not be nil")
+	contract.Requiref(step.Op() == deploy.OpRemovePendingReplace, "step.Op",
+		"must be %q, got %q", deploy.OpRemovePendingReplace, step.Op())
 	return rsm.manager.mutate(func() bool {
 		res := step.Old()
-		contract.Assert(res.PendingReplacement)
+		contract.Assertf(res.PendingReplacement, "resource %q must be pending replacement", res.URN)
 		rsm.manager.markDone(res)
 		return true
 	})
@@ -510,9 +517,9 @@ type importSnapshotMutation struct {
 }
 
 func (ism *importSnapshotMutation) End(step deploy.Step, successful bool) error {
-	contract.Require(step != nil, "step != nil")
-	contract.Require(step.Op() == deploy.OpImport || step.Op() == deploy.OpImportReplacement,
-		"step.Op() == deploy.OpImport || step.Op() == deploy.OpImportReplacement")
+	contract.Requiref(step != nil, "step", "must not be nil")
+	contract.Requiref(step.Op() == deploy.OpImport || step.Op() == deploy.OpImportReplacement, "step.Op",
+		"must be %q or %q, got %q", deploy.OpImport, deploy.OpImportReplacement, step.Op())
 
 	return ism.manager.mutate(func() bool {
 		ism.manager.markOperationComplete(step.New())
@@ -526,7 +533,7 @@ func (ism *importSnapshotMutation) End(step deploy.Step, successful bool) error 
 // markDone marks a resource as having been processed. Resources that have been marked
 // in this manner won't be persisted in the snapshot.
 func (sm *SnapshotManager) markDone(state *resource.State) {
-	contract.Assert(state != nil)
+	contract.Requiref(state != nil, "state", "must not be nil")
 	sm.dones[state] = true
 	logging.V(9).Infof("Marked old state snapshot as done: %v", state.URN)
 }
@@ -535,21 +542,21 @@ func (sm *SnapshotManager) markDone(state *resource.State) {
 // successful non-deletion operations where the given state is the new state
 // of a resource that will be persisted to the snapshot.
 func (sm *SnapshotManager) markNew(state *resource.State) {
-	contract.Assert(state != nil)
+	contract.Requiref(state != nil, "state", "must not be nil")
 	sm.resources = append(sm.resources, state)
 	logging.V(9).Infof("Appended new state snapshot to be written: %v", state.URN)
 }
 
 // markOperationPending marks a resource as undergoing an operation that will now be considered pending.
 func (sm *SnapshotManager) markOperationPending(state *resource.State, op resource.OperationType) {
-	contract.Assert(state != nil)
+	contract.Requiref(state != nil, "state", "must not be nil")
 	sm.operations = append(sm.operations, resource.NewOperation(state, op))
 	logging.V(9).Infof("SnapshotManager.markPendingOperation(%s, %s)", state.URN, string(op))
 }
 
 // markOperationComplete marks a resource as having completed the operation that it previously was performing.
 func (sm *SnapshotManager) markOperationComplete(state *resource.State) {
-	contract.Assert(state != nil)
+	contract.Requiref(state != nil, "state", "must not be nil")
 	sm.completeOps[state] = true
 	logging.V(9).Infof("SnapshotManager.markOperationComplete(%s)", state.URN)
 }


### PR DESCRIPTION
Incremental step towards #12132

Migrates uses of contract.{Assert, AssertNoError, Require} in pkg/engine
to `*f` variants so that we're required to provide more error context.

Refs #12132
