### PR TITLE
[sdk/python] Add `default` arg to `Config.get_secret`

### DIFF
--- a/changelog/pending/20230227--sdk-python--add-default-arg-to-config-get_secret.yaml
+++ b/changelog/pending/20230227--sdk-python--add-default-arg-to-config-get_secret.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add `default` arg to `Config.get_secret`

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -79,7 +79,9 @@ class Config:
         config_candidate = self._get(key, self.get_secret, self.get)
         return config_candidate if config_candidate is not None else default
 
-    def get_secret(self, key: str) -> Optional[Output[str]]:
+    def get_secret(
+        self, key: str, default: Optional[str] = None
+    ) -> Optional[Output[str]]:
         """
         Returns an optional configuration value by its key, marked as a secret,
         a default value if that key is unset and a default is provided,
@@ -90,11 +92,11 @@ class Config:
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[str]
         """
-        c = self._get(key)
-        if c is None:
+        config_candidate = self._get(key)
+        v = config_candidate if config_candidate is not None else default
+        if v is None:
             return None
-
-        return Output.secret(c)
+        return Output.secret(v)
 
     def _get_bool(
         self,

--- a/sdk/python/lib/test/test_config.py
+++ b/sdk/python/lib/test/test_config.py
@@ -1,0 +1,35 @@
+# Copyright 2016-2023, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+
+@pytest.mark.parametrize("key,default", [
+    ("string", None),
+    ("bar", "baz"),
+    ("doesnt-exist", None),
+])
+@pytest.mark.asyncio
+async def test_config_with_defaults(key, default, mock_config, config_settings):
+    expected = config_settings.get(f"test-config:{key}", default)
+
+    assert mock_config.get(key, default) == expected
+
+    result = mock_config.get_secret(key, default)
+    if result is None:
+        assert result == expected
+    else:
+        actual = await result.future()
+        assert actual == expected


### PR DESCRIPTION
This change adds the missing `default` arg to `Config.get_secret` method, for consistency with the other `get_secret_<type>` methods that have a `default` arg.

Fixes #12271