### PR TITLE
Remind users they should be setting a Python min version.

### DIFF
--- a/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
+++ b/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdkgen/python
-  description: Remind users to specify a min Python version, and use 3.7 as a default if not provided.
+  description: In codegen, use 3.7 as a default if not provided.

--- a/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
+++ b/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdkgen/python
-  description: Remind users to specify a min Python version.
+  description: Remind users to specify a min Python version, and use 3.7 as a default if not provided.

--- a/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
+++ b/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/python
+  description: Remind users to specify a min Python version.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2126,14 +2126,12 @@ func genPackageMetadata(
 
 	// Finally, the actual setup part.
 	fmt.Fprintf(w, "setup(name='%s',\n", pyPkgName)
-	// Remind the user that the schema should specify the minimum
-	// Python version.
-	if minPython, err := minimumPythonVersion(info); err == nil {
-		fmt.Fprintf(w, "      python_requires='%s',\n", minPython)
-	} else {
-		cmdutil.Diag().Infof(&diag.Diag{Message: err.Error()})
-		fmt.Fprintf(w, "      python_requires='%s',\n", defaultMinPythonVersion)
+	// Supply a default Python version if the schema does not provide one.
+	pythonVersion := defaultMinPythonVersion
+	if minPythonVersion, err := minimumPythonVersion(info); err == nil {
+		pythonVersion = minPythonVersion
 	}
+	fmt.Fprintf(w, "      python_requires='%s',\n", pythonVersion)
 	fmt.Fprintf(w, "      version=VERSION,\n")
 	if pkg.Description != "" {
 		fmt.Fprintf(w, "      description=%q,\n", sanitizePackageDescription(pkg.Description))

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -50,6 +50,12 @@ type typeDetails struct {
 
 type imports codegen.StringSet
 
+// defaultMinPythonVersion is what we use as the minimum version field in generated
+// package metadata if the schema does not provide a vaule. This version corresponds
+// to the minimum supported version as listed in the reference documentation:
+// https://www.pulumi.com/docs/reference/pkg/python/pulumi/
+const defaultMinPythonVersion = ">=3.6"
+
 func (imports imports) addType(mod *modContext, t *schema.ObjectType, input bool) {
 	imports.addTypeIf(mod, t, input, nil /*predicate*/)
 }
@@ -2125,6 +2131,7 @@ func genPackageMetadata(
 		fmt.Fprintf(w, "      python_requires='%s',\n", minPython)
 	} else {
 		cmdutil.Diag().Infof(&diag.Diag{Message: err.Error()})
+		fmt.Fprintf(w, "      python_requires='%s',\n", defaultMinPythonVersion)
 	}
 	fmt.Fprintf(w, "      version=VERSION,\n")
 	if pkg.Description != "" {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -55,7 +55,7 @@ type imports codegen.StringSet
 // package metadata if the schema does not provide a vaule. This version corresponds
 // to the minimum supported version as listed in the reference documentation:
 // https://www.pulumi.com/docs/reference/pkg/python/pulumi/
-const defaultMinPythonVersion = ">=3.6"
+const defaultMinPythonVersion = ">=3.7"
 
 func (imports imports) addType(mod *modContext, t *schema.ObjectType, input bool) {
 	imports.addTypeIf(mod, t, input, nil /*predicate*/)

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2119,8 +2119,12 @@ func genPackageMetadata(
 
 	// Finally, the actual setup part.
 	fmt.Fprintf(w, "setup(name='%s',\n", pyPkgName)
-	if pythonRequires != "" {
-		fmt.Fprintf(w, "      python_requires='%s',\n", pythonRequires)
+	// Remind the user that the schema should specify the minimum
+	// Python version.
+	if minPython, err := info.minimumPythonVersion(); err == nil {
+		fmt.Fprintf(w, "      python_requires='%s',\n", minPython)
+	} else {
+		cmdutil.Diag().Infof(&diag.Diag{Message: err.Error()})
 	}
 	fmt.Fprintf(w, "      version=VERSION,\n")
 	if pkg.Description != "" {

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -98,3 +98,22 @@ func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (int
 	}
 	return info, nil
 }
+
+// minimumPythonVersion returns a string containing the version
+// constraint specifying the minimumal version of Python required
+// by this package. For example, ">=3.8" is satified by all versions
+// of Python greater than or equal to Python 3.8.
+func (info PackageInfo) minimumPythonVersion() (string, error) {
+	if info.PythonRequires != "" {
+		return info.PythonRequires, nil
+	}
+	return "", noMinimumPythonErr{}
+}
+
+// noMinimumPythonErr is a non-fatal error indicating that the schema
+// did not provide a minimum version of Python for the Package.
+type noMinimumPythonErr struct{}
+
+func (noMinimumPythonErr) Error() string {
+	return "The schema does not require a minimum version of Python. It's recommended to provide a minimum version so package users can understand the package's requirements."
+}

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -98,22 +98,3 @@ func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (int
 	}
 	return info, nil
 }
-
-// minimumPythonVersion returns a string containing the version
-// constraint specifying the minimumal version of Python required
-// by this package. For example, ">=3.8" is satified by all versions
-// of Python greater than or equal to Python 3.8.
-func (info PackageInfo) minimumPythonVersion() (string, error) {
-	if info.PythonRequires != "" {
-		return info.PythonRequires, nil
-	}
-	return "", noMinimumPythonErr{}
-}
-
-// noMinimumPythonErr is a non-fatal error indicating that the schema
-// did not provide a minimum version of Python for the Package.
-type noMinimumPythonErr struct{}
-
-func (noMinimumPythonErr) Error() string {
-	return "The schema does not require a minimum version of Python. It's recommended to provide a minimum version so package users can understand the package's requirements."
-}

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_azure_native',
+      python_requires='>=3.6',
       version=VERSION,
       description="A native Pulumi package for creating and managing Azure resources.",
       long_description=readme(),

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_azure_native',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       description="A native Pulumi package for creating and managing Azure resources.",
       long_description=readme(),

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_foo_bar',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_foo_bar',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/different-enum/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/enum-reference/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-enum/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-python-same-module-name/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_registrygeoreplication',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_registrygeoreplication',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_repro',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_repro',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='foo_bar',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='foo_bar',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_foo',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/nested-module/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_foo',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_myedgeorder',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_myedgeorder',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/output-funcs/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_foobar',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_foobar',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_xyz',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_xyz',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_configstation',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_configstation',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_providerType',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_providerType',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mongodbatlas',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-8403/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mongodbatlas',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_my8110',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_my8110',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_aws',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_aws',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/secrets/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/secrets/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_mypkg',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='custom_py_package',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='custom_py_package',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
@@ -38,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/python/setup.py
@@ -38,6 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
+      python_requires='>=3.6',
       version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR adds a log line during SDKGen if the user does not include a minimum
Python version. IMO, we should expect all Python packages to list a minimum
Python version to provide greater clarity to our users.

In the current version of this PR, this warning is printing during module
generating; we might prefer to ensure its only printed once per package instead
of once per module.

Additionally, this turns accessing the minimum Python version into a checked error from an unchecked error, increasing safety.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes: https://github.com/pulumi/pulumi/issues/12286

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
