### PR TITLE
[go/auto/git] Fetch a commit if one is specified

### DIFF
--- a/changelog/pending/20230302--auto-go--fetch-commits-before-checkout.yaml
+++ b/changelog/pending/20230302--auto-go--fetch-commits-before-checkout.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: auto/go
+  description: Fetch commits before checkout


### PR DESCRIPTION
If a commit hash is specified for a Git repo, explicitly fetch it before attempting to check it out. This allows using commits that are not fetched by default (e.g. GitHub test merge commits).