### PR TITLE
Pass *Project to nonInteractiveCurrentBackend

### DIFF
--- a/pkg/cmd/pulumi/about.go
+++ b/pkg/cmd/pulumi/about.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ func getSummaryAbout(ctx context.Context, transitiveDependencies bool, selectedS
 	}
 
 	var backend backend.Backend
-	backend, err = nonInteractiveCurrentBackend(ctx)
+	backend, err = nonInteractiveCurrentBackend(ctx, proj)
 	if err != nil {
 		addError(err, "Could not access the backend")
 	} else if backend != nil {

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -118,15 +118,9 @@ func isFilestateBackend(opts display.Options) (bool, error) {
 	return filestate.IsFileStateBackendURL(url), nil
 }
 
-func nonInteractiveCurrentBackend(ctx context.Context) (backend.Backend, error) {
+func nonInteractiveCurrentBackend(ctx context.Context, project *workspace.Project) (backend.Backend, error) {
 	if backendInstance != nil {
 		return backendInstance, nil
-	}
-
-	// Try to read the current project
-	project, _, err := readProject()
-	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
-		return nil, err
 	}
 
 	url, err := workspace.GetCurrentCloudURL(project)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

More little steps for https://github.com/pulumi/pulumi/issues/12152. Pass the *Project to nonInteractiveCurrentBackend so it doesn't have to load the project anymore.