### PR TITLE
Pass *Project to GetCurrentCloudURL

### DIFF
--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -64,8 +64,13 @@ func newLogoutCmd() *cobra.Command {
 			}
 
 			if cloudURL == "" {
-				var err error
-				cloudURL, err = workspace.GetCurrentCloudURL()
+				// Try to read the current project
+				project, _, err := readProject()
+				if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+					return err
+				}
+
+				cloudURL, err = workspace.GetCurrentCloudURL(project)
 				if err != nil {
 					return fmt.Errorf("could not determine current cloud: %w", err)
 				}

--- a/pkg/cmd/pulumi/org.go
+++ b/pkg/cmd/pulumi/org.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -34,7 +35,13 @@ func newOrgCmd() *cobra.Command {
 			"e.g. setting the default organization for a backend",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			cloudURL, err := workspace.GetCurrentCloudURL()
+			// Try to read the current project
+			project, _, err := readProject()
+			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+				return err
+			}
+
+			cloudURL, err := workspace.GetCurrentCloudURL(project)
 			if err != nil {
 				return err
 			}
@@ -93,7 +100,13 @@ func newOrgSetDefaultCmd() *cobra.Command {
 					currentBe.Name())
 			}
 
-			cloudURL, err := workspace.GetCurrentCloudURL()
+			// Try to read the current project
+			project, _, err := readProject()
+			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+				return err
+			}
+
+			cloudURL, err := workspace.GetCurrentCloudURL(project)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -110,7 +110,13 @@ func requirePolicyPack(ctx context.Context, policyPack string) (backend.PolicyPa
 	// Attempt to log into cloud backend.
 	//
 
-	cloudURL, err := workspace.GetCurrentCloudURL()
+	// Try to read the current project
+	project, _, err := readProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, err
+	}
+
+	cloudURL, err := workspace.GetCurrentCloudURL(project)
 	if err != nil {
 		return nil, fmt.Errorf("`pulumi policy` command requires the user to be logged into the Pulumi service: %w", err)
 	}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -104,7 +104,13 @@ func isFilestateBackend(opts display.Options) (bool, error) {
 		return false, nil
 	}
 
-	url, err := workspace.GetCurrentCloudURL()
+	// Try to read the current project
+	project, _, err := readProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return false, err
+	}
+
+	url, err := workspace.GetCurrentCloudURL(project)
 	if err != nil {
 		return false, fmt.Errorf("could not get cloud url: %w", err)
 	}
@@ -117,7 +123,13 @@ func nonInteractiveCurrentBackend(ctx context.Context) (backend.Backend, error) 
 		return backendInstance, nil
 	}
 
-	url, err := workspace.GetCurrentCloudURL()
+	// Try to read the current project
+	project, _, err := readProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, err
+	}
+
+	url, err := workspace.GetCurrentCloudURL(project)
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
@@ -133,7 +145,13 @@ func currentBackend(ctx context.Context, opts display.Options) (backend.Backend,
 		return backendInstance, nil
 	}
 
-	url, err := workspace.GetCurrentCloudURL()
+	// Try to read the current project
+	project, _, err := readProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, err
+	}
+
+	url, err := workspace.GetCurrentCloudURL(project)
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -17,6 +17,7 @@ package workspace
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -150,23 +151,16 @@ func getCredsFilePath() (string, error) {
 // GetCurrentCloudURL returns the URL of the cloud we are currently connected to. This may be empty if we
 // have not logged in. Note if PULUMI_BACKEND_URL is set, the corresponding value is returned
 // instead irrespective of the backend for current project or stored credentials.
-func GetCurrentCloudURL() (string, error) {
+func GetCurrentCloudURL(project *Project) (string, error) {
 	// Allow PULUMI_BACKEND_URL to override the current cloud URL selection
 	if backend := os.Getenv(PulumiBackendURLEnvVar); backend != "" {
 		return backend, nil
 	}
 
 	var url string
-	// Try detecting backend from config
-	projPath, err := DetectProjectPath()
-	if err == nil && projPath != "" {
-		proj, err := LoadProject(projPath)
-		if err != nil {
-			return "", fmt.Errorf("could not load current project: %w", err)
-		}
-
-		if proj.Backend != nil {
-			url = proj.Backend.URL
+	if project != nil {
+		if project.Backend != nil {
+			url = project.Backend.URL
 		}
 	}
 
@@ -359,7 +353,16 @@ func GetBackendConfigDefaultOrg() (string, error) {
 		return "", err
 	}
 
-	backendURL, err := GetCurrentCloudURL()
+	var project *Project
+	projPath, err := DetectProjectPath()
+	if err == nil && !errors.Is(err, ErrProjectNotFound) {
+		project, err = LoadProject(projPath)
+		if err != nil {
+			return "", fmt.Errorf("could not load current project: %w", err)
+		}
+	}
+
+	backendURL, err := GetCurrentCloudURL(project)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Chipping away at https://github.com/pulumi/pulumi/issues/12152. This makes GetCurrentCloudURL take a `*Project` rather than loading the project itself. All call sites have been fixed up, most now need to the project loading there instead but over time we'll bump all these loads to the very top of the call stack in pkg/cmd.