### PR TITLE
vscode/settings: Enable gofumpt

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,8 @@
             "-sdk/nodejs/tests",
             "-sdk/python/env"
         ],
+        // Uses https://github.com/mvdan/gofumpt for formatting.
+        "formatting.gofumpt": true,
         // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
         "experimentalWorkspaceModule": true,
     },


### PR DESCRIPTION
We enabled gofumpt on the repository in #12347.
This updates the workspace-local VSCode configuration
to use gofumpt to format Go code.
