### PR TITLE
Set the current project as ambient context on backends.

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -123,6 +123,9 @@ type Backend interface {
 	// URL returns a URL at which information about this backend may be seen.
 	URL() string
 
+	// SetCurrentProject sets the current ambient project for this backend.
+	SetCurrentProject(proj *workspace.Project)
+
 	// GetPolicyPack returns a PolicyPack object tied to this backend, or nil if it cannot be found.
 	GetPolicyPack(ctx context.Context, policyPack string, d diag.Sink) (PolicyPack, error)
 
@@ -152,8 +155,7 @@ type Backend interface {
 	// GetStack returns a stack object tied to this backend with the given name, or nil if it cannot be found.
 	GetStack(ctx context.Context, stackRef StackReference) (Stack, error)
 	// CreateStack creates a new stack with the given name and options that are specific to the backend provider.
-	CreateStack(ctx context.Context,
-		stackRef StackReference, root string, project *workspace.Project, opts interface{}) (Stack, error)
+	CreateStack(ctx context.Context, stackRef StackReference, root string, opts interface{}) (Stack, error)
 
 	// RemoveStack removes a stack with the given name.  If force is true, the stack will be removed even if it
 	// still contains resources.  Otherwise, if the stack contains resources, a non-nil error is returned, and the

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -144,14 +144,14 @@ func makeUntypedDeployment(name tokens.QName, phrase, state string) (*apitype.Un
 func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	defer func() {
@@ -169,7 +169,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	// Create stack "b" and import a checkpoint with a secret
 	bStackRef, err := b.ParseStackReference("b")
 	assert.NoError(t, err)
-	bStack, err := b.CreateStack(ctx, bStackRef, "", nil, nil)
+	bStack, err := b.CreateStack(ctx, bStackRef, "", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, bStack)
 	defer func() {
@@ -204,7 +204,7 @@ func TestDrillError(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -222,7 +222,7 @@ func TestCancel(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -233,7 +233,7 @@ func TestCancel(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that trying to cancel a stack that isn't locked doesn't error
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.CancelCurrentUpdate(ctx, aStackRef)
@@ -260,7 +260,7 @@ func TestCancel(t *testing.T) {
 	assert.False(t, lockExists)
 
 	// Make another filestate backend which will have a different lockId
-	ob, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	ob, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	otherBackend, ok := ob.(*localBackend)
 	assert.True(t, ok)
@@ -283,7 +283,7 @@ func TestRemoveMakesBackups(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -295,7 +295,7 @@ func TestRemoveMakesBackups(t *testing.T) {
 	// Check that creating a new stack doesn't make a backup file
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -326,7 +326,7 @@ func TestRenameWorks(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
@@ -338,7 +338,7 @@ func TestRenameWorks(t *testing.T) {
 	// Create a new stack
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 
@@ -393,7 +393,7 @@ func TestLoginToNonExistingFolderFails(t *testing.T) {
 	t.Parallel()
 
 	fakeDir := "file://" + filepath.ToSlash(os.TempDir()) + "/non-existing"
-	b, err := New(cmdutil.Diag(), fakeDir)
+	b, err := New(cmdutil.Diag(), fakeDir, nil)
 	assert.Error(t, err)
 	assert.Nil(t, b)
 }
@@ -444,14 +444,14 @@ func TestHtmlEscaping(t *testing.T) {
 
 	// Login to a temp dir filestate backend
 	tmpDir := t.TempDir()
-	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir), nil)
 	assert.NoError(t, err)
 	ctx := context.Background()
 
 	// Create stack "a" and import a checkpoint with a secret
 	aStackRef, err := b.ParseStackReference("a")
 	assert.NoError(t, err)
-	aStack, err := b.CreateStack(ctx, aStackRef, "", nil, nil)
+	aStack, err := b.CreateStack(ctx, aStackRef, "", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, aStack)
 	err = b.ImportDeployment(ctx, aStack, udep)

--- a/pkg/backend/filestate/bucket_test.go
+++ b/pkg/backend/filestate/bucket_test.go
@@ -32,7 +32,7 @@ func TestWrappedBucket(t *testing.T) {
 
 	// Initialize a filestate backend, using the default Pulumi directory.
 	cloudURL := FilePathPrefix + "~"
-	b, err := New(nil, cloudURL)
+	b, err := New(nil, cloudURL, nil)
 	if err != nil {
 		t.Fatalf("Initializing new filestate backend: %v", err)
 	}

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -162,7 +162,7 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 
 	initPersister := func() *cloudSnapshotPersister {
 		server := newMockServer()
-		backendGeneric, err := New(nil, server.URL, false)
+		backendGeneric, err := New(nil, server.URL, nil, false)
 		assert.NoError(t, err)
 		backend := backendGeneric.(*cloudBackend)
 		persister := backend.newSnapshotPersister(ctx, client.UpdateIdentifier{

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -36,6 +36,7 @@ import (
 type MockBackend struct {
 	NameF                  func() string
 	URLF                   func() string
+	SetCurrentProjectF     func(proj *workspace.Project)
 	GetPolicyPackF         func(ctx context.Context, policyPack string, d diag.Sink) (PolicyPack, error)
 	SupportsTagsF          func() bool
 	SupportsOrganizationsF func() bool
@@ -43,7 +44,7 @@ type MockBackend struct {
 	ValidateStackNameF     func(s string) error
 	DoesProjectExistF      func(context.Context, string) (bool, error)
 	GetStackF              func(context.Context, StackReference) (Stack, error)
-	CreateStackF           func(context.Context, StackReference, string, *workspace.Project, interface{}) (Stack, error)
+	CreateStackF           func(context.Context, StackReference, string, interface{}) (Stack, error)
 	RemoveStackF           func(context.Context, Stack, bool) (bool, error)
 	ListStacksF            func(context.Context, ListStacksFilter, ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)
@@ -88,6 +89,13 @@ func (be *MockBackend) Name() string {
 func (be *MockBackend) URL() string {
 	if be.URLF != nil {
 		return be.URLF()
+	}
+	panic("not implemented")
+}
+
+func (be *MockBackend) SetCurrentProject(project *workspace.Project) {
+	if be.SetCurrentProjectF != nil {
+		be.SetCurrentProjectF(project)
 	}
 	panic("not implemented")
 }
@@ -156,10 +164,10 @@ func (be *MockBackend) GetStack(ctx context.Context, stackRef StackReference) (S
 }
 
 func (be *MockBackend) CreateStack(ctx context.Context, stackRef StackReference,
-	root string, project *workspace.Project, opts interface{},
+	root string, opts interface{},
 ) (Stack, error) {
 	if be.CreateStackF != nil {
-		return be.CreateStackF(ctx, stackRef, root, project, opts)
+		return be.CreateStackF(ctx, stackRef, root, opts)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -142,12 +142,12 @@ func newLoginCmd() *cobra.Command {
 
 			var be backend.Backend
 			if filestate.IsFileStateBackendURL(cloudURL) {
-				be, err = filestate.Login(cmdutil.Diag(), cloudURL)
+				be, err = filestate.Login(cmdutil.Diag(), cloudURL, project)
 				if defaultOrg != "" {
 					return fmt.Errorf("unable to set default org for this type of backend")
 				}
 			} else {
-				be, err = httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, insecure, displayOptions)
+				be, err = httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, project, insecure, displayOptions)
 				// if the user has specified a default org to associate with the backend
 				if defaultOrg != "" {
 					cloudURL, err := workspace.GetCurrentCloudURL(project)

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -83,7 +83,7 @@ func newLogoutCmd() *cobra.Command {
 				return workspace.DeleteAccount(cloudURL)
 			}
 
-			be, err = httpstate.New(cmdutil.Diag(), cloudURL, workspace.GetCloudInsecure(cloudURL))
+			be, err = httpstate.New(cmdutil.Diag(), cloudURL, nil, workspace.GetCloudInsecure(cloudURL))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -126,7 +126,7 @@ func requirePolicyPack(ctx context.Context, policyPack string) (backend.PolicyPa
 		Color: cmdutil.GetGlobalColorization(),
 	}
 
-	b, err := httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL,
+	b, err := httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), cloudURL, project,
 		workspace.GetCloudInsecure(cloudURL), displayOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -131,7 +131,7 @@ func newStackInitCmd() *cobra.Command {
 			}
 
 			var createOpts interface{} // Backend-specific config options, none currently.
-			newStack, err := createStack(ctx, b, stackRef, root, proj, createOpts, !noSelect, secretsProvider)
+			newStack, err := createStack(ctx, b, stackRef, root, createOpts, !noSelect, secretsProvider)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -83,7 +83,7 @@ func newStackSelectCmd() *cobra.Command {
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
-					s, err := stackInit(ctx, b, stack, root, project, false, secretsProvider)
+					s, err := stackInit(ctx, b, stack, root, false, secretsProvider)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -300,7 +300,7 @@ func newUpCmd() *cobra.Command {
 
 		// Create the stack, if needed.
 		if s == nil {
-			if s, err = promptAndCreateStack(ctx, b, promptForValue, stackName, root, proj, false /*setCurrent*/, yes,
+			if s, err = promptAndCreateStack(ctx, b, promptForValue, stackName, root, false /*setCurrent*/, yes,
 				opts.Display, secretsProvider); err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -129,9 +129,9 @@ func nonInteractiveCurrentBackend(ctx context.Context, project *workspace.Projec
 	}
 
 	if filestate.IsFileStateBackendURL(url) {
-		return filestate.New(cmdutil.Diag(), url)
+		return filestate.New(cmdutil.Diag(), url, project)
 	}
-	return httpstate.NewLoginManager().Current(ctx, cmdutil.Diag(), url, workspace.GetCloudInsecure(url))
+	return httpstate.NewLoginManager().Current(ctx, cmdutil.Diag(), url, project, workspace.GetCloudInsecure(url))
 }
 
 func currentBackend(ctx context.Context, project *workspace.Project, opts display.Options) (backend.Backend, error) {
@@ -145,9 +145,9 @@ func currentBackend(ctx context.Context, project *workspace.Project, opts displa
 	}
 
 	if filestate.IsFileStateBackendURL(url) {
-		return filestate.New(cmdutil.Diag(), url)
+		return filestate.New(cmdutil.Diag(), url, project)
 	}
-	return httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), url, workspace.GetCloudInsecure(url), opts)
+	return httpstate.NewLoginManager().Login(ctx, cmdutil.Diag(), url, project, workspace.GetCloudInsecure(url), opts)
 }
 
 // This is used to control the contents of the tracing header.
@@ -223,11 +223,10 @@ func createSecretsManager(
 // createStack creates a stack with the given name, and optionally selects it as the current.
 func createStack(ctx context.Context,
 	b backend.Backend, stackRef backend.StackReference,
-	root string, project *workspace.Project,
-	opts interface{}, setCurrent bool,
+	root string, opts interface{}, setCurrent bool,
 	secretsProvider string,
 ) (backend.Stack, error) {
-	stack, err := b.CreateStack(ctx, stackRef, root, project, opts)
+	stack, err := b.CreateStack(ctx, stackRef, root, opts)
 	if err != nil {
 		// If it's a well-known error, don't wrap it.
 		if _, ok := err.(*backend.StackAlreadyExistsError); ok {
@@ -322,7 +321,7 @@ func requireStack(ctx context.Context,
 			return nil, err
 		}
 
-		return createStack(ctx, b, stackRef, root, project, nil, lopt.SetCurrent(), "")
+		return createStack(ctx, b, stackRef, root, nil, lopt.SetCurrent(), "")
 	}
 
 	return nil, fmt.Errorf("no stack named '%s' found", stackName)
@@ -461,7 +460,7 @@ func chooseStack(ctx context.Context,
 			return nil, parseErr
 		}
 
-		return createStack(ctx, b, stackRef, root, proj, nil, lopt.SetCurrent(), "")
+		return createStack(ctx, b, stackRef, root, nil, lopt.SetCurrent(), "")
 	}
 
 	// With the stack name selected, look it up from the backend.


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Rather than passing a `*workspace.Project` to most backend methods, just say that backends have a "current project" property. We set this on creation (because we normally have a project before creating a backend) but we also add a `SetCurrentProject` method for `pulumi new` to use because it's the (currently) one place where we need a backend before we have the project to go with it.