### PR TITLE
[cli] Fetch update tokens in the API client

### DIFF
--- a/changelog/pending/20230301--backend-service--reduce-retrieval-validation-latency-for-update-tokens.yaml
+++ b/changelog/pending/20230301--backend-service--reduce-retrieval-validation-latency-for-update-tokens.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/service
+  description: Reduce retrieval-validation latency for update tokens

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -922,7 +922,9 @@ func (pc *Client) RenewUpdateLease(ctx context.Context, update UpdateIdentifier,
 }
 
 // InvalidateUpdateCheckpoint invalidates the checkpoint for the indicated update.
-func (pc *Client) InvalidateUpdateCheckpoint(ctx context.Context, update UpdateIdentifier, token UpdateTokenSource) error {
+func (pc *Client) InvalidateUpdateCheckpoint(ctx context.Context, update UpdateIdentifier,
+	token UpdateTokenSource) error {
+
 	req := apitype.PatchUpdateCheckpointRequest{
 		IsInvalid: true,
 	}

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -126,12 +126,14 @@ func TestGzip(t *testing.T) {
 	_, err := client.ImportStackDeployment(context.Background(), StackIdentifier{}, nil)
 	assert.NoError(t, err)
 
+	tok := updateTokenStaticSource("")
+
 	// PATCH /checkpoint
-	err = client.PatchUpdateCheckpoint(context.Background(), UpdateIdentifier{}, nil, "")
+	err = client.PatchUpdateCheckpoint(context.Background(), UpdateIdentifier{}, nil, tok)
 	assert.NoError(t, err)
 
 	// POST /events/batch
-	err = client.RecordEngineEvents(context.Background(), UpdateIdentifier{}, apitype.EngineEventBatch{}, "")
+	err = client.RecordEngineEvents(context.Background(), UpdateIdentifier{}, apitype.EngineEventBatch{}, tok)
 	assert.NoError(t, err)
 
 	// POST /events/batch
@@ -182,7 +184,7 @@ func TestPatchUpdateCheckpointVerbatimIndents(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = client.PatchUpdateCheckpointVerbatim(context.Background(),
-		UpdateIdentifier{}, sequenceNumber, indented, "token")
+		UpdateIdentifier{}, sequenceNumber, indented, updateTokenStaticSource("token"))
 	assert.NoError(t, err)
 
 	compacted := func(raw json.RawMessage) string {

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -241,6 +241,6 @@ type tokenSourceFn func() (string, error)
 
 var _ tokenSourceCapability = tokenSourceFn(nil)
 
-func (tsf tokenSourceFn) GetToken() (string, error) {
+func (tsf tokenSourceFn) GetToken(_ context.Context) (string, error) {
 	return tsf()
 }

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -78,21 +78,13 @@ func (u *cloudUpdate) GetTarget() *deploy.Target {
 func (u *cloudUpdate) Complete(status apitype.UpdateStatus) error {
 	defer u.tokenSource.Close()
 
-	token, err := u.tokenSource.GetToken()
-	if err != nil {
-		return err
-	}
-	return u.backend.client.CompleteUpdate(u.context, u.update, status, token)
+	return u.backend.client.CompleteUpdate(u.context, u.update, status, u.tokenSource)
 }
 
 // recordEngineEvents will record the events with the Pulumi Service, enabling things like viewing
 // the update logs or drilling into the timeline of an update.
 func (u *cloudUpdate) recordEngineEvents(startingSeqNumber int, events []engine.Event) error {
 	contract.Assertf(u.tokenSource != nil, "cloud update requires a token source")
-	token, err := u.tokenSource.GetToken()
-	if err != nil {
-		return err
-	}
 
 	var apiEvents apitype.EngineEventBatch
 	for idx, event := range events {
@@ -110,7 +102,7 @@ func (u *cloudUpdate) recordEngineEvents(startingSeqNumber int, events []engine.
 		apiEvents.Events = append(apiEvents.Events, apiEvent)
 	}
 
-	return u.backend.client.RecordEngineEvents(u.context, u.update, apiEvents, token)
+	return u.backend.client.RecordEngineEvents(u.context, u.update, apiEvents, u.tokenSource)
 }
 
 // RecordAndDisplayEvents inspects engine events from the given channel, and prints them to the CLI as well as

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -23,7 +23,7 @@ import (
 )
 
 type tokenSourceCapability interface {
-	GetToken() (string, error)
+	GetToken(ctx context.Context) (string, error)
 }
 
 // tokenSource is a helper type that manages the renewal of the lease token for a managed update.
@@ -130,11 +130,21 @@ func (ts *tokenSource) handleRequests(
 	}
 }
 
-func (ts *tokenSource) GetToken() (string, error) {
+func (ts *tokenSource) GetToken(ctx context.Context) (string, error) {
 	ch := make(chan tokenResponse)
-	ts.requests <- ch
-	resp := <-ch
-	return resp.token, resp.err
+
+	select {
+	case ts.requests <- ch:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+
+	select {
+	case resp := <-ch:
+		return resp.token, resp.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
 }
 
 func (ts *tokenSource) Close() {

--- a/pkg/backend/httpstate/token_source_test.go
+++ b/pkg/backend/httpstate/token_source_test.go
@@ -42,7 +42,7 @@ func TestTokenSource(t *testing.T) {
 	defer ts.Close()
 
 	for i := 0; i < 32; i++ {
-		tok, err := ts.GetToken()
+		tok, err := ts.GetToken(ctx)
 		assert.NoError(t, err)
 		assert.NoError(t, backend.VerifyToken(tok))
 		t.Logf("STEP: %d, TOKEN: %s", i, tok)
@@ -78,7 +78,7 @@ func TestTokenSourceWithQuicklyExpiringInitialToken(t *testing.T) {
 	defer ts.Close()
 
 	for i := 0; i < 8; i++ {
-		tok, err := ts.GetToken()
+		tok, err := ts.GetToken(ctx)
 		assert.NoError(t, err)
 		assert.NoError(t, backend.VerifyToken(tok))
 		t.Logf("STEP: %d, TOKEN: %s", i, tok)


### PR DESCRIPTION
Rather than fetching update tokens in consumers of the API client, fetch them in the API client itself. This minimizes the latency between the retrieval of the token and the validation of the token by the Pulumi Service. This is intended to help prevent the use of expired tokens.

Part of #7094.