### PR TITLE
[auto/nodejs] Fixes username for remote workspaces

### DIFF
--- a/changelog/pending/20230224--auto-nodejs--fixes-issue-with-specifying-a-git-username-for-remote-workspaces.yaml
+++ b/changelog/pending/20230224--auto-nodejs--fixes-issue-with-specifying-a-git-username-for-remote-workspaces.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/nodejs
+  description: Fixes issue with specifying a git username for remote workspaces

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -758,7 +758,7 @@ export class LocalWorkspace implements Workspace {
                     args.push("--remote-git-auth-password", password);
                 }
                 if (username) {
-                    args.push("--remote-git-username", username);
+                    args.push("--remote-git-auth-username", username);
                 }
             }
         }

--- a/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/remoteWorkspace.spec.ts
@@ -18,6 +18,7 @@ import {
     fullyQualifiedStackName,
     isFullyQualifiedStackName,
     LocalWorkspace,
+    LocalWorkspaceOptions,
     RemoteGitAuthArgs,
     RemoteGitProgramArgs,
     RemoteStack,
@@ -29,6 +30,193 @@ import { getTestOrg, getTestSuffix } from "./util";
 const testRepo = "https://github.com/pulumi/test-repo.git";
 
 describe("RemoteWorkspace", () => {
+    describe("remote cmd args", () => {
+        const tests: {
+            name: string;
+            opts: LocalWorkspaceOptions;
+            expected: string[];
+        }[] = [
+            {
+                name: "empty",
+                opts: {},
+                expected: [],
+            },
+            {
+                name: "just remote",
+                opts: {
+                    remote: true,
+                },
+                expected: ["--remote"],
+            },
+            {
+                name: "url",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                    },
+                },
+                expected: ["--remote", "foo"],
+            },
+            {
+                name: "path",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                        projectPath: "mypath",
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-git-repo-dir", "mypath"],
+            },
+            {
+                name: "branch",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                        branch: "mybranch",
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-git-branch", "mybranch"],
+            },
+            {
+                name: "commit",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                        commitHash: "mycommit",
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-git-commit", "mycommit"],
+            },
+            {
+                name: "auth access token",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                        auth: {
+                            personalAccessToken: "mytoken",
+                        },
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-git-auth-access-token", "mytoken"],
+            },
+            {
+                name: "auth ssh key",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                        auth: {
+                            sshPrivateKey: "mykey",
+                        },
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-git-auth-ssh-private-key", "mykey"],
+            },
+            {
+                name: "auth ssh key path",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                        auth: {
+                            sshPrivateKeyPath: "mykeypath",
+                        },
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-git-auth-ssh-private-key-path", "mykeypath"],
+            },
+            {
+                name: "auth ssh password",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                        auth: {
+                            username: "myuser",
+                            password: "mypass",
+                        },
+                    },
+                },
+                expected: [
+                    "--remote", "foo",
+                    "--remote-git-auth-password", "mypass",
+                    "--remote-git-auth-username", "myuser"],
+            },
+            {
+                name: "env",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                    },
+                    remoteEnvVars: {
+                        foo: "bar",
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-env", "foo=bar"],
+            },
+            {
+                name: "env secret",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                    },
+                    remoteEnvVars: {
+                        foo: { secret: "bar" },
+                    },
+                },
+                expected: ["--remote", "foo", "--remote-env-secret", "foo=bar"],
+            },
+            {
+                name: "pre-run command",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                    },
+                    remotePreRunCommands: ["whoami"],
+                },
+                expected: ["--remote", "foo", "--remote-pre-run-command", "whoami"],
+            },
+            {
+                name: "skip install dependencies",
+                opts: {
+                    remote: true,
+                    remoteGitProgramArgs: {
+                        stackName: "stack",
+                        url: "foo",
+                    },
+                    remoteSkipInstallDependencies: true,
+                },
+                expected: ["--remote", "foo", "--remote-skip-install-dependencies"],
+            },
+        ];
+        tests.forEach(test => {
+            it(`${test.name}`, async () => {
+                const ws = await LocalWorkspace.create(test.opts);
+                const actual = ws.remoteArgs();
+                assert.deepStrictEqual(actual, test.expected);
+            });
+        });
+    });
+
     describe("selectStack", () => {
         describe("throws appropriate errors", () => testErrors(RemoteWorkspace.selectStack));
     });


### PR DESCRIPTION
When a git username is specified for remote workspaces, we were using the wrong CLI flag. It should be `--remote-git-auth-username` not `--remote-git-username`. This change fixes this and adds tests to confirm we're using the right flag names for all the various remote workspace options.

Fixes #12264