### PR TITLE
codegen/{go,js,.net,py}: Generate retainOnDelete

### DIFF
--- a/changelog/pending/20230228--programgen-dotnet-go-nodejs-python--adds-support-for-generating-retainondelete-options.yaml
+++ b/changelog/pending/20230228--programgen-dotnet-go-nodejs-python--adds-support-for-generating-retainondelete-options.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: programgen/dotnet,go,nodejs,python
+  description: Adds support for generating RetainOnDelete options.

--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -616,6 +616,9 @@ func (g *generator) genResourceOptions(opts *pcl.ResourceOptions) string {
 	if opts.Protect != nil {
 		appendOption("Protect", opts.Protect)
 	}
+	if opts.RetainOnDelete != nil {
+		appendOption("RetainOnDelete", opts.RetainOnDelete)
+	}
 	if opts.IgnoreChanges != nil {
 		appendOption("IgnoreChanges", opts.IgnoreChanges)
 	}

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -593,6 +593,9 @@ func (g *generator) lowerResourceOptions(opts *pcl.ResourceOptions) (*model.Bloc
 	if opts.Protect != nil {
 		appendOption("Protect", opts.Protect, model.BoolType)
 	}
+	if opts.RetainOnDelete != nil {
+		appendOption("RetainOnDelete", opts.RetainOnDelete, model.BoolType)
+	}
 	if opts.IgnoreChanges != nil {
 		appendOption("IgnoreChanges", opts.IgnoreChanges, model.NewListType(model.StringType))
 	}

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -453,6 +453,9 @@ func (g *generator) genResourceOptions(opts *pcl.ResourceOptions) string {
 	if opts.Protect != nil {
 		appendOption("protect", opts.Protect)
 	}
+	if opts.RetainOnDelete != nil {
+		appendOption("retainOnDelete", opts.RetainOnDelete)
+	}
 	if opts.IgnoreChanges != nil {
 		appendOption("ignoreChanges", opts.IgnoreChanges)
 	}

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -413,6 +413,9 @@ func (g *generator) lowerResourceOptions(opts *pcl.ResourceOptions) (*model.Bloc
 	if opts.Protect != nil {
 		appendOption("protect", opts.Protect)
 	}
+	if opts.RetainOnDelete != nil {
+		appendOption("retain_on_delete", opts.RetainOnDelete)
+	}
 	if opts.IgnoreChanges != nil {
 		appendOption("ignore_changes", opts.IgnoreChanges)
 	}

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -231,6 +231,10 @@ var PulumiPulumiProgramTests = []ProgramTest{
 		// directionally correct.
 		SkipCompile: allProgLanguages,
 	},
+	{
+		Directory:   "retain-on-delete",
+		Description: "Generate RetainOnDelete option",
+	},
 }
 
 var PulumiPulumiYAMLProgramTests = []ProgramTest{

--- a/pkg/codegen/testing/test/testdata/retain-on-delete-pp/dotnet/retain-on-delete.cs
+++ b/pkg/codegen/testing/test/testdata/retain-on-delete-pp/dotnet/retain-on-delete.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Pulumi;
+using Random = Pulumi.Random;
+
+return await Deployment.RunAsync(() => 
+{
+    var foo = new Random.RandomPet("foo", new()
+    {
+    }, new CustomResourceOptions
+    {
+        RetainOnDelete = true,
+    });
+
+});
+

--- a/pkg/codegen/testing/test/testdata/retain-on-delete-pp/go/retain-on-delete.go
+++ b/pkg/codegen/testing/test/testdata/retain-on-delete-pp/go/retain-on-delete.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := random.NewRandomPet(ctx, "foo", nil, pulumi.RetainOnDelete(true))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/testing/test/testdata/retain-on-delete-pp/nodejs/retain-on-delete.ts
+++ b/pkg/codegen/testing/test/testdata/retain-on-delete-pp/nodejs/retain-on-delete.ts
@@ -1,0 +1,6 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+const foo = new random.RandomPet("foo", {}, {
+    retainOnDelete: true,
+});

--- a/pkg/codegen/testing/test/testdata/retain-on-delete-pp/python/retain-on-delete.py
+++ b/pkg/codegen/testing/test/testdata/retain-on-delete-pp/python/retain-on-delete.py
@@ -1,0 +1,4 @@
+import pulumi
+import pulumi_random as random
+
+foo = random.RandomPet("foo", opts=pulumi.ResourceOptions(retain_on_delete=True))

--- a/pkg/codegen/testing/test/testdata/retain-on-delete-pp/retain-on-delete.pp
+++ b/pkg/codegen/testing/test/testdata/retain-on-delete-pp/retain-on-delete.pp
@@ -1,0 +1,5 @@
+resource foo "random:index/randomPet:RandomPet" {
+  options {
+    retainOnDelete = true
+  }
+}

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/azure-app-service-pp/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/azure-app-service-pp/nodejs/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@pulumi/azure-native": "^1.29.0",
         "@pulumi/pulumi": "latest",
-        "@pulumi/random": "^4.2.0"
+        "@pulumi/random": "^4.11.2"
     },
     "devDependencies": {
         "@types/node": "^17.0.14",

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Random" Version="4.2.0" />
+    <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 
 </Project>

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/nodejs/package.json
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/cue-random-pp/nodejs/package.json
@@ -3,7 +3,7 @@
     "version": "",
     "dependencies": {
         "@pulumi/pulumi": "latest",
-        "@pulumi/random": "^4.2.0"
+        "@pulumi/random": "^4.11.2"
     },
     "devDependencies": {
         "@types/node": "^17.0.14",

--- a/pkg/codegen/testing/test/testdata/transpiled_examples/random-pp/dotnet/dotnet.csproj
+++ b/pkg/codegen/testing/test/testdata/transpiled_examples/random-pp/dotnet/dotnet.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Random" Version="4.2.0" />
+    <PackageReference Include="Pulumi.Random" Version="4.11.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Uses the newly added `options.retainOnDelete` in PCL
to generate the RetainOnDelete resource option
for Go, NodeJS, .NET, and Python.

Java support cannot be added without a release of pulumi/pulumi
because the new field in pcl.ResourceOptions is not yet visible
to Java.
The change has been staged at https://github.com/pulumi/pulumi-java/pull/1005
pending merge and release of #12305.

Resolves #12304
