### PR TITLE
Added the missing path flag to honor the CLI behavior

### DIFF
--- a/changelog/pending/20230223--auto-go--fixed-missing-path-flag-to-honor-the-cli-behavior.yaml
+++ b/changelog/pending/20230223--auto-go--fixed-missing-path-flag-to-honor-the-cli-behavior.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Added support for the path option for config operations

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -134,8 +134,24 @@ func (l *LocalWorkspace) PostCommandCallback(ctx context.Context, stackName stri
 // GetConfig returns the value associated with the specified stack name and key,
 // scoped to the current workspace. LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetConfig(ctx context.Context, stackName string, key string) (ConfigValue, error) {
+	return l.GetConfigWithOptions(ctx, stackName, key, nil)
+}
+
+// GetConfigWithOptions returns the value associated with the specified stack name and key,
+// using the optional ConfigOptions, scoped to the current workspace.
+// LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
+func (l *LocalWorkspace) GetConfigWithOptions(
+	ctx context.Context, stackName string, key string, opts *ConfigOptions,
+) (ConfigValue, error) {
 	var val ConfigValue
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "get", key, "--json", "--stack", stackName)
+	args := []string{"config", "get"}
+	if opts != nil {
+		if opts.Path {
+			args = append(args, "--path")
+		}
+	}
+	args = append(args, key, "--json", "--stack", stackName)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
 		return val, newAutoError(fmt.Errorf("unable to read config: %w", err), stdout, stderr, errCode)
 	}
@@ -164,14 +180,27 @@ func (l *LocalWorkspace) GetAllConfig(ctx context.Context, stackName string) (Co
 // SetConfig sets the specified key-value pair on the provided stack name.
 // LocalWorkspace writes this value to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) SetConfig(ctx context.Context, stackName string, key string, val ConfigValue) error {
+	return l.SetConfigWithOptions(ctx, stackName, key, val, nil)
+}
+
+// SetConfigWithOptions sets the specified key-value pair on the provided stack name using the optional ConfigOptions.
+// LocalWorkspace writes this value to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
+func (l *LocalWorkspace) SetConfigWithOptions(
+	ctx context.Context, stackName string, key string, val ConfigValue, opts *ConfigOptions,
+) error {
+	args := []string{"config", "set", "--stack", stackName}
+	if opts != nil {
+		if opts.Path {
+			args = append(args, "--path")
+		}
+	}
 	secretArg := "--plaintext"
 	if val.Secret {
 		secretArg = "--secret"
 	}
+	args = append(args, key, secretArg, "--non-interactive", "--", val.Value)
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx,
-		"config", "set", key, secretArg, "--stack", stackName,
-		"--non-interactive", "--", val.Value)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
 		return newAutoError(fmt.Errorf("unable to set config: %w", err), stdout, stderr, errCode)
 	}
@@ -181,8 +210,21 @@ func (l *LocalWorkspace) SetConfig(ctx context.Context, stackName string, key st
 // SetAllConfig sets all values in the provided config map for the specified stack name.
 // LocalWorkspace writes the config to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) SetAllConfig(ctx context.Context, stackName string, config ConfigMap) error {
-	args := []string{"config", "set-all", "--stack", stackName}
+	return l.SetAllConfigWithOptions(ctx, stackName, config, nil)
+}
 
