### PR TITLE
bors: Drop lint requirement

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -8,8 +8,4 @@ status = [
 ]
 pr_status = [
 	'linear-history',
-	'CI / Lint / Lint GHA',
-	'CI / Lint / Lint Go',
-	'CI / Lint / Lint Protobufs',
-	'CI / Lint / Lint SDKs',
 ]


### PR DESCRIPTION
Temporarily dropping lint requirement from bors
to unblock merging community PRs.

(Lint will still run as part of the merge workflow. This only drops it as a requirement for attempting the merge.)

Refs #12248
