### PR TITLE
sdk/py/test: Fix MergeResourceOptions test

### DIFF
--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -201,5 +201,5 @@ class MergeResourceOptions(unittest.TestCase):
         assert opts1.protect is None
         opts2 = ResourceOptions.merge(opts1, ResourceOptions(protect=True))
         assert opts2.protect is True
-        opts3 = opts2.merge(ResourceOptions())
+        opts3 = ResourceOptions.merge(opts2, ResourceOptions())
         assert opts3.protect is True


### PR DESCRIPTION
The MergeResourceOptions test was incorrectly invoking
the static method ResourceOptions.merge as an instance method.
This issue was reported by the type-checker.
