### PR TITLE
sdk/py/ComponentResource: Propagate provider to children

### DIFF
--- a/changelog/pending/20230227--sdk-python--component-resource-provider-propagation.yaml
+++ b/changelog/pending/20230227--sdk-python--component-resource-provider-propagation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fixes Component Resources not correctly propagating the provider option to its children.

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -920,16 +920,25 @@ class Resource:
             Optional[ProviderResource], opts.parent and opts.parent.get_provider(t)
         )
 
-        provider = opts.provider or ambient_provider or parent_provider
+        provider = ambient_provider or parent_provider
+        if opts.provider:
+            # If an explicit provider was passed in,
+            # its package may or may not match the package we're looking for.
+            provider_pkg = opts.provider.package
+            if pkg == provider_pkg:
+                # Explicit provider takes precedence over parent or ambient providers.
+                provider = opts.provider
 
-        if pkg and opts.provider:
-            if pkg in opts_providers:
-                message = f"There is a conflict between the `provider` field ({pkg}) and a member of the `providers` map"
+            # Regardless of whether it matches,
+            # we still want to keep the provider in the
+            # providers map, so that it can be used for child resources.
+            if provider_pkg in opts_providers:
+                message = f"There is a conflict between the `provider` field ({provider_pkg}) and a member of the `providers` map"
                 depreciation = "This will become an error by the end of July 2022. See https://github.com/pulumi/pulumi/issues/8799 for more details"
                 warnings.warn(f"{message} for resource {t}. " + depreciation)
                 log.warn(f"{message}. {depreciation}", resource=self)
             else:
-                opts_providers[pkg] = opts.provider
+                opts_providers[provider_pkg] = opts.provider
 
         # opts_providers takes priority over self._providers
         providers = {**self._providers, **opts_providers}

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -129,6 +129,46 @@ def test_depends_on_typing_variations(dep_tracker) -> None:
     ])
 
 
+@pulumi.runtime.test
+def test_component_resource_propagates_provider() -> None:
+    mocks.set_mocks(MinimalMocks())
+
+    provider = pulumi.ProviderResource('test', 'prov', {})
+    component = pulumi.ComponentResource(
+        "custom:foo:Component",
+        "comp",
+        opts=pulumi.ResourceOptions(provider=provider),
+    )
+    custom = pulumi.CustomResource(
+        "test:index:Resource",
+        "res",
+        opts=pulumi.ResourceOptions(parent=component),
+    )
+
+    assert provider == custom._provider, \
+        "Failed to propagate provider to child resource"
+
+
+@pulumi.runtime.test
+def test_component_resource_propagates_providers_list() -> None:
+    mocks.set_mocks(MinimalMocks())
+
+    provider = pulumi.ProviderResource('test', 'prov', {})
+    component = pulumi.ComponentResource(
+        "custom:foo:Component",
+        "comp",
+        opts=pulumi.ResourceOptions(providers=[provider]),
+    )
+    custom = pulumi.CustomResource(
+        "test:index:Resource",
+        "res",
+        opts=pulumi.ResourceOptions(parent=component),
+    )
+
+    assert provider == custom._provider, \
+        "Failed to propagate provider to child resource"
+
+
 def output_depending_on_resource(r: pulumi.Resource, isKnown: bool) -> pulumi.Output[None]:
     """Returns an output that depends on the given resource."""
     o = pulumi.Output.from_input(None)


### PR DESCRIPTION
It's currently possible in Pulumi to pass a ProviderResource
as a Provider option to a ComponentResource.
The ComponentResource will record the Provider for later,
and propagate it to its child resources.
This is currently the behavior in [all SDKs except Python][1].

  [1]: https://github.com/pulumi/pulumi/issues/12161#issuecomment-1446864847

The reason this didn't work was because in Python's
providers merging logic, we use the incorrect package name
when saving the provider.
Instead of using the package name reported by the provider,
we were using the package name of the current resource
(the ComponentResource in this case).

To fix this, verify that the package name of the provider
matches the package name of the resource we're building.
If it doesn't, we will still save the provider
for child resources.

Resolves #12161
