### PR TITLE
pkg/codegen/nodejs: Prefer contract.Assertf over Assert

### DIFF
--- a/pkg/codegen/nodejs/gen_lazyloads.go
+++ b/pkg/codegen/nodejs/gen_lazyloads.go
@@ -57,7 +57,7 @@ func (ll *lazyLoadGen) genReexport(w io.Writer, exp fileInfo, importPath string)
 func (*lazyLoadGen) genLazyLoads(w io.Writer, importPath string, properties ...string) {
 	sort.Strings(properties)
 	j, err := json.Marshal(properties)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "error serializing properties")
 	fmt.Fprintf(w, "utilities.lazyLoad(exports, %s, () => require(%q));\n",
 		string(j), importPath)
 }

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -324,7 +324,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 			}
 			return n, nil
 		})
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	}
 
 	var sortedVals = importSet.SortedValues()
@@ -399,9 +399,9 @@ func moduleName(module string, pkg schema.PackageReference) string {
 	// Normalize module.
 	if pkg != nil {
 		def, err := pkg.Definition()
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "error loading package definition for %q", pkg.Name())
 		err = def.ImportLanguages(map[string]schema.Language{"nodejs": Importer})
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "error importing nodejs language for %q", pkg.Name())
 		if lang, ok := def.Language["nodejs"]; ok {
 			pkgInfo := lang.(NodePackageInfo)
 			if m, ok := pkgInfo.ModuleToPackage[module]; ok {

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -244,12 +244,12 @@ func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, en
 
 	if litFrom, ok := from.(*model.LiteralValueExpression); ok {
 		fromV, err := convert.Convert(litFrom.Value, cty.Number)
-		contract.Assert(err == nil)
+		contract.AssertNoErrorf(err, "conversion of %v to number failed", litFrom.Value.Type())
 
 		from, _ := fromV.AsBigFloat().Int64()
 		if litTo, ok := to.(*model.LiteralValueExpression); ok {
 			toV, err := convert.Convert(litTo.Value, cty.Number)
-			contract.Assert(err == nil)
+			contract.AssertNoErrorf(err, "conversion of %v to number failed", litTo.Value.Type())
 
 			to, _ := toV.AsBigFloat().Int64()
 			if from == 0 {
@@ -296,7 +296,7 @@ func (g *generator) getFunctionImports(x *model.FunctionCallExpression) []string
 	}
 
 	pkg, _, _, diags := functionName(x.Args[0])
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	return []string{"@pulumi/" + pkg}
 }
 
@@ -405,7 +405,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "computeFilebase64sha256(%v)", expr.Args[0])
 	case pcl.Invoke:
 		pkg, module, fn, diags := functionName(expr.Args[0])
-		contract.Assert(len(diags) == 0)
+		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 		if module != "" {
 			module = "." + module
 		}

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -107,7 +107,7 @@ func (g *generator) parseProxyApply(parameters codegen.Set, args []model.Express
 	}
 
 	diags := arg.Typecheck(false)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected type error: %v", diags)
 	return arg, true
 }
 
@@ -123,7 +123,7 @@ func callbackParameterReferences(expr model.Expression, parameters codegen.Set) 
 	}
 
 	_, diags := model.VisitExpression(expr, model.IdentityVisitor, visitor)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected type error: %v", diags)
 	return refs
 }
 
@@ -156,7 +156,7 @@ func (g *generator) parseInterpolate(parameters codegen.Set, args []model.Expres
 		proxyArgs := make([]model.Expression, len(parameterRefs))
 		for i, p := range parameterRefs {
 			argIndex, ok := indices[p]
-			contract.Assert(ok)
+			contract.Assertf(ok, "parameter index not found")
 
 			proxyArgs[i] = args[argIndex]
 		}
@@ -226,7 +226,7 @@ func (g *generator) lowerProxyApplies(expr model.Expression) (model.Expression, 
 // this changes in the future, this transform will need to be applied in a more general way (e.g. by the apply
 // rewriter).
 func (g *generator) awaitInvokes(x model.Expression) model.Expression {
-	contract.Assert(g.asyncMain)
+	contract.Assertf(g.asyncMain, "main must be async to wrap invokes with await")
 
 	rewriter := func(x model.Expression) (model.Expression, hcl.Diagnostics) {
 		// Ignore the node if it is not a call to invoke.
@@ -236,11 +236,11 @@ func (g *generator) awaitInvokes(x model.Expression) model.Expression {
 		}
 
 		_, isPromise := call.Type().(*model.PromiseType)
-		contract.Assert(isPromise)
+		contract.Assertf(isPromise, "invoke must return a promise")
 
 		return newAwaitCall(call), nil
 	}
 	x, diags := model.VisitExpression(x, model.IdentityVisitor, rewriter)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
 	return x
 }

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -135,7 +135,7 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 func escape(s string) string {
 	// Seems the most fool-proof way of doing this is by using the JSON marshaler and then stripping the surrounding quotes
 	escaped, err := json.Marshal(s)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "JSON(%q)", s)
 	contract.Assertf(len(escaped) >= 2, "JSON(%s) expected a quoted string but returned %s", s, escaped)
 	contract.Assertf(
 		escaped[0] == byte('"') && escaped[len(escaped)-1] == byte('"'),


### PR DESCRIPTION
Incremental step towards #12132

Migrates uses of contract.{Assert, AssertNoError, Require}
to `*f` variants so that we're required to provide more error context.

Refs #12132
