### PR TITLE
ci: Don't run codegen tests for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+# Adds the ci/test-codegen label to a PR if this changes codegen.
+# Keep CODEGEN_TEST_PACKAGES in scripts/get-job-matrix.py synced.
+#
+# Ref: https://github.com/actions/labeler
+ci/test-codegen:
+  - 'pkg/codegen/docs/**'
+  - 'pkg/codegen/dotnet/**'
+  - 'pkg/codegen/go/**'
+  - 'pkg/codegen/nodejs/**'
+  - 'pkg/codegen/python/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ on:
         default: true
         description: "Build targets to produce, false builds only for Linux amd64."
         type: boolean
+      codegen-tests:
+        required: false
+        default: true
+        description: "Whether to run per-langauge codegen tests."
+        type: boolean
       lint:
         required: false
         default: true
@@ -89,6 +94,7 @@ jobs:
         id: matrix
         env:
           BUILD_ALL_TARGETS: ${{ inputs.build-all-targets }}
+          CODEGEN_TESTS: ${{ inputs.codegen-tests }}
           TEST_VERSION_SETS: ${{ inputs.test-version-sets }}
           INPUT_INTEGRATION_TEST_PLATFORMS: ${{ inputs.integration-test-platforms }}
           INPUT_ACCEPTANCE_TEST_PLATFORMS: ${{ inputs.acceptance-test-platforms }}
@@ -122,14 +128,22 @@ jobs:
             ]'
           fi
 
+          CODEGEN_TESTS_FLAG=--codegen-tests
+          PKG_UNIT_TEST_PARTITIONS=7
+          if [ "${CODEGEN_TESTS}" = "false" ]; then
+            CODEGEN_TESTS_FLAG=--no-codegen-tests
+            PKG_UNIT_TEST_PARTITIONS=2
+          fi
+
           UNIT_TEST_MATRIX=$(
             ./scripts/get-job-matrix.py \
             -vvv \
             generate-matrix \
             --kind unit-test \
+            "$CODEGEN_TESTS_FLAG" \
             --platform ubuntu-latest \
             --version-set current \
-            --partition-module pkg 7 \
+            --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \
             --partition-module sdk 1 \
             --partition-module tests 2
           )
@@ -139,6 +153,7 @@ jobs:
             -vvv \
             generate-matrix \
             --kind integration-test \
+            "$CODEGEN_TESTS_FLAG" \
             --platform "${INTEGRATION_PLATFORMS[@]}" \
             --version-set "${VERSION_SETS_TO_TEST[@]}" \
             --partition-module pkg 1 \
@@ -152,6 +167,7 @@ jobs:
             -vvv \
             generate-matrix \
             --kind acceptance-test \
+            "$CODEGEN_TESTS_FLAG" \
             --tags all xplatform_acceptance \
             --platform "${ACCEPTANCE_PLATFORMS[@]}" \
             --version-set current \

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -45,10 +45,23 @@ jobs:
       is-snapshot: true
     secrets: inherit
 
+  # Labels the PR based on affected paths.
+  # Configuration is in .github/labeler.yml.
+  label:
+    name: Add CI labels
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
   ci:
     name: CI
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: [info]
+    needs: [info, label]
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
@@ -59,6 +72,14 @@ jobs:
       version: ${{ needs.info.outputs.version }}
       lint: true
       build-all-targets: ${{ contains(github.event.pull_request.labels.*.name, 'ci/test') }}
