### PR TITLE
pkg/resource: Prefer Assertf in some subpackages

### DIFF
--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -114,7 +114,7 @@ func (prov *Provider) DiffConfig(urn resource.URN, olds, news resource.PropertyM
 	return prov.DiffConfigF(urn, olds, news, ignoreChanges)
 }
 func (prov *Provider) Configure(inputs resource.PropertyMap) error {
-	contract.Assert(!prov.configured)
+	contract.Assertf(!prov.configured, "provider %v was already configured", prov.Name)
 	prov.configured = true
 
 	if prov.ConfigureF == nil {
@@ -126,7 +126,7 @@ func (prov *Provider) Configure(inputs resource.PropertyMap) error {
 
 func (prov *Provider) Check(urn resource.URN,
 	olds, news resource.PropertyMap, _ bool, randomSeed []byte) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	contract.Assert(randomSeed != nil)
+	contract.Requiref(randomSeed != nil, "randomSeed", "must not be nil")
 	if prov.CheckF == nil {
 		return news, nil, nil
 	}

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -92,7 +92,7 @@ func (p ProviderRequest) Name() tokens.QName {
 	}
 
 	// This thing that we generated must be a QName.
-	contract.Assert(tokens.IsQName(base))
+	contract.Assertf(tokens.IsQName(base), "generated provider name %q is not a QName", base)
 	return tokens.QName(base)
 }
 

--- a/pkg/resource/deploy/providers/reference.go
+++ b/pkg/resource/deploy/providers/reference.go
@@ -53,7 +53,7 @@ func MakeProviderType(pkg tokens.Package) tokens.Type {
 
 // GetProviderPackage returns the provider package for the given type token.
 func GetProviderPackage(typ tokens.Type) tokens.Package {
-	contract.Require(IsProviderType(typ), "typ")
+	contract.Requiref(IsProviderType(typ), "typ", "must be a provider type token, got %q", typ)
 	return tokens.Package(typ.Name())
 }
 
@@ -113,7 +113,7 @@ func NewDenyDefaultProvider(name tokens.QName) Reference {
 //
 // Panics if called on a provider that is not a DenyDefaultProvider.
 func GetDeniedDefaultProviderPkg(ref Reference) string {
-	contract.Assert(IsDenyDefaultsProvider(ref))
+	contract.Requiref(IsDenyDefaultsProvider(ref), "ref", "must be a DenyDefaultProvider, got %v", ref)
 	return ref.URN().Name().String()
 }
 
@@ -131,7 +131,7 @@ func NewReference(urn resource.URN, id resource.ID) (Reference, error) {
 
 func mustNewReference(urn resource.URN, id resource.ID) Reference {
 	ref, err := NewReference(urn, id)
-	contract.Assert(err == nil)
+	contract.AssertNoErrorf(err, "could not create reference with URN '%v' and ID '%v'", urn, id)
 	return ref
 }
 

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -218,13 +218,13 @@ func (r *Registry) label() string {
 
 // GetSchema returns the JSON-serialized schema for the provider.
 func (r *Registry) GetSchema(version int) ([]byte, error) {
-	contract.Fail()
+	contract.Failf("GetSchema must not be called on the provider registry")
 
 	return nil, errors.New("the provider registry has no schema")
 }
 
 func (r *Registry) GetMapping(key string) ([]byte, string, error) {
-	contract.Fail()
+	contract.Failf("GetMapping must not be called on the provider registry")
 
 	return nil, "", errors.New("the provider registry has no mappings")
 }
@@ -233,19 +233,19 @@ func (r *Registry) GetMapping(key string) ([]byte, string, error) {
 func (r *Registry) CheckConfig(urn resource.URN, olds,
 	news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
 
-	contract.Fail()
+	contract.Failf("CheckConfig must not be called on the provider registry")
 	return nil, nil, errors.New("the provider registry is not configurable")
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
 func (r *Registry) DiffConfig(urn resource.URN, olds, news resource.PropertyMap,
 	allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
-	contract.Fail()
+	contract.Failf("DiffConfig must not be called on the provider registry")
 	return plugin.DiffResult{}, errors.New("the provider registry is not configurable")
 }
 
 func (r *Registry) Configure(props resource.PropertyMap) error {
-	contract.Fail()
+	contract.Failf("Configure must not be called on the provider registry")
 	return errors.New("the provider registry is not configurable")
 }
 
@@ -260,7 +260,7 @@ func (r *Registry) Configure(props resource.PropertyMap) error {
 func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
 	allowUnknowns bool, randomSeed []byte) (resource.PropertyMap, []plugin.CheckFailure, error) {
 
-	contract.Require(IsProviderType(urn.Type()), "urn")
+	contract.Requiref(IsProviderType(urn.Type()), "urn", "must be a provider type, got %v", urn.Type())
 
 	label := fmt.Sprintf("%s.Check(%s)", r.label(), urn)
 	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(olds), len(news))
@@ -304,7 +304,7 @@ func (r *Registry) RegisterAlias(providerURN, alias resource.URN) {
 // previously been loaded by a call to Check.
 func (r *Registry) Diff(urn resource.URN, id resource.ID, olds, news resource.PropertyMap,
 	allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
-	contract.Require(id != "", "id")
+	contract.Requiref(id != "", "id", "must not be empty")
 
 	label := fmt.Sprintf("%s.Diff(%s,%s)", r.label(), urn, id)
 	logging.V(7).Infof("%s: executing (#olds=%d,#news=%d)", label, len(olds), len(news))
@@ -392,7 +392,7 @@ func (r *Registry) Create(urn resource.URN, news resource.PropertyMap, timeout f
 			return "", nil, resource.StatusOK, err
 		}
 		id = resource.ID(uuid.String())
-		contract.Assert(id != UnknownID)
+		contract.Assertf(id != UnknownID, "resource ID must not be unknown")
 	}
 
 	r.setProvider(mustNewReference(urn, id), provider)
@@ -426,11 +426,11 @@ func (r *Registry) Update(urn resource.URN, id resource.ID, olds, news resource.
 // registry was created (i.e. it must have been present in the state handed to NewRegistry).
 func (r *Registry) Delete(urn resource.URN, id resource.ID, props resource.PropertyMap,
 	timeout float64) (resource.Status, error) {
-	contract.Assert(!r.isPreview)
+	contract.Assertf(!r.isPreview, "Delete must not be called during preview")
 
 	ref := mustNewReference(urn, id)
 	provider, has := r.deleteProvider(ref)
-	contract.Assert(has)
+	contract.Assertf(has, "could not find provider to delete (%v)", ref)
 
 	closeErr := r.host.CloseProvider(provider)
 	contract.IgnoreError(closeErr)
@@ -452,7 +452,7 @@ func (r *Registry) Invoke(tok tokens.ModuleMember,
 
 	// It is the responsibility of the eval source to ensure that we never attempt an invoke using the provider
 	// registry.
-	contract.Fail()
+	contract.Failf("Invoke must not be called on the provider registry")
 	return nil, nil, errors.New("the provider registry is not invokable")
 }
 
@@ -468,7 +468,7 @@ func (r *Registry) Call(tok tokens.ModuleMember, args resource.PropertyMap, info
 
 	// It is the responsibility of the eval source to ensure that we never attempt an call using the provider
 	// registry.
-	contract.Fail()
+	contract.Failf("Call must not be called on the provider registry")
 	return plugin.CallResult{}, errors.New("the provider registry is not callable")
 }
 

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -42,8 +42,8 @@ func DeleteResource(
 	snapshot *deploy.Snapshot, condemnedRes *resource.State,
 	onProtected func(*resource.State) error, targetDependents bool,
 ) error {
-	contract.Require(snapshot != nil, "snapshot")
-	contract.Require(condemnedRes != nil, "state")
+	contract.Requiref(snapshot != nil, "snapshot", "must not be nil")
+	contract.Requiref(condemnedRes != nil, "condemnedRes", "must not be nil")
 
 	handleProtected := func(res *resource.State) error {
 		if !res.Protect {
@@ -155,7 +155,7 @@ func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 // RenameStack changes the `stackName` component of every URN in a snapshot. In addition, it rewrites the name of
 // the root Stack resource itself. May optionally change the project/package name as well.
 func RenameStack(snap *deploy.Snapshot, newName tokens.Name, newProject tokens.PackageName) error {
-	contract.Require(snap != nil, "snap")
+	contract.Requiref(snap != nil, "snap", "must not be nil")
 
 	rewriteUrn := func(u resource.URN) resource.URN {
 		project := u.Project()
@@ -173,7 +173,7 @@ func RenameStack(snap *deploy.Snapshot, newName tokens.Name, newProject tokens.P
 	}
 
 	rewriteState := func(res *resource.State) {
-		contract.Assert(res != nil)
+		contract.Assertf(res != nil, "resource state must not be nil")
 
 		res.URN = rewriteUrn(res.URN)
 

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -30,7 +30,7 @@ func (dg *DependencyGraph) DependingOn(res *resource.State,
 	dependentSet := make(map[resource.URN]bool)
 
 	cursorIndex, ok := dg.index[res]
-	contract.Assert(ok)
+	contract.Assertf(ok, "could not determine index for resource %s", res.URN)
 	dependentSet[res.URN] = true
 
 	isDependent := func(candidate *resource.State) bool {
@@ -47,7 +47,7 @@ func (dg *DependencyGraph) DependingOn(res *resource.State,
 		}
 		if candidate.Provider != "" {
 			ref, err := providers.ParseReference(candidate.Provider)
-			contract.Assert(err == nil)
+			contract.AssertNoErrorf(err, "cannot parse provider reference %q", candidate.Provider)
 			if dependentSet[ref.URN()] {
 				return true
 			}
@@ -91,12 +91,12 @@ func (dg *DependencyGraph) DependenciesOf(res *resource.State) ResourceSet {
 
 	if res.Provider != "" {
 		ref, err := providers.ParseReference(res.Provider)
-		contract.Assert(err == nil)
+		contract.AssertNoErrorf(err, "cannot parse provider reference %q", res.Provider)
 		dependentUrns[ref.URN()] = true
 	}
 
 	cursorIndex, ok := dg.index[res]
-	contract.Assert(ok)
+	contract.Assertf(ok, "could not determine index for resource %s", res.URN)
 	for i := cursorIndex - 1; i >= 0; i-- {
 		candidate := dg.resources[i]
 		// Include all resources that are dependencies of the resource
@@ -168,7 +168,7 @@ func markAsDependency(urn resource.URN, urns map[resource.URN]*node, dependedPro
 		r.marked = true
 		if r.resource.Provider != "" {
 			ref, err := providers.ParseReference(r.resource.Provider)
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "cannot parse provider reference %q", r.resource.Provider)
 			dependedProviders[ref.URN()] = struct{}{}
 		}
 		for _, dep := range r.resource.Dependencies {

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -134,7 +134,7 @@ func DeserializeCheckpoint(
 	ctx context.Context,
 	secretsProvider secrets.Provider,
 	chkpoint *apitype.CheckpointV3) (*deploy.Snapshot, error) {
-	contract.Require(chkpoint != nil, "chkpoint")
+	contract.Requiref(chkpoint != nil, "chkpoint", "must not be nil")
 	if chkpoint.Latest != nil {
 		return DeserializeDeploymentV3(ctx, *chkpoint.Latest, secretsProvider)
 	}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -97,7 +97,7 @@ func ValidateUntypedDeployment(deployment *apitype.UntypedDeployment) error {
 
 // SerializeDeployment serializes an entire snapshot as a deploy record.
 func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets bool) (*apitype.DeploymentV3, error) {
-	contract.Require(snap != nil, "snap")
+	contract.Requiref(snap != nil, "snap", "must not be nil")
 
 	// Capture the version information into a manifest.
 	manifest := snap.Manifest.Serialize()
@@ -167,7 +167,7 @@ func DeserializeUntypedDeployment(
 	deployment *apitype.UntypedDeployment,
 	secretsProv secrets.Provider) (*deploy.Snapshot, error) {
 
-	contract.Require(deployment != nil, "deployment")
+	contract.Requiref(deployment != nil, "deployment", "must not be nil")
 	switch {
 	case deployment.Version > apitype.DeploymentSchemaVersionCurrent:
 		return nil, ErrDeploymentSchemaVersionTooNew
@@ -285,8 +285,8 @@ func DeserializeDeploymentV3(
 
 // SerializeResource turns a resource into a structure suitable for serialization.
 func SerializeResource(res *resource.State, enc config.Encrypter, showSecrets bool) (apitype.ResourceV3, error) {
-	contract.Assert(res != nil)
-	contract.Assertf(string(res.URN) != "", "Unexpected empty resource resource.URN")
+	contract.Requiref(res != nil, "res", "must not be nil")
+	contract.Requiref(res.URN != "", "res", "must have a URN")
 
 	// Serialize all input and output properties recursively, and add them if non-empty.
 	var inputs map[string]interface{}
@@ -576,14 +576,14 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 					if err != nil {
 						return resource.PropertyValue{}, err
 					}
-					contract.Assert(isasset)
+					contract.Assertf(isasset, "resource with asset signature is not an asset")
 					return resource.NewAssetProperty(asset), nil
 				case resource.ArchiveSig:
 					archive, isarchive, err := resource.DeserializeArchive(objmap)
 					if err != nil {
 						return resource.PropertyValue{}, err
 					}
-					contract.Assert(isarchive)
+					contract.Assertf(isarchive, "resource with archive signature is not an archive")
 					return resource.NewArchiveProperty(archive), nil
 				case resource.SecretSig:
 					ciphertext, cipherOk := objmap["ciphertext"].(string)


### PR DESCRIPTION
Incremental step towards #12132

Migrates some uses of contract.{Assert, AssertNoError, Require} in
pkg/resource to `*f` variants so that we're required to provide more
error context.

Refs #12132
