### PR TITLE
Add stack tag support for python automation api sdk

### DIFF
--- a/changelog/pending/20230224--auto-python--enable-programmatic-tagging-of-stacks-python-only.yaml
+++ b/changelog/pending/20230224--auto-python--enable-programmatic-tagging-of-stacks-python-only.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/python
+  description: Enable programmatic tagging of stacks (Python only)

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -38,6 +38,7 @@ from ._output import OutputMap, OutputValue
 from ._cmd import _run_pulumi_cmd, CommandResult, OnOutput
 from ._minimum_version import _MINIMUM_VERSION
 from .errors import InvalidVersionError
+from ._tag import TagMap
 
 if TYPE_CHECKING:
     from pulumi.automation._remote_workspace import RemoteGitAuth
@@ -272,6 +273,26 @@ class LocalWorkspace(Workspace):
             ["config", "refresh", "--force", "--stack", stack_name]
         )
         self.get_all_config(stack_name)
+
+    def get_tag(self, stack_name: str, key: str) -> str:
+        result = self._run_pulumi_cmd_sync(
+            ["stack", "tag", "get", key, "--stack", stack_name]
+        )
+        return result.stdout.strip()
+
+    def set_tag(self, stack_name: str, key: str, value: str) -> None:
+        self._run_pulumi_cmd_sync(
+            ["stack", "tag", "set", key, value, "--stack", stack_name]
+        )
+
+    def remove_tag(self, stack_name: str, key: str) -> None:
+        self._run_pulumi_cmd_sync(["stack", "tag", "rm", key, "--stack", stack_name])
+
+    def list_tags(self, stack_name: str) -> TagMap:
+        result = self._run_pulumi_cmd_sync(
+            ["stack", "tag", "ls", "--json", "--stack", stack_name]
+        )
+        return json.loads(result.stdout)
 
     def who_am_i(self) -> WhoAmIResult:
         result = self._run_pulumi_cmd_sync(["whoami"])

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -33,6 +33,7 @@ from ._workspace import Workspace, PulumiFn, Deployment
 from ..runtime.settings import _GRPC_CHANNEL_OPTIONS
 from ..runtime.proto import language_pb2_grpc
 from ._representable import _Representable
+from ._tag import TagMap
 
 _DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -632,6 +633,42 @@ class Stack:
     def refresh_config(self) -> None:
         """Gets and sets the config map used with the last update."""
         self.workspace.refresh_config(self.name)
+
+    def get_tag(self, key: str) -> str:
+        """
+        Returns the tag value associated with specified key.
+
+        :param key: The key to use for the tag lookup.
+        :returns: str
+        """
+        return self.workspace.get_tag(self.name, key)
+
+    def set_tag(self, key: str, value: str) -> None:
+        """
+        Sets a tag key-value pair on the Stack in the associated Workspace.
+
+        :param key: The tag key to set.
+        :param value: The tag value to set.
+        """
+        self.workspace.set_tag(self.name, key, value)
+
+    def remove_tag(self, key: str) -> None:
+        """
+        Removes the specified key-value pair on the provided stack name.
+
+        :param stack_name: The name of the stack.
+        :param key: The tag key to remove.
+        """
+        self.workspace.remove_tag(self.name, key)
+
+    def list_tags(self) -> TagMap:
+        """
+        Returns the tag map for the specified tag name, scoped to the Workspace.
+
+        :param stack_name: The name of the stack.
+        :returns: TagMap
+        """
+        return self.workspace.list_tags(self.name)
 
     def outputs(self) -> OutputMap:
         """

--- a/sdk/python/lib/pulumi/automation/_tag.py
+++ b/sdk/python/lib/pulumi/automation/_tag.py
@@ -1,0 +1,18 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import MutableMapping
+
+TagMap = MutableMapping[str, str]
+"""TagMap is a key-value map of tag metadata associated with a stack."""

--- a/sdk/python/lib/pulumi/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_workspace.py
@@ -20,6 +20,7 @@ from ._stack_settings import StackSettings
 from ._project_settings import ProjectSettings
 from ._config import ConfigMap, ConfigValue
 from ._output import OutputMap
+from ._tag import TagMap
 
 PulumiFn = Callable[[], None]
 
@@ -259,6 +260,45 @@ class Workspace(ABC):
         Gets and sets the config map used with the last update for Stack matching stack name.
 
         :param stack_name: The name of the stack.
+        """
+
+    @abstractmethod
+    def get_tag(self, stack_name: str, key: str) -> str:
+        """
+        Returns the value associated with the specified stack name and key,
+        scoped to the Workspace.
+
+        :param stack_name: The name of the stack.
+        :param key: The key to use for the tag lookup.
+        :returns: str
+        """
+
+    @abstractmethod
+    def set_tag(self, stack_name: str, key: str, value: str) -> None:
+        """
+        Sets the specified key-value pair on the provided stack name.
+
+        :param stack_name: The name of the stack.
+        :param key: The tag key to set.
+        :param value: The tag value to set.
+        """
+
+    @abstractmethod
+    def remove_tag(self, stack_name: str, key: str) -> None:
+        """
+        Removes the specified key-value pair on the provided stack name.
+
+        :param stack_name: The name of the stack.
+        :param key: The tag key to remove.
+        """
+
+    @abstractmethod
+    def list_tags(self, stack_name: str) -> TagMap:
+        """
+        Returns the tag map for the specified tag name, scoped to the Workspace.
+
+        :param stack_name: The name of the stack.
+        :returns: TagMap
         """
 
     @abstractmethod

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -319,6 +319,35 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertFalse(arr.secret)
         self.assertEqual(arr.value, "[\"one\",\"two\",\"three\"]")
 
+    def test_tag_methods(self):
+        project_name = "python_test"
+        runtime = "python"
+        project_settings = ProjectSettings(name=project_name, runtime=runtime)
+        ws = LocalWorkspace(project_settings=project_settings)
+        stack_name = stack_namer(project_name)
+        _ = Stack.create(stack_name, ws)
+
+        # Lists tag values
+        result = ws.list_tags(stack_name)
+        self.assertEqual(result["pulumi:project"], project_name)
+        self.assertEqual(result["pulumi:runtime"], runtime)
+
+        # Sets tag values
+        ws.set_tag(stack_name, "foo", "bar")
+        result = ws.list_tags(stack_name)
+        self.assertEqual(result["foo"], "bar")
+
+        # Removes tag values
+        ws.remove_tag(stack_name, "foo")
+        result = ws.list_tags(stack_name)
+        self.assertTrue("foo" not in result)
+
+        # Gets a single tag value
+        result = ws.get_tag(stack_name, "pulumi:project")
+        self.assertEqual(result, project_name)
+
+        ws.remove_stack(stack_name)
+
     def test_stack_status_methods(self):
         project_name = "python_test"
         project_settings = ProjectSettings(name=project_name, runtime="python")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds support for tagging stacks with the Python automation API.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

* https://github.com/pulumi/pulumi/issues/11936 (Python support)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