+// SetAllConfigWithOptions sets all values in the provided config map for the specified stack name
+// using the optional ConfigOptions.
+// LocalWorkspace writes the config to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
+func (l *LocalWorkspace) SetAllConfigWithOptions(
+	ctx context.Context, stackName string, config ConfigMap, opts *ConfigOptions,
+) error {
+	args := []string{"config", "set-all", "--stack", stackName}
+	if opts != nil {
+		if opts.Path {
+			args = append(args, "--path")
+		}
+	}
 	for k, v := range config {
 		secretArg := "--plaintext"
 		if v.Secret {
@@ -201,7 +243,22 @@ func (l *LocalWorkspace) SetAllConfig(ctx context.Context, stackName string, con
 // RemoveConfig removes the specified key-value pair on the provided stack name.
 // It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) RemoveConfig(ctx context.Context, stackName string, key string) error {
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "rm", key, "--stack", stackName)
+	return l.RemoveConfigWithOptions(ctx, stackName, key, nil)
+}
+
+// RemoveConfigWithOptions removes the specified key-value pair on the provided stack name.
+// It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
+func (l *LocalWorkspace) RemoveConfigWithOptions(
+	ctx context.Context, stackName string, key string, opts *ConfigOptions,
+) error {
+	args := []string{"config", "rm"}
+	if opts != nil {
+		if opts.Path {
+			args = append(args, "--path")
+		}
+	}
+	args = append(args, key, "--stack", stackName)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
 		return newAutoError(fmt.Errorf("could not remove config: %w", err), stdout, stderr, errCode)
 	}
@@ -211,7 +268,21 @@ func (l *LocalWorkspace) RemoveConfig(ctx context.Context, stackName string, key
 // RemoveAllConfig removes all values in the provided key list for the specified stack name
 // It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) RemoveAllConfig(ctx context.Context, stackName string, keys []string) error {
+	return l.RemoveAllConfigWithOptions(ctx, stackName, keys, nil)
+}
+
+// RemoveAllConfigWithOptions removes all values in the provided key list for the specified stack name
+// using the optional ConfigOptions
+// It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
+func (l *LocalWorkspace) RemoveAllConfigWithOptions(
+	ctx context.Context, stackName string, keys []string, opts *ConfigOptions,
+) error {
 	args := []string{"config", "rm-all", "--stack", stackName}
+	if opts != nil {
+		if opts.Path {
+			args = append(args, "--path")
+		}
+	}
 	args = append(args, keys...)
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -671,6 +671,11 @@ func (s *Stack) GetConfig(ctx context.Context, key string) (ConfigValue, error) 
 	return s.Workspace().GetConfig(ctx, s.Name(), key)
 }
 
+// GetConfigWithOptions returns the config value associated with the specified key using the optional ConfigOptions.
+func (s *Stack) GetConfigWithOptions(ctx context.Context, key string, opts *ConfigOptions) (ConfigValue, error) {
+	return s.Workspace().GetConfigWithOptions(ctx, s.Name(), key, opts)
+}
+
 // GetAllConfig returns the full config map.
 func (s *Stack) GetAllConfig(ctx context.Context) (ConfigMap, error) {
 	return s.Workspace().GetAllConfig(ctx, s.Name())
@@ -681,9 +686,19 @@ func (s *Stack) SetConfig(ctx context.Context, key string, val ConfigValue) erro
 	return s.Workspace().SetConfig(ctx, s.Name(), key, val)
 }
 
+// SetConfigWithOptions sets the specified config key-value pair using the optional ConfigOptions.
+func (s *Stack) SetConfigWithOptions(ctx context.Context, key string, val ConfigValue, opts *ConfigOptions) error {
+	return s.Workspace().SetConfigWithOptions(ctx, s.Name(), key, val, opts)
+}
+
 // SetAllConfig sets all values in the provided config map.
 func (s *Stack) SetAllConfig(ctx context.Context, config ConfigMap) error {
 	return s.Workspace().SetAllConfig(ctx, s.Name(), config)
+}
+
+// SetAllConfigWithOptions sets all values in the provided config map using the optional ConfigOptions.
+func (s *Stack) SetAllConfigWithOptions(ctx context.Context, config ConfigMap, opts *ConfigOptions) error {
+	return s.Workspace().SetAllConfigWithOptions(ctx, s.Name(), config, opts)
 }
 
 // RemoveConfig removes the specified config key-value pair.
@@ -691,9 +706,19 @@ func (s *Stack) RemoveConfig(ctx context.Context, key string) error {
 	return s.Workspace().RemoveConfig(ctx, s.Name(), key)
 }
 
+// RemoveConfigWithOptions removes the specified config key-value pair using the optional ConfigOptions.
+func (s *Stack) RemoveConfigWithOptions(ctx context.Context, key string, opts *ConfigOptions) error {
+	return s.Workspace().RemoveConfigWithOptions(ctx, s.Name(), key, opts)
+}
+
 // RemoveAllConfig removes all values in the provided list of keys.
 func (s *Stack) RemoveAllConfig(ctx context.Context, keys []string) error {
 	return s.Workspace().RemoveAllConfig(ctx, s.Name(), keys)
+}
+
+// RemoveAllConfigWithOptions removes all values in the provided list of keys using the optional ConfigOptions.
+func (s *Stack) RemoveAllConfigWithOptions(ctx context.Context, keys []string, opts *ConfigOptions) error {
+	return s.Workspace().RemoveAllConfigWithOptions(ctx, s.Name(), keys, opts)
 }
 
 // RefreshConfig gets and sets the config map used with the last Update.

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -47,16 +47,32 @@ type Workspace interface {
 	// GetConfig returns the value associated with the specified stack name and key,
 	// scoped to the current workspace.
 	GetConfig(context.Context, string, string) (ConfigValue, error)
+	// GetConfigWithOptions returns the value associated with the specified stack name and key
+	// using the optional ConfigOptions,
+	// scoped to the current workspace.
+	GetConfigWithOptions(context.Context, string, string, *ConfigOptions) (ConfigValue, error)
 	// GetAllConfig returns the config map for the specified stack name, scoped to the current workspace.
 	GetAllConfig(context.Context, string) (ConfigMap, error)
 	// SetConfig sets the specified key-value pair on the provided stack name.
 	SetConfig(context.Context, string, string, ConfigValue) error
+	// SetConfigWithOptions sets the specified key-value pair on the provided stack name
+	// using the optional ConfigOptions.
+	SetConfigWithOptions(context.Context, string, string, ConfigValue, *ConfigOptions) error
 	// SetAllConfig sets all values in the provided config map for the specified stack name.
 	SetAllConfig(context.Context, string, ConfigMap) error
+	// SetAllConfigWithOptions sets all values in the provided config map for the specified stack name
+	// using the optional ConfigOptions.
+	SetAllConfigWithOptions(context.Context, string, ConfigMap, *ConfigOptions) error
 	// RemoveConfig removes the specified key-value pair on the provided stack name.
 	RemoveConfig(context.Context, string, string) error
+	// RemoveConfigWithOptions removes the specified key-value pair on the provided stack name
+	// using the optional ConfigOptions.
+	RemoveConfigWithOptions(context.Context, string, string, *ConfigOptions) error
 	// RemoveAllConfig removes all values in the provided key list for the specified stack name.
 	RemoveAllConfig(context.Context, string, []string) error
+	// RemoveAllConfigWithOptions removes all values in the provided key list for the specified stack name
+	// using the optional ConfigOptions.
+	RemoveAllConfigWithOptions(context.Context, string, []string, *ConfigOptions) error
 	// RefreshConfig gets and sets the config map used with the last Update for Stack matching stack name.
 	RefreshConfig(context.Context, string) (ConfigMap, error)
 	// GetTag returns the value associated with the specified stack name and key.
@@ -129,6 +145,12 @@ type Workspace interface {
 type ConfigValue struct {
 	Value  string
 	Secret bool
+}
+
+// ConfigOptions is a configuration option used by a Pulumi program.
+// Allows to use the path flag while getting/setting the configuration.
+type ConfigOptions struct {
+	Path bool
 }
 
 // ConfigMap is a map of ConfigValue used by Pulumi programs.


### PR DESCRIPTION
Added the missing --path flag to solve the gap with the CLI and honor the same behavior. Fix #12254

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This solves the gap between the CLI and the automation API.

Fixes # (issue)
https://github.com/pulumi/pulumi/issues/12254
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
