### PR TITLE
Cleanup node-pipes folder after Run

### DIFF
--- a/changelog/pending/20230227--sdk-nodejs--cleanup-temporary-pulumi-node-pipes-folders-after-running.yaml
+++ b/changelog/pending/20230227--sdk-nodejs--cleanup-temporary-pulumi-node-pipes-folders-after-running.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Cleanup temporary pulumi-node-pipes folders after running.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -514,6 +514,7 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 	if err != nil {
 		return nil, err
 	}
+	defer pipes.shutdown()
 
 	// Channel producing the final response we want to issue to our caller. Will get the result of
 	// the actual nodejs process we launch, or any results caused by errors in our server/pipes.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_unix.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_unix.go
@@ -91,13 +91,11 @@ func (p *unixPipes) connect() error {
 func (p *unixPipes) shutdown() {
 	if p.reqPipe != nil {
 		contract.IgnoreClose(p.reqPipe)
-		contract.IgnoreError(os.Remove(p.reqPath))
 	}
 
 	if p.resPipe != nil {
 		contract.IgnoreClose(p.resPipe)
-		contract.IgnoreError(os.Remove(p.resPath))
 	}
 
-	contract.IgnoreError(os.Remove(p.dir))
+	contract.IgnoreError(os.RemoveAll(p.dir))
 }


### PR DESCRIPTION

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/12263

This calls shutdown on the pipes created in `Run` to ensure they always get cleaned up. Changed the multiple `Remove` calls to just a single `RemoveAll`, oddly the multiple `Remove` calls didn't seem to delete everything.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works - Manually checked.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
