### PR TITLE
chore(all): strings.Replace(..., -1) => strings.Replace(...)

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -60,7 +60,7 @@ type OverStackLimitError struct {
 
 func (e OverStackLimitError) Error() string {
 	m := e.Message
-	m = strings.Replace(m, "Conflict: ", "over stack limit: ", -1)
+	m = strings.ReplaceAll(m, "Conflict: ", "over stack limit: ")
 	return m
 }
 

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -58,7 +58,7 @@ func (rp *cloudRequiredPolicy) Install(ctx context.Context) (string, error) {
 		version = strconv.Itoa(policy.Version)
 	}
 	policyPackPath, installed, err := workspace.GetPolicyPath(rp.OrgName(),
-		strings.Replace(policy.Name, tokens.QNameDelimiter, "_", -1), version)
+		strings.ReplaceAll(policy.Name, tokens.QNameDelimiter, "_"), version)
 	if err != nil {
 		// Failed to get a sensible PolicyPack path.
 		return "", err

--- a/pkg/cmd/pulumi/convert_test.go
+++ b/pkg/cmd/pulumi/convert_test.go
@@ -55,7 +55,7 @@ func TestPclConvert(t *testing.T) {
 	// On Windows, we need to replace \r\n with \n to match the expected string below
 	pclCode := string(pclBytes)
 	if runtime.GOOS == "windows" {
-		pclCode = strings.Replace(pclCode, "\r\n", "\n", -1)
+		pclCode = strings.ReplaceAll(pclCode, "\r\n", "\n")
 	}
 	expectedPclCode := `key = readFile("key.pub")
 

--- a/pkg/cmd/pulumi/gen_markdown.go
+++ b/pkg/cmd/pulumi/gen_markdown.go
@@ -50,7 +50,7 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 
 				// Add some front matter to each file.
 				fileNameWithoutExtension := strings.TrimSuffix(filepath.Base(s), ".md")
-				title := strings.Replace(fileNameWithoutExtension, "_", " ", -1)
+				title := strings.ReplaceAll(fileNameWithoutExtension, "_", " ")
 				buf := new(bytes.Buffer)
 				buf.WriteString("---\n")
 				buf.WriteString(fmt.Sprintf("title: %q\n", title))

--- a/pkg/cmd/pulumi/policy_ls.go
+++ b/pkg/cmd/pulumi/policy_ls.go
@@ -103,7 +103,7 @@ func formatPolicyPacksConsole(policyPacks []apitype.PolicyPackWithVersions) erro
 		name := packs.Name
 
 		// Version Tags column
-		versionTags := strings.Trim(strings.Replace(fmt.Sprint(packs.VersionTags), " ", ", ", -1), "[]")
+		versionTags := strings.Trim(strings.ReplaceAll(fmt.Sprint(packs.VersionTags), " ", ", "), "[]")
 
 		// Render the columns.
 		columns := []string{name, versionTags}

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -904,7 +904,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	}
 
 	if r.DeprecationMessage != "" {
-		fmt.Fprintf(w, "    [Obsolete(@\"%s\")]\n", strings.Replace(r.DeprecationMessage, `"`, `""`, -1))
+		fmt.Fprintf(w, "    [Obsolete(@\"%s\")]\n", strings.ReplaceAll(r.DeprecationMessage, `"`, `""`))
 	}
 	fmt.Fprintf(w, "    [%sResourceType(\"%s\")]\n", namespaceName(mod.namespaces, mod.pkg.Name()), r.Token)
 	fmt.Fprintf(w, "    public partial class %s : %s\n", className, baseType)
@@ -1421,7 +1421,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 	}
 
 	if fun.DeprecationMessage != "" {
-		fmt.Fprintf(w, "    [Obsolete(@\"%s\")]\n", strings.Replace(fun.DeprecationMessage, `"`, `""`, -1))
+		fmt.Fprintf(w, "    [Obsolete(@\"%s\")]\n", strings.ReplaceAll(fun.DeprecationMessage, `"`, `""`))
 	}
 
 	// Open the class we'll use for data sources.
@@ -1647,7 +1647,7 @@ func (mod *modContext) genEnums(w io.Writer, enums []*schema.EnumType) error {
 
 func printObsoleteAttribute(w io.Writer, deprecationMessage, indent string) {
 	if deprecationMessage != "" {
-		fmt.Fprintf(w, "%s[Obsolete(@\"%s\")]\n", indent, strings.Replace(deprecationMessage, `"`, `""`, -1))
+		fmt.Fprintf(w, "%s[Obsolete(@\"%s\")]\n", indent, strings.ReplaceAll(deprecationMessage, `"`, `""`))
 	}
 }
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1169,7 +1169,7 @@ func (g *generator) functionName(tokenArg model.Expression) (string, string, str
 		}
 	}
 	modOrAlias := g.getModOrAlias(pkg, module, module)
-	mod := strings.Replace(modOrAlias, "/", ".", -1)
+	mod := strings.ReplaceAll(modOrAlias, "/", ".")
 	return pkg, mod, Title(member), diagnostics
 }
 

