### PR TITLE
pkg/resource/deploy: Prefer Assertf

### DIFF
--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -97,7 +97,7 @@ func (p *builtinProvider) Check(urn resource.URN, state, inputs resource.Propert
 func (p *builtinProvider) Diff(urn resource.URN, id resource.ID, state, inputs resource.PropertyMap,
 	allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
 
-	contract.Assert(urn.Type() == stackReferenceType)
+	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
 
 	if !inputs["name"].DeepEquals(state["name"]) {
 		return plugin.DiffResult{
@@ -112,7 +112,7 @@ func (p *builtinProvider) Diff(urn resource.URN, id resource.ID, state, inputs r
 func (p *builtinProvider) Create(urn resource.URN, inputs resource.PropertyMap, timeout float64,
 	preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
 
-	contract.Assert(urn.Type() == stackReferenceType)
+	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
 
 	state, err := p.readStackReference(inputs)
 	if err != nil {
@@ -136,7 +136,7 @@ func (p *builtinProvider) Update(urn resource.URN, id resource.ID, state, inputs
 	ignoreChanges []string, preview bool) (resource.PropertyMap, resource.Status, error) {
 
 	contract.Failf("unexpected update for builtin resource %v", urn)
-	contract.Assert(urn.Type() == stackReferenceType)
+	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
 
 	return state, resource.StatusOK, errors.New("unexpected update for builtin resource")
 }
@@ -144,16 +144,16 @@ func (p *builtinProvider) Update(urn resource.URN, id resource.ID, state, inputs
 func (p *builtinProvider) Delete(urn resource.URN, id resource.ID,
 	state resource.PropertyMap, timeout float64) (resource.Status, error) {
 
-	contract.Assert(urn.Type() == stackReferenceType)
+	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
 
 	return resource.StatusOK, nil
 }
 
 func (p *builtinProvider) Read(urn resource.URN, id resource.ID,
 	inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
-	contract.Assertf(urn != "", "Read URN was empty")
-	contract.Assertf(id != "", "Read ID was empty")
-	contract.Assert(urn.Type() == stackReferenceType)
+	contract.Requiref(urn != "", "urn", "must not be empty")
+	contract.Requiref(id != "", "id", "must not be empty")
+	contract.Assertf(urn.Type() == stackReferenceType, "expected resource type %v, got %v", stackReferenceType, urn.Type())
 
 	outputs, err := p.readStackReference(state)
 	if err != nil {
@@ -227,8 +227,8 @@ func (p *builtinProvider) SignalCancellation() error {
 
 func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resource.PropertyMap, error) {
 	name, ok := inputs["name"]
-	contract.Assert(ok)
-	contract.Assert(name.IsString())
+	contract.Assertf(ok, "missing required property 'name'")
+	contract.Assertf(name.IsString(), "expected 'name' to be a string")
 
 	if p.backendClient == nil {
 		return nil, errors.New("no backend client is available")
@@ -260,8 +260,8 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 
 func (p *builtinProvider) readStackResourceOutputs(inputs resource.PropertyMap) (resource.PropertyMap, error) {
 	name, ok := inputs["stackName"]
-	contract.Assert(ok)
-	contract.Assert(name.IsString())
+	contract.Assertf(ok, "missing required property 'stackName'")
+	contract.Assertf(name.IsString(), "expected 'stackName' to be a string")
 
 	if p.backendClient == nil {
 		return nil, errors.New("no backend client is available")
@@ -280,8 +280,8 @@ func (p *builtinProvider) readStackResourceOutputs(inputs resource.PropertyMap) 
 
 func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.PropertyMap, error) {
 	urn, ok := inputs["urn"]
-	contract.Assert(ok)
-	contract.Assert(urn.IsString())
+	contract.Assertf(ok, "missing required property 'urn'")
+	contract.Assertf(urn.IsString(), "expected 'urn' to be a string")
 
 	state, ok := p.resources.get(resource.URN(urn.StringValue()))
 	if !ok {

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -337,7 +337,8 @@ func addDefaultProviders(target *Target, source Source, prev *Snapshot) error {
 
 			urn, id := defaultProviderURN(target, source, pkg), resource.ID(uuid.String())
 			ref, err = providers.NewReference(urn, id)
-			contract.Assert(err == nil)
+			contract.Assertf(err == nil,
+				"could not create provider reference with URN %v and ID %v", urn, id)
 
 			provider := &resource.State{
 				Type:    urn.Type(),
@@ -424,9 +425,9 @@ func buildResourceMap(prev *Snapshot, preview bool) ([]*resource.State, map[reso
 func NewDeployment(ctx *plugin.Context, target *Target, prev *Snapshot, plan *Plan, source Source,
 	localPolicyPackPaths []string, preview bool, backendClient BackendClient) (*Deployment, error) {
 
-	contract.Assert(ctx != nil)
-	contract.Assert(target != nil)
-	contract.Assert(source != nil)
+	contract.Requiref(ctx != nil, "ctx", "must not be nil")
+	contract.Requiref(target != nil, "target", "must not be nil")
+	contract.Requiref(source != nil, "source", "must not be nil")
 
 	if err := migrateProviders(target, prev, source); err != nil {
 		return nil, err
@@ -513,7 +514,7 @@ func defaultProviderURN(target *Target, source Source, pkg tokens.Package) resou
 
 // generateEventURN generates a URN for the resource associated with the given event.
 func (d *Deployment) generateEventURN(event SourceEvent) resource.URN {
-	contract.Require(event != nil, "event != nil")
+	contract.Requiref(event != nil, "event", "must not be nil")
 
 	switch e := event.(type) {
 	case RegisterResourceEvent:

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -409,7 +409,7 @@ func (ex *deploymentExecutor) performDeletes(
 // handleSingleEvent handles a single source event. For all incoming events, it produces a chain that needs
 // to be executed and schedules the chain for execution.
 func (ex *deploymentExecutor) handleSingleEvent(event SourceEvent) result.Result {
-	contract.Require(event != nil, "event != nil")
+	contract.Requiref(event != nil, "event", "must not be nil")
 
 	var steps []Step
 	var res result.Result
@@ -570,8 +570,8 @@ func (ex *deploymentExecutor) rebuildBaseState(resourceToStep map[*resource.Stat
 
 		if new == nil {
 			if refresh {
-				contract.Assertf(old.Custom, "Expected custom resource")
-				contract.Assert(!providers.IsProviderType(old.Type))
+				contract.Assertf(old.Custom, "expected custom resource")
+				contract.Assertf(!providers.IsProviderType(old.Type), "expected non-provider resource")
 			}
 			continue
 		}

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -501,7 +501,7 @@ func (rp *ResourcePlan) checkOutputs(
 	oldOutputs resource.PropertyMap,
 	newOutputs resource.PropertyMap,
 ) error {
-	contract.Assert(rp.Goal != nil)
+	contract.Assertf(rp.Goal != nil, "resource plan goal must be set")
 
 	// Check that the property diffs meet the constraints set in the plan.
 	if err := checkDiff(oldOutputs, newOutputs, rp.Goal.OutputDiff); err != nil {
@@ -516,10 +516,14 @@ func (rp *ResourcePlan) checkGoal(
 	newInputs resource.PropertyMap,
 	programGoal *resource.Goal) error {
 
-	contract.Assert(programGoal != nil)
+	contract.Requiref(programGoal != nil, "programGoal", "must not be nil")
 	// rp.Goal may be nil, but if it isn't Type and Name should match
-	contract.Assert(rp.Goal == nil || rp.Goal.Type == programGoal.Type)
-	contract.Assert(rp.Goal == nil || rp.Goal.Name == programGoal.Name)
+	if rp.Goal != nil {
+		contract.Assertf(rp.Goal.Type == programGoal.Type,
+			"resource plan goal type (%v) does not match program goal type (%v)", rp.Goal.Type, programGoal.Type)
+		contract.Assertf(rp.Goal.Name == programGoal.Name,
+			"resource plan goal name (%v) does not match program goal name (%v)", rp.Goal.Type, programGoal.Name)
+	}
 
 	if rp.Goal == nil {
 		// If the plan goal is nil it expected a delete

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -84,9 +84,10 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 
 	fixProvider := func(provider string) string {
 		ref, err := providers.ParseReference(provider)
-		contract.AssertNoError(err)
-		ref, err = providers.NewReference(fixUrn(ref.URN()), ref.ID())
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "malformed provider reference: %s", provider)
+		newURN := fixUrn(ref.URN())
+		ref, err = providers.NewReference(newURN, ref.ID())
+		contract.AssertNoErrorf(err, "could not create provider reference with URN %s and ID %s", newURN, ref.ID())
 		return ref.String()
 	}
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -165,18 +165,18 @@ func (iter *evalSourceIterator) Next() (SourceEvent, result.Result) {
 	// Await the program to compute some more state and then inspect what it has to say.
 	select {
 	case reg := <-iter.regChan:
-		contract.Assert(reg != nil)
+		contract.Assertf(reg != nil, "received a nil registerResourceEvent")
 		goal := reg.Goal()
 		logging.V(5).Infof("EvalSourceIterator produced a registration: t=%v,name=%v,#props=%v",
 			goal.Type, goal.Name, len(goal.Properties))
 		return reg, nil
 	case regOut := <-iter.regOutChan:
-		contract.Assert(regOut != nil)
+		contract.Assertf(regOut != nil, "received a nil registerResourceOutputsEvent")
 		logging.V(5).Infof("EvalSourceIterator produced a completion: urn=%v,#outs=%v",
 			regOut.URN(), len(regOut.Outputs()))
 		return regOut, nil
 	case read := <-iter.regReadChan:
-		contract.Assert(read != nil)
+		contract.Assertf(read != nil, "received a nil readResourceEvent")
 		logging.V(5).Infoln("EvalSourceIterator produced a read")
 		return read, nil
 	case res := <-iter.finChan:
@@ -397,7 +397,7 @@ func (d *defaultProviders) handleRequest(req providers.ProviderRequest) (provide
 	}
 
 	ref, err = providers.NewReference(result.State.URN, id)
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "could not create provider reference with URN %s and ID %s", result.State.URN, id)
 	d.providers[req.String()] = ref
 
 	return ref, nil
@@ -974,7 +974,7 @@ func (rm *resmon) ReadResource(ctx context.Context,
 		return nil, rpcerror.New(codes.Unavailable, "resource monitor shut down while waiting on step's done channel")
 	}
 
-	contract.Assert(result != nil)
+	contract.Assertf(result != nil, "ReadResource operation returned a nil result")
 	marshaled, err := plugin.MarshalProperties(result.State.Outputs, plugin.MarshalOptions{
 		Label:         label,
 		KeepUnknowns:  true,

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -70,16 +70,20 @@ type SameStep struct {
 var _ Step = (*SameStep)(nil)
 
 func NewSameStep(deployment *Deployment, reg RegisterResourceEvent, old, new *resource.State) Step {
-	contract.Assert(old != nil)
-	contract.Assert(old.URN != "")
-	contract.Assert(old.ID != "" || !old.Custom)
-	contract.Assert(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type))
-	contract.Assert(!old.Delete)
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID == "")
-	contract.Assert(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type))
-	contract.Assert(!new.Delete)
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(old.URN != "", "old", "must have a URN")
+	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is custom")
+	contract.Requiref(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type),
+		"old", "must have or be a provider if it is a custom resource")
+	contract.Requiref(!old.Delete, "old", "must not be marked for deletion")
+
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID == "", "new", "must not have an ID")
+	contract.Requiref(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type),
+		"new", "must have or be a provider if it is a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
+
 	return &SameStep{
 		deployment: deployment,
 		reg:        reg,
@@ -93,11 +97,12 @@ func NewSameStep(deployment *Deployment, reg RegisterResourceEvent, old, new *re
 // actually creating the resource, but ensure that we complete resource-registration and convey the
 // right information downstream. For example, we will not write these into the checkpoint file.
 func NewSkippedCreateStep(deployment *Deployment, reg RegisterResourceEvent, new *resource.State) Step {
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID == "")
-	contract.Assert(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type))
-	contract.Assert(!new.Delete)
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID == "", "new", "must not have an ID")
+	contract.Requiref(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type),
+		"new", "must have or be a provider if it is a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
 
 	// Make the old state here a direct copy of the new state
 	old := *new
@@ -161,13 +166,16 @@ type CreateStep struct {
 var _ Step = (*CreateStep)(nil)
 
 func NewCreateStep(deployment *Deployment, reg RegisterResourceEvent, new *resource.State) Step {
-	contract.Assert(reg != nil)
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID == "")
-	contract.Assert(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type))
-	contract.Assert(!new.Delete)
-	contract.Assert(!new.External)
+	contract.Requiref(reg != nil, "reg", "must not be nil")
+
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID == "", "new", "must not have an ID")
+	contract.Requiref(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type),
+		"new", "must have or be a provider if it is a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
+	contract.Requiref(!new.External, "new", "must not be external")
+
 	return &CreateStep{
 		deployment: deployment,
 		reg:        reg,
@@ -178,17 +186,21 @@ func NewCreateStep(deployment *Deployment, reg RegisterResourceEvent, new *resou
 func NewCreateReplacementStep(deployment *Deployment, reg RegisterResourceEvent, old, new *resource.State,
 	keys, diffs []resource.PropertyKey, detailedDiff map[string]plugin.PropertyDiff, pendingDelete bool) Step {
 
-	contract.Assert(reg != nil)
-	contract.Assert(old != nil)
-	contract.Assert(old.URN != "")
-	contract.Assert(old.ID != "" || !old.Custom)
-	contract.Assert(!old.Delete)
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID == "")
-	contract.Assert(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type))
-	contract.Assert(!new.Delete)
-	contract.Assert(!new.External)
+	contract.Requiref(reg != nil, "reg", "must not be nil")
+
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(old.URN != "", "old", "must have a URN")
+	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is a custom resource")
+	contract.Requiref(!old.Delete, "old", "must not be marked for deletion")
+
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID == "", "new", "must not have an ID")
+	contract.Requiref(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type),
+		"new", "must have or be a provider if it is a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
+	contract.Requiref(!new.External, "new", "must not be external")
+
 	return &CreateStep{
 		deployment:    deployment,
 		reg:           reg,
@@ -277,11 +289,12 @@ type DeleteStep struct {
 var _ Step = (*DeleteStep)(nil)
 
 func NewDeleteStep(deployment *Deployment, otherDeletions map[resource.URN]bool, old *resource.State) Step {
-	contract.Assert(old != nil)
-	contract.Assert(old.URN != "")
-	contract.Assert(old.ID != "" || !old.Custom)
-	contract.Assert(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type))
-	contract.Assert(otherDeletions != nil)
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(old.URN != "", "old", "must have a URN")
+	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is a custom resource")
+	contract.Requiref(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type),
+		"old", "must have or be a provider if it is a custom resource")
+	contract.Requiref(otherDeletions != nil, "otherDeletions", "must not be nil")
 	return &DeleteStep{
 		deployment:     deployment,
 		old:            old,
@@ -295,11 +308,13 @@ func NewDeleteReplacementStep(
 	old *resource.State,
 	pendingReplace bool,
 ) Step {
-	contract.Assert(old != nil)
-	contract.Assert(old.URN != "")
-	contract.Assert(old.ID != "" || !old.Custom)
-	contract.Assert(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type))
-	contract.Assert(otherDeletions != nil)
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(old.URN != "", "old", "must have a URN")
+	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is a custom resource")
+	contract.Requiref(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type),
+		"old", "must have or be a provider if it is a custom resource")
+
+	contract.Requiref(otherDeletions != nil, "otherDeletions", "must not be nil")
 
 	// There are two cases in which we create a delete-replacment step:
 	//
@@ -313,7 +328,8 @@ func NewDeleteReplacementStep(
 	// In the latter case, the resource must be deleted, but the deletion may not occur if an earlier step fails.
 	// The engine requires that the fact that the old resource must be deleted is persisted in the checkpoint so
 	// that it can issue a deletion of this resource on the next update to this stack.
-	contract.Assert(pendingReplace != old.Delete)
+	contract.Assertf(pendingReplace != old.Delete,
+		"resource %v cannot be pending replacement and deletion at the same time", old.URN)
 	old.PendingReplacement = pendingReplace
 	return &DeleteStep{
 		deployment:     deployment,
@@ -406,8 +422,8 @@ type RemovePendingReplaceStep struct {
 }
 
 func NewRemovePendingReplaceStep(deployment *Deployment, old *resource.State) Step {
-	contract.Assert(old != nil)
-	contract.Assert(old.PendingReplacement)
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(old.PendingReplacement, "old", "must be pending replacement")
 	return &RemovePendingReplaceStep{
 		deployment: deployment,
 		old:        old,
@@ -446,20 +462,24 @@ var _ Step = (*UpdateStep)(nil)
 
 func NewUpdateStep(deployment *Deployment, reg RegisterResourceEvent, old, new *resource.State,
 	stables, diffs []resource.PropertyKey, detailedDiff map[string]plugin.PropertyDiff,
-
 	ignoreChanges []string) Step {
-	contract.Assert(old != nil)
-	contract.Assert(old.URN != "")
-	contract.Assert(old.ID != "" || !old.Custom)
-	contract.Assert(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type))
-	contract.Assert(!old.Delete)
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID == "")
-	contract.Assert(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type))
-	contract.Assert(!new.Delete)
-	contract.Assert(!new.External)
-	contract.Assert(!old.External)
+
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(old.URN != "", "old", "must have a URN")
+	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is a custom resource")
+	contract.Requiref(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type),
+		"old", "must have or be a provider if it is a custom resource")
+	contract.Requiref(!old.Delete, "old", "must not be marked for deletion")
+	contract.Requiref(!old.External, "old", "must not be an external resource")
+
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID == "", "new", "must not have an ID")
+	contract.Requiref(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type),
+		"new", "must have or be a provider if it is a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
+	contract.Requiref(!new.External, "new", "must not be an external resource")
+
 	return &UpdateStep{
 		deployment:    deployment,
 		reg:           reg,
@@ -543,14 +563,15 @@ var _ Step = (*ReplaceStep)(nil)
 func NewReplaceStep(deployment *Deployment, old, new *resource.State, keys, diffs []resource.PropertyKey,
 	detailedDiff map[string]plugin.PropertyDiff, pendingDelete bool) Step {
 
-	contract.Assert(old != nil)
-	contract.Assert(old.URN != "")
-	contract.Assert(old.ID != "" || !old.Custom)
-	contract.Assert(!old.Delete)
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(old.URN != "", "old", "must have a URN")
+	contract.Requiref(old.ID != "" || !old.Custom, "old", "must have an ID if it is a custom resource")
+	contract.Requiref(!old.Delete, "old", "must not be marked for deletion")
+
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
 	// contract.Assert(new.ID == "")
-	contract.Assert(!new.Delete)
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
 	return &ReplaceStep{
 		deployment:    deployment,
 		old:           old,
@@ -577,7 +598,8 @@ func (s *ReplaceStep) Logical() bool                                { return tru
 
 func (s *ReplaceStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error) {
 	// If this is a pending delete, we should have marked the old resource for deletion in the CreateReplacement step.
-	contract.Assert(!s.pendingDelete || s.old.Delete)
+	contract.Assertf(!s.pendingDelete || s.old.Delete,
+		"old resource %v should be marked for deletion if pending delete", s.old.URN)
 	return resource.StatusOK, func() {}, nil
 }
 
@@ -601,16 +623,17 @@ type ReadStep struct {
 
 // NewReadStep creates a new Read step.
 func NewReadStep(deployment *Deployment, event ReadResourceEvent, old, new *resource.State) Step {
-	contract.Assert(new != nil)
-	contract.Assertf(new.URN != "", "Read URN was empty")
-	contract.Assertf(new.ID != "", "Read ID was empty")
-	contract.Assertf(new.External, "target of Read step must be marked External")
-	contract.Assertf(new.Custom, "target of Read step must be Custom")
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID != "", "new", "must have an ID")
+	contract.Requiref(new.External, "new", "must be marked as external")
+	contract.Requiref(new.Custom, "new", "must be a custom resource")
 
 	// If Old was given, it's either an external resource or its ID is equal to the
 	// ID that we are preparing to read.
 	if old != nil {
-		contract.Assert(old.ID == new.ID || old.External)
+		contract.Requiref(old.ID == new.ID || old.External,
+			"old", "must have the same ID as new or be external")
 	}
 
 	return &ReadStep{
@@ -625,13 +648,15 @@ func NewReadStep(deployment *Deployment, event ReadResourceEvent, old, new *reso
 // NewReadReplacementStep creates a new Read step with the `replacing` flag set. When executed,
 // it will pend deletion of the "old" resource, which must not be an external resource.
 func NewReadReplacementStep(deployment *Deployment, event ReadResourceEvent, old, new *resource.State) Step {
-	contract.Assert(new != nil)
-	contract.Assertf(new.URN != "", "Read URN was empty")
-	contract.Assertf(new.ID != "", "Read ID was empty")
-	contract.Assertf(new.External, "target of ReadReplacement step must be marked External")
-	contract.Assertf(new.Custom, "target of ReadReplacement step must be Custom")
-	contract.Assert(old != nil)
-	contract.Assertf(!old.External, "old target of ReadReplacement step must not be External")
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID != "", "new", "must have an ID")
+	contract.Requiref(new.External, "new", "must be marked as external")
+	contract.Requiref(new.Custom, "new", "must be a custom resource")
+
+	contract.Requiref(old != nil, "old", "must not be nil")
+	contract.Requiref(!old.External, "old", "must not be marked as external")
+
 	return &ReadStep{
 		deployment: deployment,
 		event:      event,
@@ -724,7 +749,7 @@ type RefreshStep struct {
 
 // NewRefreshStep creates a new Refresh step.
 func NewRefreshStep(deployment *Deployment, old *resource.State, done chan<- bool) Step {
-	contract.Assert(old != nil)
+	contract.Requiref(old != nil, "old", "must not be nil")
 
 	// NOTE: we set the new state to the old state by default so that we don't interpret step failures as deletes.
 	return &RefreshStep{
@@ -840,13 +865,13 @@ type ImportStep struct {
 func NewImportStep(deployment *Deployment, reg RegisterResourceEvent, new *resource.State,
 	ignoreChanges []string, randomSeed []byte) Step {
 
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID != "")
-	contract.Assert(new.Custom)
-	contract.Assert(!new.Delete)
-	contract.Assert(!new.External)
-	contract.Assert(randomSeed != nil)
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID != "", "new", "must have an ID")
+	contract.Requiref(new.Custom, "new", "must be a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
+	contract.Requiref(!new.External, "new", "must not be external")
+	contract.Requiref(randomSeed != nil, "randomSeed", "must not be nil")
 
 	return &ImportStep{
 		deployment:    deployment,
@@ -860,14 +885,16 @@ func NewImportStep(deployment *Deployment, reg RegisterResourceEvent, new *resou
 func NewImportReplacementStep(deployment *Deployment, reg RegisterResourceEvent, original, new *resource.State,
 	ignoreChanges []string, randomSeed []byte) Step {
 
-	contract.Assert(original != nil)
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID != "")
-	contract.Assert(new.Custom)
-	contract.Assert(!new.Delete)
-	contract.Assert(!new.External)
-	contract.Assert(randomSeed != nil)
+	contract.Requiref(original != nil, "original", "must not be nil")
+
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID != "", "new", "must have an ID")
+	contract.Requiref(new.Custom, "new", "must be a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
+	contract.Requiref(!new.External, "new", "must not be external")
+
+	contract.Requiref(randomSeed != nil, "randomSeed", "must not be nil")
 
 	return &ImportStep{
 		deployment:    deployment,
@@ -881,13 +908,14 @@ func NewImportReplacementStep(deployment *Deployment, reg RegisterResourceEvent,
 }
 
 func newImportDeploymentStep(deployment *Deployment, new *resource.State, randomSeed []byte) Step {
-	contract.Assert(new != nil)
-	contract.Assert(new.URN != "")
-	contract.Assert(new.ID != "")
-	contract.Assert(new.Custom)
-	contract.Assert(!new.Delete)
-	contract.Assert(!new.External)
-	contract.Assert(randomSeed != nil)
+	contract.Requiref(new != nil, "new", "must not be nil")
+	contract.Requiref(new.URN != "", "new", "must have a URN")
+	contract.Requiref(new.ID != "", "new", "must have an ID")
+	contract.Requiref(new.Custom, "new", "must be a custom resource")
+	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
+	contract.Requiref(!new.External, "new", "must not be external")
+
+	contract.Requiref(randomSeed != nil, "randomSeed", "must not be nil")
 
 	return &ImportStep{
 		deployment: deployment,
@@ -969,7 +997,7 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 
 	// If this step came from an import deployment, we need to fetch any required inputs from the state.
 	if s.planned {
-		contract.Assert(len(s.new.Inputs) == 0)
+		contract.Assertf(len(s.new.Inputs) == 0, "import resource cannot have existing inputs")
 
 		// Get the import object and see if it had properties set
 		var inputProperties []string
@@ -1008,7 +1036,7 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			var errorMessage string
 			if len(inputProperties) == 0 {
 				ref, err := providers.ParseReference(s.Provider())
-				contract.Assert(err == nil)
+				contract.AssertNoErrorf(err, "failed to parse provider reference %q", s.Provider())
 
 				pkgName := ref.URN().Type().Name()
 				errorMessage = fmt.Sprintf("This is almost certainly a bug in the `%s` provider.", pkgName)


### PR DESCRIPTION
pkg/resource/deploy has a bunch of Assert usages
without messages.

This migrates all of them to `*f` variants,
preferring `Requiref` for paramters.

Refs #12132
