### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/scripts/set-output
+++ b/.github/scripts/set-output
@@ -22,4 +22,4 @@ OUTPUT_NAME="$1"
 VALUE="$2"
 
 ESCAPED="$(echo -n "${VALUE}" | jq -Rsc ".")" # JSON encode
-echo "::set-output name=${OUTPUT_NAME}::${ESCAPED}"
+echo "${OUTPUT_NAME}=${ESCAPED}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -205,8 +205,9 @@ jobs:
           cache: enable
       - name: Generate artifact name
         id: goenv
+        shell: bash
         run: |
-          echo "::set-output name=CLI-TARGET::$(go env GOOS)-$(go env GOARCH)"
+          echo "CLI-TARGET=$(go env GOOS)-$(go env GOARCH)" >> "${GITHUB_OUTPUT}"
 
       # Ensure tests do not rely on pre-installed packages in CI. Unit tests must run absent a local
       # Pulumi install, and integration tests must only test the version built by CI.

--- a/.github/workflows/ci-test-docs-generation.yml
+++ b/.github/workflows/ci-test-docs-generation.yml
@@ -133,8 +133,8 @@ jobs:
 
           popd
 
-          echo "::set-output name=branchName::${BRANCH_NAME}"
-          echo "::set-output name=prNumber::${PR_NUMBER}"
+          echo "branchName=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "prNumber=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
 
       - name: Create draft docs PR
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |
@@ -36,8 +36,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >>" ${GITHUB_OUTPUT}"
       - run: command -v pulumi
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
@@ -62,8 +62,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
       - run: command -v pulumi
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
@@ -87,8 +87,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |
@@ -106,8 +106,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |
@@ -151,8 +151,8 @@ jobs:
       - name: Pulumi Version Details
         id: vars
         run: |
-          echo "::set-output name=installed-version::$(pulumi version)"
-          echo "::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)"
+          echo "installed-version=$(pulumi version)" >> "${GITHUB_OUTPUT}"
+          echo "expected-version=v$(curl -sS https://www.pulumi.com/latest-version)" >> "${GITHUB_OUTPUT}"
       - name: Error if incorrect version found
         if: ${{ steps.vars.outputs.expected-version != steps.vars.outputs.installed-version }}
         run: |

--- a/.github/workflows/pr-test-codegen-test-on-dispatch.yml
+++ b/.github/workflows/pr-test-codegen-test-on-dispatch.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Create URL to the run output
         id: vars
-        run: echo "::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${GITHUB_OUTPUT}"
       - name: Update with Result
         uses: peter-evans/create-or-update-comment@v2
         with:

--- a/.github/workflows/pr-test-docs-generation-on-dispatch.yml
+++ b/.github/workflows/pr-test-docs-generation-on-dispatch.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Create URL to the run output
         id: vars
-        run: echo "::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${GITHUB_OUTPUT}"
       - name: Update with Result
         uses: peter-evans/create-or-update-comment@v1
         with:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #12244 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
