### PR TITLE
pkg/codegen/python: Prefer contract.Assertf over Assert

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -161,8 +161,9 @@ func (mod *modContext) details(t *schema.ObjectType) *typeDetails {
 func (mod *modContext) modNameAndName(pkg schema.PackageReference, t schema.Type, input bool) (modName string, name string) {
 	var info PackageInfo
 	p, err := pkg.Definition()
-	contract.AssertNoError(err)
-	contract.AssertNoError(p.ImportLanguages(map[string]schema.Language{"python": Importer}))
+	contract.AssertNoErrorf(err, "error loading definition for package %q", pkg.Name())
+	contract.AssertNoErrorf(p.ImportLanguages(map[string]schema.Language{"python": Importer}),
+		"error importing python language plugin for package %q", pkg.Name())
 	if v, ok := p.Language["python"].(PackageInfo); ok {
 		info = v
 	}
@@ -378,7 +379,7 @@ func typingImports() []string {
 
 func (mod *modContext) generateCommonImports(w io.Writer, imports imports, typingImports []string) {
 	rel, err := filepath.Rel(mod.mod, "")
-	contract.Assert(err == nil)
+	contract.AssertNoErrorf(err, "could not turn %q into a relative path", mod.mod)
 	relRoot := path.Dir(rel)
 	relImport := relPathToRelImport(relRoot)
 
@@ -744,7 +745,7 @@ func (mod *modContext) genInit(exports []string) string {
 	// If there are resources in this module, register the module with the runtime.
 	if len(mod.resources) != 0 {
 		err := genResourceMappings(mod, w)
-		contract.Assert(err == nil)
+		contract.AssertNoErrorf(err, "error generating resource mappings")
 	}
 
 	return w.String()
@@ -752,14 +753,14 @@ func (mod *modContext) genInit(exports []string) string {
 
 func (mod *modContext) getRelImportFromRoot() string {
 	rel, err := filepath.Rel(mod.mod, "")
-	contract.Assert(err == nil)
+	contract.AssertNoErrorf(err, "error turning %q into a relative path", mod.mod)
 	relRoot := path.Dir(rel)
 	return relPathToRelImport(relRoot)
 }
 
 func (mod *modContext) genUtilitiesImport() string {
 	rel, err := filepath.Rel(mod.mod, "")
-	contract.Assert(err == nil)
+	contract.AssertNoErrorf(err, "error turning %q into a relative path", mod.mod)
 	relRoot := path.Dir(rel)
 	relImport := relPathToRelImport(relRoot)
 	return fmt.Sprintf("from %s import _utilities", relImport)
@@ -772,7 +773,7 @@ func (mod *modContext) importObjectType(t *schema.ObjectType, input bool) string
 
 	tok := t.Token
 	parts := strings.Split(tok, ":")
-	contract.Assert(len(parts) == 3)
+	contract.Assertf(len(parts) == 3, "type token %q is not in the form '<pkg>:<mod>:<type>'", tok)
 	refPkgName := parts[0]
 
 	modName := mod.tokenToModule(tok)
@@ -828,7 +829,7 @@ func (mod *modContext) importResourceType(r *schema.ResourceType) string {
 
 	tok := r.Token
 	parts := strings.Split(tok, ":")
-	contract.Assert(len(parts) == 3)
+	contract.Assertf(len(parts) == 3, "type token %q is not in the form '<pkg>:<mod>:<type>'", tok)
 
 	// If it's a provider resource, import the top-level package.
 	if parts[0] == "pulumi" && parts[1] == "providers" {

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -241,7 +241,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 			}
 			return n, nil
 		})
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "unexpected diagnostics reported: %v", diags)
 	}
 
 	var imports []string
@@ -319,7 +319,7 @@ func resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) {
 			})
 		} else {
 			err = pkg.ImportLanguages(map[string]schema.Language{"python": Importer})
-			contract.AssertNoError(err)
+			contract.AssertNoErrorf(err, "failed to import python language plugin for package %s", pkg.Name)
 			if lang, ok := pkg.Language["python"]; ok {
 				pkgInfo := lang.(PackageInfo)
 				if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {
@@ -351,13 +351,13 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type)
 
 	// Example: aws, s3/BucketLogging, BucketLogging, []Diagnostics
 	pkgName, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
-	contract.Assert(len(diagnostics) == 0)
+	contract.Assertf(len(diagnostics) == 0, "unexpected diagnostics reported: %v", diagnostics)
 
 	modName := objType.PackageReference.TokenToModule(token)
 
 	// Normalize module.
 	pkg, err := objType.PackageReference.Definition()
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error loading definition for package %q", objType.PackageReference.Name())
 	if lang, ok := pkg.Language["python"]; ok {
 		pkgInfo := lang.(PackageInfo)
 		if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -214,7 +214,7 @@ func (g *generator) getFunctionImports(x *model.FunctionCallExpression) []string
 	}
 
 	pkg, _, _, diags := functionName(x.Args[0])
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	return []string{"pulumi_" + pkg}
 }
 
@@ -256,7 +256,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 						tag = fmt.Sprintf("%v", member.Value)
 					}
 					tag, err := makeSafeEnumName(tag, enumName)
-					contract.AssertNoError(err)
+					contract.AssertNoErrorf(err, "error sanitizing enum name")
 					g.Fgenf(w, "%s.%s.%s", pkg, enumName, tag)
 				}, func(from model.Expression) {
 					g.Fgenf(w, "%s.%s(%.v)", pkg, enumName, from)
@@ -305,7 +305,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 
 		pkg, module, fn, diags := functionName(expr.Args[0])
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 		if module != "" {
 			module = "." + module
 		}
@@ -542,7 +542,7 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, p
 		switch key.Type() {
 		case cty.String:
 			keyVal := key.AsString()
-			contract.Assert(isLegalIdentifier(keyVal))
+			contract.Assertf(isLegalIdentifier(keyVal), "illegal identifier: %q", keyVal)
 			g.Fgenf(w, ".%s", keyVal)
 		case cty.Number:
 			idx, _ := key.AsBigFloat().Int64()

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -58,7 +58,7 @@ func (g *generator) parseProxyApply(parameters codegen.Set, args []model.Express
 	}
 
 	diags := arg.Typecheck(false)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	return arg, true
 }
 

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -256,7 +256,7 @@ func (qa *quoteAllocator) freeExpression(x model.Expression) (model.Expression, 
 	}
 
 	quotes, ok := qa.allocations.quotes[x]
-	contract.Assert(ok)
+	contract.Assertf(ok, "cannot free unknown expression")
 	qa.free(quotes)
 	return x, nil
 }


### PR DESCRIPTION
Incremental step towards #12132

Migrates uses of contract.{Assert, AssertNoError, Require}
to `*f` variants so that we're required to provide more error context.

Refs #12132
