### PR TITLE
ci/rebase: Run for members and owners

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -7,7 +7,7 @@ jobs:
     name: Rebase
     runs-on: ubuntu-latest
     if: >-
-      github.event.comment.author_association == 'COLLABORATOR' &&
+      contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.comment.author_association) &&
       github.event.issue.pull_request != '' && 
       (
         contains(github.event.comment.body, '/rebase') || 


### PR DESCRIPTION
The `/rebase` command only runs for collaborators right now, but not for repository members or owners.
This updates the job to support the command from owners and members.
(See https://docs.github.com/en/graphql/reference/enums#commentauthorassociation.)

The `fromJSON` business is necessary to be able to represent the array in the GitHub expression.
(See https://docs.github.com/en/actions/learn-github-actions/expressio˚ns#example-matching-an-array-of-strings.)

Refs #12251
