### PR TITLE
ci: Run action-install-gh-release with auth

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -187,18 +187,24 @@ jobs:
           echo "PULUMI_GO_DEP_ROOT=$(dirname "$(pwd)")" | tee -a "${GITHUB_ENV}"
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.7.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:
           repo: pulumi/pulumictl
           tag: v0.0.32
           cache: enable
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v1.7.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:
           repo: gotestyourself/gotestsum
           tag: v1.8.1
           cache: enable
       - name: Install goteststats
         uses: jaxxstorm/action-install-gh-release@v1.7.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,8 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Install Pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.7.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         with:
           repo: pulumi/pulumictl
           tag: v0.0.32


### PR DESCRIPTION
We have a few places in CI where we use action-install-gh-release
to download and install specific or latest binary releases of a
dependency.

Nearly all these steps, besides the one in ci-test-codegen,
were unauthenticated.
This caused us to run into rate limits with the GitHub API
when trying to get the latest release and resulted in delays like:

```
Run jaxxstorm/action-install-gh-release@v1.7.1
==> System reported platform: linux
==> Using platform: linux
==> System reported arch: x64
==> Using arch: x64
Warning: RateLimit detected for request GET /repos/{owner}/{repo}/releases/tags/{tag}.
Retrying after 3300 seconds.
Error: The operation was canceled.
```

This sets GITHUB_TOKEN for all instances of this step
so that we're less likely to get rate limited by GitHub on this.
