### PR TITLE
Retry 403 rate limit errors from github

### DIFF
--- a/changelog/pending/20230228--cli-plugin--retry-403-rate-limit-errors-from-github-when-downloading-plugins.yaml
+++ b/changelog/pending/20230228--cli-plugin--retry-403-rate-limit-errors-from-github-when-downloading-plugins.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/plugin
+  description: Retry 403 rate limit errors from GitHub when downloading plugins.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adding a small retry loop to the github downloader to retry 403 errors _iff_ they're due to rate limits. We can't just retry all 403 errors because that code could be returned for other errors as well.

Fixes https://github.com/pulumi/pulumi/issues/11013

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
