### PR TITLE
sdk/go/ResourceOption: Provider option takes precedence

### DIFF
--- a/changelog/pending/20230228--sdk-go--fixes-overwrite-of-the-provider-option-by-the-providers-option-due-to-ordering.yaml
+++ b/changelog/pending/20230228--sdk-go--fixes-overwrite-of-the-provider-option-by-the-providers-option-due-to-ordering.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fixes overwrite of the Provider option by the Providers option due to ordering.

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1042,7 +1042,13 @@ func (ctx *Context) mergeProviders(t string, parent Resource, provider ProviderR
 	// copy specific provider, if any
 	if provider != nil {
 		pkg := provider.getPackage()
-		if _, alreadyExists := providerMap[pkg]; alreadyExists {
+		// We want to warn users if there's a conflicting
+		// provider entry in the map.
+		// However, since we merge the Provider into the Providers map
+		// when combining the functional options,
+		// there will always be a conflicting entry in the map.
+		// So we need to also check that it's a different provider.
+		if other, alreadyExists := providerMap[pkg]; alreadyExists && other != provider {
 			err := ctx.Log.Warn(fmt.Sprintf("Provider for %s conflicts with providers map. %s %s", pkg,
 				"This will become an error in july 2022.",
 				"See https://github.com/pulumi/pulumi/issues/8799 for more details.",

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -67,93 +67,93 @@ func TestResourceOptionMergingProvider(t *testing.T) {
 
 	// all providers are merged into a map
 	// last specified provider for a given pkg wins
-	p1 := &testProv{foo: "a"}
-	p1.pkg = "aws"
-	p2 := &testProv{foo: "b"}
-	p2.pkg = "aws"
-	p3 := &testProv{foo: "c"}
-	p3.pkg = "azure"
+	aws1 := &testProv{foo: "a"}
+	aws1.pkg = "aws"
+	aws2 := &testProv{foo: "b"}
+	aws2.pkg = "aws"
+	azure := &testProv{foo: "c"}
+	azure.pkg = "azure"
 
 	t.Run("two singleton options for same pkg", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Provider(p1), Provider(p2))
+		opts := merge(Provider(aws1), Provider(aws2))
 		assert.Equal(t, 1, len(opts.Providers))
-		assert.Equal(t, p2, opts.Providers["aws"])
+		assert.Equal(t, aws2, opts.Providers["aws"])
 	})
 
 	t.Run("two singleton options for different pkg", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Provider(p1), Provider(p3))
+		opts := merge(Provider(aws1), Provider(azure))
 		assert.Equal(t, 2, len(opts.Providers))
-		assert.Equal(t, p1, opts.Providers["aws"])
-		assert.Equal(t, p3, opts.Providers["azure"])
+		assert.Equal(t, aws1, opts.Providers["aws"])
+		assert.Equal(t, azure, opts.Providers["azure"])
 	})
 
 	t.Run("singleton and array", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Provider(p1), Providers(p2, p3))
+		opts := merge(Provider(aws1), Providers(aws2, azure))
 		assert.Equal(t, 2, len(opts.Providers))
-		assert.Equal(t, p2, opts.Providers["aws"])
-		assert.Equal(t, p3, opts.Providers["azure"])
+		assert.Equal(t, aws2, opts.Providers["aws"])
+		assert.Equal(t, azure, opts.Providers["azure"])
 	})
 
 	t.Run("singleton and single value array", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Provider(p1), Providers(p2))
+		opts := merge(Provider(aws1), Providers(aws2))
 		assert.Equal(t, 1, len(opts.Providers))
-		assert.Equal(t, p2, opts.Providers["aws"])
+		assert.Equal(t, aws2, opts.Providers["aws"])
 	})
 
 	t.Run("two arrays", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Providers(p1), Providers(p3))
+		opts := merge(Providers(aws1), Providers(azure))
 		assert.Equal(t, 2, len(opts.Providers))
-		assert.Equal(t, p1, opts.Providers["aws"])
-		assert.Equal(t, p3, opts.Providers["azure"])
+		assert.Equal(t, aws1, opts.Providers["aws"])
+		assert.Equal(t, azure, opts.Providers["azure"])
 	})
 
 	t.Run("overlapping arrays", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Providers(p1, p2), Providers(p1, p3))
