### PR TITLE
Remind the user to provide a License in Python codegen.

### DIFF
--- a/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
+++ b/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: sdkgen/python
-  description: Remind users to specify a min Python version.
+  description: Remind users to specify a min Python version and a license file when the associated schema fields are unset.

--- a/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
+++ b/changelog/pending/20230225--sdkgen-python--remind-users-to-specify-a-min-python-version.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/python
+  description: Remind users to specify a min Python version.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2117,8 +2117,12 @@ func genPackageMetadata(
 
 	// Finally, the actual setup part.
 	fmt.Fprintf(w, "setup(name='%s',\n", pyPkgName)
-	if pythonRequires != "" {
-		fmt.Fprintf(w, "      python_requires='%s',\n", pythonRequires)
+	// Remind the user that the schema should specify the minimum
+	// Python version.
+	if minPython, err := info.minimumPythonVersion(); err == nil {
+		fmt.Fprintf(w, "      python_requires='%s',\n", minPython)
+	} else {
+		cmdutil.Diag().Infof(&diag.Diag{Message: err.Error()})
 	}
 	fmt.Fprintf(w, "      version=VERSION,\n")
 	if pkg.Description != "" {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2151,8 +2151,12 @@ func genPackageMetadata(
 		fmt.Fprintf(w, "          'Repository': '%s'\n", pkg.Repository)
 		fmt.Fprintf(w, "      },\n")
 	}
-	if pkg.License != "" {
-		fmt.Fprintf(w, "      license='%s',\n", pkg.License)
+	// Remind the user to provide a license if none is provided in
+	// the schema.
+	if license, err := pkg.GetLicense(); err == nil {
+		fmt.Fprintf(w, "      license='%s',\n", license)
+	} else {
+		cmdutil.Diag().Infof(&diag.Diag{Message: err.Error()})
 	}
 	fmt.Fprintf(w, "      packages=find_packages(),\n")
 

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -98,3 +98,22 @@ func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (int
 	}
 	return info, nil
 }
+
+// minimumPythonVersion returns a string containing the version
+// constraint specifying the minimumal version of Python required
+// by this package. For example, ">=3.8" is satified by all versions
+// of Python greater than or equal to Python 3.8.
+func (info PackageInfo) minimumPythonVersion() (string, error) {
+	if info.PythonRequires != "" {
+		return info.PythonRequires, nil
+	}
+	return "", noMinimumPythonErr{}
+}
+
+// noMinimumPythonErr is a non-fatal error indicating that the schema
+// did not provide a minimum version of Python for the Package.
+type noMinimumPythonErr struct{}
+
+func (noMinimumPythonErr) Error() string {
+	return "The schema does not require a minimum version of Python. It's recommended to provide a minimum version so package users can understand the package's requirements."
+}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -633,6 +633,23 @@ type Package struct {
 	importedLanguages map[string]struct{}
 }
 
+// A NoLicenseErr is a recoverable error created the Package does not provide
+// a license.
+type NoLicenseErr struct{}
+
+func (NoLicenseErr) Error() string {
+	return "No license was provided for this package. Consider specifying a license in the provider schema."
+}
+
+// GetLicense is a checked access to the pkg.License field, returning
+// an error when the License is not provided.
+func (pkg *Package) GetLicense() (string, error) {
+	if pkg != nil && pkg.License != "" {
+		return pkg.License, nil
+	}
+	return "", NoLicenseErr{}
+}
+
 // Language provides hooks for importing language-specific metadata in a package.
 type Language interface {
 	// ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR is similar to #12287; it turns access to the license file into a checked
error instead of an unchecked error, improving safety. It also issues a log
when the field is unset in the schema, since the License field should be set
under most circumstances.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12286

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
