### PR TITLE
Python grpc 1.51.3 contains universal2 binaries (x86_64 & arm64)

### DIFF
--- a/changelog/pending/20230301--sdk-python--grpc-1-51.3-python-sdk-contains-native-arm64-binaries.yaml
+++ b/changelog/pending/20230301--sdk-python--grpc-1-51.3-python-sdk-contains-native-arm64-binaries.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: grpc 1.51.3 Python SDK contains native arm64 binaries (universal2)

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -45,7 +45,7 @@ setup(name='pulumi',
       # Keep this list in sync with Pipfile
       install_requires=[
           'protobuf~=4.21',
-          'grpcio==1.50',
+          'grpcio==1.51.3',
           'dill~=0.3',
           'six~=1.12',
           'semver~=2.8',

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,7 +1,7 @@
 # Packages needed by the library.
 # Keep this list in sync with setup.py.
 protobuf~=4.21
-grpcio==1.50
+grpcio==1.51.3
 dill~=0.3
 six~=1.12
 semver~=2.8


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

[grpc 1.51.3](https://github.com/grpc/grpc/releases/tag/v1.51.3) contains a wheel with native arm64 binaries (universal2), easing the installation of the Pulumi Python SDK on Apple M1/M2 machines.grp

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
