### PR TITLE
scripts/retry: set-output is deprecated

### DIFF
--- a/scripts/retry
+++ b/scripts/retry
@@ -39,8 +39,8 @@ run_tests() {
 
 run_tests "${@}"
 
-echo "::set-output name=TEST_SUCCESS::${success}"
-echo "::set-output name=TEST_RETRIED::${retried}"
+echo "TEST_SUCCESS=${success}" >> "$GITHUB_OUTPUT"
+echo "TEST_RETRIED=${retried}" >> "$GITHUB_OUTPUT"
 
 if ! "${success}"; then
     exit 1


### PR DESCRIPTION
The set-output command has been deprecated by GitHub.
Replace it with the GITHUB_OUTPUT based variant.

This was the only remaining instance of `::set-output`
in the repository after e4e96c96d.
