### PR TITLE
Pass root and project to GetTags methods

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -154,7 +154,9 @@ type Backend interface {
 	// GetStack returns a stack object tied to this backend with the given name, or nil if it cannot be found.
 	GetStack(ctx context.Context, stackRef StackReference) (Stack, error)
 	// CreateStack creates a new stack with the given name and options that are specific to the backend provider.
-	CreateStack(ctx context.Context, stackRef StackReference, project *workspace.Project, opts interface{}) (Stack, error)
+	CreateStack(ctx context.Context,
+		stackRef StackReference, root string, project *workspace.Project, opts interface{}) (Stack, error)
+
 	// RemoveStack removes a stack with the given name.  If force is true, the stack will be removed even if it
 	// still contains resources.  Otherwise, if the stack contains resources, a non-nil error is returned, and the
 	// first boolean return value will be set to true.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -309,7 +309,7 @@ func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string)
 }
 
 func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackReference,
-	project *workspace.Project, opts interface{}) (backend.Stack, error) {
+	root string, project *workspace.Project, opts interface{}) (backend.Stack, error) {
 
 	err := b.Lock(ctx, stackRef)
 	if err != nil {
@@ -328,10 +328,8 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 		return nil, &backend.StackAlreadyExistsError{StackName: string(stackName)}
 	}
 
-	tags, err := backend.GetEnvironmentTagsForCurrentStack()
-	if err != nil {
-		return nil, fmt.Errorf("getting stack tags: %w", err)
-	}
+	tags := backend.GetEnvironmentTagsForCurrentStack(root, project)
+
 	if err = validation.ValidateStackProperties(string(stackName), tags); err != nil {
 		return nil, fmt.Errorf("validating stack properties: %w", err)
 	}

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -151,7 +151,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	defer func() {
@@ -169,7 +169,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Create stack "b" and import a checkpoint with a secret
 	bStackRef, err := b.ParseStackReference("b")
 	assert.NoError(t, err)
-	bStack, err := b.CreateStack(ctx, bStackRef, nil, nil)
+	bStack, err := b.CreateStack(ctx, bStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, bStack)
 	defer func() {
@@ -234,7 +234,7 @@ func TestCancel(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that trying to cancel a stack that isn't locked doesn't error
-	aStack, err := b.CreateStack(ctx, aStackRef, nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.CancelCurrentUpdate(ctx, aStackRef)
@@ -296,7 +296,7 @@ func TestRemoveMakesBackups(t *testing.T) {
 	// Check that creating a new stack doesn't make a backup file
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -339,7 +339,7 @@ func TestRenameWorks(t *testing.T) {
 	// Create a new stack
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -452,7 +452,7 @@ func TestHtmlEscaping(t *testing.T) {
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.ImportDeployment(ctx, aStack, udep)

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -43,7 +43,7 @@ type MockBackend struct {
 	ValidateStackNameF     func(s string) error
 	DoesProjectExistF      func(context.Context, string) (bool, error)
 	GetStackF              func(context.Context, StackReference) (Stack, error)
-	CreateStackF           func(context.Context, StackReference, *workspace.Project, interface{}) (Stack, error)
+	CreateStackF           func(context.Context, StackReference, string, *workspace.Project, interface{}) (Stack, error)
 	RemoveStackF           func(context.Context, Stack, bool) (bool, error)
 	ListStacksF            func(context.Context, ListStacksFilter, ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)
@@ -154,10 +154,10 @@ func (be *MockBackend) GetStack(ctx context.Context, stackRef StackReference) (S
 }
 
 func (be *MockBackend) CreateStack(ctx context.Context, stackRef StackReference,
-	project *workspace.Project, opts interface{}) (Stack, error) {
+	root string, project *workspace.Project, opts interface{}) (Stack, error) {
 
 	if be.CreateStackF != nil {
-		return be.CreateStackF(ctx, stackRef, project, opts)
+		return be.CreateStackF(ctx, stackRef, root, project, opts)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -225,12 +225,12 @@ func createStack(ctx context.Context,
 	b backend.Backend, stackRef backend.StackReference, opts interface{}, setCurrent bool,
 	secretsProvider string) (backend.Stack, error) {
 
-	project, _, err := readProject()
+	project, root, err := readProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}
 
-	stack, err := b.CreateStack(ctx, stackRef, project, opts)
+	stack, err := b.CreateStack(ctx, stackRef, root, project, opts)
 	if err != nil {
 		// If it's a well-known error, don't wrap it.
 		if _, ok := err.(*backend.StackAlreadyExistsError); ok {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Next little bit for https://github.com/pulumi/pulumi/issues/12152. We now pass the root directory and project (if we have them, they can be "" and nil) to `GetEnvironmentTagsForCurrentStack`. Plumbing this up the call chain required adding "root" to the CreateStack call as well.