+      # codegen tests take quite a while to run.
+      # Run them only if ci/test or ci/test-codegen is set.
+      # The latter is set by the label action if relevant files change.
+      codegen-tests:  >- # No newlines or trailing newline.
+        ${{
+          contains(github.event.pull_request.labels.*.name, 'ci/test') ||
+          contains(github.event.pull_request.labels.*.name, 'ci/test-codegen')
+        }}
       test-version-sets: >- # No newlines or trailing newline.
         ${{
           contains(github.event.pull_request.labels.*.name, 'ci/test')

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -72,6 +72,27 @@ def is_unit_test(pkg: str) -> bool:
         or pkg in INTEGRATION_TEST_PACKAGES
     )
 
+# Keep this in sync with .github/labeler.yml.
+CODEGEN_TEST_PACKAGES = {
+    "github.com/pulumi/pulumi/pkg/v3/codegen/docs",
+    "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet",
+    "github.com/pulumi/pulumi/pkg/v3/codegen/go",
+    "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs",
+    "github.com/pulumi/pulumi/pkg/v3/codegen/python",
+}
+
+def is_codegen_test(pkg: str) -> bool:
+    """Checks if a package is a per-language codegen test"""
+    if pkg in CODEGEN_TEST_PACKAGES:
+        return True
+
+    for codegen_pkg in CODEGEN_TEST_PACKAGES:
+        if pkg.startswith(codegen_pkg + "/"):
+            return True
+
+    return False
+
+
 class MakefileTest(TypedDict):
     name: str
     run: str
@@ -348,6 +369,7 @@ def get_matrix(
     platforms: List[str],
     version_sets: List[VersionSet],
     fast: bool = False,
+    codegen_tests: bool = False,
 ) -> Matrix:
     """Compute a job matrix"""
     if kind == JobKind.INTEGRATION_TEST:
@@ -374,6 +396,8 @@ def get_matrix(
     for item in partition_modules:
         go_packages = run_list_packages(item.module_dir, tags)
         go_packages = set(go_packages) - partitioned_packages
+        if not codegen_tests:
+            go_packages = {pkg for pkg in go_packages if not is_codegen_test(pkg)}
 
         if kind == JobKind.INTEGRATION_TEST or kind == JobKind.ACCEPTANCE_TEST:
             go_packages = {pkg for pkg in go_packages if not is_unit_test(pkg)}
@@ -453,6 +477,7 @@ def generate_matrix(args: argparse.Namespace):
         partition_modules=partition_modules,
         partition_packages=partition_packages,
         version_sets=version_sets,
+        codegen_tests=args.codegen_tests,
     )
 
     if not matrix["platform"] or not matrix["test-suite"] or not matrix["version-set"]:
@@ -469,6 +494,13 @@ def add_generate_matrix_args(parser: argparse.ArgumentParser):
         required=True,
         choices=[kind.value for kind in JobKind],
         help="Kind of output to generate",
+    )
+    parser.add_argument(
+        "--codegen-tests",
+        required=False,
+        default=True,
+        action=argparse.BooleanOptionalAction,  # adds --no-codegen-tests
+        help="Whether to include per-langauge codegen tests",
     )
     parser.add_argument(
         "--fast", action="store_true", default=False, help="Exclude slow tests"


### PR DESCRIPTION
We currently run all codegen tests in pkg/codegen/$lang
for every PR.
These tests take quite a while to run and lock up many GitHub workers
for this entire duration.

This change attempts to address this issue
by running codegen tests only for those PRs
that touch the codegen directories.

The machinery to make this work is roughly as follows:

- In the on-pr workflow, when we're figuring out what we're doing
  we label the PR with ci/test-codegen.
  We use [actions/labeler] to do this.
  The name of the label matches "ci/test" which tells the system
  to run all integration and unit tests.
- Using the label, we decide whether we want to run codegen tests,
  and pass that onto the test matrix generator.
- The test matrix generator filters out these packages
  and their subpackages from the list of tests under consideration.
- Everything else proceeds as normal.

Things to note:

- The codegen-tests input defaults to true.
  All other invocations will run with code gen tests
  so these will continue to run on merge.
  Only PRs (from on-pr.yml) set it to false.
- Since the number of tests is remarkably smaller without these tests,
  we can significantly reduce the number of partitions we use
  for pkg/ unit tests.
  This should alleviate pressure on GitHub workers further.

The choice to use [actions/labeler] was made because GitHub
does not support filtering on files in the pull request
inside `if` clauses or other `${{ .. }}` expressions.

  [actions/labeler]: https://github.com/actions/labeler

This is a pretty blunt approach to the problem.
If we wanted to be more targeted,
instead of filtering at the get-job-matrix.py level,
we could instead set an environment variable
and add t.Skips in {program,sdk,type}_driver
if that environment variable is set.

Resolves #12334