+		opts := merge(Providers(aws1, aws2), Providers(aws1, azure))
 		assert.Equal(t, 2, len(opts.Providers))
-		assert.Equal(t, p1, opts.Providers["aws"])
-		assert.Equal(t, p3, opts.Providers["azure"])
+		assert.Equal(t, aws1, opts.Providers["aws"])
+		assert.Equal(t, azure, opts.Providers["azure"])
 	})
 
-	m1 := map[string]ProviderResource{"aws": p1}
-	m2 := map[string]ProviderResource{"aws": p2}
-	m3 := map[string]ProviderResource{"aws": p2, "azure": p3}
+	m1 := map[string]ProviderResource{"aws": aws1}
+	m2 := map[string]ProviderResource{"aws": aws2}
+	m3 := map[string]ProviderResource{"aws": aws2, "azure": azure}
 
 	t.Run("single value maps", func(t *testing.T) {
 		t.Parallel()
 
 		opts := merge(ProviderMap(m1), ProviderMap(m2))
 		assert.Equal(t, 1, len(opts.Providers))
-		assert.Equal(t, p2, opts.Providers["aws"])
+		assert.Equal(t, aws2, opts.Providers["aws"])
 	})
 
 	t.Run("singleton with map", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Provider(p1), ProviderMap(m3))
+		opts := merge(Provider(aws1), ProviderMap(m3))
 		assert.Equal(t, 2, len(opts.Providers))
-		assert.Equal(t, p2, opts.Providers["aws"])
-		assert.Equal(t, p3, opts.Providers["azure"])
+		assert.Equal(t, aws2, opts.Providers["aws"])
+		assert.Equal(t, azure, opts.Providers["azure"])
 	})
 
 	t.Run("array and map", func(t *testing.T) {
 		t.Parallel()
 
-		opts := merge(Providers(p2, p1), ProviderMap(m3))
+		opts := merge(Providers(aws2, aws1), ProviderMap(m3))
 		assert.Equal(t, 2, len(opts.Providers))
-		assert.Equal(t, p2, opts.Providers["aws"])
-		assert.Equal(t, p3, opts.Providers["azure"])
+		assert.Equal(t, aws2, opts.Providers["aws"])
+		assert.Equal(t, azure, opts.Providers["azure"])
 	})
 }
 


### PR DESCRIPTION
This change fixes a discrepancy in the Provider and Providers options
versus other SDKs:
Provider option doesn't always take precedence in the Go SDK.

## Background

Suppose we have providers 'ambient' and 'local' for the same package.
We want to use 'local' directly for the resource,
and 'ambient' for its child resources.
So we pass the options,
`Providers(ambient)` to put ambient into the bag of providers,
and `Provider(local)` to use it for the resource.

    NewResource(ctx, Providers(ambient), Provider(local))

This works as expected, but if we flip the order of the options,
it doesn't:

    NewResource(ctx, Provider(local), Providers(ambient))

This is because of how the two options are merged in the Go SDK.
`Provider(..)` unconditionally turns into `Providers(..)`,
losing the information about it being explicitly set for that resource.

https://github.com/pulumi/pulumi/blob/fbc66dd29e922eab3ce7870110ae55b5366cff1e/sdk/go/pulumi/resource.go#L458-L462

## Fix

Unfortunately, we can't just stop merging Provider into Providers.
In Go, we use functional options to implement resource options.
Unlike other SDKs, this makes it possible to provide the same option
multiple times.

Due to the prior merging logic, we've established in the Go SDK
that the following two are roughly equivalent:

    NewResource(.., Provider(p1), Provider(p2), Provider(p3))
    NewResource(.., Providers(p1, p2, p3))

If we change this now, it is likely to break users of the Go SDK.
Therefore, we need to retain this part of the behavior.

To fix this, we separately track the last passed `Provider`.
This will take precedence when we try to get the provider for a
resource.

Note:
We already had a Provider field on resourceOptions,
as well as machinery to have it take precedence.
We simply neglected to set that field when we refactored
ResourceOption merging in the past.

Resolves #12192
