### PR TITLE
Update dotnet codegen to net6.0

### DIFF
--- a/changelog/pending/20230302--sdkgen-dotnet--update-sdkgen-to-target-dotnet-6.yaml
+++ b/changelog/pending/20230302--sdkgen-dotnet--update-sdkgen-to-target-dotnet-6.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen/dotnet
+  description: Update sdkgen to target dotnet 6.

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -2222,7 +2222,7 @@ func genProjectFile(pkg *schema.Package,
 		// only add a package reference to Pulumi if we're not referencing a local Pulumi project
 		// which we usually do when testing schemas locally
 		if !referencedLocalPulumiProject {
-			packageReferences["Pulumi"] = "[3.23.0,4)"
+			packageReferences["Pulumi"] = "[3.54.1.0,4)"
 		}
 	}
 

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -132,7 +132,7 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
     <RepositoryUrl>{{.Package.Repository}}</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/dotnet/Pulumi.AzureNative.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-azure-native</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Random" Version="4.2" ExcludeAssets="contentFiles" />

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/different-enum/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/different-enum/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/enum-reference/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/pkg/codegen/testing/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.28.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
+++ b/pkg/codegen/testing/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/other-owned/dotnet/Other.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/other-owned/dotnet/Other.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -50,7 +50,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -50,7 +50,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/pkg/codegen/testing/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
+++ b/pkg/codegen/testing/test/testdata/provider-config-schema/dotnet/Configstation.Pulumi.Configstation.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
+++ b/pkg/codegen/testing/test/testdata/provider-type-schema/dotnet/Pulumi.ProviderType.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/pkg/codegen/testing/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/testing/test/testdata/secrets/dotnet/Pulumi.Mypkg.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
     <PackageReference Include="Pulumi.Random" Version="4.2.0" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.23.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>

--- a/pkg/codegen/testing/test/testdata/simplified-invokes/dotnet/Pulumi.Std.csproj
+++ b/pkg/codegen/testing/test/testdata/simplified-invokes/dotnet/Pulumi.Std.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi-std</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

netcore3.1 is out of support, we've just been waiting on ecosystem and providers to update build scripts to support this.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
