### PR TITLE
sdk/go: Fix panic from uninitialized parent resources

### DIFF
--- a/changelog/pending/20230228--sdk-go--fix-panic-from-attempting-to-create-a-resource-with-an-uninitialized-parent-resource.yaml
+++ b/changelog/pending/20230228--sdk-go--fix-panic-from-attempting-to-create-a-resource-with-an-uninitialized-parent-resource.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Fix panic from attempting to create a resource with an uninitialized parent resource.

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -806,6 +806,20 @@ func (ctx *Context) registerResource(
 	parent := options.Parent
 	if options.Parent == nil {
 		options.Parent = ctx.stack
+	} else {
+		// Guard against uninitialized parent resources to prevent
+		// panics from invalid state further down the line.
+		// Uninitialized parent resources won't have a URN.
+		if parent.URN().getState() == nil {
+			var msg string
+			if _, parentIsCustom := parent.(CustomResource); !parentIsCustom {
+				msg = "parent component resource %T has not been registered: " +
+					"did you mean to call RegisterComponentResource?"
+			} else {
+				msg = "parent resource %T has not been registered"
+			}
+			return fmt.Errorf(msg, parent)
+		}
 	}
 
 	// Before anything else, if there are transformations registered, give them a chance to run to modify the


### PR DESCRIPTION
# Description

The Go SDK panics if RegisterResource is called with a parent resource
that is uninitialized
(hasn't had its RegisterResource or RegisterComponentResource call yet).

The panic is during alias collapsing:
the system fails to read the unintialized parent resource's URN
from a zero-valued URNOutput.

Guard against this panic by verifying that the value passed to `Parent`
has been initialized.
We do this by checking the name of the resource--names are not allowed
to be empty when a resource is registered.

Resolves #12138

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