--- a/pkg/codegen/hcl2/syntax/comments_test.go
+++ b/pkg/codegen/hcl2/syntax/comments_test.go
@@ -18,7 +18,7 @@ func commentString(trivia []Trivia) string {
 	for _, t := range trivia {
 		if comment, ok := t.(Comment); ok {
 			for _, l := range comment.Lines {
-				s += strings.Replace(l, "✱", "*", -1)
+				s += strings.ReplaceAll(l, "✱", "*")
 			}
 		}
 	}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -173,7 +173,7 @@ func (mod *modContext) tokenToModName(tok string) string {
 	}
 
 	if modName != "" {
-		modName = strings.Replace(modName, "/", ".", -1) + "."
+		modName = strings.ReplaceAll(modName, "/", ".") + "."
 	}
 
 	return modName
@@ -380,7 +380,7 @@ func isStringType(t schema.Type) bool {
 }
 
 func sanitizeComment(str string) string {
-	return strings.Replace(str, "*/", "*&#47;", -1)
+	return strings.ReplaceAll(str, "*/", "*&#47;")
 }
 
 func printComment(w io.Writer, comment, deprecationMessage, indent string) {
@@ -2669,7 +2669,7 @@ func LanguageResources(pkg *schema.Package) (map[string]LanguageResource, error)
 				continue
 			}
 
-			packagePath := strings.Replace(modName, "/", ".", -1)
+			packagePath := strings.ReplaceAll(modName, "/", ".")
 			lr := LanguageResource{
 				Resource: r,
 				Name:     resourceName(r),

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -224,7 +224,7 @@ func functionName(tokenArg model.Expression) (string, string, string, hcl.Diagno
 
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
-	return pkg, strings.Replace(module, "/", ".", -1), member, diagnostics
+	return pkg, strings.ReplaceAll(module, "/", "."), member, diagnostics
 }
 
 func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, entries bool) {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2924,7 +2924,7 @@ func LanguageResources(tool string, pkg *schema.Package) (map[string]LanguageRes
 				continue
 			}
 
-			packagePath := strings.Replace(modName, "/", ".", -1)
+			packagePath := strings.ReplaceAll(modName, "/", ".")
 			lr := LanguageResource{
 				Resource: r,
 				Package:  packagePath,

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -186,7 +186,7 @@ func functionName(tokenArg model.Expression) (string, string, string, hcl.Diagno
 
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
-	return makeValidIdentifier(pkg), strings.Replace(module, "/", ".", -1), title(member), diagnostics
+	return makeValidIdentifier(pkg), strings.ReplaceAll(module, "/", "."), title(member), diagnostics
 }
 
 var functionImports = map[string][]string{

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -227,7 +227,7 @@ func TestReferenceRenderer(t *testing.T) {
 				doc := doc
 
 				text := []byte(fmt.Sprintf("[entity](%s)", doc.entity))
-				expected := strings.Replace(doc.entity, "/", "_", -1) + "\n"
+				expected := strings.ReplaceAll(doc.entity, "/", "_") + "\n"
 
 				parsed := ParseDocs(text)
 				actual := []byte(RenderDocsToString(text, parsed, WithReferenceRenderer(

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2192,7 +2192,7 @@ func getSanitizedModulePath(pkg string) string {
 	re := regexp.MustCompile(`v\d`)
 	v := re.FindString(pkg)
 	if v != "" {
-		return strings.TrimSuffix(strings.Replace(pkg, v, "", -1), "/")
+		return strings.TrimSuffix(strings.ReplaceAll(pkg, v, ""), "/")
 	}
 	return pkg
 

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -59,7 +59,7 @@ func ReplaceInFile(old, new, path string) error {
 	if err != nil {
 		return err
 	}
-	newContents := strings.Replace(string(rawContents), old, new, -1)
+	newContents := strings.ReplaceAll(string(rawContents), old, new)
 	return os.WriteFile(path, []byte(newContents), os.ModePerm)
 }
 

--- a/sdk/go/common/diag/colors/colors.go
+++ b/sdk/go/common/diag/colors/colors.go
@@ -245,7 +245,7 @@ func clampString(s string, maxWidth int) string {
 // Highlight takes an input string, a sequence of commands, and replaces all occurrences of that string with
 // a "highlighted" version surrounded by those commands and a final reset afterwards.
 func Highlight(s, text, commands string) string {
-	return strings.Replace(s, text, commands+text+Reset, -1)
+	return strings.ReplaceAll(s, text, commands+text+Reset)
 }
 
 var (

--- a/sdk/go/common/resource/asset.go
+++ b/sdk/go/common/resource/asset.go
@@ -162,7 +162,7 @@ func MassageIfUserProgramCodeAsset(asset *Asset, debug bool) *Asset {
 	text := asset.Text
 	replaceNewlines := func() {
 		for {
-			newText := strings.Replace(text, "\n\n\n", "\n\n", -1)
+			newText := strings.ReplaceAll(text, "\n\n\n", "\n\n")
 			if len(newText) == len(text) {
 				break
 			}

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -58,7 +58,7 @@ var _ Analyzer = (*analyzer)(nil)
 func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	// Load the plugin's path by using the standard workspace logic.
 	path, err := workspace.GetPluginPath(
-		workspace.AnalyzerPlugin, strings.Replace(string(name), tokens.QNameDelimiter, "_", -1),
+		workspace.AnalyzerPlugin, strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
 		nil, host.GetProjectPlugins())
 	if err != nil {
 		return nil, rpcerror.Convert(err)

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -54,7 +54,7 @@ func NewLanguageRuntime(host Host, ctx *Context, root, pwd, runtime string,
 	options map[string]interface{}) (LanguageRuntime, error) {
 
 	path, err := workspace.GetPluginPath(
-		workspace.LanguagePlugin, strings.Replace(runtime, tokens.QNameDelimiter, "_", -1), nil, host.GetProjectPlugins())
+		workspace.LanguagePlugin, strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"), nil, host.GetProjectPlugins())
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -167,7 +167,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 	} else {
 		// Load the plugin's path by using the standard workspace logic.
 		path, err := workspace.GetPluginPath(
-			workspace.ResourcePlugin, strings.Replace(string(pkg), tokens.QNameDelimiter, "_", -1),
+			workspace.ResourcePlugin, strings.ReplaceAll(string(pkg), tokens.QNameDelimiter, "_"),
 			version, host.GetProjectPlugins())
 		if err != nil {
 			return nil, err

--- a/sdk/go/common/util/cmdutil/exit.go
+++ b/sdk/go/common/util/cmdutil/exit.go
@@ -148,7 +148,7 @@ func Exit(err error) {
 // ExitError issues an error and exits with a standard error exit code.
 func ExitError(msg string) {
 	// Escape percent sign before passing the message as a format string (e.g., msg could contain %PATH% on Windows).
-	format := strings.Replace(msg, "%", "%%", -1)
+	format := strings.ReplaceAll(msg, "%", "%%")
 	exitErrorCodef(-1, format)
 }
 

--- a/sdk/go/common/util/fsutil/qname.go
+++ b/sdk/go/common/util/fsutil/qname.go
@@ -23,7 +23,7 @@ import (
 
 // QnamePath just cleans a name and makes sure it's appropriate to use as a path.
 func QnamePath(nm tokens.QName) string {
-	return strings.Replace(string(nm), tokens.QNameDelimiter, string(os.PathSeparator), -1)
+	return strings.ReplaceAll(string(nm), tokens.QNameDelimiter, string(os.PathSeparator))
 }
 
 // NamePath just cleans a name and makes sure it's appropriate to use as a path.

--- a/sdk/go/common/util/rpcutil/writer_test.go
+++ b/sdk/go/common/util/rpcutil/writer_test.go
@@ -135,7 +135,7 @@ func TestWriter_Terminal(t *testing.T) {
 		outBytes, err := io.ReadAll(&server.stdout)
 		assert.NoError(t, err)
 		// echo adds an extra \n at the end, and line discipline will cause \n to come back as \r\n
-		expected := strings.Replace(text+"\n", "\n", "\r\n", -1)
+		expected := strings.ReplaceAll(text+"\n", "\n", "\r\n")
 		assert.Equal(t, []byte(expected), outBytes)
 
 		errBytes, err := io.ReadAll(&server.stderr)

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -792,10 +792,10 @@ func newTemplateNotFoundError(templateDir string, templateName string) error {
 func transform(content string, projectName string, projectDescription string) string {
 	// On Windows, we need to replace \n with \r\n because go-git does not currently handle it.
 	if runtime.GOOS == "windows" {
-		content = strings.Replace(content, "\n", "\r\n", -1)
+		content = strings.ReplaceAll(content, "\n", "\r\n")
 	}
-	content = strings.Replace(content, "${PROJECT}", projectName, -1)
-	content = strings.Replace(content, "${DESCRIPTION}", projectDescription, -1)
+	content = strings.ReplaceAll(content, "${PROJECT}", projectName)
+	content = strings.ReplaceAll(content, "${DESCRIPTION}", projectDescription)
 	return content
 }
 

--- a/sdk/go/common/workspace/workspace.go
+++ b/sdk/go/common/workspace/workspace.go
@@ -204,5 +204,5 @@ func sha1HexString(value string) string {
 
 // qnameFileName takes a qname and cleans it for use as a filename (by replacing tokens.QNameDelimter with a dash)
 func qnameFileName(nm tokens.QName) string {
-	return strings.Replace(string(nm), tokens.QNameDelimiter, "-", -1)
+	return strings.ReplaceAll(string(nm), tokens.QNameDelimiter, "-")
 }


### PR DESCRIPTION
Replaces all instances of `strings.Replace(s, old, new, -1)`
with the equivalent `strings.ReplaceAll(s, old, new)`.
This function has been available since Go 1.12.
