### PR TITLE
Add stack tag support for go automation api sdk

### DIFF
--- a/changelog/pending/20230227--auto-go--enable-programmatic-tagging-of-stacks-go-only.yaml
+++ b/changelog/pending/20230227--auto-go--enable-programmatic-tagging-of-stacks-go-only.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Enable programmatic tagging of stacks (Go only)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1418,6 +1418,56 @@ func TestNestedConfig(t *testing.T) {
 	assert.JSONEq(t, "[\"one\",\"two\",\"three\"]", list.Value)
 }
 
+func TestTagFunctions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, randomStackName())
+
+	pDir := filepath.Join(".", "test", "testproj")
+	s, err := UpsertStackLocalSource(ctx, stackName, pDir)
+	if err != nil {
+		t.Errorf("failed to initialize stack, err: %v", err)
+		t.FailNow()
+	}
+	ws := s.Workspace()
+
+	// -- lists tag values --
+	tags, err := ws.ListTags(ctx, stackName)
+	if err != nil {
+		t.Errorf("failed to list tags, err: %v", err)
+		t.FailNow()
+	}
+	assert.Equal(t, pName, tags["pulumi:project"])
+
+	// -- sets tag values --
+	err = ws.SetTag(ctx, stackName, "foo", "bar")
+	if err != nil {
+		t.Errorf("set tag failed, err: %v", err)
+		t.FailNow()
+	}
+
+	// -- gets a single tag value --
+	tag, err := ws.GetTag(ctx, stackName, "foo")
+	if err != nil {
+		t.Errorf("get tag failed, err: %v", err)
+		t.FailNow()
+	}
+	assert.Equal(t, "bar", tag)
+
+	// -- removes tag value --
+	err = ws.RemoveTag(ctx, stackName, "foo")
+	if err != nil {
+		t.Errorf("remove tag failed, err: %v", err)
+		t.FailNow()
+	}
+	tags, _ = ws.ListTags(ctx, stackName)
+	assert.NotContains(t, tags, "foo", "failed to remove tag")
+
+	err = s.Workspace().RemoveStack(ctx, stackName)
+	assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
+}
+
 //nolint:paralleltest // mutates environment variables
 func TestStructuredOutput(t *testing.T) {
 	ctx := context.Background()

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -700,6 +700,26 @@ func (s *Stack) RefreshConfig(ctx context.Context) (ConfigMap, error) {
 	return s.Workspace().RefreshConfig(ctx, s.Name())
 }
 
+// GetTag returns the tag value associated with specified key.
+func (s *Stack) GetTag(ctx context.Context, key string) (string, error) {
+	return s.Workspace().GetTag(ctx, s.Name(), key)
+}
+
+// SetTag sets a tag key-value pair on the stack.
+func (s *Stack) SetTag(ctx context.Context, key string, value string) error {
+	return s.Workspace().SetTag(ctx, s.Name(), key, value)
+}
+
+// RemoveTag removes the specified tag key-value pair from the stack.
+func (s *Stack) RemoveTag(ctx context.Context, key string) error {
+	return s.Workspace().RemoveTag(ctx, s.Name(), key)
+}
+
+// ListTags returns the full key-value tag map associated with the stack.
+func (s *Stack) ListTags(ctx context.Context) (map[string]string, error) {
+	return s.Workspace().ListTags(ctx, s.Name())
+}
+
 // Info returns a summary of the Stack including its URL.
 func (s *Stack) Info(ctx context.Context) (StackSummary, error) {
 	var info StackSummary

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -59,6 +59,14 @@ type Workspace interface {
 	RemoveAllConfig(context.Context, string, []string) error
 	// RefreshConfig gets and sets the config map used with the last Update for Stack matching stack name.
 	RefreshConfig(context.Context, string) (ConfigMap, error)
+	// GetTag returns the value associated with the specified stack name and key.
+	GetTag(context.Context, string, string) (string, error)
+	// SetTag sets the specified key-value pair on the provided stack name.
+	SetTag(context.Context, string, string, string) error
+	// RemoveTag removes the specified key-value pair on the provided stack name.
+	RemoveTag(context.Context, string, string) error
+	// ListTags returns the tag map for the specified stack name.
+	ListTags(context.Context, string) (map[string]string, error)
 	// GetEnvVars returns the environment values scoped to the current workspace.
 	GetEnvVars() map[string]string
 	// SetEnvVars sets the specified map of environment values scoped to the current workspace.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds support for tagging stacks with the Go automation API.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

* https://github.com/pulumi/pulumi/issues/11936 (Go support)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
