### PR TITLE
testdata/schema: Add random 4.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,8 @@ schema-%: curl.ensure jq.ensure
 #
 # pkg/codegen/testing/utils/host.go depends on this list, update that file on changes.
 #
+# pkg/codegen/testing/test/helpers.go depends on some of this list, update that file on changes.
+#
 # pkg/codegen/schema/schema_test.go depends on kubernetes@3.7.2, update that file on changes.
 #
 # As a courtesy to reviewers, please make changes to this list and the committed schema files in a
@@ -189,6 +191,7 @@ get_schemas: \
 			schema-kubernetes!3.7.2     \
 			schema-random!4.2.0         \
 			schema-random!4.3.1         \
+			schema-random!4.11.2        \
 			schema-eks!0.37.1           \
 			schema-eks!0.40.0           \
 			schema-docker!3.1.0         \

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -371,6 +371,6 @@ const (
 	AzureNativeSchema SchemaVersion = "1.29.0"
 	AzureSchema       SchemaVersion = "4.18.0"
 	KubernetesSchema  SchemaVersion = "3.7.2"
-	RandomSchema      SchemaVersion = "4.2.0"
+	RandomSchema      SchemaVersion = "4.11.2"
 	EksSchema         SchemaVersion = "0.37.1"
 )

--- a/pkg/codegen/testing/test/testdata/random-4.11.2.json
+++ b/pkg/codegen/testing/test/testdata/random-4.11.2.json
@@ -1,0 +1,864 @@
+{
+  "name": "random",
+  "description": "A Pulumi package to safely use randomness in Pulumi programs.",
+  "keywords": [
+    "pulumi",
+    "random"
+  ],
+  "homepage": "https://pulumi.io",
+  "license": "Apache-2.0",
+  "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/terraform-providers/terraform-provider-random).",
+  "repository": "https://github.com/pulumi/pulumi-random",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "csharp": {
+      "compatibility": "tfbridge20",
+      "namespaces": {
+        "random": "Random"
+      },
+      "packageReferences": {
+        "Pulumi": "3.*"
+      }
+    },
+    "go": {
+      "generateExtraInputTypes": true,
+      "generateResourceContainerTypes": true,
+      "importBasePath": "github.com/pulumi/pulumi-random/sdk/v4/go/random"
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^10.0.0"
+      },
+      "disableUnionOutputTypes": true,
+      "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
+      "packageName": "",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
+      "typescriptVersion": ""
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "readme": "> This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n> first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n> please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
+      "requires": {
+        "pulumi": ">=3.0.0,<4.0.0"
+      }
+    }
+  },
+  "config": {},
+  "provider": {
+    "description": "The provider type for the random package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+  },
+  "resources": {
+    "random:index/randomId:RandomId": {
+      "description": "The resource `random.RandomId` generates random numbers that are intended to be\nused as unique identifiers for other resources.\n\nThis resource *does* use a cryptographic random number generator in order\nto minimize the chance of collisions, making the results of this resource\nwhen a 16-byte identifier is requested of equivalent uniqueness to a\ntype-4 UUID.\n\nThis resource can be used in conjunction with resources that have\nthe `create_before_destroy` lifecycle flag set to avoid conflicts with\nunique names during the brief period where both the old and new resources\nexist concurrently.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\n// The following example shows how to generate a unique name for an AWS EC2\n// instance that changes each time a new AMI id is selected.\nconst serverRandomId = new random.RandomId(\"serverRandomId\", {\n    keepers: {\n        ami_id: _var.ami_id,\n    },\n    byteLength: 8,\n});\nconst serverInstance = new aws.ec2.Instance(\"serverInstance\", {\n    tags: {\n        Name: pulumi.interpolate`web-server ${serverRandomId.hex}`,\n    },\n    ami: serverRandomId.keepers.apply(keepers => keepers?.amiId),\n});\n// ... (other aws_instance arguments) ...\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nreturn await Deployment.RunAsync(() => \n{\n    // The following example shows how to generate a unique name for an AWS EC2\n    // instance that changes each time a new AMI id is selected.\n    var serverRandomId = new Random.RandomId(\"serverRandomId\", new()\n    {\n        Keepers = \n        {\n            { \"ami_id\", @var.Ami_id },\n        },\n        ByteLength = 8,\n    });\n\n    var serverInstance = new Aws.Ec2.Instance(\"serverInstance\", new()\n    {\n        Tags = \n        {\n            { \"Name\", serverRandomId.Hex.Apply(hex => $\"web-server {hex}\") },\n        },\n        Ami = serverRandomId.Keepers.Apply(keepers => keepers?.AmiId),\n    });\n\n    // ... (other aws_instance arguments) ...\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2\"\n\t\"github.com/pulumi/pulumi-random/sdk/v4/go/random\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tserverRandomId, err := random.NewRandomId(ctx, \"serverRandomId\", &random.RandomIdArgs{\n\t\t\tKeepers: pulumi.StringMap{\n\t\t\t\t\"ami_id\": pulumi.Any(_var.Ami_id),\n\t\t\t},\n\t\t\tByteLength: pulumi.Int(8),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = ec2.NewInstance(ctx, \"serverInstance\", &ec2.InstanceArgs{\n\t\t\tTags: pulumi.StringMap{\n\t\t\t\t\"Name\": serverRandomId.Hex.ApplyT(func(hex string) (string, error) {\n\t\t\t\t\treturn fmt.Sprintf(\"web-server %v\", hex), nil\n\t\t\t\t}).(pulumi.StringOutput),\n\t\t\t},\n\t\t\tAmi: serverRandomId.Keepers.ApplyT(func(keepers interface{}) (*string, error) {\n\t\t\t\treturn &keepers.AmiId, nil\n\t\t\t}).(pulumi.StringPtrOutput),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.random.RandomId;\nimport com.pulumi.random.RandomIdArgs;\nimport com.pulumi.aws.ec2.Instance;\nimport com.pulumi.aws.ec2.InstanceArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var serverRandomId = new RandomId(\"serverRandomId\", RandomIdArgs.builder()        \n            .keepers(Map.of(\"ami_id\", var_.ami_id()))\n            .byteLength(8)\n            .build());\n\n        var serverInstance = new Instance(\"serverInstance\", InstanceArgs.builder()        \n            .tags(Map.of(\"Name\", serverRandomId.hex().applyValue(hex -> String.format(\"web-server %s\", hex))))\n            .ami(serverRandomId.keepers().applyValue(keepers -> keepers.amiId()))\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  # The following example shows how to generate a unique name for an AWS EC2\n  # instance that changes each time a new AMI id is selected.\n  serverRandomId:\n    type: random:RandomId\n    properties:\n      keepers:\n        ami_id: ${var.ami_id}\n      byteLength: 8\n  serverInstance:\n    type: aws:ec2:Instance\n    properties:\n      tags:\n        Name: web-server ${serverRandomId.hex}\n      # Read the AMI id \"through\" the random_id resource to ensure that\n      #   # both will change together.\n      ami: ${serverRandomId.keepers.amiId}\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nRandom IDs can be imported using the b64_url with an optional prefix. This can be used to replace a config value with a value interpolated from the random provider without experiencing diffs. Example with no prefix\n\n```sh\n $ pulumi import random:index/randomId:RandomId server p-9hUg\n```\n\n Example with prefix (prefix is separated by a ,)\n\n```sh\n $ pulumi import random:index/randomId:RandomId server my-prefix-,p-9hUg\n```\n\n ",
+      "properties": {
+        "b64Std": {
+          "type": "string",
+          "description": "The generated id presented in base64 without additional transformations.\n"
+        },
+        "b64Url": {
+          "type": "string",
+          "description": "The generated id presented in base64, using the URL-friendly character set: case-sensitive letters, digits and the characters `_` and `-`.\n"
+        },
+        "byteLength": {
+          "type": "integer",
+          "description": "The number of random bytes to produce. The minimum value is 1, which produces eight bits of randomness.\n"
+        },
+        "dec": {
+          "type": "string",
+          "description": "The generated id presented in non-padded decimal digits.\n"
+        },
+        "hex": {
+          "type": "string",
+          "description": "The generated id presented in padded hexadecimal digits. This result will always be twice as long as the requested byte length.\n"
+        },
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Arbitrary string to prefix the output value with. This string is supplied as-is, meaning it is not guaranteed to be URL-safe or base64 encoded.\n"
+        }
+      },
+      "required": [
+        "b64Std",
+        "b64Url",
+        "byteLength",
+        "dec",
+        "hex"
+      ],
+      "inputProperties": {
+        "byteLength": {
+          "type": "integer",
+          "description": "The number of random bytes to produce. The minimum value is 1, which produces eight bits of randomness.\n"
+        },
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Arbitrary string to prefix the output value with. This string is supplied as-is, meaning it is not guaranteed to be URL-safe or base64 encoded.\n"
+        }
+      },
+      "requiredInputs": [
+        "byteLength"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomId resources.\n",
+        "properties": {
+          "b64Std": {
+            "type": "string",
+            "description": "The generated id presented in base64 without additional transformations.\n"
+          },
+          "b64Url": {
+            "type": "string",
+            "description": "The generated id presented in base64, using the URL-friendly character set: case-sensitive letters, digits and the characters `_` and `-`.\n"
+          },
+          "byteLength": {
+            "type": "integer",
+            "description": "The number of random bytes to produce. The minimum value is 1, which produces eight bits of randomness.\n"
+          },
+          "dec": {
+            "type": "string",
+            "description": "The generated id presented in non-padded decimal digits.\n"
+          },
+          "hex": {
+            "type": "string",
+            "description": "The generated id presented in padded hexadecimal digits. This result will always be twice as long as the requested byte length.\n"
+          },
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+          },
+          "prefix": {
+            "type": "string",
+            "description": "Arbitrary string to prefix the output value with. This string is supplied as-is, meaning it is not guaranteed to be URL-safe or base64 encoded.\n"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "random:index/randomInteger:RandomInteger": {
+      "description": "The resource `random.RandomInteger` generates random values from a given range, described by the `min` and `max` attributes of a given resource.\n\nThis resource can be used in conjunction with resources that have the `create_before_destroy` lifecycle flag set, to avoid conflicts with unique names during the brief period where both the old and new resources exist concurrently.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\n// The following example shows how to generate a random priority\n// between 1 and 50000 for a aws_alb_listener_rule resource:\nconst priority = new random.RandomInteger(\"priority\", {\n    min: 1,\n    max: 50000,\n    keepers: {\n        listener_arn: _var.listener_arn,\n    },\n});\nconst main = new aws.alb.ListenerRule(\"main\", {\n    listenerArn: priority.keepers.apply(keepers => keepers?.listenerArn),\n    priority: priority.result,\n    actions: [{\n        type: \"forward\",\n        targetGroupArn: _var.target_group_arn,\n    }],\n});\n// ... (other aws_alb_listener_rule arguments) ...\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nreturn await Deployment.RunAsync(() => \n{\n    // The following example shows how to generate a random priority\n    // between 1 and 50000 for a aws_alb_listener_rule resource:\n    var priority = new Random.RandomInteger(\"priority\", new()\n    {\n        Min = 1,\n        Max = 50000,\n        Keepers = \n        {\n            { \"listener_arn\", @var.Listener_arn },\n        },\n    });\n\n    var main = new Aws.Alb.ListenerRule(\"main\", new()\n    {\n        ListenerArn = priority.Keepers.Apply(keepers => keepers?.ListenerArn),\n        Priority = priority.Result,\n        Actions = new[]\n        {\n            new Aws.Alb.Inputs.ListenerRuleActionArgs\n            {\n                Type = \"forward\",\n                TargetGroupArn = @var.Target_group_arn,\n            },\n        },\n    });\n\n    // ... (other aws_alb_listener_rule arguments) ...\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/alb\"\n\t\"github.com/pulumi/pulumi-random/sdk/v4/go/random\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tpriority, err := random.NewRandomInteger(ctx, \"priority\", &random.RandomIntegerArgs{\n\t\t\tMin: pulumi.Int(1),\n\t\t\tMax: pulumi.Int(50000),\n\t\t\tKeepers: pulumi.StringMap{\n\t\t\t\t\"listener_arn\": pulumi.Any(_var.Listener_arn),\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = alb.NewListenerRule(ctx, \"main\", &alb.ListenerRuleArgs{\n\t\t\tListenerArn: priority.Keepers.ApplyT(func(keepers interface{}) (*string, error) {\n\t\t\t\treturn &keepers.ListenerArn, nil\n\t\t\t}).(pulumi.StringPtrOutput),\n\t\t\tPriority: priority.Result,\n\t\t\tActions: alb.ListenerRuleActionArray{\n\t\t\t\t&alb.ListenerRuleActionArgs{\n\t\t\t\t\tType:           pulumi.String(\"forward\"),\n\t\t\t\t\tTargetGroupArn: pulumi.Any(_var.Target_group_arn),\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.random.RandomInteger;\nimport com.pulumi.random.RandomIntegerArgs;\nimport com.pulumi.aws.alb.ListenerRule;\nimport com.pulumi.aws.alb.ListenerRuleArgs;\nimport com.pulumi.aws.alb.inputs.ListenerRuleActionArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var priority = new RandomInteger(\"priority\", RandomIntegerArgs.builder()        \n            .min(1)\n            .max(50000)\n            .keepers(Map.of(\"listener_arn\", var_.listener_arn()))\n            .build());\n\n        var main = new ListenerRule(\"main\", ListenerRuleArgs.builder()        \n            .listenerArn(priority.keepers().applyValue(keepers -> keepers.listenerArn()))\n            .priority(priority.result())\n            .actions(ListenerRuleActionArgs.builder()\n                .type(\"forward\")\n                .targetGroupArn(var_.target_group_arn())\n                .build())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  # The following example shows how to generate a random priority\n  # between 1 and 50000 for a aws_alb_listener_rule resource:\n  priority:\n    type: random:RandomInteger\n    properties:\n      min: 1\n      max: 50000\n      keepers:\n        listener_arn: ${var.listener_arn}\n  main:\n    type: aws:alb:ListenerRule\n    properties:\n      listenerArn: ${priority.keepers.listenerArn}\n      priority: ${priority.result}\n      actions:\n        - type: forward\n          targetGroupArn: ${var.target_group_arn}\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nRandom integers can be imported using the result, min, and max, with an optional seed. This can be used to replace a config value with a value interpolated from the random provider without experiencing diffs. Example (values are separated by a ,)\n\n```sh\n $ pulumi import random:index/randomInteger:RandomInteger priority 15390,1,50000\n```\n\n ",
+      "properties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "max": {
+          "type": "integer",
+          "description": "The maximum inclusive value of the range.\n"
+        },
+        "min": {
+          "type": "integer",
+          "description": "The minimum inclusive value of the range.\n"
+        },
+        "result": {
+          "type": "integer",
+          "description": "The random integer result.\n"
+        },
+        "seed": {
+          "type": "string",
+          "description": "A custom seed to always produce the same value.\n"
+        }
+      },
+      "required": [
+        "max",
+        "min",
+        "result"
+      ],
+      "inputProperties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "max": {
+          "type": "integer",
+          "description": "The maximum inclusive value of the range.\n"
+        },
+        "min": {
+          "type": "integer",
+          "description": "The minimum inclusive value of the range.\n"
+        },
+        "seed": {
+          "type": "string",
+          "description": "A custom seed to always produce the same value.\n"
+        }
+      },
+      "requiredInputs": [
+        "max",
+        "min"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomInteger resources.\n",
+        "properties": {
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+          },
+          "max": {
+            "type": "integer",
+            "description": "The maximum inclusive value of the range.\n"
+          },
+          "min": {
+            "type": "integer",
+            "description": "The minimum inclusive value of the range.\n"
+          },
+          "result": {
+            "type": "integer",
+            "description": "The random integer result.\n"
+          },
+          "seed": {
+            "type": "string",
+            "description": "A custom seed to always produce the same value.\n"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "random:index/randomPassword:RandomPassword": {
+      "description": "{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\nconst password = new random.RandomPassword(\"password\", {\n    length: 16,\n    special: true,\n    overrideSpecial: `!#$%&*()-_=+[]{}<>:?`,\n});\nconst example = new aws.rds.Instance(\"example\", {\n    instanceClass: \"db.t3.micro\",\n    allocatedStorage: 64,\n    engine: \"mysql\",\n    username: \"someone\",\n    password: password.result,\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\nimport pulumi_random as random\n\npassword = random.RandomPassword(\"password\",\n    length=16,\n    special=True,\n    override_special=\"!#$%&*()-_=+[]{}<>:?\")\nexample = aws.rds.Instance(\"example\",\n    instance_class=\"db.t3.micro\",\n    allocated_storage=64,\n    engine=\"mysql\",\n    username=\"someone\",\n    password=password.result)\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nreturn await Deployment.RunAsync(() => \n{\n    var password = new Random.RandomPassword(\"password\", new()\n    {\n        Length = 16,\n        Special = true,\n        OverrideSpecial = \"!#$%&*()-_=+[]{}<>:?\",\n    });\n\n    var example = new Aws.Rds.Instance(\"example\", new()\n    {\n        InstanceClass = \"db.t3.micro\",\n        AllocatedStorage = 64,\n        Engine = \"mysql\",\n        Username = \"someone\",\n        Password = password.Result,\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/rds\"\n\t\"github.com/pulumi/pulumi-random/sdk/v4/go/random\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tpassword, err := random.NewRandomPassword(ctx, \"password\", &random.RandomPasswordArgs{\n\t\t\tLength:          pulumi.Int(16),\n\t\t\tSpecial:         pulumi.Bool(true),\n\t\t\tOverrideSpecial: pulumi.String(fmt.Sprintf(\"!#$%v&*()-_=+[]{}<>:?\", \"%\")),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = rds.NewInstance(ctx, \"example\", &rds.InstanceArgs{\n\t\t\tInstanceClass:    pulumi.String(\"db.t3.micro\"),\n\t\t\tAllocatedStorage: pulumi.Int(64),\n\t\t\tEngine:           pulumi.String(\"mysql\"),\n\t\t\tUsername:         pulumi.String(\"someone\"),\n\t\t\tPassword:         password.Result,\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.random.RandomPassword;\nimport com.pulumi.random.RandomPasswordArgs;\nimport com.pulumi.aws.rds.Instance;\nimport com.pulumi.aws.rds.InstanceArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var password = new RandomPassword(\"password\", RandomPasswordArgs.builder()        \n            .length(16)\n            .special(true)\n            .overrideSpecial(\"!#$%&*()-_=+[]{}<>:?\")\n            .build());\n\n        var example = new Instance(\"example\", InstanceArgs.builder()        \n            .instanceClass(\"db.t3.micro\")\n            .allocatedStorage(64)\n            .engine(\"mysql\")\n            .username(\"someone\")\n            .password(password.result())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  password:\n    type: random:RandomPassword\n    properties:\n      length: 16\n      special: true\n      overrideSpecial: '!#$%&*()-_=+[]{}<>:?'\n  example:\n    type: aws:rds:Instance\n    properties:\n      instanceClass: db.t3.micro\n      allocatedStorage: 64\n      engine: mysql\n      username: someone\n      password: ${password.result}\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\n### Avoiding Replacement\n\n```sh\n $ pulumi import random:index/randomPassword:RandomPassword If the resource were imported using `random_password.password securepassword`,\n```\n\n replacement could be avoided by using1. Attribute values that match the imported ID and defaults:\n\n\n\n terraform\n\n\n\n resource \"random_password\" \"password\" {\n\n\n\n\n\n length = 14\n\n\n\n\n\n lower\n\n= true\n\n\n\n } 2. Attribute values that match the imported ID and omit the attributes with defaults:\n\n\n\n terraform\n\n\n\n resource \"random_password\" \"password\" {\n\n\n\n\n\n length = 14\n\n\n\n } 3. `ignore_changes` specifying the attributes to ignore:\n\n\n\n terraform\n\n\n\n resource \"random_password\" \"password\" {\n\n\n\n\n\n length = 16\n\n\n\n\n\n lower\n\n= false\n\n\n\n\n\n lifecycle {\n\n\n\n\n\n\n\n ignore_changes = [\n\n\n\n\n\n\n\n\n\n length,\n\n\n\n\n\n\n\n\n\n lower,\n\n\n\n\n\n\n\n ]\n\n\n\n\n\n }\n\n\n\n }\n\n\n\n **NOTE** `ignore_changes` is only required until the resource is recreated after import,\n\n\n\n after which it will use the configuration values specified. ",
+      "properties": {
+        "bcryptHash": {
+          "type": "string",
+          "description": "A bcrypt hash of the generated random string.\n",
+          "secret": true
+        },
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "length": {
+          "type": "integer",
+          "description": "The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).\n"
+        },
+        "lower": {
+          "type": "boolean",
+          "description": "Include lowercase alphabet characters in the result. Default value is `true`.\n"
+        },
+        "minLower": {
+          "type": "integer",
+          "description": "Minimum number of lowercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "minNumeric": {
+          "type": "integer",
+          "description": "Minimum number of numeric characters in the result. Default value is `0`.\n"
+        },
+        "minSpecial": {
+          "type": "integer",
+          "description": "Minimum number of special characters in the result. Default value is `0`.\n"
+        },
+        "minUpper": {
+          "type": "integer",
+          "description": "Minimum number of uppercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "number": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.\n",
+          "deprecationMessage": "**NOTE**: This is deprecated, use `numeric` instead."
+        },
+        "numeric": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`.\n"
+        },
+        "overrideSpecial": {
+          "type": "string",
+          "description": "Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.\n"
+        },
+        "result": {
+          "type": "string",
+          "description": "The generated random string.\n",
+          "secret": true
+        },
+        "special": {
+          "type": "boolean",
+          "description": "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.\n"
+        },
+        "upper": {
+          "type": "boolean",
+          "description": "Include uppercase alphabet characters in the result. Default value is `true`.\n"
+        }
+      },
+      "required": [
+        "bcryptHash",
+        "length",
+        "lower",
+        "minLower",
+        "minNumeric",
+        "minSpecial",
+        "minUpper",
+        "number",
+        "numeric",
+        "result",
+        "special",
+        "upper"
+      ],
+      "inputProperties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "length": {
+          "type": "integer",
+          "description": "The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).\n"
+        },
+        "lower": {
+          "type": "boolean",
+          "description": "Include lowercase alphabet characters in the result. Default value is `true`.\n"
+        },
+        "minLower": {
+          "type": "integer",
+          "description": "Minimum number of lowercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "minNumeric": {
+          "type": "integer",
+          "description": "Minimum number of numeric characters in the result. Default value is `0`.\n"
+        },
+        "minSpecial": {
+          "type": "integer",
+          "description": "Minimum number of special characters in the result. Default value is `0`.\n"
+        },
+        "minUpper": {
+          "type": "integer",
+          "description": "Minimum number of uppercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "number": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.\n",
+          "deprecationMessage": "**NOTE**: This is deprecated, use `numeric` instead."
+        },
+        "numeric": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`.\n"
+        },
+        "overrideSpecial": {
+          "type": "string",
+          "description": "Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.\n"
+        },
+        "special": {
+          "type": "boolean",
+          "description": "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.\n"
+        },
+        "upper": {
+          "type": "boolean",
+          "description": "Include uppercase alphabet characters in the result. Default value is `true`.\n"
+        }
+      },
+      "requiredInputs": [
+        "length"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomPassword resources.\n",
+        "properties": {
+          "bcryptHash": {
+            "type": "string",
+            "description": "A bcrypt hash of the generated random string.\n",
+            "secret": true
+          },
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+          },
+          "length": {
+            "type": "integer",
+            "description": "The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).\n"
+          },
+          "lower": {
+            "type": "boolean",
+            "description": "Include lowercase alphabet characters in the result. Default value is `true`.\n"
+          },
+          "minLower": {
+            "type": "integer",
+            "description": "Minimum number of lowercase alphabet characters in the result. Default value is `0`.\n"
+          },
+          "minNumeric": {
+            "type": "integer",
+            "description": "Minimum number of numeric characters in the result. Default value is `0`.\n"
+          },
+          "minSpecial": {
+            "type": "integer",
+            "description": "Minimum number of special characters in the result. Default value is `0`.\n"
+          },
+          "minUpper": {
+            "type": "integer",
+            "description": "Minimum number of uppercase alphabet characters in the result. Default value is `0`.\n"
+          },
+          "number": {
+            "type": "boolean",
+            "description": "Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.\n",
+            "deprecationMessage": "**NOTE**: This is deprecated, use `numeric` instead."
+          },
+          "numeric": {
+            "type": "boolean",
+            "description": "Include numeric characters in the result. Default value is `true`.\n"
+          },
+          "overrideSpecial": {
+            "type": "string",
+            "description": "Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.\n"
+          },
+          "result": {
+            "type": "string",
+            "description": "The generated random string.\n",
+            "secret": true
+          },
+          "special": {
+            "type": "boolean",
+            "description": "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.\n"
+          },
+          "upper": {
+            "type": "boolean",
+            "description": "Include uppercase alphabet characters in the result. Default value is `true`.\n"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "random:index/randomPet:RandomPet": {
+      "description": "The resource `random.RandomPet` generates random pet names that are intended to be used as unique identifiers for other resources.\n\nThis resource can be used in conjunction with resources that have the `create_before_destroy` lifecycle flag set, to avoid conflicts with unique names during the brief period where both the old and new resources exist concurrently.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\n// The following example shows how to generate a unique pet name\n// for an AWS EC2 instance that changes each time a new AMI id is\n// selected.\nconst serverRandomPet = new random.RandomPet(\"serverRandomPet\", {keepers: {\n    ami_id: _var.ami_id,\n}});\nconst serverInstance = new aws.ec2.Instance(\"serverInstance\", {\n    tags: {\n        Name: pulumi.interpolate`web-server-${serverRandomPet.id}`,\n    },\n    ami: serverRandomPet.keepers.apply(keepers => keepers?.amiId),\n});\n// ... (other aws_instance arguments) ...\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nreturn await Deployment.RunAsync(() => \n{\n    // The following example shows how to generate a unique pet name\n    // for an AWS EC2 instance that changes each time a new AMI id is\n    // selected.\n    var serverRandomPet = new Random.RandomPet(\"serverRandomPet\", new()\n    {\n        Keepers = \n        {\n            { \"ami_id\", @var.Ami_id },\n        },\n    });\n\n    var serverInstance = new Aws.Ec2.Instance(\"serverInstance\", new()\n    {\n        Tags = \n        {\n            { \"Name\", serverRandomPet.Id.Apply(id => $\"web-server-{id}\") },\n        },\n        Ami = serverRandomPet.Keepers.Apply(keepers => keepers?.AmiId),\n    });\n\n    // ... (other aws_instance arguments) ...\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2\"\n\t\"github.com/pulumi/pulumi-random/sdk/v4/go/random\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\tserverRandomPet, err := random.NewRandomPet(ctx, \"serverRandomPet\", &random.RandomPetArgs{\n\t\t\tKeepers: pulumi.StringMap{\n\t\t\t\t\"ami_id\": pulumi.Any(_var.Ami_id),\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = ec2.NewInstance(ctx, \"serverInstance\", &ec2.InstanceArgs{\n\t\t\tTags: pulumi.StringMap{\n\t\t\t\t\"Name\": serverRandomPet.ID().ApplyT(func(id string) (string, error) {\n\t\t\t\t\treturn fmt.Sprintf(\"web-server-%v\", id), nil\n\t\t\t\t}).(pulumi.StringOutput),\n\t\t\t},\n\t\t\tAmi: serverRandomPet.Keepers.ApplyT(func(keepers interface{}) (*string, error) {\n\t\t\t\treturn &keepers.AmiId, nil\n\t\t\t}).(pulumi.StringPtrOutput),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.random.RandomPet;\nimport com.pulumi.random.RandomPetArgs;\nimport com.pulumi.aws.ec2.Instance;\nimport com.pulumi.aws.ec2.InstanceArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var serverRandomPet = new RandomPet(\"serverRandomPet\", RandomPetArgs.builder()        \n            .keepers(Map.of(\"ami_id\", var_.ami_id()))\n            .build());\n\n        var serverInstance = new Instance(\"serverInstance\", InstanceArgs.builder()        \n            .tags(Map.of(\"Name\", serverRandomPet.id().applyValue(id -> String.format(\"web-server-%s\", id))))\n            .ami(serverRandomPet.keepers().applyValue(keepers -> keepers.amiId()))\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  # The following example shows how to generate a unique pet name\n  # for an AWS EC2 instance that changes each time a new AMI id is\n  # selected.\n  serverRandomPet:\n    type: random:RandomPet\n    properties:\n      keepers:\n        ami_id: ${var.ami_id}\n  serverInstance:\n    type: aws:ec2:Instance\n    properties:\n      tags:\n        Name: web-server-${serverRandomPet.id}\n      # Read the AMI id \"through\" the random_pet resource to ensure that\n      #   # both will change together.\n      ami: ${serverRandomPet.keepers.amiId}\n```\n{{% /example %}}\n{{% /examples %}}",
+      "properties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "length": {
+          "type": "integer",
+          "description": "The length (in words) of the pet name. Defaults to 2\n"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "A string to prefix the name with.\n"
+        },
+        "separator": {
+          "type": "string",
+          "description": "The character to separate words in the pet name. Defaults to \"-\"\n"
+        }
+      },
+      "required": [
+        "length",
+        "separator"
+      ],
+      "inputProperties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "length": {
+          "type": "integer",
+          "description": "The length (in words) of the pet name. Defaults to 2\n"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "A string to prefix the name with.\n"
+        },
+        "separator": {
+          "type": "string",
+          "description": "The character to separate words in the pet name. Defaults to \"-\"\n"
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomPet resources.\n",
+        "properties": {
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+          },
+          "length": {
+            "type": "integer",
+            "description": "The length (in words) of the pet name. Defaults to 2\n"
+          },
+          "prefix": {
+            "type": "string",
+            "description": "A string to prefix the name with.\n"
+          },
+          "separator": {
+            "type": "string",
+            "description": "The character to separate words in the pet name. Defaults to \"-\"\n"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "random:index/randomShuffle:RandomShuffle": {
+      "description": "The resource `random.RandomShuffle` generates a random permutation of a list of strings given as an argument.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\nconst az = new random.RandomShuffle(\"az\", {\n    inputs: [\n        \"us-west-1a\",\n        \"us-west-1c\",\n        \"us-west-1d\",\n        \"us-west-1e\",\n    ],\n    resultCount: 2,\n});\nconst example = new aws.elb.LoadBalancer(\"example\", {availabilityZones: [az.results]});\n// ... and other aws_elb arguments ...\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\nimport pulumi_random as random\n\naz = random.RandomShuffle(\"az\",\n    inputs=[\n        \"us-west-1a\",\n        \"us-west-1c\",\n        \"us-west-1d\",\n        \"us-west-1e\",\n    ],\n    result_count=2)\nexample = aws.elb.LoadBalancer(\"example\", availability_zones=[az.results])\n# ... and other aws_elb arguments ...\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nreturn await Deployment.RunAsync(() => \n{\n    var az = new Random.RandomShuffle(\"az\", new()\n    {\n        Inputs = new[]\n        {\n            \"us-west-1a\",\n            \"us-west-1c\",\n            \"us-west-1d\",\n            \"us-west-1e\",\n        },\n        ResultCount = 2,\n    });\n\n    var example = new Aws.Elb.LoadBalancer(\"example\", new()\n    {\n        AvailabilityZones = new[]\n        {\n            az.Results,\n        },\n    });\n\n    // ... and other aws_elb arguments ...\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/elb\"\n\t\"github.com/pulumi/pulumi-random/sdk/v4/go/random\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\taz, err := random.NewRandomShuffle(ctx, \"az\", &random.RandomShuffleArgs{\n\t\t\tInputs: pulumi.StringArray{\n\t\t\t\tpulumi.String(\"us-west-1a\"),\n\t\t\t\tpulumi.String(\"us-west-1c\"),\n\t\t\t\tpulumi.String(\"us-west-1d\"),\n\t\t\t\tpulumi.String(\"us-west-1e\"),\n\t\t\t},\n\t\t\tResultCount: pulumi.Int(2),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = elb.NewLoadBalancer(ctx, \"example\", &elb.LoadBalancerArgs{\n\t\t\tAvailabilityZones: pulumi.StringArray{\n\t\t\t\taz.Results,\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.random.RandomShuffle;\nimport com.pulumi.random.RandomShuffleArgs;\nimport com.pulumi.aws.elb.LoadBalancer;\nimport com.pulumi.aws.elb.LoadBalancerArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var az = new RandomShuffle(\"az\", RandomShuffleArgs.builder()        \n            .inputs(            \n                \"us-west-1a\",\n                \"us-west-1c\",\n                \"us-west-1d\",\n                \"us-west-1e\")\n            .resultCount(2)\n            .build());\n\n        var example = new LoadBalancer(\"example\", LoadBalancerArgs.builder()        \n            .availabilityZones(az.results())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  az:\n    type: random:RandomShuffle\n    properties:\n      inputs:\n        - us-west-1a\n        - us-west-1c\n        - us-west-1d\n        - us-west-1e\n      resultCount: 2\n  example:\n    type: aws:elb:LoadBalancer\n    properties:\n      # Place the ELB in any two of the given availability zones, selected\n      #   # at random.\n      availabilityZones:\n        - ${az.results}\n```\n{{% /example %}}\n{{% /examples %}}",
+      "properties": {
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of strings to shuffle.\n"
+        },
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "resultCount": {
+          "type": "integer",
+          "description": "The number of results to return. Defaults to the number of items in the `input` list. If fewer items are requested, some elements will be excluded from the result. If more items are requested, items will be repeated in the result but not more frequently than the number of items in the input list.\n"
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Random permutation of the list of strings given in `input`.\n"
+        },
+        "seed": {
+          "type": "string",
+          "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the list.\n"
+        }
+      },
+      "required": [
+        "inputs",
+        "results"
+      ],
+      "inputProperties": {
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of strings to shuffle.\n"
+        },
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "resultCount": {
+          "type": "integer",
+          "description": "The number of results to return. Defaults to the number of items in the `input` list. If fewer items are requested, some elements will be excluded from the result. If more items are requested, items will be repeated in the result but not more frequently than the number of items in the input list.\n"
+        },
+        "seed": {
+          "type": "string",
+          "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the list.\n"
+        }
+      },
+      "requiredInputs": [
+        "inputs"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomShuffle resources.\n",
+        "properties": {
+          "inputs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of strings to shuffle.\n"
+          },
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+          },
+          "resultCount": {
+            "type": "integer",
+            "description": "The number of results to return. Defaults to the number of items in the `input` list. If fewer items are requested, some elements will be excluded from the result. If more items are requested, items will be repeated in the result but not more frequently than the number of items in the input list.\n"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Random permutation of the list of strings given in `input`.\n"
+          },
+          "seed": {
+            "type": "string",
+            "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the list.\n"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "random:index/randomString:RandomString": {
+      "description": "The resource `random.RandomString` generates a random permutation of alphanumeric characters and optionally special characters.\n\nThis resource *does* use a cryptographic random number generator.\n\nHistorically this resource's intended usage has been ambiguous as the original example used it in a password. For backwards compatibility it will continue to exist. For unique ids please use random_id, for sensitive random values please use random_password.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as random from \"@pulumi/random\";\n\nconst random = new random.RandomString(\"random\", {\n    length: 16,\n    overrideSpecial: `/@£$`,\n    special: true,\n});\n```\n```python\nimport pulumi\nimport pulumi_random as random\n\nrandom = random.RandomString(\"random\",\n    length=16,\n    override_special=\"/@£$\",\n    special=True)\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Random = Pulumi.Random;\n\nreturn await Deployment.RunAsync(() => \n{\n    var random = new Random.RandomString(\"random\", new()\n    {\n        Length = 16,\n        OverrideSpecial = \"/@£$\",\n        Special = true,\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/pulumi/pulumi-random/sdk/v4/go/random\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\t_, err := random.NewRandomString(ctx, \"random\", &random.RandomStringArgs{\n\t\t\tLength:          pulumi.Int(16),\n\t\t\tOverrideSpecial: pulumi.String(fmt.Sprintf(\"/@£$\")),\n\t\t\tSpecial:         pulumi.Bool(true),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.random.RandomString;\nimport com.pulumi.random.RandomStringArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var random = new RandomString(\"random\", RandomStringArgs.builder()        \n            .length(16)\n            .overrideSpecial(\"/@£$\")\n            .special(true)\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  random:\n    type: random:RandomString\n    properties:\n      length: 16\n      overrideSpecial: /@£$\n      special: true\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\n### Avoiding Replacement\n\n```sh\n $ pulumi import random:index/randomString:RandomString If the resource were imported using `random_string.test test`,\n```\n\n replacement can be avoided by using1. Attribute values that match the imported ID and defaults:\n\n\n\n terraform\n\n\n\n resource \"random_string\" \"test\" {\n\n\n\n\n\n length = 4\n\n\n\n\n\n lower\n\n= true\n\n\n\n } 2. Attribute values that match the imported ID and omit the attributes with defaults:\n\n\n\n terraform\n\n\n\n resource \"random_string\" \"test\" {\n\n\n\n\n\n length = 4\n\n\n\n } 3. `ignore_changes` specifying the attributes to ignore:\n\n\n\n terraform\n\n\n\n resource \"random_string\" \"test\" {\n\n\n\n\n\n length = 16\n\n\n\n\n\n lower\n\n= false\n\n\n\n\n\n lifecycle {\n\n\n\n\n\n\n\n ignore_changes = [\n\n\n\n\n\n\n\n\n\n length,\n\n\n\n\n\n\n\n\n\n lower,\n\n\n\n\n\n\n\n ]\n\n\n\n\n\n }\n\n\n\n }\n\n\n\n **NOTE** `ignore_changes` is only required until the resource is recreated after import,\n\n\n\n after which it will use the configuration values specified. ",
+      "properties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "length": {
+          "type": "integer",
+          "description": "The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).\n"
+        },
+        "lower": {
+          "type": "boolean",
+          "description": "Include lowercase alphabet characters in the result. Default value is `true`.\n"
+        },
+        "minLower": {
+          "type": "integer",
+          "description": "Minimum number of lowercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "minNumeric": {
+          "type": "integer",
+          "description": "Minimum number of numeric characters in the result. Default value is `0`.\n"
+        },
+        "minSpecial": {
+          "type": "integer",
+          "description": "Minimum number of special characters in the result. Default value is `0`.\n"
+        },
+        "minUpper": {
+          "type": "integer",
+          "description": "Minimum number of uppercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "number": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.\n",
+          "deprecationMessage": "**NOTE**: This is deprecated, use `numeric` instead."
+        },
+        "numeric": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`.\n"
+        },
+        "overrideSpecial": {
+          "type": "string",
+          "description": "Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.\n"
+        },
+        "result": {
+          "type": "string",
+          "description": "The generated random string.\n"
+        },
+        "special": {
+          "type": "boolean",
+          "description": "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.\n"
+        },
+        "upper": {
+          "type": "boolean",
+          "description": "Include uppercase alphabet characters in the result. Default value is `true`.\n"
+        }
+      },
+      "required": [
+        "length",
+        "lower",
+        "minLower",
+        "minNumeric",
+        "minSpecial",
+        "minUpper",
+        "number",
+        "numeric",
+        "result",
+        "special",
+        "upper"
+      ],
+      "inputProperties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "length": {
+          "type": "integer",
+          "description": "The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).\n"
+        },
+        "lower": {
+          "type": "boolean",
+          "description": "Include lowercase alphabet characters in the result. Default value is `true`.\n"
+        },
+        "minLower": {
+          "type": "integer",
+          "description": "Minimum number of lowercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "minNumeric": {
+          "type": "integer",
+          "description": "Minimum number of numeric characters in the result. Default value is `0`.\n"
+        },
+        "minSpecial": {
+          "type": "integer",
+          "description": "Minimum number of special characters in the result. Default value is `0`.\n"
+        },
+        "minUpper": {
+          "type": "integer",
+          "description": "Minimum number of uppercase alphabet characters in the result. Default value is `0`.\n"
+        },
+        "number": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.\n",
+          "deprecationMessage": "**NOTE**: This is deprecated, use `numeric` instead."
+        },
+        "numeric": {
+          "type": "boolean",
+          "description": "Include numeric characters in the result. Default value is `true`.\n"
+        },
+        "overrideSpecial": {
+          "type": "string",
+          "description": "Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.\n"
+        },
+        "special": {
+          "type": "boolean",
+          "description": "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.\n"
+        },
+        "upper": {
+          "type": "boolean",
+          "description": "Include uppercase alphabet characters in the result. Default value is `true`.\n"
+        }
+      },
+      "requiredInputs": [
+        "length"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomString resources.\n",
+        "properties": {
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+          },
+          "length": {
+            "type": "integer",
+            "description": "The length of the string desired. The minimum value for length is 1 and, length must also be >= (`min_upper` + `min_lower` + `min_numeric` + `min_special`).\n"
+          },
+          "lower": {
+            "type": "boolean",
+            "description": "Include lowercase alphabet characters in the result. Default value is `true`.\n"
+          },
+          "minLower": {
+            "type": "integer",
+            "description": "Minimum number of lowercase alphabet characters in the result. Default value is `0`.\n"
+          },
+          "minNumeric": {
+            "type": "integer",
+            "description": "Minimum number of numeric characters in the result. Default value is `0`.\n"
+          },
+          "minSpecial": {
+            "type": "integer",
+            "description": "Minimum number of special characters in the result. Default value is `0`.\n"
+          },
+          "minUpper": {
+            "type": "integer",
+            "description": "Minimum number of uppercase alphabet characters in the result. Default value is `0`.\n"
+          },
+          "number": {
+            "type": "boolean",
+            "description": "Include numeric characters in the result. Default value is `true`. **NOTE**: This is deprecated, use `numeric` instead.\n",
+            "deprecationMessage": "**NOTE**: This is deprecated, use `numeric` instead."
+          },
+          "numeric": {
+            "type": "boolean",
+            "description": "Include numeric characters in the result. Default value is `true`.\n"
+          },
+          "overrideSpecial": {
+            "type": "string",
+            "description": "Supply your own list of special characters to use for string generation.  This overrides the default character list in the special argument.  The `special` argument must still be set to true for any overwritten characters to be used in generation.\n"
+          },
+          "result": {
+            "type": "string",
+            "description": "The generated random string.\n"
+          },
+          "special": {
+            "type": "boolean",
+            "description": "Include special characters in the result. These are `!@#$%&*()-_=+[]{}<>:?`. Default value is `true`.\n"
+          },
+          "upper": {
+            "type": "boolean",
+            "description": "Include uppercase alphabet characters in the result. Default value is `true`.\n"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "random:index/randomUuid:RandomUuid": {
+      "description": "The resource `random.RandomUuid` generates random uuid string that is intended to be used as unique identifiers for other resources.\n\nThis resource uses [hashicorp/go-uuid](https://github.com/hashicorp/go-uuid) to generate a UUID-formatted string for use with services needed a unique string identifier.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as azure from \"@pulumi/azure\";\nimport * as random from \"@pulumi/random\";\n\nconst testRandomUuid = new random.RandomUuid(\"testRandomUuid\", {});\nconst testResourceGroup = new azure.core.ResourceGroup(\"testResourceGroup\", {location: \"Central US\"});\n```\n```python\nimport pulumi\nimport pulumi_azure as azure\nimport pulumi_random as random\n\ntest_random_uuid = random.RandomUuid(\"testRandomUuid\")\ntest_resource_group = azure.core.ResourceGroup(\"testResourceGroup\", location=\"Central US\")\n```\n```csharp\nusing System.Collections.Generic;\nusing Pulumi;\nusing Azure = Pulumi.Azure;\nusing Random = Pulumi.Random;\n\nreturn await Deployment.RunAsync(() => \n{\n    var testRandomUuid = new Random.RandomUuid(\"testRandomUuid\");\n\n    var testResourceGroup = new Azure.Core.ResourceGroup(\"testResourceGroup\", new()\n    {\n        Location = \"Central US\",\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-azure/sdk/v5/go/azure/core\"\n\t\"github.com/pulumi/pulumi-random/sdk/v4/go/random\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\t_, err := random.NewRandomUuid(ctx, \"testRandomUuid\", nil)\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = core.NewResourceGroup(ctx, \"testResourceGroup\", &core.ResourceGroupArgs{\n\t\t\tLocation: pulumi.String(\"Central US\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.random.RandomUuid;\nimport com.pulumi.azure.core.ResourceGroup;\nimport com.pulumi.azure.core.ResourceGroupArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var testRandomUuid = new RandomUuid(\"testRandomUuid\");\n\n        var testResourceGroup = new ResourceGroup(\"testResourceGroup\", ResourceGroupArgs.builder()        \n            .location(\"Central US\")\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  testRandomUuid:\n    type: random:RandomUuid\n  testResourceGroup:\n    type: azure:core:ResourceGroup\n    properties:\n      location: Central US\n```\n{{% /example %}}\n{{% /examples %}}\n\n## Import\n\nRandom UUID's can be imported. This can be used to replace a config value with a value interpolated from the random provider without experiencing diffs.\n\n```sh\n $ pulumi import random:index/randomUuid:RandomUuid main aabbccdd-eeff-0011-2233-445566778899\n```\n\n ",
+      "properties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        },
+        "result": {
+          "type": "string",
+          "description": "The generated uuid presented in string format.\n"
+        }
+      },
+      "required": [
+        "result"
+      ],
+      "inputProperties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomUuid resources.\n",
+        "properties": {
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for more information.\n"
+          },
+          "result": {
+            "type": "string",
+            "description": "The generated uuid presented in string format.\n"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "version": "4.11.2"
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -59,6 +59,7 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 		SchemaProvider{"azure-native", "1.29.0"},
 		SchemaProvider{"random", "4.2.0"},
 		SchemaProvider{"random", "4.3.1"},
+		SchemaProvider{"random", "4.11.2"},
 		SchemaProvider{"kubernetes", "3.7.0"},
 		SchemaProvider{"kubernetes", "3.7.2"},
 		SchemaProvider{"eks", "0.37.1"},


### PR DESCRIPTION
Adds the most recent relese of pulumi-random to included schemas.
We need something newer than 4.2.0 or 4.3.1 (both from 2021)
to test options added since then, like retainOnDelete.

Refs https://github.com/pulumi/pulumi/pull/12306#issuecomment-1450923083
